### PR TITLE
Fix non-idempotent embedding migration (closes #5)

### DIFF
--- a/crates/storage/migrations/007_chunked_embeddings.sql
+++ b/crates/storage/migrations/007_chunked_embeddings.sql
@@ -1,10 +1,31 @@
 -- Convert embedding columns from a single vector to an array of vectors
 -- so that long content can be chunked and each chunk embedded separately.
 -- Existing single vectors are wrapped into single-element arrays; NULLs stay NULL.
-ALTER TABLE knowledge_base
-  ALTER COLUMN embedding TYPE vector[]
-  USING CASE WHEN embedding IS NOT NULL THEN ARRAY[embedding] ELSE NULL END;
+--
+-- Idempotent: the ALTER only runs when the column is still plain `vector`
+-- (data_type = 'USER-DEFINED'). Once converted to `vector[]` (data_type =
+-- 'ARRAY'), subsequent runs are no-ops — without this guard each restart
+-- wraps the column in another ARRAY[...] layer and eventually trips
+-- Postgres's 6-dimension array limit.
+DO $$
+BEGIN
+    IF (SELECT data_type
+          FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'knowledge_base'
+           AND column_name = 'embedding') = 'USER-DEFINED' THEN
+        ALTER TABLE knowledge_base
+          ALTER COLUMN embedding TYPE vector[]
+          USING CASE WHEN embedding IS NOT NULL THEN ARRAY[embedding] ELSE NULL END;
+    END IF;
 
-ALTER TABLE tool_definitions
-  ALTER COLUMN embedding TYPE vector[]
-  USING CASE WHEN embedding IS NOT NULL THEN ARRAY[embedding] ELSE NULL END;
+    IF (SELECT data_type
+          FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'tool_definitions'
+           AND column_name = 'embedding') = 'USER-DEFINED' THEN
+        ALTER TABLE tool_definitions
+          ALTER COLUMN embedding TYPE vector[]
+          USING CASE WHEN embedding IS NOT NULL THEN ARRAY[embedding] ELSE NULL END;
+    END IF;
+END $$;

--- a/crates/storage/migrations/010_fix_damaged_embeddings.sql
+++ b/crates/storage/migrations/010_fix_damaged_embeddings.sql
@@ -1,0 +1,32 @@
+-- Repair embedding columns damaged by repeated non-idempotent runs of
+-- migration 007 before it was made idempotent. Each re-run wrapped the
+-- column in another ARRAY[...] layer; after 6 runs the type exceeds
+-- Postgres's array-dimension limit.
+--
+-- `pg_attribute.attndims` is the declared number of array dimensions for
+-- the column: `vector` is 0, `vector[]` is 1, `vector[][]` is 2, etc.
+-- Anything above 1 is damaged and gets dropped + re-added. Embeddings are
+-- regenerated on demand, so no other data is affected.
+DO $$
+DECLARE
+    kb_ndims INT;
+    td_ndims INT;
+BEGIN
+    SELECT attndims INTO kb_ndims
+      FROM pg_attribute
+     WHERE attrelid = 'knowledge_base'::regclass
+       AND attname = 'embedding';
+    IF kb_ndims IS NOT NULL AND kb_ndims > 1 THEN
+        ALTER TABLE knowledge_base DROP COLUMN embedding;
+        ALTER TABLE knowledge_base ADD COLUMN embedding vector[];
+    END IF;
+
+    SELECT attndims INTO td_ndims
+      FROM pg_attribute
+     WHERE attrelid = 'tool_definitions'::regclass
+       AND attname = 'embedding';
+    IF td_ndims IS NOT NULL AND td_ndims > 1 THEN
+        ALTER TABLE tool_definitions DROP COLUMN embedding;
+        ALTER TABLE tool_definitions ADD COLUMN embedding vector[];
+    END IF;
+END $$;

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -75,5 +75,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Repair damage from pre-idempotent runs of migration 007 on existing
+    // databases. No-op on fresh installs.
+    sqlx::raw_sql(include_str!(
+        "../migrations/010_fix_damaged_embeddings.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Migration `007_chunked_embeddings.sql` previously wrapped `knowledge_base.embedding` and `tool_definitions.embedding` in another `ARRAY[...]` on every daemon startup (migrations run blindly with no tracking table). After seven restarts the declared array dimensionality exceeded Postgres's 6-dimension cap and migrations began failing hard with `number of array dimensions (7) exceeds the maximum allowed (6)`.

- `007` now guards the `ALTER ... TYPE vector[]` with `information_schema.columns.data_type = 'USER-DEFINED'` so it only fires on a plain `vector` column. Subsequent runs are no-ops.
- New `010_fix_damaged_embeddings.sql` repairs existing damaged installs: when `pg_attribute.attndims > 1`, drop and re-add the `embedding` column as `vector[]`. Only embedding data is affected — those values regenerate on demand.
- `pool.rs` wired up to run migration 010.

## Test plan

- [x] `cargo build -p desktop-assistant-storage` clean
- [x] `cargo test -p desktop-assistant-storage --lib` — 22 passed
- [x] `just backend-reinstall` against a damaged local dev database — succeeds, service `active`
- [x] `pg_attribute.attndims` for both `knowledge_base.embedding` and `tool_definitions.embedding` reports `1` after the fix
- [x] Idempotency confirmed: second `systemctl --user restart` leaves `attndims = 1` (no further growth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)