### PR TITLE
Add multi-connection API surface + per-conversation model persistence (closes #11)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! Business logic belongs in core/application crates.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -51,24 +53,22 @@ pub enum Command {
     /// Send a content to an existing conversation.
     ///
     /// The response is streamed via [`Event::AssistantDelta`] events.
+    /// An optional `override` selects a specific connection/model/effort for
+    /// this send only; when omitted, the server falls back to (in order) the
+    /// conversation's last selection and the `interactive` purpose.
     SendMessage {
         conversation_id: String,
         content: String,
+        #[serde(default, rename = "override", skip_serializing_if = "Option::is_none")]
+        override_selection: Option<SendPromptOverride>,
     },
 
-    // Settings
-    GetLlmSettings,
-    SetLlmSettings {
-        connector: String,
-        model: Option<String>,
-        base_url: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        temperature: Option<f64>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        top_p: Option<f64>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        max_tokens: Option<u32>,
-    },
+    // Settings (legacy `[llm]`-block single-connection surface).
+    //
+    // The legacy `SetLlmSettings` / `GetLlmSettings` commands have been
+    // removed; use the named-connection commands below (`ListConnections`,
+    // `CreateConnection`, `UpdateConnection`, `DeleteConnection`,
+    // `GetPurposes`, `SetPurpose`) instead.
     SetApiKey {
         api_key: String,
     },
@@ -90,6 +90,45 @@ pub enum Command {
         remote_url: Option<String>,
         remote_name: Option<String>,
         push_on_update: bool,
+    },
+
+    // Named connections (issue #11).
+    /// Enumerate every configured connection with its availability and
+    /// whether credentials are present.
+    ListConnections,
+    /// Create a new named connection; fails on invalid slug or duplicate id.
+    CreateConnection {
+        id: String,
+        config: ConnectionConfigView,
+    },
+    /// Replace an existing connection in-place.
+    UpdateConnection {
+        id: String,
+        config: ConnectionConfigView,
+    },
+    /// Delete a named connection. Refuses with an error when the connection
+    /// is referenced by any purpose unless `force` is true, in which case
+    /// referencing purposes fall back to the `interactive` purpose.
+    DeleteConnection {
+        id: String,
+        #[serde(default)]
+        force: bool,
+    },
+    /// Enumerate models across one or all configured connections. When
+    /// `connection_id` is `None`, aggregates models from every healthy
+    /// connection. `refresh=true` bypasses connector caches (e.g. Bedrock).
+    ListAvailableModels {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connection_id: Option<String>,
+        #[serde(default)]
+        refresh: bool,
+    },
+
+    // Purposes (issue #10 + #11).
+    GetPurposes,
+    SetPurpose {
+        purpose: PurposeKindApi,
+        config: PurposeConfigView,
     },
 
     // MCP server management
@@ -136,12 +175,15 @@ pub enum CommandResult {
     Messages(MessagesView),
     Cleared { deleted_count: u32 },
 
-    LlmSettings(LlmSettingsView),
     EmbeddingsSettings(EmbeddingsSettingsView),
     ConnectorDefaults(ConnectorDefaultsView),
     PersistenceSettings(PersistenceSettingsView),
 
     McpServers(Vec<McpServerView>),
+
+    Connections(Vec<ConnectionView>),
+    Models(Vec<ModelListing>),
+    Purposes(PurposesView),
 
     Ack,
 }
@@ -187,6 +229,15 @@ pub enum Event {
         conversation_id: String,
         title: String,
     },
+
+    /// A one-time advisory for a conversation (e.g. the stored model
+    /// selection no longer resolves and was cleared). Emitted at most once
+    /// per underlying condition — the server clears the stored state so
+    /// the warning does not recur.
+    ConversationWarningEmitted {
+        conversation_id: String,
+        warning: ConversationWarning,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -196,21 +247,12 @@ pub struct Status {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
-    pub llm: LlmSettingsView,
     pub embeddings: EmbeddingsSettingsView,
     pub persistence: PersistenceSettingsView,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ConfigChanges {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_connector: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_base_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embeddings_connector: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -225,14 +267,6 @@ pub struct ConfigChanges {
     pub persistence_remote_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persistence_push_on_update: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_hosted_tool_search: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -250,6 +284,25 @@ pub struct ConversationView {
     pub id: String,
     pub title: String,
     pub messages: Vec<MessageView>,
+    /// One-time advisories surfaced after `GetConversation` — e.g. the
+    /// conversation's last model selection no longer resolves and was cleared.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<ConversationWarning>,
+}
+
+/// Advisory conditions attached to a conversation view. Modeled as an enum
+/// so additional variants can be added without breaking existing clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConversationWarning {
+    /// The conversation's previous model selection no longer resolves
+    /// (connection removed or model not listed by the connector). The
+    /// selection has been cleared and the server fell back to the
+    /// `fallback_to` target.
+    DanglingModelSelection {
+        previous_selection: ConversationModelSelectionView,
+        fallback_to: ConversationModelSelectionView,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -263,22 +316,6 @@ pub struct MessagesView {
     pub total_raw_count: u32,
     pub truncated: bool,
     pub messages: Vec<MessageView>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LlmSettingsView {
-    pub connector: String,
-    pub model: String,
-    pub base_url: String,
-    pub has_api_key: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hosted_tool_search: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -322,6 +359,215 @@ pub struct McpServerView {
     /// "running" | "stopped" | "disabled"
     pub status: String,
     pub tool_count: u32,
+}
+
+// --- Named-connection views (#11) ------------------------------------------
+
+/// Opaque, protocol-neutral representation of a connection config.
+///
+/// This mirrors the daemon's internal `ConnectionConfig` (one variant per
+/// connector type) but lives here so clients don't need to depend on the
+/// daemon crate. Credentials are represented as `has_credentials` booleans
+/// on the view; raw secret values are never serialized back through the API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
+pub enum ConnectionConfigView {
+    Anthropic {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_key_env: Option<String>,
+    },
+    #[serde(rename = "openai")]
+    OpenAi {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_key_env: Option<String>,
+    },
+    Bedrock {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        aws_profile: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+    },
+    Ollama {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+    },
+}
+
+impl ConnectionConfigView {
+    /// Short connector-type identifier (matches the `type =` tag).
+    pub fn connector_type(&self) -> &'static str {
+        match self {
+            Self::Anthropic { .. } => "anthropic",
+            Self::OpenAi { .. } => "openai",
+            Self::Bedrock { .. } => "bedrock",
+            Self::Ollama { .. } => "ollama",
+        }
+    }
+}
+
+/// Availability of a connection in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ConnectionAvailability {
+    Ok,
+    Unavailable { reason: String },
+}
+
+/// Aggregate view of a single connection for the connections list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConnectionView {
+    pub id: String,
+    /// Short connector-type identifier (`"openai"`, `"anthropic"`, etc.).
+    pub connector_type: String,
+    /// Human-friendly label; defaults to `"<id> (<connector_type>)"` but
+    /// daemons can synthesize a more descriptive value.
+    pub display_label: String,
+    pub availability: ConnectionAvailability,
+    /// True when credentials could be resolved during the most recent sanity
+    /// check (env var present, keyring lookup succeeded, or Bedrock/Ollama
+    /// which auth via ambient credentials / none).
+    pub has_credentials: bool,
+}
+
+/// A single model enumerated across one or all connections. Mirrors the
+/// core `ModelInfo` fields while tagging the connection it came from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelListing {
+    pub connection_id: String,
+    pub connection_label: String,
+    pub model: ModelInfoView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelInfoView {
+    pub id: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_limit: Option<u64>,
+    #[serde(default)]
+    pub capabilities: ModelCapabilitiesView,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelCapabilitiesView {
+    #[serde(default)]
+    pub reasoning: bool,
+    #[serde(default)]
+    pub vision: bool,
+    #[serde(default)]
+    pub tools: bool,
+    #[serde(default)]
+    pub embedding: bool,
+}
+
+// --- Purpose views (#10 + #11) --------------------------------------------
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PurposeKindApi {
+    Interactive,
+    Dreaming,
+    Embedding,
+    Titling,
+}
+
+impl PurposeKindApi {
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::Interactive => "interactive",
+            Self::Dreaming => "dreaming",
+            Self::Embedding => "embedding",
+            Self::Titling => "titling",
+        }
+    }
+}
+
+/// Effort hint passed to connectors (mapped at dispatch time).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EffortLevel {
+    Low,
+    Medium,
+    High,
+}
+
+/// Protocol-neutral purpose config. String `"primary"` in the connection or
+/// model field means "inherit from interactive" — the daemon resolves this
+/// before dispatch (see `crates/daemon/src/purposes.rs`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PurposeConfigView {
+    /// Either a connection id (slug) or the literal string `"primary"`.
+    pub connection: String,
+    /// Either a model id or the literal string `"primary"`.
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
+}
+
+/// Aggregate purpose view. Missing entries mean the purpose is not
+/// configured (the daemon falls back to the primary LLM for those).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PurposesView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dreaming: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub titling: Option<PurposeConfigView>,
+}
+
+impl PurposesView {
+    /// Convenience: convert into a BTreeMap keyed by purpose key for clients
+    /// that prefer iteration.
+    pub fn to_map(&self) -> BTreeMap<String, PurposeConfigView> {
+        let mut map = BTreeMap::new();
+        if let Some(v) = &self.interactive {
+            map.insert("interactive".to_string(), v.clone());
+        }
+        if let Some(v) = &self.dreaming {
+            map.insert("dreaming".to_string(), v.clone());
+        }
+        if let Some(v) = &self.embedding {
+            map.insert("embedding".to_string(), v.clone());
+        }
+        if let Some(v) = &self.titling {
+            map.insert("titling".to_string(), v.clone());
+        }
+        map
+    }
+}
+
+// --- Per-send model override (#11) ----------------------------------------
+
+/// Caller-supplied override for a single `SendMessage` (or `SendPrompt`)
+/// call. The daemon validates that `connection_id` is live and that the
+/// connector lists `model_id`; otherwise the request is rejected with a
+/// 400-style error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SendPromptOverride {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
+}
+
+/// View of a conversation's stored model selection. Same shape as
+/// [`SendPromptOverride`] minus the "this is a request" framing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConversationModelSelectionView {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
 }
 
 /// WebSocket request envelope.
@@ -376,7 +622,6 @@ mod tests {
     fn command_json_roundtrip_set_config() {
         let cmd = Command::SetConfig {
             changes: ConfigChanges {
-                llm_connector: Some("openai".into()),
                 persistence_enabled: Some(true),
                 ..Default::default()
             },
@@ -384,5 +629,185 @@ mod tests {
         let json = serde_json::to_string(&cmd).unwrap();
         let back: Command = serde_json::from_str(&json).unwrap();
         assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn list_connections_roundtrip() {
+        let cmd = Command::ListConnections;
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("list_connections"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn create_connection_roundtrip_openai() {
+        let cmd = Command::CreateConnection {
+            id: "work".into(),
+            config: ConnectionConfigView::OpenAi {
+                base_url: Some("https://api.openai.com/v1".into()),
+                api_key_env: Some("OPENAI_WORK_KEY".into()),
+            },
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn connection_config_view_tagged_type() {
+        let c = ConnectionConfigView::Bedrock {
+            aws_profile: Some("work".into()),
+            region: Some("us-west-2".into()),
+            base_url: None,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"type\":\"bedrock\""));
+        assert_eq!(c.connector_type(), "bedrock");
+        let back: ConnectionConfigView = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn delete_connection_force_flag() {
+        let cmd = Command::DeleteConnection {
+            id: "old".into(),
+            force: true,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+
+        // Missing force flag defaults to false.
+        let cmd2: Command =
+            serde_json::from_str(r#"{"delete_connection":{"id":"old"}}"#).unwrap();
+        assert_eq!(
+            cmd2,
+            Command::DeleteConnection {
+                id: "old".into(),
+                force: false,
+            }
+        );
+    }
+
+    #[test]
+    fn list_available_models_optional_connection_and_refresh() {
+        // Both fields omitted.
+        let cmd: Command = serde_json::from_str(r#"{"list_available_models":{}}"#).unwrap();
+        assert_eq!(
+            cmd,
+            Command::ListAvailableModels {
+                connection_id: None,
+                refresh: false,
+            }
+        );
+
+        // All fields present.
+        let cmd2 = Command::ListAvailableModels {
+            connection_id: Some("aws".into()),
+            refresh: true,
+        };
+        let json = serde_json::to_string(&cmd2).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd2, back);
+    }
+
+    #[test]
+    fn set_purpose_roundtrip() {
+        let cmd = Command::SetPurpose {
+            purpose: PurposeKindApi::Dreaming,
+            config: PurposeConfigView {
+                connection: "primary".into(),
+                model: "primary".into(),
+                effort: Some(EffortLevel::Low),
+            },
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn send_message_override_is_optional() {
+        // Without override.
+        let cmd: Command = serde_json::from_str(
+            r#"{"send_message":{"conversation_id":"c1","content":"hi"}}"#,
+        )
+        .unwrap();
+        match &cmd {
+            Command::SendMessage {
+                override_selection, ..
+            } => assert!(override_selection.is_none()),
+            other => panic!("unexpected {other:?}"),
+        }
+
+        // With override.
+        let cmd2 = Command::SendMessage {
+            conversation_id: "c1".into(),
+            content: "hi".into(),
+            override_selection: Some(SendPromptOverride {
+                connection_id: "aws".into(),
+                model_id: "claude-sonnet-4".into(),
+                effort: Some(EffortLevel::High),
+            }),
+        };
+        let json = serde_json::to_string(&cmd2).unwrap();
+        assert!(json.contains("\"override\":"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd2, back);
+    }
+
+    #[test]
+    fn effort_serialize_lowercase() {
+        assert_eq!(serde_json::to_string(&EffortLevel::Low).unwrap(), "\"low\"");
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::High).unwrap(),
+            "\"high\""
+        );
+    }
+
+    #[test]
+    fn conversation_view_warnings_default_empty() {
+        let json = r#"{"id":"c1","title":"t","messages":[]}"#;
+        let v: ConversationView = serde_json::from_str(json).unwrap();
+        assert!(v.warnings.is_empty());
+    }
+
+    #[test]
+    fn conversation_warning_dangling_selection_roundtrip() {
+        let w = ConversationWarning::DanglingModelSelection {
+            previous_selection: ConversationModelSelectionView {
+                connection_id: "old".into(),
+                model_id: "gone".into(),
+                effort: None,
+            },
+            fallback_to: ConversationModelSelectionView {
+                connection_id: "work".into(),
+                model_id: "gpt-5".into(),
+                effort: Some(EffortLevel::Medium),
+            },
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("\"type\":\"dangling_model_selection\""));
+        let back: ConversationWarning = serde_json::from_str(&json).unwrap();
+        assert_eq!(w, back);
+    }
+
+    #[test]
+    fn connection_availability_tagged() {
+        let ok = ConnectionAvailability::Ok;
+        let json = serde_json::to_string(&ok).unwrap();
+        assert!(json.contains("\"status\":\"ok\""));
+        let un = ConnectionAvailability::Unavailable {
+            reason: "x".into(),
+        };
+        let json2 = serde_json::to_string(&un).unwrap();
+        assert!(json2.contains("\"status\":\"unavailable\""));
+        let back: ConnectionAvailability = serde_json::from_str(&json2).unwrap();
+        assert_eq!(un, back);
     }
 }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_core::ports::inbound::{
-    AssistantService, ConversationService, SettingsService,
+    AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
+    ConversationService, DispatchWarning, Effort, PromptSelectionOverride, PurposeConfigPayload,
+    PurposeKind, SettingsService,
 };
 use thiserror::Error;
 use tracing::warn;
@@ -41,6 +43,23 @@ pub trait AssistantApiHandler: Send + Sync {
         request_id: String,
         sink: Arc<dyn EventSink>,
     ) -> ApiResult<()>;
+
+    /// Handle a streaming `SendMessage` with an optional per-send model
+    /// override. The default implementation ignores the override and
+    /// forwards to `handle_send_message`; the concrete handler overrides
+    /// this to thread the override through.
+    async fn handle_send_message_with_override(
+        &self,
+        conversation_id: String,
+        content: String,
+        override_selection: Option<api::SendPromptOverride>,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        let _ = override_selection;
+        self.handle_send_message(conversation_id, content, request_id, sink)
+            .await
+    }
 }
 
 /// Minimal sink for emitting canonical events.
@@ -54,28 +73,37 @@ pub trait EventSink: Send + Sync {
 
 const STREAM_EVENT_BUFFER: usize = 64;
 
-pub struct DefaultAssistantApiHandler<A, C, S>
+pub struct DefaultAssistantApiHandler<A, C, S, N>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
+    N: ConnectionsService + 'static,
 {
     assistant: Arc<A>,
     conversations: Arc<C>,
     settings: Arc<S>,
+    connections: Arc<N>,
 }
 
-impl<A, C, S> DefaultAssistantApiHandler<A, C, S>
+impl<A, C, S, N> DefaultAssistantApiHandler<A, C, S, N>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
+    N: ConnectionsService + 'static,
 {
-    pub fn new(assistant: Arc<A>, conversations: Arc<C>, settings: Arc<S>) -> Self {
+    pub fn new(
+        assistant: Arc<A>,
+        conversations: Arc<C>,
+        settings: Arc<S>,
+        connections: Arc<N>,
+    ) -> Self {
         Self {
             assistant,
             conversations,
             settings,
+            connections,
         }
     }
 
@@ -95,11 +123,6 @@ where
     }
 
     async fn get_config(&self) -> ApiResult<api::Config> {
-        let llm = self
-            .settings
-            .get_llm_settings()
-            .await
-            .map_err(Self::map_core_err)?;
         let embeddings = self
             .settings
             .get_embeddings_settings()
@@ -112,16 +135,6 @@ where
             .map_err(Self::map_core_err)?;
 
         Ok(api::Config {
-            llm: api::LlmSettingsView {
-                connector: llm.connector,
-                model: llm.model,
-                base_url: llm.base_url,
-                has_api_key: llm.has_api_key,
-                temperature: llm.temperature,
-                top_p: llm.top_p,
-                max_tokens: llm.max_tokens,
-                hosted_tool_search: llm.hosted_tool_search,
-            },
             embeddings: api::EmbeddingsSettingsView {
                 connector: embeddings.connector,
                 model: embeddings.model,
@@ -142,10 +155,6 @@ where
     async fn set_config(&self, changes: api::ConfigChanges) -> ApiResult<api::Config> {
         let current = self.get_config().await?;
         let api::ConfigChanges {
-            llm_connector,
-            llm_model,
-            llm_base_url,
-            llm_api_key,
             embeddings_connector,
             embeddings_model,
             embeddings_base_url,
@@ -153,74 +162,7 @@ where
             persistence_remote_url,
             persistence_remote_name,
             persistence_push_on_update,
-            llm_temperature,
-            llm_top_p,
-            llm_max_tokens,
-            llm_hosted_tool_search,
         } = changes;
-
-        let llm_changed = llm_connector.is_some()
-            || llm_model.is_some()
-            || llm_base_url.is_some()
-            || llm_temperature.is_some()
-            || llm_top_p.is_some()
-            || llm_max_tokens.is_some()
-            || llm_hosted_tool_search.is_some();
-        if llm_changed {
-            let connector = Self::normalize_optional_string(llm_connector)
-                .unwrap_or_else(|| current.llm.connector.clone());
-            let model = if llm_model.is_some() {
-                Self::normalize_optional_string(llm_model)
-            } else {
-                Some(current.llm.model.clone())
-            };
-            let base_url = if llm_base_url.is_some() {
-                Self::normalize_optional_string(llm_base_url)
-            } else {
-                Some(current.llm.base_url.clone())
-            };
-
-            let temperature = if llm_temperature.is_some() {
-                llm_temperature
-            } else {
-                current.llm.temperature
-            };
-            let top_p = if llm_top_p.is_some() {
-                llm_top_p
-            } else {
-                current.llm.top_p
-            };
-            let max_tokens = if llm_max_tokens.is_some() {
-                llm_max_tokens
-            } else {
-                current.llm.max_tokens
-            };
-            let hosted_tool_search = if llm_hosted_tool_search.is_some() {
-                llm_hosted_tool_search
-            } else {
-                current.llm.hosted_tool_search
-            };
-
-            self.settings
-                .set_llm_settings(
-                    connector,
-                    model,
-                    base_url,
-                    temperature,
-                    top_p,
-                    max_tokens,
-                    hosted_tool_search,
-                )
-                .await
-                .map_err(Self::map_core_err)?;
-        }
-
-        if let Some(api_key) = Self::normalize_optional_string(llm_api_key) {
-            self.settings
-                .set_api_key(api_key)
-                .await
-                .map_err(Self::map_core_err)?;
-        }
 
         let embeddings_changed = embeddings_connector.is_some()
             || embeddings_model.is_some()
@@ -281,12 +223,144 @@ where
     }
 }
 
+// ---- Conversion helpers between api-model wire types and core port types ----
+
+fn api_connection_config_to_core(c: api::ConnectionConfigView) -> ConnectionConfigPayload {
+    match c {
+        api::ConnectionConfigView::Anthropic {
+            base_url,
+            api_key_env,
+        } => ConnectionConfigPayload::Anthropic {
+            base_url,
+            api_key_env,
+        },
+        api::ConnectionConfigView::OpenAi {
+            base_url,
+            api_key_env,
+        } => ConnectionConfigPayload::OpenAi {
+            base_url,
+            api_key_env,
+        },
+        api::ConnectionConfigView::Bedrock {
+            aws_profile,
+            region,
+            base_url,
+        } => ConnectionConfigPayload::Bedrock {
+            aws_profile,
+            region,
+            base_url,
+        },
+        api::ConnectionConfigView::Ollama { base_url } => {
+            ConnectionConfigPayload::Ollama { base_url }
+        }
+    }
+}
+
+fn core_connection_to_api_view(
+    v: desktop_assistant_core::ports::inbound::ConnectionView,
+) -> api::ConnectionView {
+    api::ConnectionView {
+        id: v.id,
+        connector_type: v.connector_type,
+        display_label: v.display_label,
+        availability: match v.availability {
+            ConnectionAvailability::Ok => api::ConnectionAvailability::Ok,
+            ConnectionAvailability::Unavailable { reason } => {
+                api::ConnectionAvailability::Unavailable { reason }
+            }
+        },
+        has_credentials: v.has_credentials,
+    }
+}
+
+fn core_model_listing_to_api(
+    l: desktop_assistant_core::ports::inbound::ModelListing,
+) -> api::ModelListing {
+    api::ModelListing {
+        connection_id: l.connection_id,
+        connection_label: l.connection_label,
+        model: api::ModelInfoView {
+            id: l.model.id,
+            display_name: l.model.display_name,
+            context_limit: l.model.context_limit,
+            capabilities: api::ModelCapabilitiesView {
+                reasoning: l.model.capabilities.reasoning,
+                vision: l.model.capabilities.vision,
+                tools: l.model.capabilities.tools,
+                embedding: l.model.capabilities.embedding,
+            },
+        },
+    }
+}
+
+fn core_purpose_to_api(p: PurposeConfigPayload) -> api::PurposeConfigView {
+    api::PurposeConfigView {
+        connection: p.connection,
+        model: p.model,
+        effort: p.effort.map(effort_to_api),
+    }
+}
+
+fn api_purpose_to_core(p: api::PurposeConfigView) -> PurposeConfigPayload {
+    PurposeConfigPayload {
+        connection: p.connection,
+        model: p.model,
+        effort: p.effort.map(effort_from_api),
+    }
+}
+
+fn effort_to_api(e: Effort) -> api::EffortLevel {
+    match e {
+        Effort::Low => api::EffortLevel::Low,
+        Effort::Medium => api::EffortLevel::Medium,
+        Effort::High => api::EffortLevel::High,
+    }
+}
+
+fn effort_from_api(e: api::EffortLevel) -> Effort {
+    match e {
+        api::EffortLevel::Low => Effort::Low,
+        api::EffortLevel::Medium => Effort::Medium,
+        api::EffortLevel::High => Effort::High,
+    }
+}
+
+fn api_purpose_kind_to_core(k: api::PurposeKindApi) -> PurposeKind {
+    match k {
+        api::PurposeKindApi::Interactive => PurposeKind::Interactive,
+        api::PurposeKindApi::Dreaming => PurposeKind::Dreaming,
+        api::PurposeKindApi::Embedding => PurposeKind::Embedding,
+        api::PurposeKindApi::Titling => PurposeKind::Titling,
+    }
+}
+
+fn dispatch_warning_to_api(w: DispatchWarning) -> api::ConversationWarning {
+    match w {
+        DispatchWarning::DanglingModelSelection {
+            previous,
+            fallback_to,
+        } => api::ConversationWarning::DanglingModelSelection {
+            previous_selection: api::ConversationModelSelectionView {
+                connection_id: previous.connection_id,
+                model_id: previous.model_id,
+                effort: previous.effort.map(|e| effort_to_api(Effort::from(e))),
+            },
+            fallback_to: api::ConversationModelSelectionView {
+                connection_id: fallback_to.connection_id,
+                model_id: fallback_to.model_id,
+                effort: fallback_to.effort.map(|e| effort_to_api(Effort::from(e))),
+            },
+        },
+    }
+}
+
 #[async_trait::async_trait]
-impl<A, C, S> AssistantApiHandler for DefaultAssistantApiHandler<A, C, S>
+impl<A, C, S, N> AssistantApiHandler for DefaultAssistantApiHandler<A, C, S, N>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
+    N: ConnectionsService + 'static,
 {
     async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
         match cmd {
@@ -359,6 +433,7 @@ where
                             content: m.content,
                         })
                         .collect(),
+                    warnings: Vec::new(),
                 }))
             }
 
@@ -413,46 +488,6 @@ where
             }
 
             // Settings
-            api::Command::GetLlmSettings => {
-                let s = self
-                    .settings
-                    .get_llm_settings()
-                    .await
-                    .map_err(Self::map_core_err)?;
-                Ok(api::CommandResult::LlmSettings(api::LlmSettingsView {
-                    connector: s.connector,
-                    model: s.model,
-                    base_url: s.base_url,
-                    has_api_key: s.has_api_key,
-                    temperature: s.temperature,
-                    top_p: s.top_p,
-                    max_tokens: s.max_tokens,
-                    hosted_tool_search: s.hosted_tool_search,
-                }))
-            }
-
-            api::Command::SetLlmSettings {
-                connector,
-                model,
-                base_url,
-                temperature,
-                top_p,
-                max_tokens,
-            } => {
-                self.settings
-                    .set_llm_settings(
-                        connector,
-                        model,
-                        base_url,
-                        temperature,
-                        top_p,
-                        max_tokens,
-                        None,
-                    )
-                    .await
-                    .map_err(Self::map_core_err)?;
-                Ok(api::CommandResult::Ack)
-            }
 
             api::Command::SetApiKey { api_key } => {
                 self.settings
@@ -615,6 +650,81 @@ where
                 ))
             }
 
+            // Named connections (#11)
+            api::Command::ListConnections => {
+                let views = self
+                    .connections
+                    .list_connections()
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Connections(
+                    views.into_iter().map(core_connection_to_api_view).collect(),
+                ))
+            }
+
+            api::Command::CreateConnection { id, config } => {
+                self.connections
+                    .create_connection(id, api_connection_config_to_core(config))
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            api::Command::UpdateConnection { id, config } => {
+                self.connections
+                    .update_connection(id, api_connection_config_to_core(config))
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            api::Command::DeleteConnection { id, force } => {
+                self.connections
+                    .delete_connection(id, force)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            api::Command::ListAvailableModels {
+                connection_id,
+                refresh,
+            } => {
+                let listings = self
+                    .connections
+                    .list_available_models(connection_id, refresh)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Models(
+                    listings.into_iter().map(core_model_listing_to_api).collect(),
+                ))
+            }
+
+            api::Command::GetPurposes => {
+                let p = self
+                    .connections
+                    .get_purposes()
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Purposes(api::PurposesView {
+                    interactive: p.interactive.map(core_purpose_to_api),
+                    dreaming: p.dreaming.map(core_purpose_to_api),
+                    embedding: p.embedding.map(core_purpose_to_api),
+                    titling: p.titling.map(core_purpose_to_api),
+                }))
+            }
+
+            api::Command::SetPurpose { purpose, config } => {
+                self.connections
+                    .set_purpose(
+                        api_purpose_kind_to_core(purpose),
+                        api_purpose_to_core(config),
+                    )
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
             // Streamed commands are handled elsewhere.
             api::Command::SendMessage { .. } => Err(ApiError::Unsupported),
         }
@@ -624,6 +734,18 @@ where
         &self,
         conversation_id: String,
         content: String,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        self.handle_send_message_with_override(conversation_id, content, None, request_id, sink)
+            .await
+    }
+
+    async fn handle_send_message_with_override(
+        &self,
+        conversation_id: String,
+        content: String,
+        override_selection: Option<api::SendPromptOverride>,
         request_id: String,
         sink: Arc<dyn EventSink>,
     ) -> ApiResult<()> {
@@ -670,11 +792,18 @@ where
                 });
             });
 
-        let full = self
+        let override_for_core = override_selection.map(|o| PromptSelectionOverride {
+            connection_id: o.connection_id,
+            model_id: o.model_id,
+            effort: o.effort.map(effort_from_api),
+        });
+
+        let outcome = self
             .conversations
-            .send_prompt(
+            .send_prompt_with_override(
                 &desktop_assistant_core::domain::ConversationId::from(conversation_id.as_str()),
                 content,
+                override_for_core,
                 callback,
                 on_status,
             )
@@ -684,8 +813,19 @@ where
             warn!("stream forwarder task failed: {e}");
         }
 
-        match full {
-            Ok(full_response) => {
+        match outcome {
+            Ok(outcome) => {
+                // Emit any one-time advisory warnings before the completion frame.
+                for w in outcome.warnings {
+                    let _ = sink
+                        .emit(api::Event::ConversationWarningEmitted {
+                            conversation_id: conversation_id.clone(),
+                            warning: dispatch_warning_to_api(w),
+                        })
+                        .await;
+                }
+
+                let full_response = outcome.response;
                 let _ = sink
                     .emit(api::Event::AssistantCompleted {
                         conversation_id: conversation_id.clone(),
@@ -736,11 +876,62 @@ mod tests {
     };
     use desktop_assistant_core::ports::inbound::{
         BackendTasksSettingsView, ConnectorDefaultsView, DatabaseSettingsView,
-        EmbeddingsSettingsView, LlmSettingsView, PersistenceSettingsView,
+        EmbeddingsSettingsView, LlmSettingsView, ModelListing as CoreModelListing,
+        PersistenceSettingsView, PurposesView as CorePurposesView,
     };
     use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct FakeConnections;
+    impl ConnectionsService for FakeConnections {
+        async fn list_connections(
+            &self,
+        ) -> Result<
+            Vec<desktop_assistant_core::ports::inbound::ConnectionView>,
+            CoreError,
+        > {
+            Ok(vec![])
+        }
+        async fn create_connection(
+            &self,
+            _id: String,
+            _config: ConnectionConfigPayload,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn update_connection(
+            &self,
+            _id: String,
+            _config: ConnectionConfigPayload,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn delete_connection(
+            &self,
+            _id: String,
+            _force: bool,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn list_available_models(
+            &self,
+            _connection_id: Option<String>,
+            _refresh: bool,
+        ) -> Result<Vec<CoreModelListing>, CoreError> {
+            Ok(vec![])
+        }
+        async fn get_purposes(&self) -> Result<CorePurposesView, CoreError> {
+            Ok(CorePurposesView::default())
+        }
+        async fn set_purpose(
+            &self,
+            _purpose: PurposeKind,
+            _config: PurposeConfigPayload,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+    }
 
     struct FakeAssistant;
     impl AssistantService for FakeAssistant {
@@ -1025,6 +1216,7 @@ mod tests {
             }
         }
 
+        #[allow(dead_code)]
         fn snapshot(&self) -> SettingsState {
             self.state.lock().unwrap().clone()
         }
@@ -1310,6 +1502,7 @@ mod tests {
             Arc::new(FakeAssistant),
             Arc::new(FakeConversations),
             Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
         );
 
         let res = h.handle_command(api::Command::Ping).await.unwrap();
@@ -1327,6 +1520,7 @@ mod tests {
             Arc::new(FakeAssistant),
             Arc::new(FakeConversations),
             Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
         );
 
         let sink = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
@@ -1349,6 +1543,7 @@ mod tests {
                 aborted: Arc::clone(&aborted),
             }),
             Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
         );
 
         h.handle_send_message("c1".into(), "hi".into(), "r1".into(), Arc::new(DropSink))
@@ -1365,6 +1560,7 @@ mod tests {
             Arc::new(FakeAssistant),
             Arc::new(FakeConversations),
             Arc::clone(&settings),
+            Arc::new(FakeConnections),
         );
 
         let res = h.handle_command(api::Command::GetConfig).await.unwrap();
@@ -1372,7 +1568,6 @@ mod tests {
             panic!("unexpected result variant");
         };
 
-        assert_eq!(config.llm.connector, "openai");
         assert_eq!(config.embeddings.model, "text-embedding-3-small");
         assert_eq!(config.persistence.remote_name, "origin");
     }
@@ -1384,15 +1579,14 @@ mod tests {
             Arc::new(FakeAssistant),
             Arc::new(FakeConversations),
             Arc::clone(&settings),
+            Arc::new(FakeConnections),
         );
 
         let res = h
             .handle_command(api::Command::SetConfig {
                 changes: api::ConfigChanges {
-                    llm_connector: Some("ollama".into()),
-                    llm_model: Some("llama3.1:8b".into()),
-                    llm_base_url: Some("http://localhost:11434".into()),
-                    llm_api_key: Some("test-key".into()),
+                    embeddings_connector: Some("openai".into()),
+                    embeddings_model: Some("text-embedding-3-large".into()),
                     persistence_enabled: Some(true),
                     persistence_remote_url: Some("git@example.com/repo.git".into()),
                     persistence_remote_name: Some("upstream".into()),
@@ -1406,12 +1600,8 @@ mod tests {
         let api::CommandResult::Config(config) = res else {
             panic!("unexpected result variant");
         };
-        assert_eq!(config.llm.connector, "ollama");
-        assert_eq!(config.llm.model, "llama3.1:8b");
+        assert_eq!(config.embeddings.model, "text-embedding-3-large");
         assert_eq!(config.persistence.remote_name, "upstream");
-        assert!(config.llm.has_api_key);
-
-        let snapshot = settings.snapshot();
-        assert!(snapshot.api_key_set);
+        assert!(!config.persistence.push_on_update);
     }
 }

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -259,6 +259,7 @@ impl WsClient {
             .send_command(api::Command::SendMessage {
                 conversation_id: conversation_id.to_string(),
                 content: prompt.to_string(),
+                override_selection: None,
             })
             .await?;
         let api::CommandResult::Ack = result else {
@@ -325,6 +326,9 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             message,
         }),
         api::Event::ConfigChanged { .. } => None,
+        // Conversation advisories surface via a separate channel on the
+        // desktop UI; the streaming signal enum doesn't carry them yet.
+        api::Event::ConversationWarningEmitted { .. } => None,
     }
 }
 
@@ -369,16 +373,6 @@ mod tests {
     fn ignores_non_stream_config_events() {
         let event = map_event_to_signal(api::Event::ConfigChanged {
             config: api::Config {
-                llm: api::LlmSettingsView {
-                    connector: "openai".to_string(),
-                    model: "gpt-5.4".to_string(),
-                    base_url: "https://api.openai.com/v1".to_string(),
-                    has_api_key: true,
-                    temperature: None,
-                    top_p: None,
-                    max_tokens: None,
-                    hosted_tool_search: None,
-                },
                 embeddings: api::EmbeddingsSettingsView {
                     connector: "openai".to_string(),
                     model: "text-embedding-3-small".to_string(),

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -1,6 +1,6 @@
 use crate::CoreError;
 use crate::domain::{Conversation, ConversationId, ConversationSummary};
-use crate::ports::llm::{ChunkCallback, StatusCallback};
+use crate::ports::llm::{ChunkCallback, ModelInfo, StatusCallback};
 
 #[derive(Debug, Clone)]
 pub struct LlmSettingsView {
@@ -152,6 +152,263 @@ pub trait ConversationService: Send + Sync {
         on_chunk: ChunkCallback,
         on_status: StatusCallback,
     ) -> impl std::future::Future<Output = Result<String, CoreError>> + Send;
+
+    /// Send a prompt with optional per-send model/connection override.
+    ///
+    /// Resolution priority inside the core service:
+    /// 1. `override_selection`, when supplied (validated against the
+    ///    registry; invalid selections produce `CoreError::Llm`).
+    /// 2. The conversation's stored `last_model_selection`, when it still
+    ///    resolves to a live connection + listed model.
+    /// 3. The `interactive` purpose from the daemon config.
+    ///
+    /// Returns the assistant's full response text plus any advisory
+    /// warnings that should be surfaced to the client (for example, a
+    /// dangling stored selection that was cleared on this call). Default
+    /// implementation ignores overrides and delegates to `send_prompt`; the
+    /// concrete `ConversationHandler` overrides this with the full
+    /// resolution path.
+    fn send_prompt_with_override(
+        &self,
+        conversation_id: &ConversationId,
+        prompt: String,
+        override_selection: Option<PromptSelectionOverride>,
+        on_chunk: ChunkCallback,
+        on_status: StatusCallback,
+    ) -> impl std::future::Future<Output = Result<PromptDispatchOutcome, CoreError>> + Send
+    where
+        Self: Sync,
+    {
+        async move {
+            let _ = override_selection;
+            let text = self
+                .send_prompt(conversation_id, prompt, on_chunk, on_status)
+                .await?;
+            Ok(PromptDispatchOutcome {
+                response: text,
+                warnings: Vec::new(),
+            })
+        }
+    }
+}
+
+/// Effort hint passed to connectors and mapped to per-connector request
+/// parameters at dispatch time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Effort {
+    Low,
+    Medium,
+    High,
+}
+
+/// Per-send selection override (model/connection/effort). Supplied by API
+/// clients via `SendPrompt { override: ... }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptSelectionOverride {
+    pub connection_id: String,
+    pub model_id: String,
+    pub effort: Option<Effort>,
+}
+
+/// Stored per-conversation model selection. Serialized to JSON in the
+/// `conversations.last_model_selection` column.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ConversationModelSelection {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<SerdeEffort>,
+}
+
+/// Serde-friendly `Effort` that maps to lowercase strings in JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SerdeEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl From<SerdeEffort> for Effort {
+    fn from(e: SerdeEffort) -> Self {
+        match e {
+            SerdeEffort::Low => Effort::Low,
+            SerdeEffort::Medium => Effort::Medium,
+            SerdeEffort::High => Effort::High,
+        }
+    }
+}
+
+impl From<Effort> for SerdeEffort {
+    fn from(e: Effort) -> Self {
+        match e {
+            Effort::Low => SerdeEffort::Low,
+            Effort::Medium => SerdeEffort::Medium,
+            Effort::High => SerdeEffort::High,
+        }
+    }
+}
+
+/// Advisory attached to a `send_prompt_with_override` result. Returned
+/// alongside the response text so adapters can surface a one-time UI hint
+/// to the client (e.g. "your previous model selection no longer resolves,
+/// falling back to purpose default").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchWarning {
+    DanglingModelSelection {
+        previous: ConversationModelSelection,
+        fallback_to: ConversationModelSelection,
+    },
+}
+
+/// Successful outcome from `send_prompt_with_override`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptDispatchOutcome {
+    pub response: String,
+    pub warnings: Vec<DispatchWarning>,
+}
+
+/// Availability of a connection in the registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionAvailability {
+    Ok,
+    Unavailable { reason: String },
+}
+
+/// Protocol-neutral connection config view for the inbound port.
+///
+/// Mirrors `crates/daemon/src/connections.rs::ConnectionConfig` but is
+/// decoupled so the core crate has no dependency on the daemon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionConfigPayload {
+    Anthropic {
+        base_url: Option<String>,
+        api_key_env: Option<String>,
+    },
+    OpenAi {
+        base_url: Option<String>,
+        api_key_env: Option<String>,
+    },
+    Bedrock {
+        aws_profile: Option<String>,
+        region: Option<String>,
+        base_url: Option<String>,
+    },
+    Ollama {
+        base_url: Option<String>,
+    },
+}
+
+impl ConnectionConfigPayload {
+    pub fn connector_type(&self) -> &'static str {
+        match self {
+            Self::Anthropic { .. } => "anthropic",
+            Self::OpenAi { .. } => "openai",
+            Self::Bedrock { .. } => "bedrock",
+            Self::Ollama { .. } => "ollama",
+        }
+    }
+}
+
+/// A single configured connection, including status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionView {
+    pub id: String,
+    pub connector_type: String,
+    pub display_label: String,
+    pub availability: ConnectionAvailability,
+    pub has_credentials: bool,
+}
+
+/// A model enumerated under a connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelListing {
+    pub connection_id: String,
+    pub connection_label: String,
+    pub model: ModelInfo,
+}
+
+/// Purpose kind identifiers — mirrors
+/// `crates/daemon/src/purposes.rs::PurposeKind` via string keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PurposeKind {
+    Interactive,
+    Dreaming,
+    Embedding,
+    Titling,
+}
+
+impl PurposeKind {
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::Interactive => "interactive",
+            Self::Dreaming => "dreaming",
+            Self::Embedding => "embedding",
+            Self::Titling => "titling",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurposeConfigPayload {
+    /// Either a connection id, or the literal `"primary"` (inherit).
+    pub connection: String,
+    /// Either a model id, or the literal `"primary"`.
+    pub model: String,
+    pub effort: Option<Effort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PurposesView {
+    pub interactive: Option<PurposeConfigPayload>,
+    pub dreaming: Option<PurposeConfigPayload>,
+    pub embedding: Option<PurposeConfigPayload>,
+    pub titling: Option<PurposeConfigPayload>,
+}
+
+/// Inbound port for connection + purpose management (issue #11).
+///
+/// Implemented by the daemon against its `ConnectionRegistry` and on-disk
+/// config. Adapters (D-Bus, WebSocket) dispatch through this trait so the
+/// daemon remains the single source of truth for connection state.
+pub trait ConnectionsService: Send + Sync {
+    fn list_connections(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<ConnectionView>, CoreError>> + Send;
+
+    fn create_connection(
+        &self,
+        id: String,
+        config: ConnectionConfigPayload,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    fn update_connection(
+        &self,
+        id: String,
+        config: ConnectionConfigPayload,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    fn delete_connection(
+        &self,
+        id: String,
+        force: bool,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    fn list_available_models(
+        &self,
+        connection_id: Option<String>,
+        refresh: bool,
+    ) -> impl std::future::Future<Output = Result<Vec<ModelListing>, CoreError>> + Send;
+
+    fn get_purposes(
+        &self,
+    ) -> impl std::future::Future<Output = Result<PurposesView, CoreError>> + Send;
+
+    fn set_purpose(
+        &self,
+        purpose: PurposeKind,
+        config: PurposeConfigPayload,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
 }
 
 /// Inbound port for assistant settings.

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -1,0 +1,1076 @@
+//! Daemon-side implementation of the connection/purpose management API
+//! (issue #11) plus the wrapper that threads per-send overrides through
+//! the core `ConversationHandler`.
+//!
+//! Architecture notes:
+//!
+//! - [`DaemonConnectionsService`] wraps a shared [`ConnectionRegistry`]
+//!   (plus the on-disk config) and implements the
+//!   [`ConnectionsService`](desktop_assistant_core::ports::inbound::ConnectionsService)
+//!   inbound port. Writes mutate the on-disk config and rebuild the
+//!   registry; reads snapshot registry state.
+//!
+//! - [`RoutingConversationHandler`] is a thin wrapper over the primary
+//!   `ConversationHandler`. It implements `ConversationService` so adapters
+//!   can call it interchangeably. On a send-with-override, it:
+//!   1. Validates the override against the live registry (connection
+//!      exists + model is listed).
+//!   2. Persists the override on the conversation row.
+//!   3. Delegates to the inner handler.
+//!   Stored-but-dangling selections are detected, cleared, and surfaced
+//!   via a one-time [`DispatchWarning::DanglingModelSelection`].
+//!
+//! See the ticket body on #11 for the full priority table
+//! (override → stored → interactive).
+
+use std::sync::{Arc, Mutex, RwLock};
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationSummary};
+use desktop_assistant_core::ports::inbound::{
+    ConnectionAvailability as CoreConnectionAvailability, ConnectionConfigPayload,
+    ConnectionView as CoreConnectionView, ConnectionsService, ConversationModelSelection,
+    ConversationService, DispatchWarning, Effort, ModelListing as CoreModelListing,
+    PromptDispatchOutcome, PromptSelectionOverride, PurposeConfigPayload,
+    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SerdeEffort,
+};
+use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, StatusCallback};
+
+use crate::config::{
+    DaemonConfig, default_daemon_config_path, load_daemon_config, save_daemon_config,
+};
+use crate::connections::{
+    AnthropicConnection, BedrockConnection, ConnectionConfig, ConnectionId, OllamaConnection,
+    OpenAiConnection,
+};
+use crate::purposes::{
+    ConnectionRef, Effort as PurposeEffort, ModelRef, PurposeConfig, PurposeKind,
+};
+use crate::registry::{ConnectionHealth, ConnectionRegistry, build_registry};
+
+/// Shared, mutable handle to the registry + current config. Writes acquire
+/// the outer `RwLock` in write mode, replace the inner values, then drop;
+/// reads take a read lock and clone out whatever they need.
+pub struct RegistryHandle {
+    state: RwLock<RegistryState>,
+    config_path: std::path::PathBuf,
+}
+
+struct RegistryState {
+    config: DaemonConfig,
+    registry: ConnectionRegistry,
+}
+
+impl RegistryHandle {
+    pub fn new(config: DaemonConfig, registry: ConnectionRegistry) -> Self {
+        Self {
+            state: RwLock::new(RegistryState { config, registry }),
+            config_path: default_daemon_config_path(),
+        }
+    }
+
+    pub fn with_config_path(mut self, path: std::path::PathBuf) -> Self {
+        self.config_path = path;
+        self
+    }
+
+    /// Snapshot of every connection status — used for list/validate paths.
+    fn connection_views(&self) -> Vec<CoreConnectionView> {
+        let state = self.state.read().expect("registry state poisoned");
+        state
+            .registry
+            .status()
+            .into_iter()
+            .map(|st| {
+                let healthy = matches!(st.health, ConnectionHealth::Ok);
+                CoreConnectionView {
+                    id: st.id.as_str().to_string(),
+                    connector_type: st.connector_type.clone(),
+                    display_label: format!("{} ({})", st.id, st.connector_type),
+                    availability: match st.health {
+                        ConnectionHealth::Ok => CoreConnectionAvailability::Ok,
+                        ConnectionHealth::Unavailable { reason } => {
+                            CoreConnectionAvailability::Unavailable { reason }
+                        }
+                    },
+                    has_credentials: healthy,
+                }
+            })
+            .collect()
+    }
+
+    #[allow(dead_code)]
+    fn is_healthy(&self, id: &ConnectionId) -> bool {
+        let state = self.state.read().expect("registry state poisoned");
+        state
+            .registry
+            .status_of(id)
+            .is_some_and(|s| matches!(s.health, ConnectionHealth::Ok))
+    }
+
+    /// Is the given (connection, model) pair currently routable? Connection
+    /// must be live and `list_models()` must include the model id.
+    async fn connection_lists_model(
+        &self,
+        id: &ConnectionId,
+        model_id: &str,
+    ) -> Result<bool, CoreError> {
+        let Some(client) = self.client_for(id) else {
+            return Ok(false);
+        };
+        let models = client.list_models().await?;
+        Ok(models.iter().any(|m| m.id == model_id))
+    }
+
+    /// Fetch the live client handle for a connection id, if any. The
+    /// returned `Arc` can be awaited on without holding any registry
+    /// locks, which keeps the async futures `Send`.
+    fn client_for(
+        &self,
+        id: &ConnectionId,
+    ) -> Option<std::sync::Arc<crate::registry::AnyLlmClient>> {
+        let state = self.state.read().expect("registry state poisoned");
+        state.registry.get(id)
+    }
+
+    /// Connector-type tag for a given connection id, if declared.
+    fn connector_type_for(&self, id: &ConnectionId) -> Option<String> {
+        let state = self.state.read().expect("registry state poisoned");
+        state
+            .registry
+            .status_of(id)
+            .map(|s| s.connector_type.clone())
+    }
+
+    /// Mutate the config: callers provide a closure that operates on the
+    /// current `DaemonConfig`. On success we rewrite the config file and
+    /// rebuild the registry.
+    fn mutate_config<F>(&self, op: F) -> Result<(), CoreError>
+    where
+        F: FnOnce(&mut DaemonConfig) -> Result<(), String>,
+    {
+        let mut state = self.state.write().expect("registry state poisoned");
+        let mut new_config = state.config.clone();
+        op(&mut new_config).map_err(CoreError::Llm)?;
+        save_daemon_config(&self.config_path, &new_config)
+            .map_err(|e| CoreError::Storage(format!("saving config: {e}")))?;
+        let registry = build_registry(&new_config);
+        state.config = new_config;
+        state.registry = registry;
+        Ok(())
+    }
+
+    /// Read-only snapshot of the current `DaemonConfig`. Used by purposes
+    /// and model-listing paths.
+    pub fn snapshot_config(&self) -> DaemonConfig {
+        self.state
+            .read()
+            .expect("registry state poisoned")
+            .config
+            .clone()
+    }
+
+    /// Reload the registry (and re-read the config from disk). Used when
+    /// external tools mutate the config file.
+    #[allow(dead_code)]
+    pub fn reload(&self) -> anyhow::Result<()> {
+        let config = load_daemon_config(&self.config_path)?.unwrap_or_default();
+        let registry = build_registry(&config);
+        let mut state = self.state.write().expect("registry state poisoned");
+        state.config = config;
+        state.registry = registry;
+        Ok(())
+    }
+}
+
+// --- ConnectionsService impl -----------------------------------------------
+
+pub struct DaemonConnectionsService {
+    registry: Arc<RegistryHandle>,
+}
+
+impl DaemonConnectionsService {
+    pub fn new(registry: Arc<RegistryHandle>) -> Self {
+        Self { registry }
+    }
+}
+
+impl ConnectionsService for DaemonConnectionsService {
+    async fn list_connections(&self) -> Result<Vec<CoreConnectionView>, CoreError> {
+        Ok(self.registry.connection_views())
+    }
+
+    async fn create_connection(
+        &self,
+        id: String,
+        config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        let id_valid = ConnectionId::new(id.clone())
+            .map_err(|e| CoreError::Llm(format!("invalid connection id: {e}")))?;
+        let new_conn = payload_to_connection(config);
+        self.registry.mutate_config(|cfg| {
+            if cfg.connections.contains_key(id_valid.as_str()) {
+                return Err(format!("connection id {:?} already exists", id_valid));
+            }
+            cfg.connections.insert(id_valid.as_str().to_string(), new_conn);
+            Ok(())
+        })
+    }
+
+    async fn update_connection(
+        &self,
+        id: String,
+        config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        let id_valid = ConnectionId::new(id.clone())
+            .map_err(|e| CoreError::Llm(format!("invalid connection id: {e}")))?;
+        let new_conn = payload_to_connection(config);
+        self.registry.mutate_config(|cfg| {
+            if !cfg.connections.contains_key(id_valid.as_str()) {
+                return Err(format!("connection id {:?} does not exist", id_valid));
+            }
+            cfg.connections
+                .insert(id_valid.as_str().to_string(), new_conn);
+            Ok(())
+        })
+    }
+
+    async fn delete_connection(&self, id: String, force: bool) -> Result<(), CoreError> {
+        let id_valid = ConnectionId::new(id.clone())
+            .map_err(|e| CoreError::Llm(format!("invalid connection id: {e}")))?;
+        self.registry.mutate_config(|cfg| {
+            if !cfg.connections.contains_key(id_valid.as_str()) {
+                return Err(format!("connection id {:?} does not exist", id_valid));
+            }
+            // Check whether any purpose references this id.
+            let referenced_by: Vec<PurposeKind> = purposes_referencing(&cfg.purposes, &id_valid);
+            if !referenced_by.is_empty() && !force {
+                let names: Vec<&'static str> =
+                    referenced_by.iter().map(|k| k.as_key()).collect();
+                return Err(format!(
+                    "connection {:?} is referenced by purposes {:?}; pass force=true to cascade",
+                    id_valid, names
+                ));
+            }
+            // Force path: reset referencing purposes to inherit from
+            // interactive. If interactive itself is being deleted, switch it
+            // to some other remaining connection (or wipe it).
+            cfg.connections.shift_remove(id_valid.as_str());
+            for kind in referenced_by {
+                if kind == PurposeKind::Interactive {
+                    // Pick a replacement: first remaining connection, if any.
+                    if let Some((new_interactive_id, _)) = cfg.connections.iter().next() {
+                        let new_id = new_interactive_id.clone();
+                        if let Some(p) = cfg.purposes.interactive.as_mut() {
+                            p.connection = ConnectionRef::Named(
+                                ConnectionId::new(new_id)
+                                    .expect("existing key was already validated"),
+                            );
+                        }
+                    } else {
+                        // No connections left — clear interactive entirely.
+                        cfg.purposes.interactive = None;
+                    }
+                    continue;
+                }
+                let slot = match kind {
+                    PurposeKind::Dreaming => cfg.purposes.dreaming.as_mut(),
+                    PurposeKind::Embedding => cfg.purposes.embedding.as_mut(),
+                    PurposeKind::Titling => cfg.purposes.titling.as_mut(),
+                    PurposeKind::Interactive => unreachable!(),
+                };
+                if let Some(p) = slot {
+                    p.connection = ConnectionRef::Primary;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    async fn list_available_models(
+        &self,
+        connection_id: Option<String>,
+        refresh: bool,
+    ) -> Result<Vec<CoreModelListing>, CoreError> {
+        // Snapshot (id, label, client) triples before awaiting anything.
+        // Holding the read lock across `.await` would leave the returned
+        // future `!Send`; cloning `Arc<AnyLlmClient>` releases the lock up
+        // front and the awaits run unlocked.
+        let targets: Vec<(ConnectionId, String, std::sync::Arc<crate::registry::AnyLlmClient>)> = {
+            let state = self
+                .registry
+                .state
+                .read()
+                .expect("registry state poisoned");
+            if let Some(id_raw) = &connection_id {
+                let id = ConnectionId::new(id_raw.clone())
+                    .map_err(|e| CoreError::Llm(format!("invalid connection id: {e}")))?;
+                let Some(st) = state.registry.status_of(&id) else {
+                    return Err(CoreError::Llm(format!("connection {id} is not declared")));
+                };
+                if !matches!(st.health, ConnectionHealth::Ok) {
+                    return Err(CoreError::Llm(format!("connection {id} is not live")));
+                }
+                let label = format!("{} ({})", st.id, st.connector_type);
+                let Some(client) = state.registry.get(&id) else {
+                    return Err(CoreError::Llm(format!("connection {id} is not live")));
+                };
+                vec![(id, label, client)]
+            } else {
+                state
+                    .registry
+                    .status()
+                    .into_iter()
+                    .filter(|s| matches!(s.health, ConnectionHealth::Ok))
+                    .filter_map(|s| {
+                        let label = format!("{} ({})", s.id, s.connector_type);
+                        let client = state.registry.get(&s.id)?;
+                        Some((s.id, label, client))
+                    })
+                    .collect()
+            }
+        };
+
+        let mut out: Vec<CoreModelListing> = Vec::new();
+        for (id, label, client) in targets {
+            let list_result = if refresh {
+                client.refresh_models().await
+            } else {
+                client.list_models().await
+            };
+            match list_result {
+                Ok(models) => {
+                    for m in models {
+                        out.push(CoreModelListing {
+                            connection_id: id.as_str().to_string(),
+                            connection_label: label.clone(),
+                            model: m,
+                        });
+                    }
+                }
+                Err(e) => {
+                    // Single-connection path surfaces the error; aggregate
+                    // path logs and continues so one broken endpoint
+                    // doesn't break the whole listing.
+                    if connection_id.is_some() {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        connection = %id,
+                        "list_models failed during aggregation: {e}"
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn get_purposes(&self) -> Result<CorePurposesView, CoreError> {
+        let config = self.registry.snapshot_config();
+        Ok(CorePurposesView {
+            interactive: config.purposes.interactive.as_ref().map(purpose_to_payload),
+            dreaming: config.purposes.dreaming.as_ref().map(purpose_to_payload),
+            embedding: config.purposes.embedding.as_ref().map(purpose_to_payload),
+            titling: config.purposes.titling.as_ref().map(purpose_to_payload),
+        })
+    }
+
+    async fn set_purpose(
+        &self,
+        purpose: CorePurposeKind,
+        config: PurposeConfigPayload,
+    ) -> Result<(), CoreError> {
+        let purpose_kind = core_to_internal_purpose(purpose);
+        let new_cfg = payload_to_purpose(config)
+            .map_err(|e| CoreError::Llm(format!("invalid purpose config: {e}")))?;
+
+        // Interactive cannot use `"primary"` for connection or model.
+        if purpose_kind == PurposeKind::Interactive {
+            if matches!(new_cfg.connection, ConnectionRef::Primary) {
+                return Err(CoreError::Llm(
+                    "interactive purpose cannot use connection \"primary\" — nothing to inherit from"
+                        .to_string(),
+                ));
+            }
+            if matches!(new_cfg.model, ModelRef::Primary) {
+                return Err(CoreError::Llm(
+                    "interactive purpose cannot use model \"primary\" — nothing to inherit from"
+                        .to_string(),
+                ));
+            }
+        }
+
+        self.registry.mutate_config(|cfg| {
+            cfg.purposes.set(purpose_kind, Some(new_cfg));
+            cfg.purposes
+                .validate()
+                .map_err(|e| format!("{e}"))
+        })
+    }
+}
+
+// --- RoutingConversationHandler --------------------------------------------
+
+/// Callback the daemon supplies to fetch (and optionally store) the
+/// conversation's last model selection. Abstracted as a trait so tests can
+/// provide an in-memory implementation.
+pub trait ConversationSelectionStore: Send + Sync {
+    fn get_selection(
+        &self,
+        id: &ConversationId,
+    ) -> impl std::future::Future<
+        Output = Result<Option<ConversationModelSelection>, CoreError>,
+    > + Send;
+
+    fn set_selection(
+        &self,
+        id: &ConversationId,
+        selection: Option<&ConversationModelSelection>,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+}
+
+pub struct RoutingConversationHandler<S, Inner>
+where
+    S: ConversationSelectionStore + 'static,
+    Inner: ConversationService + 'static,
+{
+    inner: Arc<Inner>,
+    selection_store: Arc<S>,
+    registry: Arc<RegistryHandle>,
+}
+
+impl<S, Inner> RoutingConversationHandler<S, Inner>
+where
+    S: ConversationSelectionStore + 'static,
+    Inner: ConversationService + 'static,
+{
+    pub fn new(inner: Arc<Inner>, selection_store: Arc<S>, registry: Arc<RegistryHandle>) -> Self {
+        Self {
+            inner,
+            selection_store,
+            registry,
+        }
+    }
+
+    /// Resolve the interactive purpose from the current config. Used as
+    /// the ultimate fallback (priority #3) when neither an override nor a
+    /// valid stored selection exists.
+    fn interactive_selection(&self) -> Option<ConversationModelSelection> {
+        let cfg = self.registry.snapshot_config();
+        cfg.purposes.interactive.as_ref().and_then(|p| {
+            let connection_id = match &p.connection {
+                ConnectionRef::Named(id) => id.as_str().to_string(),
+                ConnectionRef::Primary => return None,
+            };
+            let model_id = match &p.model {
+                ModelRef::Named(m) => m.clone(),
+                ModelRef::Primary => return None,
+            };
+            Some(ConversationModelSelection {
+                connection_id,
+                model_id,
+                effort: p.effort.map(effort_internal_to_serde),
+            })
+        })
+    }
+
+    /// Check a stored selection against the live registry. Returns
+    /// `(is_still_valid)`. When invalid, the caller is responsible for
+    /// clearing the stored selection and emitting a warning.
+    async fn selection_is_live(
+        &self,
+        sel: &ConversationModelSelection,
+    ) -> Result<bool, CoreError> {
+        let Ok(id) = ConnectionId::new(sel.connection_id.clone()) else {
+            return Ok(false);
+        };
+        self.registry.connection_lists_model(&id, &sel.model_id).await
+    }
+
+    /// Translate the effort hint into per-connector parameters and log
+    /// what the dispatch layer would send. This is the effort-mapping hook
+    /// the ticket calls out; each connector currently receives the mapping
+    /// via a `tracing::debug!` line, and the wire-level plumbing into
+    /// `stream_completion` will be wired up on a follow-up (noted in the
+    /// PR body — see issue #11).
+    fn apply_effort_mapping(
+        connector_type: &str,
+        model_id: &str,
+        effort: Option<Effort>,
+    ) {
+        let Some(effort) = effort else {
+            return;
+        };
+        match connector_type {
+            "anthropic" | "bedrock" => {
+                let budget = map_anthropic_thinking_budget(effort);
+                tracing::debug!(
+                    connector = connector_type,
+                    model = model_id,
+                    effort = ?effort,
+                    thinking_budget_tokens = budget,
+                    "mapped effort to Anthropic extended-thinking budget"
+                );
+            }
+            "openai" => {
+                let token = map_openai_reasoning_effort(effort);
+                tracing::debug!(
+                    connector = connector_type,
+                    model = model_id,
+                    effort = ?effort,
+                    reasoning_effort = token,
+                    "mapped effort to OpenAI reasoning_effort"
+                );
+            }
+            "ollama" => {
+                tracing::debug!(
+                    connector = connector_type,
+                    effort = ?effort,
+                    "effort is a no-op on Ollama"
+                );
+            }
+            other => {
+                tracing::debug!(
+                    connector = other,
+                    effort = ?effort,
+                    "no effort mapping defined for connector"
+                );
+            }
+        }
+    }
+}
+
+impl<S, Inner> ConversationService for RoutingConversationHandler<S, Inner>
+where
+    S: ConversationSelectionStore + 'static,
+    Inner: ConversationService + 'static,
+{
+    async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+        self.inner.create_conversation(title).await
+    }
+
+    async fn list_conversations(
+        &self,
+        max_age_days: Option<u32>,
+        include_archived: bool,
+    ) -> Result<Vec<ConversationSummary>, CoreError> {
+        self.inner.list_conversations(max_age_days, include_archived).await
+    }
+
+    async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+        self.inner.get_conversation(id).await
+    }
+
+    async fn delete_conversation(&self, id: &ConversationId) -> Result<(), CoreError> {
+        self.inner.delete_conversation(id).await
+    }
+
+    async fn rename_conversation(
+        &self,
+        id: &ConversationId,
+        title: String,
+    ) -> Result<(), CoreError> {
+        self.inner.rename_conversation(id, title).await
+    }
+
+    async fn archive_conversation(&self, id: &ConversationId) -> Result<(), CoreError> {
+        self.inner.archive_conversation(id).await
+    }
+
+    async fn unarchive_conversation(&self, id: &ConversationId) -> Result<(), CoreError> {
+        self.inner.unarchive_conversation(id).await
+    }
+
+    async fn clear_all_history(&self) -> Result<u32, CoreError> {
+        self.inner.clear_all_history().await
+    }
+
+    async fn send_prompt(
+        &self,
+        conversation_id: &ConversationId,
+        prompt: String,
+        on_chunk: ChunkCallback,
+        on_status: StatusCallback,
+    ) -> Result<String, CoreError> {
+        self.inner
+            .send_prompt(conversation_id, prompt, on_chunk, on_status)
+            .await
+    }
+
+    async fn send_prompt_with_override(
+        &self,
+        conversation_id: &ConversationId,
+        prompt: String,
+        override_selection: Option<PromptSelectionOverride>,
+        on_chunk: ChunkCallback,
+        on_status: StatusCallback,
+    ) -> Result<PromptDispatchOutcome, CoreError> {
+        let mut warnings: Vec<DispatchWarning> = Vec::new();
+
+        // Resolve the effective selection following priority:
+        //   1. override (validate first; hard error if invalid)
+        //   2. stored conversation selection (validate; warn + fallback if dangling)
+        //   3. interactive purpose
+        let effective_selection: Option<ConversationModelSelection> = if let Some(override_sel) =
+            override_selection
+        {
+            let id = ConnectionId::new(override_sel.connection_id.clone())
+                .map_err(|e| CoreError::Llm(format!("invalid connection id in override: {e}")))?;
+            let is_live = self
+                .registry
+                .connection_lists_model(&id, &override_sel.model_id)
+                .await?;
+            if !is_live {
+                return Err(CoreError::Llm(format!(
+                    "override target {}/{} is not a live (connection, model) pair",
+                    override_sel.connection_id, override_sel.model_id
+                )));
+            }
+            let sel = ConversationModelSelection {
+                connection_id: override_sel.connection_id,
+                model_id: override_sel.model_id,
+                effort: override_sel.effort.map(SerdeEffort::from),
+            };
+            // Persist before dispatch so a crash mid-call doesn't lose the
+            // user's choice.
+            self.selection_store
+                .set_selection(conversation_id, Some(&sel))
+                .await?;
+            Some(sel)
+        } else if let Some(stored) = self.selection_store.get_selection(conversation_id).await? {
+            if self.selection_is_live(&stored).await? {
+                Some(stored)
+            } else {
+                // Dangling. Fall back to interactive; clear; emit a
+                // one-time warning.
+                let fallback = self.interactive_selection();
+                self.selection_store
+                    .set_selection(conversation_id, None)
+                    .await?;
+                if let Some(ref fb) = fallback {
+                    warnings.push(DispatchWarning::DanglingModelSelection {
+                        previous: stored,
+                        fallback_to: fb.clone(),
+                    });
+                }
+                fallback
+            }
+        } else {
+            self.interactive_selection()
+        };
+
+        // Emit effort-mapping debug lines for the chosen dispatch target.
+        if let Some(sel) = effective_selection.as_ref() {
+            let connector_type = ConnectionId::new(sel.connection_id.clone())
+                .ok()
+                .and_then(|id| self.registry.connector_type_for(&id))
+                .unwrap_or_default();
+            Self::apply_effort_mapping(
+                &connector_type,
+                &sel.model_id,
+                sel.effort.map(Effort::from),
+            );
+        }
+
+        // Dispatch via the inner (interactive-purpose) handler. The
+        // override/stored selection has been validated and persisted; wire-
+        // level routing to the selected connection+model is noted as a
+        // follow-up in the PR body.
+        let response = self
+            .inner
+            .send_prompt(conversation_id, prompt, on_chunk, on_status)
+            .await?;
+        Ok(PromptDispatchOutcome {
+            response,
+            warnings,
+        })
+    }
+}
+
+// --- In-memory ConversationSelectionStore (for tests) ----------------------
+
+/// Trivial in-memory store used by the daemon test suite. Production code
+/// uses the Postgres-backed store via the storage crate.
+#[allow(dead_code)]
+pub struct InMemoryConversationSelectionStore {
+    inner: Mutex<std::collections::HashMap<String, ConversationModelSelection>>,
+}
+
+impl Default for InMemoryConversationSelectionStore {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl ConversationSelectionStore for InMemoryConversationSelectionStore {
+    async fn get_selection(
+        &self,
+        id: &ConversationId,
+    ) -> Result<Option<ConversationModelSelection>, CoreError> {
+        Ok(self
+            .inner
+            .lock()
+            .expect("selection store poisoned")
+            .get(&id.0)
+            .cloned())
+    }
+
+    async fn set_selection(
+        &self,
+        id: &ConversationId,
+        selection: Option<&ConversationModelSelection>,
+    ) -> Result<(), CoreError> {
+        let mut map = self.inner.lock().expect("selection store poisoned");
+        match selection {
+            Some(sel) => {
+                map.insert(id.0.clone(), sel.clone());
+            }
+            None => {
+                map.remove(&id.0);
+            }
+        }
+        Ok(())
+    }
+}
+
+// --- Effort → per-connector param mapping ----------------------------------
+
+/// Anthropic extended-thinking `budget_tokens`. Defaults: Low = off (0, no
+/// thinking), Medium = 8_000, High = 24_000. Connector expected to treat
+/// `0` as "disable extended thinking" and any positive number as a budget.
+pub fn map_anthropic_thinking_budget(e: Effort) -> u32 {
+    match e {
+        Effort::Low => 0,
+        Effort::Medium => 8_000,
+        Effort::High => 24_000,
+    }
+}
+
+/// OpenAI `reasoning_effort` literal. Pass through verbatim.
+pub fn map_openai_reasoning_effort(e: Effort) -> &'static str {
+    match e {
+        Effort::Low => "low",
+        Effort::Medium => "medium",
+        Effort::High => "high",
+    }
+}
+
+// --- Conversions between core payload / internal config types -------------
+
+fn payload_to_connection(payload: ConnectionConfigPayload) -> ConnectionConfig {
+    match payload {
+        ConnectionConfigPayload::Anthropic {
+            base_url,
+            api_key_env,
+        } => ConnectionConfig::Anthropic(AnthropicConnection {
+            base_url,
+            api_key_env,
+            secret: None,
+        }),
+        ConnectionConfigPayload::OpenAi {
+            base_url,
+            api_key_env,
+        } => ConnectionConfig::OpenAi(OpenAiConnection {
+            base_url,
+            api_key_env,
+            secret: None,
+        }),
+        ConnectionConfigPayload::Bedrock {
+            aws_profile,
+            region,
+            base_url,
+        } => ConnectionConfig::Bedrock(BedrockConnection {
+            aws_profile,
+            region,
+            base_url,
+        }),
+        ConnectionConfigPayload::Ollama { base_url } => {
+            ConnectionConfig::Ollama(OllamaConnection { base_url })
+        }
+    }
+}
+
+fn purpose_to_payload(p: &PurposeConfig) -> PurposeConfigPayload {
+    PurposeConfigPayload {
+        connection: match &p.connection {
+            ConnectionRef::Named(id) => id.as_str().to_string(),
+            ConnectionRef::Primary => "primary".to_string(),
+        },
+        model: match &p.model {
+            ModelRef::Named(m) => m.clone(),
+            ModelRef::Primary => "primary".to_string(),
+        },
+        effort: p.effort.map(purpose_effort_to_core),
+    }
+}
+
+fn payload_to_purpose(p: PurposeConfigPayload) -> Result<PurposeConfig, String> {
+    let connection = if p.connection == "primary" {
+        ConnectionRef::Primary
+    } else {
+        ConnectionRef::Named(
+            ConnectionId::new(p.connection.clone())
+                .map_err(|e| format!("connection {:?}: {e}", p.connection))?,
+        )
+    };
+    let model = if p.model == "primary" {
+        ModelRef::Primary
+    } else {
+        ModelRef::Named(p.model)
+    };
+    Ok(PurposeConfig {
+        connection,
+        model,
+        effort: p.effort.map(core_effort_to_purpose),
+    })
+}
+
+fn purpose_effort_to_core(e: PurposeEffort) -> Effort {
+    match e {
+        PurposeEffort::Low => Effort::Low,
+        PurposeEffort::Medium => Effort::Medium,
+        PurposeEffort::High => Effort::High,
+    }
+}
+
+fn core_effort_to_purpose(e: Effort) -> PurposeEffort {
+    match e {
+        Effort::Low => PurposeEffort::Low,
+        Effort::Medium => PurposeEffort::Medium,
+        Effort::High => PurposeEffort::High,
+    }
+}
+
+fn effort_internal_to_serde(e: PurposeEffort) -> SerdeEffort {
+    match e {
+        PurposeEffort::Low => SerdeEffort::Low,
+        PurposeEffort::Medium => SerdeEffort::Medium,
+        PurposeEffort::High => SerdeEffort::High,
+    }
+}
+
+fn core_to_internal_purpose(k: CorePurposeKind) -> PurposeKind {
+    match k {
+        CorePurposeKind::Interactive => PurposeKind::Interactive,
+        CorePurposeKind::Dreaming => PurposeKind::Dreaming,
+        CorePurposeKind::Embedding => PurposeKind::Embedding,
+        CorePurposeKind::Titling => PurposeKind::Titling,
+    }
+}
+
+fn purposes_referencing(purposes: &crate::purposes::Purposes, id: &ConnectionId) -> Vec<PurposeKind> {
+    let mut out = Vec::new();
+    for kind in PurposeKind::all() {
+        if let Some(p) = purposes.get(kind)
+            && let ConnectionRef::Named(refd) = &p.connection
+            && refd == id
+        {
+            out.push(kind);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connections::{BedrockConnection, ConnectionConfig, OllamaConnection};
+
+    fn tmp_config_path() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "desktop-assistant-test-{}.toml",
+            uuid::Uuid::new_v4().simple()
+        ));
+        p
+    }
+
+    fn config_with_connections(pairs: &[(&str, ConnectionConfig)]) -> DaemonConfig {
+        let mut cfg = DaemonConfig::default();
+        for (id, c) in pairs {
+            cfg.connections.insert(id.to_string(), c.clone());
+        }
+        cfg
+    }
+
+    fn ollama_local() -> ConnectionConfig {
+        ConnectionConfig::Ollama(OllamaConnection {
+            base_url: Some("http://localhost:11434".into()),
+        })
+    }
+
+    fn bedrock_work() -> ConnectionConfig {
+        ConnectionConfig::Bedrock(BedrockConnection {
+            aws_profile: Some("work".into()),
+            region: Some("us-west-2".into()),
+            base_url: None,
+        })
+    }
+
+    fn make_handle_with(cfg: DaemonConfig) -> Arc<RegistryHandle> {
+        let registry = build_registry(&cfg);
+        Arc::new(RegistryHandle::new(cfg, registry).with_config_path(tmp_config_path()))
+    }
+
+    #[tokio::test]
+    async fn list_connections_returns_declared_order() {
+        let cfg = config_with_connections(&[
+            ("local", ollama_local()),
+            ("aws", bedrock_work()),
+        ]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let views = svc.list_connections().await.unwrap();
+        assert_eq!(views.len(), 2);
+        assert_eq!(views[0].id, "local");
+        assert_eq!(views[1].id, "aws");
+    }
+
+    #[tokio::test]
+    async fn create_connection_rejects_bad_slug() {
+        let svc = DaemonConnectionsService::new(make_handle_with(DaemonConfig::default()));
+        let err = svc
+            .create_connection(
+                "Bad Id!".to_string(),
+                ConnectionConfigPayload::Ollama {
+                    base_url: Some("http://localhost:11434".into()),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("invalid connection id"));
+    }
+
+    #[tokio::test]
+    async fn create_connection_rejects_duplicate_id() {
+        let cfg = config_with_connections(&[("local", ollama_local())]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let err = svc
+            .create_connection(
+                "local".to_string(),
+                ConnectionConfigPayload::Ollama {
+                    base_url: Some("http://localhost:11434".into()),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn delete_connection_refuses_when_referenced_without_force() {
+        let mut cfg = config_with_connections(&[
+            ("local", ollama_local()),
+            ("aws", bedrock_work()),
+        ]);
+        cfg.purposes.interactive = Some(PurposeConfig {
+            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+            model: ModelRef::Named("llama3".into()),
+            effort: None,
+        });
+        cfg.purposes.dreaming = Some(PurposeConfig {
+            connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+            model: ModelRef::Named("claude".into()),
+            effort: None,
+        });
+
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let err = svc
+            .delete_connection("aws".to_string(), false)
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("referenced"));
+    }
+
+    #[tokio::test]
+    async fn delete_connection_force_cascades_to_primary() {
+        let mut cfg = config_with_connections(&[
+            ("local", ollama_local()),
+            ("aws", bedrock_work()),
+        ]);
+        cfg.purposes.interactive = Some(PurposeConfig {
+            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+            model: ModelRef::Named("llama3".into()),
+            effort: None,
+        });
+        cfg.purposes.dreaming = Some(PurposeConfig {
+            connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+            model: ModelRef::Named("claude".into()),
+            effort: None,
+        });
+
+        let handle = make_handle_with(cfg);
+        let svc = DaemonConnectionsService::new(Arc::clone(&handle));
+        svc.delete_connection("aws".to_string(), true).await.unwrap();
+
+        let cfg = handle.snapshot_config();
+        assert!(!cfg.connections.contains_key("aws"));
+        let dreaming = cfg.purposes.dreaming.as_ref().expect("dreaming still set");
+        assert!(matches!(dreaming.connection, ConnectionRef::Primary));
+    }
+
+    #[tokio::test]
+    async fn set_purpose_rejects_primary_in_interactive() {
+        let cfg = config_with_connections(&[("local", ollama_local())]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let err = svc
+            .set_purpose(
+                CorePurposeKind::Interactive,
+                PurposeConfigPayload {
+                    connection: "primary".into(),
+                    model: "llama3".into(),
+                    effort: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("interactive"));
+    }
+
+    #[tokio::test]
+    async fn get_purposes_returns_current_config() {
+        let mut cfg = config_with_connections(&[("local", ollama_local())]);
+        cfg.purposes.interactive = Some(PurposeConfig {
+            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+            model: ModelRef::Named("llama3".into()),
+            effort: Some(PurposeEffort::Medium),
+        });
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let view = svc.get_purposes().await.unwrap();
+        let i = view.interactive.expect("interactive set");
+        assert_eq!(i.connection, "local");
+        assert_eq!(i.model, "llama3");
+        assert_eq!(i.effort, Some(Effort::Medium));
+    }
+
+    #[test]
+    fn anthropic_effort_mapping_table() {
+        assert_eq!(map_anthropic_thinking_budget(Effort::Low), 0);
+        assert_eq!(map_anthropic_thinking_budget(Effort::Medium), 8_000);
+        assert_eq!(map_anthropic_thinking_budget(Effort::High), 24_000);
+    }
+
+    #[test]
+    fn openai_effort_mapping_table() {
+        assert_eq!(map_openai_reasoning_effort(Effort::Low), "low");
+        assert_eq!(map_openai_reasoning_effort(Effort::Medium), "medium");
+        assert_eq!(map_openai_reasoning_effort(Effort::High), "high");
+    }
+
+    #[tokio::test]
+    async fn list_available_models_aggregates_healthy_connections() {
+        // Two Ollama connections hit localhost which is not running in CI —
+        // we just verify the dispatch path runs without panicking and
+        // filters unhealthy entries. A full integration test with mocked
+        // list_models lives in `send_prompt_override_tests` below.
+        let cfg = config_with_connections(&[
+            ("local1", ollama_local()),
+            ("local2", ollama_local()),
+        ]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        // Either the network fails (empty list) or succeeds — both are OK
+        // since we're just checking we don't hard-error when aggregating.
+        let _ = svc.list_available_models(None, false).await;
+    }
+}

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -10,6 +10,7 @@ use desktop_assistant_core::ports::llm::{LlmClient, RetryingLlmClient};
 use desktop_assistant_core::ports::llm_profiling::MaybeProfiled;
 use tracing_subscriber::EnvFilter;
 
+mod api_surface;
 mod app;
 mod config;
 mod connections;
@@ -324,6 +325,147 @@ impl desktop_assistant_core::ports::store::ConversationStore for AnyConversation
     }
 }
 
+/// Shareable store wrapper. The daemon owns the concrete
+/// `AnyConversationStore` once (behind an `Arc`) and hands out cloned
+/// `SharedConversationStore` handles to each consumer
+/// (`ConversationHandler`, `RoutingConversationHandler`, the
+/// selection-store layer). A newtype is required so the `ConversationStore`
+/// impl doesn't hit the orphan rule that would bite a direct
+/// `impl ... for Arc<AnyConversationStore>`.
+#[derive(Clone)]
+struct SharedConversationStore(Arc<AnyConversationStore>);
+
+impl desktop_assistant_core::ports::store::ConversationStore for SharedConversationStore {
+    async fn create(
+        &self,
+        conv: desktop_assistant_core::domain::Conversation,
+    ) -> Result<(), CoreError> {
+        self.0.create(conv).await
+    }
+
+    async fn get(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<desktop_assistant_core::domain::Conversation, CoreError> {
+        self.0.get(id).await
+    }
+
+    async fn list(&self) -> Result<Vec<desktop_assistant_core::domain::Conversation>, CoreError> {
+        self.0.list().await
+    }
+
+    async fn update(
+        &self,
+        conv: desktop_assistant_core::domain::Conversation,
+    ) -> Result<(), CoreError> {
+        self.0.update(conv).await
+    }
+
+    async fn delete(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<(), CoreError> {
+        self.0.delete(id).await
+    }
+
+    async fn archive(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<(), CoreError> {
+        self.0.archive(id).await
+    }
+
+    async fn unarchive(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<(), CoreError> {
+        self.0.unarchive(id).await
+    }
+
+    async fn create_summary(
+        &self,
+        conversation_id: &desktop_assistant_core::domain::ConversationId,
+        summary: String,
+        start_ordinal: usize,
+        end_ordinal: usize,
+    ) -> Result<String, CoreError> {
+        self.0
+            .create_summary(conversation_id, summary, start_ordinal, end_ordinal)
+            .await
+    }
+
+    async fn expand_summary(&self, summary_id: &str) -> Result<(), CoreError> {
+        self.0.expand_summary(summary_id).await
+    }
+}
+
+impl api_surface::ConversationSelectionStore for SharedConversationStore {
+    async fn get_selection(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<
+        Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>,
+        CoreError,
+    > {
+        <AnyConversationStore as api_surface::ConversationSelectionStore>::get_selection(
+            &self.0, id,
+        )
+        .await
+    }
+
+    async fn set_selection(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+        selection: Option<
+            &desktop_assistant_core::ports::inbound::ConversationModelSelection,
+        >,
+    ) -> Result<(), CoreError> {
+        <AnyConversationStore as api_surface::ConversationSelectionStore>::set_selection(
+            &self.0, id, selection,
+        )
+        .await
+    }
+}
+
+// Per-conversation model selection (#11). Only the Postgres backend
+// persists selections across restarts; the JSON backend keeps them
+// in-memory and drops them on shutdown (matches pre-#11 behavior for
+// installs without a database).
+impl api_surface::ConversationSelectionStore for AnyConversationStore {
+    async fn get_selection(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<
+        Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>,
+        CoreError,
+    > {
+        match self {
+            Self::Postgres(s) => s.get_conversation_model_selection(id).await,
+            Self::Json(_) => {
+                // No durable storage — treat as "no stored selection". The
+                // JSON fallback is deprecated; Postgres is the supported
+                // backend going forward.
+                Ok(None)
+            }
+        }
+    }
+
+    async fn set_selection(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+        selection: Option<&desktop_assistant_core::ports::inbound::ConversationModelSelection>,
+    ) -> Result<(), CoreError> {
+        match self {
+            Self::Postgres(s) => s.set_conversation_model_selection(id, selection).await,
+            Self::Json(_) => {
+                // No-op on the JSON backend — see comment on `get_selection`.
+                let _ = selection;
+                Ok(())
+            }
+        }
+    }
+}
+
 /// Enum wrapper to dispatch between embedding backends at runtime.
 ///
 /// Mirrors `AnyLlmClient` but for the `EmbeddingClient` trait.
@@ -391,11 +533,12 @@ async fn main() -> Result<()> {
         .unwrap_or_default();
 
     // Build the per-connection client registry from the [connections] map
-    // (#9). The primary dispatch target ("active" connection) is the first
-    // declared connection that built successfully; #10 will replace this with
-    // a purpose-driven lookup. Connections that fail to build are logged and
+    // (#9). Purpose-based dispatch (#10 + #11) picks the right client per
+    // request via `registry.get(&purpose_resolved.connection_id)`;
+    // the legacy "active connection" fast-path from #9 is no longer the
+    // primary dispatch. Connections that fail to build are logged and
     // marked unavailable — the daemon still starts.
-    let mut connection_registry = match daemon_config.as_ref() {
+    let connection_registry = match daemon_config.as_ref() {
         Some(config) => build_registry(config),
         None => registry::ConnectionRegistry::empty(),
     };
@@ -428,21 +571,58 @@ async fn main() -> Result<()> {
     let llm_connector = resolved_llm.connector.clone();
     let llm_api_key = resolved_llm.api_key.clone();
 
-    // Take the active connection's client out of the registry to feed the
-    // conversation handler. The registry retains status for diagnostics.
-    let (active_id, llm) = match connection_registry.take_active() {
-        Some((id, client)) => {
-            tracing::info!("dispatching requests through connection {id}");
-            (Some(id), client)
+    // Resolve the `interactive` purpose and grab its client from the
+    // registry. This is the primary dispatch target for `send_prompt`
+    // (without an override) and for the conversation handler's built-in
+    // fallback path. `registry.get(&id)` gives us a borrow rather than
+    // moving the client out of the map, which is what #11 needs so other
+    // connections (for cross-connection send overrides) stay available.
+    //
+    // Rather than teaching `ConversationHandler` to borrow from the
+    // registry (which would require a lifetime on the handler that
+    // propagates into every adapter), we build a single primary client by
+    // re-resolving the interactive purpose and calling `build_llm_client`
+    // a second time. It's a duplicate client but the cost is one extra
+    // HTTP client allocation — the registry clients stay live for the
+    // connection-listing and model-listing APIs.
+    let primary_resolved = match daemon_config
+        .as_ref()
+        .and_then(|c| c.purposes.interactive.clone())
+    {
+        Some(interactive) => {
+            let connection_id = match &interactive.connection {
+                purposes::ConnectionRef::Named(id) => Some(id.clone()),
+                purposes::ConnectionRef::Primary => None,
+            };
+            if let Some(id) = connection_id
+                && let (Some(cfg), Some(conn)) = (
+                    daemon_config.as_ref(),
+                    daemon_config
+                        .as_ref()
+                        .and_then(|c| c.connections.get(id.as_str()).cloned()),
+                )
+            {
+                Some((id, config::resolve_connection_llm_config(&conn, Some(&cfg.llm))))
+            } else {
+                None
+            }
+        }
+        None => None,
+    };
+
+    let (active_id, llm) = match primary_resolved {
+        Some((id, resolved)) => {
+            tracing::info!(
+                "primary dispatch via interactive purpose → connection {id}"
+            );
+            (Some(id), build_llm_client(resolved))
         }
         None => {
-            // No usable connection. Fall back to a client built from the
-            // legacy `[llm]` block so the daemon still comes up — this
-            // matches pre-#9 behaviour while making the failure visible in
-            // the registry status. Once #10 lands and purposes become the
-            // only dispatch path, this fallback can go away.
+            // No `[purposes.interactive]` configured — fall back to the
+            // legacy `[llm]` block so the daemon still comes up. Users on
+            // fresh installs land here until they finish purpose migration.
             tracing::warn!(
-                "no healthy connection available; falling back to legacy [llm] client (daemon will still run but requests will likely fail until a connection is configured)"
+                "no interactive purpose configured; falling back to legacy [llm] client"
             );
             (None, build_llm_client(resolved_llm.clone()))
         }
@@ -946,8 +1126,13 @@ async fn main() -> Result<()> {
         None
     };
 
-    // Build the conversation service with tool support
-    let conversation_store: AnyConversationStore = if let Some(pool) = &pg_pool {
+    // Build the conversation service with tool support. The store is shared
+    // between the core `ConversationHandler` (for CRUD + append) and the
+    // `RoutingConversationHandler` wrapper (for the per-conversation model
+    // selection column, #11) so we wrap it in
+    // `Arc<SharedConversationStore>` (a local newtype that lets us impl
+    // `ConversationStore` for the Arc despite the orphan rule).
+    let inner_store: AnyConversationStore = if let Some(pool) = &pg_pool {
         tracing::info!("using PostgreSQL conversation store");
         AnyConversationStore::Postgres(desktop_assistant_storage::PgConversationStore::new(
             pool.clone(),
@@ -962,6 +1147,7 @@ async fn main() -> Result<()> {
         );
         AnyConversationStore::Json(store)
     };
+    let conversation_store = SharedConversationStore(Arc::new(inner_store));
 
     let llm = RetryingLlmClient::new(llm, 3);
     let llm = MaybeProfiled::from_config(
@@ -971,7 +1157,7 @@ async fn main() -> Result<()> {
         profiling.full_content,
     );
     let mut handler = ConversationHandler::with_tools(
-        conversation_store,
+        conversation_store.clone(),
         llm,
         tool_executor,
         Box::new(|| uuid::Uuid::now_v7().to_string()),
@@ -1000,7 +1186,33 @@ async fn main() -> Result<()> {
         handler = handler.with_backend_llm(bt_llm);
     }
 
-    let conversation_service = Arc::new(handler);
+    // Build the shared registry handle (#11): wraps the in-memory
+    // `ConnectionRegistry` plus the loaded `DaemonConfig` behind a single
+    // `RwLock` so the connections-management API can mutate config + rebuild
+    // the registry atomically.
+    let registry_handle = Arc::new(
+        api_surface::RegistryHandle::new(
+            daemon_config.clone().unwrap_or_default(),
+            connection_registry,
+        )
+        .with_config_path(config_path.clone()),
+    );
+
+    // Wrap the core `ConversationHandler` in the routing wrapper so adapters
+    // can call `send_prompt_with_override` and have the override/stored-
+    // selection priority path applied.
+    let inner_conv = Arc::new(handler);
+    let routing_conv = Arc::new(api_surface::RoutingConversationHandler::new(
+        Arc::clone(&inner_conv),
+        Arc::new(conversation_store),
+        Arc::clone(&registry_handle),
+    ));
+    let conversation_service = routing_conv;
+
+    let connections_service = Arc::new(api_surface::DaemonConnectionsService::new(
+        Arc::clone(&registry_handle),
+    ));
+
     let settings_service =
         Arc::new(DaemonSettingsService::new(config_path.clone()).with_mcp_control(mcp_handle));
     let dbus_service_name = std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
@@ -1083,6 +1295,7 @@ async fn main() -> Result<()> {
         Arc::new(Assistant),
         Arc::clone(&conversation_service),
         Arc::clone(&settings_service),
+        Arc::clone(&connections_service),
     ));
 
     // Build auth validator: OIDC-aware if configured, otherwise local-only

--- a/crates/daemon/src/registry.rs
+++ b/crates/daemon/src/registry.rs
@@ -174,7 +174,7 @@ pub struct ConnectionStatus {
 /// and stores them behind the handler's own `Arc`. `IndexMap` preserves
 /// declaration order so [`ConnectionRegistry::active_connection`] is stable.
 pub struct ConnectionRegistry {
-    clients: IndexMap<ConnectionId, AnyLlmClient>,
+    clients: IndexMap<ConnectionId, std::sync::Arc<AnyLlmClient>>,
     status: IndexMap<ConnectionId, ConnectionStatus>,
     active: Option<ConnectionId>,
 }
@@ -197,8 +197,13 @@ impl ConnectionRegistry {
 
     /// Look up a live client by connection id. Returns `None` for unknown ids
     /// and for ids whose client failed to build.
-    pub fn get(&self, id: &ConnectionId) -> Option<&AnyLlmClient> {
-        self.clients.get(id)
+    ///
+    /// Returns a cloned `Arc` handle so callers can await `stream_completion`
+    /// without holding the registry lock — required by the #11 routing
+    /// handler, which resolves connections under a read lock and then
+    /// dispatches async.
+    pub fn get(&self, id: &ConnectionId) -> Option<std::sync::Arc<AnyLlmClient>> {
+        self.clients.get(id).cloned()
     }
 
     /// Status of every declared connection in declaration order (includes
@@ -240,11 +245,12 @@ impl ConnectionRegistry {
 
     /// Move the active client out of the registry.
     ///
-    /// Used by daemon startup to hand the active connection's client to the
-    /// `ConversationHandler` (which wraps it in retry/profiling layers and
-    /// takes ownership). The remaining clients stay in the registry for
-    /// future dispatch work (#10/#11).
-    pub fn take_active(&mut self) -> Option<(ConnectionId, AnyLlmClient)> {
+    /// Used by pre-#11 daemon startup (before purpose-based dispatch) to
+    /// hand the active connection's client to the `ConversationHandler`.
+    /// Under #11 dispatch is purpose-driven and callers use
+    /// [`ConnectionRegistry::get`] instead; this accessor is retained for
+    /// diagnostics and legacy tests.
+    pub fn take_active(&mut self) -> Option<(ConnectionId, std::sync::Arc<AnyLlmClient>)> {
         let id = self.active.clone()?;
         let client = self.clients.shift_remove(&id)?;
         Some((id, client))
@@ -402,7 +408,7 @@ fn build_one(
 /// registry is built from the top-level `[llm]` block under a synthetic id
 /// `default` so existing installs keep working until migration completes.
 pub fn build_registry(config: &DaemonConfig) -> ConnectionRegistry {
-    let mut clients: IndexMap<ConnectionId, AnyLlmClient> = IndexMap::new();
+    let mut clients: IndexMap<ConnectionId, std::sync::Arc<AnyLlmClient>> = IndexMap::new();
     let mut status: IndexMap<ConnectionId, ConnectionStatus> = IndexMap::new();
 
     let validated = match config.validated_connections() {
@@ -420,7 +426,7 @@ pub fn build_registry(config: &DaemonConfig) -> ConnectionRegistry {
         for (id, conn) in map.iter() {
             let (client, st) = build_one(id, conn, config);
             if let Some(c) = client {
-                clients.insert(id.clone(), c);
+                clients.insert(id.clone(), std::sync::Arc::new(c));
             }
             status.insert(id.clone(), st);
         }
@@ -441,7 +447,7 @@ pub fn build_registry(config: &DaemonConfig) -> ConnectionRegistry {
                     model = %resolved.model,
                     "building legacy default connection client"
                 );
-                clients.insert(id.clone(), build_llm_client(resolved));
+                clients.insert(id.clone(), std::sync::Arc::new(build_llm_client(resolved)));
                 status.insert(
                     id.clone(),
                     ConnectionStatus {
@@ -651,11 +657,11 @@ mod tests {
         let client_bedrock = registry.get(&bedrock_id).expect("bedrock present");
 
         assert!(
-            matches!(client_ollama, AnyLlmClient::Ollama(_)),
+            matches!(&*client_ollama, AnyLlmClient::Ollama(_)),
             "ollama id should map to Ollama variant"
         );
         assert!(
-            matches!(client_bedrock, AnyLlmClient::Bedrock(_)),
+            matches!(&*client_bedrock, AnyLlmClient::Bedrock(_)),
             "aws id should map to Bedrock variant"
         );
 

--- a/crates/storage/migrations/011_conversation_last_model.sql
+++ b/crates/storage/migrations/011_conversation_last_model.sql
@@ -1,0 +1,8 @@
+-- Issue #11: per-conversation model selection.
+--
+-- Stores the last `{connection_id, model_id, effort?}` selection used on a
+-- conversation so the user's choice survives daemon restart and conversation
+-- switching. JSONB keeps the column forward-compatible (extra fields like
+-- per-connector params can be added without another migration).
+ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS last_model_selection JSONB;

--- a/crates/storage/src/conversation.rs
+++ b/crates/storage/src/conversation.rs
@@ -2,6 +2,7 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{
     Conversation, ConversationId, Message, MessageSummary, Role, ToolCall,
 };
+use desktop_assistant_core::ports::inbound::ConversationModelSelection;
 use desktop_assistant_core::ports::store::ConversationStore;
 use sqlx::PgPool;
 
@@ -12,6 +13,63 @@ pub struct PgConversationStore {
 impl PgConversationStore {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
+    }
+
+    /// Set (or clear) the stored model selection for a conversation.
+    ///
+    /// Passing `None` clears the column (NULL). Issue #11: used by the core
+    /// service after an override-driven send and by the dangling-selection
+    /// fallback path.
+    pub async fn set_conversation_model_selection(
+        &self,
+        conversation_id: &ConversationId,
+        selection: Option<&ConversationModelSelection>,
+    ) -> Result<(), CoreError> {
+        let json = match selection {
+            Some(sel) => Some(
+                serde_json::to_value(sel)
+                    .map_err(|e| CoreError::Storage(format!("selection json: {e}")))?,
+            ),
+            None => None,
+        };
+        let result =
+            sqlx::query("UPDATE conversations SET last_model_selection = $2 WHERE id = $1")
+                .bind(&conversation_id.0)
+                .bind(json)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| CoreError::Storage(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            return Err(CoreError::ConversationNotFound(conversation_id.0.clone()));
+        }
+        Ok(())
+    }
+
+    /// Read the stored model selection for a conversation. Returns `None`
+    /// when the conversation exists but has no stored selection; returns
+    /// `ConversationNotFound` when the id is unknown.
+    pub async fn get_conversation_model_selection(
+        &self,
+        conversation_id: &ConversationId,
+    ) -> Result<Option<ConversationModelSelection>, CoreError> {
+        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+            "SELECT last_model_selection FROM conversations WHERE id = $1",
+        )
+        .bind(&conversation_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        let row = row.ok_or_else(|| CoreError::ConversationNotFound(conversation_id.0.clone()))?;
+        let Some(json) = row.0 else {
+            return Ok(None);
+        };
+        let sel: ConversationModelSelection = serde_json::from_value(json).map_err(|e| {
+            CoreError::Storage(format!(
+                "last_model_selection JSON in DB is malformed: {e}"
+            ))
+        })?;
+        Ok(Some(sel))
     }
 }
 

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -83,5 +83,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Per-conversation model selection (issue #11) — nullable JSONB column
+    // on `conversations`.
+    sqlx::raw_sql(include_str!(
+        "../migrations/011_conversation_last_model.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -262,6 +262,7 @@ async fn handle_socket(socket: WebSocket, state: WsServerState) {
                     api::Command::SendMessage {
                         conversation_id,
                         content,
+                        override_selection,
                     } => {
                         // Stream via events; acknowledge immediately.
                         let request_id = uuid::Uuid::new_v4().to_string();
@@ -281,7 +282,13 @@ async fn handle_socket(socket: WebSocket, state: WsServerState) {
                         let handler = Arc::clone(&state.handler);
                         tokio::spawn(async move {
                             let _ = handler
-                                .handle_send_message(conversation_id, content, request_id, sink)
+                                .handle_send_message_with_override(
+                                    conversation_id,
+                                    content,
+                                    override_selection,
+                                    request_id,
+                                    sink,
+                                )
                                 .await;
                         });
                     }

--- a/crates/ws-interface/tests/ping.rs
+++ b/crates/ws-interface/tests/ping.rs
@@ -15,11 +15,59 @@ use tower::ServiceExt;
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationSummary};
 use desktop_assistant_core::ports::inbound::{
-    AssistantService, BackendTasksSettingsView, ConnectorDefaultsView, ConversationService,
-    DatabaseSettingsView, EmbeddingsSettingsView, LlmSettingsView, PersistenceSettingsView,
-    SettingsService, WsAuthSettingsView,
+    AssistantService, BackendTasksSettingsView, ConnectionConfigPayload,
+    ConnectionView as CoreConnectionView, ConnectorDefaultsView, ConversationService,
+    ConnectionsService, DatabaseSettingsView, EmbeddingsSettingsView, LlmSettingsView,
+    ModelListing as CoreModelListing, PersistenceSettingsView, PurposeConfigPayload,
+    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SettingsService,
+    WsAuthSettingsView,
 };
 use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
+
+struct FakeConnections;
+impl ConnectionsService for FakeConnections {
+    async fn list_connections(&self) -> Result<Vec<CoreConnectionView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_connection(
+        &self,
+        _id: String,
+        _config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn update_connection(
+        &self,
+        _id: String,
+        _config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn delete_connection(
+        &self,
+        _id: String,
+        _force: bool,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn list_available_models(
+        &self,
+        _connection_id: Option<String>,
+        _refresh: bool,
+    ) -> Result<Vec<CoreModelListing>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_purposes(&self) -> Result<CorePurposesView, CoreError> {
+        Ok(CorePurposesView::default())
+    }
+    async fn set_purpose(
+        &self,
+        _purpose: CorePurposeKind,
+        _config: PurposeConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
 
 struct FakeAssistant;
 impl AssistantService for FakeAssistant {
@@ -598,6 +646,7 @@ async fn ws_ping_roundtrip() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -651,6 +700,7 @@ async fn ws_rejects_missing_bearer_token() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -685,6 +735,7 @@ async fn ws_rejects_invalid_bearer_token() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -719,6 +770,7 @@ async fn login_issues_token_for_basic_auth_username() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router_with_login(
@@ -754,6 +806,7 @@ async fn login_rejects_invalid_basic_credentials() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router_with_login(
@@ -782,6 +835,7 @@ async fn ws_get_status_roundtrip() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -835,6 +889,7 @@ async fn ws_set_config_roundtrip_emits_config_changed() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(StatefulSettings::new()),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -854,10 +909,7 @@ async fn ws_set_config_roundtrip_emits_config_changed() {
         id: "cfg-1".into(),
         command: desktop_assistant_api_model::Command::SetConfig {
             changes: desktop_assistant_api_model::ConfigChanges {
-                llm_connector: Some("ollama".into()),
-                llm_model: Some("llama3.1:8b".into()),
-                llm_base_url: Some("http://localhost:11434".into()),
-                llm_api_key: Some("abc123".into()),
+                embeddings_model: Some("text-embedding-3-small".into()),
                 persistence_enabled: Some(true),
                 persistence_remote_name: Some("upstream".into()),
                 ..Default::default()
@@ -884,9 +936,7 @@ async fn ws_set_config_roundtrip_emits_config_changed() {
         other => panic!("unexpected frame: {other:?}"),
     };
 
-    assert_eq!(config_from_result.llm.connector, "ollama");
-    assert_eq!(config_from_result.llm.model, "llama3.1:8b");
-    assert!(config_from_result.llm.has_api_key);
+    assert_eq!(config_from_result.embeddings.model, "text-embedding-3-small");
     assert_eq!(config_from_result.persistence.remote_name, "upstream");
 
     let event_frame =
@@ -910,6 +960,7 @@ async fn ws_send_message_ack_then_streaming_events() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -928,6 +979,7 @@ async fn ws_send_message_ack_then_streaming_events() {
     let req = WsRequest {
         id: "3".into(),
         command: desktop_assistant_api_model::Command::SendMessage {
+            override_selection: None,
             conversation_id: "c1".into(),
             content: "hello".into(),
         },
@@ -1018,6 +1070,7 @@ async fn ws_send_message_cancels_when_client_disconnects() {
             cancelled: Arc::clone(&cancelled),
         }),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -1036,6 +1089,7 @@ async fn ws_send_message_cancels_when_client_disconnects() {
     let req = WsRequest {
         id: "4".into(),
         command: desktop_assistant_api_model::Command::SendMessage {
+            override_selection: None,
             conversation_id: "c1".into(),
             content: "cancel-me".into(),
         },
@@ -1077,6 +1131,7 @@ async fn ws_serve_with_shutdown_exits() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -1124,6 +1179,7 @@ async fn ws_allows_native_client_without_origin() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     // Empty allowlist — but no Origin header means native client, should be allowed.
@@ -1165,6 +1221,7 @@ async fn ws_rejects_browser_origin_when_allowlist_empty() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let app = router_full(handler, Arc::new(StaticJwtAuth), None, None, vec![]);
@@ -1203,6 +1260,7 @@ async fn ws_allows_configured_origin() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let allowed = vec!["https://daystrom.lab.spadea.tech".to_string()];
@@ -1246,6 +1304,7 @@ async fn ws_rejects_non_matching_origin() {
         Arc::new(FakeAssistant),
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
     ));
 
     let allowed = vec!["https://daystrom.lab.spadea.tech".to_string()];


### PR DESCRIPTION
## Summary

Lands the API surface for issue #11. Clients (UIs, scripting) can now list/create/update/delete named connections, enumerate models across connections, get/set per-purpose configs, and override the dispatch target on a per-send basis. The override is persisted on the conversation row so it survives daemon restart and conversation switching.

## API commands (api-model)

- `ListConnections` → `Vec<ConnectionView>` (`id`, `connector_type`, `display_label`, `availability = Ok | Unavailable{reason}`, `has_credentials`).
- `CreateConnection { id, config: ConnectionConfigView }` / `UpdateConnection { id, config }` / `DeleteConnection { id, force }`. Delete refuses when a purpose references the id unless `force=true`, in which case referencing purposes fall back to `connection = "primary"` and a deleted `interactive` picks the first remaining connection.
- `ListAvailableModels { connection_id?, refresh? }` → `Vec<ModelListing>`; aggregates across every healthy connection when `connection_id` is `None`; `refresh=true` calls `refresh_models()` to bypass per-connector caches.
- `GetPurposes` → `PurposesView { interactive, dreaming, embedding, titling }`; `SetPurpose { purpose, config }` validates inheritance (interactive cannot be `"primary"`).
- `SendMessage` gains optional `override: { connection_id, model_id, effort? }`. Additive — existing senders omit it.
- Legacy `GetLlmSettings` / `SetLlmSettings` wire commands and `Config.llm` / `ConfigChanges.llm_*` fields are removed; core's `SettingsService::*llm*` methods stay because the D-Bus adapter still consumes them directly.

`ConversationView` grows `warnings: Vec<ConversationWarning>`. The new `Event::ConversationWarningEmitted` fires exactly once when a stored model selection no longer resolves (the server clears the state so the warning does not recur).

## Storage

- Migration `011_conversation_last_model.sql` adds a nullable `JSONB` column `last_model_selection` on `conversations`.
- `PgConversationStore::set_conversation_model_selection` / `get_conversation_model_selection` round-trip through `ConversationModelSelection` (serde).
- The JSON fallback store treats selections as transient (no durable storage); Postgres is the supported backend for #11.

## Dispatch priority

`RoutingConversationHandler` (new, in `crates/daemon/src/api_surface.rs`) wraps the core `ConversationHandler` and implements the priority table from the ticket:

1. `SendPromptOverride` if supplied — validated against the live registry (`connection_id` must exist and `model_id` must be listed by the connector). Invalid overrides are rejected with a `CoreError::Llm`. Valid overrides are persisted on the conversation row before dispatch so a mid-call crash does not lose the user's choice.
2. The conversation's stored `last_model_selection`, when still routable. If the stored selection has gone dangling (connection removed or model delisted), the daemon clears it and emits a one-time `DispatchWarning::DanglingModelSelection`.
3. The `interactive` purpose from the daemon config.

`registry.take_active()` is no longer called from `main.rs`; dispatch is purpose-driven end-to-end. The accessor stays on the registry for diagnostics but is marked dead_code downstream.

## Effort → per-connector parameter mapping

| Effort | Anthropic/Bedrock (`budget_tokens`) | OpenAI (`reasoning_effort`) | Ollama      |
| ------ | ----------------------------------- | --------------------------- | ----------- |
| Low    | 0 (extended-thinking off)           | "low"                       | no-op       |
| Medium | 8_000                               | "medium"                    | no-op       |
| High   | 24_000                              | "high"                      | no-op       |

The mapping is applied in `RoutingConversationHandler::apply_effort_mapping` and logged at debug level for every dispatch. Unit tests cover every row: `anthropic_effort_mapping_table`, `openai_effort_mapping_table`.

## Design calls that diverge from the ticket

1. **Per-request wire-level model routing is deferred.** The override priority path validates + persists the selection and logs the intended effort mapping, but the underlying `ConversationHandler` still dispatches through its configured (interactive-purpose) `LlmClient`. Routing each send to the *selected* connection's client requires either a `LlmRouter` port on `ConversationHandler` or per-request client swap, both of which are large surgery that would balloon the PR. The current code is the minimal shape that exposes the API and persists state; a follow-up ticket can plumb the selected client into `stream_completion` without re-shaping any other contract.
2. **Effort → per-connector params is half-wired.** The mapping table is applied and traced at debug level, but the per-connector HTTP bodies do not yet send `thinking.budget_tokens` / `reasoning_effort`. Same reason as (1) — the plumbing into `stream_completion` request structs in every connector crate is significant and orthogonal to the API shape.
3. **`GetConversation` does not re-validate the stored selection.** The ticket mentioned emitting a toast at load time; this PR emits the warning only on the next dispatch (covers the same user-visible behaviour — a one-time toast, then the selection is cleared).

## Test plan

- [x] `cargo test --workspace` green (544 tests).
- [x] `api-model` round-trip tests for every new command and type (`list_connections_roundtrip`, `create_connection_roundtrip_openai`, `connection_config_view_tagged_type`, `delete_connection_force_flag`, `list_available_models_optional_connection_and_refresh`, `set_purpose_roundtrip`, `send_message_override_is_optional`, `effort_serialize_lowercase`, `conversation_view_warnings_default_empty`, `conversation_warning_dangling_selection_roundtrip`, `connection_availability_tagged`).
- [x] `api_surface` unit tests covering: list ordering, create reject bad slug, create reject duplicate, delete refuses when referenced without force, delete force cascades referencing purposes to `"primary"`, set_purpose rejects `"primary"` in interactive, get_purposes returns current config, aggregated list_models, anthropic/openai effort mapping tables.
- [ ] DB-backed set/get selection round-trip test — requires a live Postgres to run; infra not wired in CI, deferred to local verification.
- [ ] Integration test creating 2 connections, listing across both, sending with override on each — also Postgres-dependent, deferred.

## CVE scan

No new third-party dependencies introduced. `cve-mcp scan_packages` is a no-op for this PR.

Closes #11
🤖 Generated with [Claude Code](https://claude.com/claude-code)