### PR TITLE
Wire per-request routing + effort threading (closes #18)

### DIFF
--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -11,6 +11,106 @@ pub type ChunkCallback = Box<dyn FnMut(String) -> bool + Send>;
 /// (e.g. "Searching knowledge base...", "Querying timeclock sessions...").
 pub type StatusCallback = Box<dyn FnMut(String) + Send>;
 
+tokio::task_local! {
+    /// Per-turn reasoning configuration. Set by the daemon-side routing
+    /// handler via [`with_reasoning_config`] before invoking `send_prompt`;
+    /// read by [`current_reasoning_config`] inside the dispatch loop and
+    /// forwarded to connectors through [`LlmClient::stream_completion`].
+    ///
+    /// Lives in the task-local slot so each concurrent turn can carry a
+    /// distinct reasoning config without any coupling between the routing
+    /// wrapper and the core `ConversationHandler`.
+    static REASONING_CONFIG: ReasoningConfig;
+}
+
+/// Run `fut` with the given reasoning config installed as the current
+/// task-local value. All `current_reasoning_config()` calls inside the
+/// future (and any sub-tasks that inherit the scope) observe `config`.
+pub async fn with_reasoning_config<F, T>(config: ReasoningConfig, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    REASONING_CONFIG.scope(config, fut).await
+}
+
+/// Current task-local reasoning config, or `ReasoningConfig::default()`
+/// (all `None`) when not set. Safe to call from any async context.
+pub fn current_reasoning_config() -> ReasoningConfig {
+    REASONING_CONFIG
+        .try_with(|c| *c)
+        .unwrap_or_default()
+}
+
+/// Reasoning / extended-thinking level for a single LLM turn.
+///
+/// Mirrors the tri-state `Effort` knob that the daemon exposes on
+/// `SendMessage.override`. Kept in core so the `LlmClient` trait is
+/// self-contained and connectors don't take a daemon dependency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningLevel {
+    Low,
+    Medium,
+    High,
+}
+
+impl ReasoningLevel {
+    /// Lowercase literal used in OpenAI's `reasoning_effort` request field.
+    pub fn as_openai_effort(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+/// Per-turn reasoning configuration threaded from the routing handler
+/// through the `LlmClient` trait into per-connector request bodies.
+///
+/// All fields default to `None`, which means "no reasoning-related fields
+/// in the request body" — i.e. the existing behavior. The daemon-side
+/// routing handler populates the appropriate field based on the caller's
+/// `Effort` hint and the selected connector type.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReasoningConfig {
+    /// Anthropic extended-thinking budget in tokens. When `Some(N > 0)`,
+    /// the Anthropic connector adds `thinking: { type: "enabled",
+    /// budget_tokens: N }` to the request. The Bedrock connector forwards
+    /// the same shape via `additionalModelRequestFields` for Claude models.
+    /// `None` or `Some(0)` disables extended thinking.
+    pub thinking_budget_tokens: Option<u32>,
+    /// OpenAI `reasoning_effort` literal. When `Some(level)` and the model
+    /// supports reasoning (o-series / GPT-5 reasoning), the OpenAI
+    /// connector adds `reasoning_effort: "..."` to the request.
+    pub reasoning_effort: Option<ReasoningLevel>,
+}
+
+impl ReasoningConfig {
+    /// Convenience constructor for the Anthropic-flavored side only.
+    pub fn with_thinking_budget(budget: u32) -> Self {
+        Self {
+            thinking_budget_tokens: Some(budget),
+            reasoning_effort: None,
+        }
+    }
+
+    /// Convenience constructor for the OpenAI-flavored side only.
+    pub fn with_reasoning_effort(level: ReasoningLevel) -> Self {
+        Self {
+            thinking_budget_tokens: None,
+            reasoning_effort: Some(level),
+        }
+    }
+
+    /// True when no reasoning-related fields would be added to the
+    /// request body. Used by connectors to skip log spam on the fast
+    /// path.
+    pub fn is_empty(self) -> bool {
+        self.thinking_budget_tokens.is_none() && self.reasoning_effort.is_none()
+    }
+}
+
 /// Token usage statistics from an LLM call.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TokenUsage {
@@ -153,11 +253,16 @@ pub trait LlmClient: Send + Sync {
     /// Stream a completion from the LLM given a message history.
     /// Calls `on_chunk` for each text token/chunk received.
     /// Optionally accepts tool definitions to enable tool calling.
+    /// `reasoning` carries optional extended-thinking / reasoning-effort
+    /// hints; connectors may ignore it (Ollama) or translate it into a
+    /// per-API request field (Anthropic `thinking`, OpenAI
+    /// `reasoning_effort`, Bedrock `additionalModelRequestFields`).
     /// Returns an `LlmResponse` which may include tool calls.
     fn stream_completion(
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> impl std::future::Future<Output = Result<LlmResponse, CoreError>> + Send;
 
@@ -177,6 +282,7 @@ pub trait LlmClient: Send + Sync {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> impl std::future::Future<Output = Result<LlmResponse, CoreError>> + Send {
         async move {
@@ -184,7 +290,8 @@ pub trait LlmClient: Send + Sync {
             for ns in namespaces {
                 all.extend(ns.tools.iter().cloned());
             }
-            self.stream_completion(messages, &all, on_chunk).await
+            self.stream_completion(messages, &all, reasoning, on_chunk)
+                .await
         }
     }
 
@@ -262,6 +369,7 @@ impl<L: LlmClient> LlmClient for RetryingLlmClient<L> {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         // Store the real callback behind Arc<Mutex<Option<...>>> so we can
@@ -280,7 +388,11 @@ impl<L: LlmClient> LlmClient for RetryingLlmClient<L> {
             });
 
             let msgs = messages.clone();
-            match self.inner.stream_completion(msgs, tools, proxy_cb).await {
+            match self
+                .inner
+                .stream_completion(msgs, tools, reasoning, proxy_cb)
+                .await
+            {
                 Ok(response) => return Ok(response),
                 Err(e) if attempt < self.max_retries && is_retryable_error(&e) => {
                     let delay_secs = 1u64 << attempt;
@@ -307,6 +419,7 @@ impl<L: LlmClient> LlmClient for RetryingLlmClient<L> {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let shared_cb: Arc<Mutex<Option<ChunkCallback>>> = Arc::new(Mutex::new(Some(on_chunk)));
@@ -325,7 +438,9 @@ impl<L: LlmClient> LlmClient for RetryingLlmClient<L> {
             let msgs = messages.clone();
             match self
                 .inner
-                .stream_completion_with_namespaces(msgs, core_tools, namespaces, proxy_cb)
+                .stream_completion_with_namespaces(
+                    msgs, core_tools, namespaces, reasoning, proxy_cb,
+                )
                 .await
             {
                 Ok(response) => return Ok(response),
@@ -368,6 +483,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             let mut full = String::new();
@@ -409,6 +525,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(move |chunk| {
                     received_clone.lock().unwrap().push(chunk);
                     true
@@ -434,6 +551,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(move |_chunk| {
                     let mut c = count_clone.lock().unwrap();
                     *c += 1;
@@ -516,6 +634,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             let mut count = self.remaining_failures.lock().unwrap();
@@ -543,6 +662,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(move |chunk| {
                     received_clone.lock().unwrap().push(chunk);
                     true
@@ -565,6 +685,7 @@ mod tests {
                 &self,
                 _messages: Vec<Message>,
                 _tools: &[ToolDefinition],
+                _reasoning: ReasoningConfig,
                 _on_chunk: ChunkCallback,
             ) -> Result<LlmResponse, CoreError> {
                 Err(CoreError::Llm("invalid API key".into()))
@@ -576,6 +697,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await;
@@ -699,6 +821,7 @@ mod tests {
                 &self,
                 _messages: Vec<Message>,
                 _tools: &[ToolDefinition],
+                _reasoning: ReasoningConfig,
                 _on_chunk: ChunkCallback,
             ) -> Result<LlmResponse, CoreError> {
                 Ok(LlmResponse::text(""))
@@ -722,6 +845,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await;

--- a/crates/core/src/ports/llm_profiling.rs
+++ b/crates/core/src/ports/llm_profiling.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 
 use crate::CoreError;
 use crate::domain::{Message, Role, ToolDefinition, ToolNamespace};
-use crate::ports::llm::{ChunkCallback, LlmClient, LlmResponse, ModelInfo, TokenUsage};
+use crate::ports::llm::{
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig, TokenUsage,
+};
 
 /// JSONL profiling entry written for each LLM call.
 #[derive(Serialize)]
@@ -202,6 +204,7 @@ impl<L: LlmClient> LlmClient for ProfilingLlmClient<L> {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let tool_names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
@@ -212,7 +215,7 @@ impl<L: LlmClient> LlmClient for ProfilingLlmClient<L> {
         let start = Instant::now();
         let result = self
             .inner
-            .stream_completion(messages, tools, on_chunk)
+            .stream_completion(messages, tools, reasoning, on_chunk)
             .await;
         let duration_ms = start.elapsed().as_millis();
 
@@ -237,6 +240,7 @@ impl<L: LlmClient> LlmClient for ProfilingLlmClient<L> {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let mut all_names: Vec<String> = core_tools.iter().map(|t| t.name.clone()).collect();
@@ -252,7 +256,9 @@ impl<L: LlmClient> LlmClient for ProfilingLlmClient<L> {
         let start = Instant::now();
         let result = self
             .inner
-            .stream_completion_with_namespaces(messages, core_tools, namespaces, on_chunk)
+            .stream_completion_with_namespaces(
+                messages, core_tools, namespaces, reasoning, on_chunk,
+            )
             .await;
         let duration_ms = start.elapsed().as_millis();
 
@@ -386,11 +392,18 @@ impl<L: LlmClient> LlmClient for MaybeProfiled<L> {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         match self {
-            Self::Plain(l) => l.stream_completion(messages, tools, on_chunk).await,
-            Self::Profiled(l) => l.stream_completion(messages, tools, on_chunk).await,
+            Self::Plain(l) => {
+                l.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
+            Self::Profiled(l) => {
+                l.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
         }
     }
 
@@ -406,16 +419,21 @@ impl<L: LlmClient> LlmClient for MaybeProfiled<L> {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         match self {
             Self::Plain(l) => {
-                l.stream_completion_with_namespaces(messages, core_tools, namespaces, on_chunk)
-                    .await
+                l.stream_completion_with_namespaces(
+                    messages, core_tools, namespaces, reasoning, on_chunk,
+                )
+                .await
             }
             Self::Profiled(l) => {
-                l.stream_completion_with_namespaces(messages, core_tools, namespaces, on_chunk)
-                    .await
+                l.stream_completion_with_namespaces(
+                    messages, core_tools, namespaces, reasoning, on_chunk,
+                )
+                .await
             }
         }
     }
@@ -433,6 +451,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             _on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             Ok(LlmResponse::text("mock response").with_usage(TokenUsage {
@@ -462,6 +481,7 @@ mod tests {
                     "Read a file",
                     serde_json::json!({"type": "object"}),
                 )],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await
@@ -491,6 +511,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -4,7 +4,7 @@ use crate::domain::{
     ToolDefinition, ToolNamespace,
 };
 use crate::ports::inbound::ConversationService;
-use crate::ports::llm::{ChunkCallback, LlmClient, StatusCallback};
+use crate::ports::llm::{ChunkCallback, LlmClient, ReasoningConfig, StatusCallback};
 use crate::ports::store::ConversationStore;
 use crate::ports::tools::ToolExecutor;
 use chrono::{Duration, Local};
@@ -409,7 +409,7 @@ async fn generate_conversation_title<L: LlmClient>(initial_prompt: &str, llm: &L
         ),
     ];
     match llm
-        .stream_completion(messages, &[], Box::new(|_| true))
+        .stream_completion(messages, &[], ReasoningConfig::default(), Box::new(|_| true))
         .await
     {
         Ok(response) => sanitize_generated_title(&response.text),
@@ -528,7 +528,12 @@ async fn generate_context_summary<L: LlmClient>(
     ];
 
     match llm
-        .stream_completion(llm_messages, &[], Box::new(|_| true))
+        .stream_completion(
+            llm_messages,
+            &[],
+            ReasoningConfig::default(),
+            Box::new(|_| true),
+        )
         .await
     {
         Ok(response) if !response.text.trim().is_empty() => response.text.trim().to_string(),
@@ -594,7 +599,7 @@ async fn categorize_tool_namespaces<L: LlmClient>(
     ];
 
     let response = match llm
-        .stream_completion(messages, &[], Box::new(|_| true))
+        .stream_completion(messages, &[], ReasoningConfig::default(), Box::new(|_| true))
         .await
     {
         Ok(r) => r,
@@ -990,6 +995,13 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 }
             });
 
+            // Reasoning config is threaded through a task-local set by
+            // the daemon-side routing wrapper (`RoutingConversationHandler`)
+            // before it calls `send_prompt`. In tests / standalone uses
+            // with no wrapper, the slot is unset and we pass the default
+            // empty config, matching the pre-issue-18 behaviour.
+            let reasoning = crate::ports::llm::current_reasoning_config();
+
             let response =
                 match if use_hosted_search && !namespaces.is_empty() && !hosted_search_demoted {
                     self.llm
@@ -997,12 +1009,18 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                             llm_messages,
                             &tool_defs,
                             &namespaces,
+                            reasoning,
                             filtered_chunk_callback,
                         )
                         .await
                 } else {
                     self.llm
-                        .stream_completion(llm_messages, &tool_defs, filtered_chunk_callback)
+                        .stream_completion(
+                            llm_messages,
+                            &tool_defs,
+                            reasoning,
+                            filtered_chunk_callback,
+                        )
                         .await
                 } {
                     Ok(r) => r,
@@ -1420,6 +1438,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             let mut full = String::new();
@@ -1728,6 +1747,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             let response = {
@@ -2043,6 +2063,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             let call_idx = {
@@ -2285,6 +2306,7 @@ mod tests {
             &self,
             messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             _on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             // Only capture the first call (the main LLM turn). The second call
@@ -2866,6 +2888,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             on_chunk(self.text.clone());
@@ -2999,6 +3022,7 @@ mod tests {
             &self,
             _messages: Vec<Message>,
             _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
             mut on_chunk: ChunkCallback,
         ) -> Result<LlmResponse, CoreError> {
             self.call_count.fetch_add(1, Ordering::Relaxed);
@@ -3105,6 +3129,7 @@ mod tests {
                 &self,
                 _messages: Vec<Message>,
                 _tools: &[ToolDefinition],
+                _reasoning: ReasoningConfig,
                 _on_chunk: ChunkCallback,
             ) -> Result<LlmResponse, CoreError> {
                 self.call_count.fetch_add(1, Ordering::Relaxed);

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -34,7 +34,10 @@ use desktop_assistant_core::ports::inbound::{
     PromptDispatchOutcome, PromptSelectionOverride, PurposeConfigPayload,
     PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SerdeEffort,
 };
-use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, StatusCallback};
+use desktop_assistant_core::ports::llm::{
+    ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback,
+    with_reasoning_config,
+};
 
 use crate::config::{
     DaemonConfig, default_daemon_config_path, load_daemon_config, save_daemon_config,
@@ -125,7 +128,7 @@ impl RegistryHandle {
     /// Fetch the live client handle for a connection id, if any. The
     /// returned `Arc` can be awaited on without holding any registry
     /// locks, which keeps the async futures `Send`.
-    fn client_for(
+    pub(crate) fn client_for(
         &self,
         id: &ConnectionId,
     ) -> Option<std::sync::Arc<crate::registry::AnyLlmClient>> {
@@ -134,7 +137,7 @@ impl RegistryHandle {
     }
 
     /// Connector-type tag for a given connection id, if declared.
-    fn connector_type_for(&self, id: &ConnectionId) -> Option<String> {
+    pub(crate) fn connector_type_for(&self, id: &ConnectionId) -> Option<String> {
         let state = self.state.read().expect("registry state poisoned");
         state
             .registry
@@ -487,19 +490,27 @@ where
         self.registry.connection_lists_model(&id, &sel.model_id).await
     }
 
-    /// Translate the effort hint into per-connector parameters and log
-    /// what the dispatch layer would send. This is the effort-mapping hook
-    /// the ticket calls out; each connector currently receives the mapping
-    /// via a `tracing::debug!` line, and the wire-level plumbing into
-    /// `stream_completion` will be wired up on a follow-up (noted in the
-    /// PR body — see issue #11).
+    /// Translate the effort hint into the per-connector
+    /// [`ReasoningConfig`] the connector's dispatch path expects.
+    ///
+    /// - Anthropic / Bedrock (Claude): populates
+    ///   `thinking_budget_tokens` using
+    ///   [`map_anthropic_thinking_budget`].
+    /// - OpenAI: populates `reasoning_effort` using
+    ///   [`map_openai_reasoning_effort`]. The connector itself applies a
+    ///   per-model capability gate and silently drops the field for
+    ///   non-reasoning models.
+    /// - Ollama / unknown: returns an empty `ReasoningConfig` (no-op).
+    ///
+    /// The returned value is installed on the turn's task-local
+    /// [`with_reasoning_config`] scope by the caller.
     fn apply_effort_mapping(
         connector_type: &str,
         model_id: &str,
         effort: Option<Effort>,
-    ) {
+    ) -> ReasoningConfig {
         let Some(effort) = effort else {
-            return;
+            return ReasoningConfig::default();
         };
         match connector_type {
             "anthropic" | "bedrock" => {
@@ -511,30 +522,30 @@ where
                     thinking_budget_tokens = budget,
                     "mapped effort to Anthropic extended-thinking budget"
                 );
+                if budget == 0 {
+                    ReasoningConfig::default()
+                } else {
+                    ReasoningConfig::with_thinking_budget(budget)
+                }
             }
             "openai" => {
-                let token = map_openai_reasoning_effort(effort);
+                let level = map_effort_to_reasoning_level(effort);
                 tracing::debug!(
                     connector = connector_type,
                     model = model_id,
                     effort = ?effort,
-                    reasoning_effort = token,
+                    reasoning_level = ?level,
                     "mapped effort to OpenAI reasoning_effort"
                 );
+                ReasoningConfig::with_reasoning_effort(level)
             }
-            "ollama" => {
+            _ => {
                 tracing::debug!(
                     connector = connector_type,
                     effort = ?effort,
-                    "effort is a no-op on Ollama"
+                    "no reasoning mapping defined for connector (no-op)"
                 );
-            }
-            other => {
-                tracing::debug!(
-                    connector = other,
-                    effort = ?effort,
-                    "no effort mapping defined for connector"
-                );
+                ReasoningConfig::default()
             }
         }
     }
@@ -592,9 +603,16 @@ where
         on_chunk: ChunkCallback,
         on_status: StatusCallback,
     ) -> Result<String, CoreError> {
-        self.inner
-            .send_prompt(conversation_id, prompt, on_chunk, on_status)
-            .await
+        // The plain `send_prompt` path is invoked by adapters that don't
+        // carry an explicit override (legacy D-Bus/WS endpoints). We
+        // still want per-conversation stored selections and the
+        // interactive-purpose fallback to route the turn to the right
+        // connection + effort, so we route it through the same
+        // resolution + dispatch machinery as the override path.
+        let outcome = self
+            .send_prompt_with_override(conversation_id, prompt, None, on_chunk, on_status)
+            .await?;
+        Ok(outcome.response)
     }
 
     async fn send_prompt_with_override(
@@ -659,27 +677,67 @@ where
             self.interactive_selection()
         };
 
-        // Emit effort-mapping debug lines for the chosen dispatch target.
+        // Resolve the per-turn routing target:
+        //   - `active_client`: the `Arc<AnyLlmClient>` dispatch must use
+        //     for this turn. Installed on a task-local consulted by
+        //     `RoutingLlmClient::stream_completion`. When `None`, the
+        //     handler's static interactive-purpose fallback is used.
+        //   - `reasoning`: the `ReasoningConfig` populated from the
+        //     per-connector effort mapping. Installed on a second
+        //     task-local read by the core `ConversationHandler` dispatch
+        //     loop and forwarded into `stream_completion(... reasoning
+        //     ...)`.
+        let mut active_client: Option<std::sync::Arc<crate::registry::AnyLlmClient>> = None;
+        let mut reasoning = ReasoningConfig::default();
         if let Some(sel) = effective_selection.as_ref() {
-            let connector_type = ConnectionId::new(sel.connection_id.clone())
-                .ok()
-                .and_then(|id| self.registry.connector_type_for(&id))
+            let id = ConnectionId::new(sel.connection_id.clone()).map_err(|e| {
+                CoreError::Llm(format!(
+                    "resolved selection has malformed connection id {:?}: {e}",
+                    sel.connection_id
+                ))
+            })?;
+            // Reject Unavailable (or undeclared) connections with a
+            // clean 400-style error rather than silently falling back.
+            let connector_type = self
+                .registry
+                .connector_type_for(&id)
                 .unwrap_or_default();
-            Self::apply_effort_mapping(
-                &connector_type,
-                &sel.model_id,
-                sel.effort.map(Effort::from),
-            );
+            match self.registry.client_for(&id) {
+                Some(client) => {
+                    active_client = Some(client);
+                }
+                None => {
+                    return Err(CoreError::Llm(format!(
+                        "resolved connection {} is not live; requested model {} cannot be dispatched",
+                        sel.connection_id, sel.model_id
+                    )));
+                }
+            }
+            reasoning =
+                Self::apply_effort_mapping(&connector_type, &sel.model_id, sel.effort.map(Effort::from));
         }
 
-        // Dispatch via the inner (interactive-purpose) handler. The
-        // override/stored selection has been validated and persisted; wire-
-        // level routing to the selected connection+model is noted as a
-        // follow-up in the PR body.
-        let response = self
-            .inner
-            .send_prompt(conversation_id, prompt, on_chunk, on_status)
-            .await?;
+        // Install both task-locals, then delegate to the inner core
+        // handler. The handler reads the task-locals inside its
+        // `send_prompt` dispatch loop:
+        //   - `RoutingLlmClient` picks the active client on each
+        //     `stream_completion` call.
+        //   - `current_reasoning_config()` surfaces `reasoning` into the
+        //     connector's request body.
+        let inner = Arc::clone(&self.inner);
+        let conv_id = conversation_id.clone();
+        let response = {
+            let dispatch = async move {
+                inner
+                    .send_prompt(&conv_id, prompt, on_chunk, on_status)
+                    .await
+            };
+            let dispatch = with_reasoning_config(reasoning, dispatch);
+            match active_client {
+                Some(c) => crate::routing_llm::with_active_client(c, dispatch).await,
+                None => dispatch.await,
+            }
+        }?;
         Ok(PromptDispatchOutcome {
             response,
             warnings,
@@ -749,11 +807,27 @@ pub fn map_anthropic_thinking_budget(e: Effort) -> u32 {
 }
 
 /// OpenAI `reasoning_effort` literal. Pass through verbatim.
+///
+/// Retained as the canonical Effort → wire-token table even after the
+/// main dispatch path switched to [`map_effort_to_reasoning_level`] +
+/// the connector's own per-model capability gate; keeps the mapping
+/// truth-source documented in one place for future providers.
+#[allow(dead_code)]
 pub fn map_openai_reasoning_effort(e: Effort) -> &'static str {
     match e {
         Effort::Low => "low",
         Effort::Medium => "medium",
         Effort::High => "high",
+    }
+}
+
+/// `Effort` → core-level [`ReasoningLevel`], used when threading the
+/// per-turn hint into the `LlmClient` trait.
+pub fn map_effort_to_reasoning_level(e: Effort) -> ReasoningLevel {
+    match e {
+        Effort::Low => ReasoningLevel::Low,
+        Effort::Medium => ReasoningLevel::Medium,
+        Effort::High => ReasoningLevel::High,
     }
 }
 
@@ -1072,5 +1146,306 @@ mod tests {
         // Either the network fails (empty list) or succeeds — both are OK
         // since we're just checking we don't hard-error when aggregating.
         let _ = svc.list_available_models(None, false).await;
+    }
+
+    // ----- RoutingConversationHandler dispatch-routing tests -----------
+    //
+    // These tests cover the per-turn routing logic added in #18:
+    // - priority resolution across override/stored/interactive
+    // - task-local reasoning config installation
+    // - per-connector effort mapping into ReasoningConfig
+    // - clean error on Unavailable connection
+
+    mod routing_dispatch {
+        use super::*;
+        use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationSummary};
+        use desktop_assistant_core::ports::inbound::{
+            ConversationService, PromptSelectionOverride,
+        };
+        use std::sync::Mutex as StdMutex;
+
+        /// Inner `ConversationService` mock that records each call. Dispatch
+        /// paths under test go through `RoutingConversationHandler ->
+        /// inner.send_prompt`, so we snapshot the task-local values at
+        /// dispatch time into the captured record.
+        struct CapturingInner {
+            captured_reasoning: StdMutex<Vec<ReasoningConfig>>,
+        }
+
+        impl CapturingInner {
+            fn new() -> Self {
+                Self {
+                    captured_reasoning: StdMutex::new(Vec::new()),
+                }
+            }
+        }
+
+        impl ConversationService for CapturingInner {
+            async fn create_conversation(
+                &self,
+                title: String,
+            ) -> Result<Conversation, CoreError> {
+                Ok(Conversation::new("c1", title))
+            }
+            async fn list_conversations(
+                &self,
+                _max_age_days: Option<u32>,
+                _include_archived: bool,
+            ) -> Result<Vec<ConversationSummary>, CoreError> {
+                Ok(vec![])
+            }
+            async fn get_conversation(
+                &self,
+                id: &ConversationId,
+            ) -> Result<Conversation, CoreError> {
+                Ok(Conversation::new(id.as_str(), "t"))
+            }
+            async fn delete_conversation(
+                &self,
+                _id: &ConversationId,
+            ) -> Result<(), CoreError> {
+                Ok(())
+            }
+            async fn rename_conversation(
+                &self,
+                _id: &ConversationId,
+                _title: String,
+            ) -> Result<(), CoreError> {
+                Ok(())
+            }
+            async fn archive_conversation(
+                &self,
+                _id: &ConversationId,
+            ) -> Result<(), CoreError> {
+                Ok(())
+            }
+            async fn unarchive_conversation(
+                &self,
+                _id: &ConversationId,
+            ) -> Result<(), CoreError> {
+                Ok(())
+            }
+            async fn clear_all_history(&self) -> Result<u32, CoreError> {
+                Ok(0)
+            }
+            async fn send_prompt(
+                &self,
+                _conversation_id: &ConversationId,
+                _prompt: String,
+                _on_chunk: desktop_assistant_core::ports::llm::ChunkCallback,
+                _on_status: desktop_assistant_core::ports::llm::StatusCallback,
+            ) -> Result<String, CoreError> {
+                // Snapshot the task-local reasoning config the routing
+                // wrapper installed on the calling scope; asserting on
+                // this value proves the plumbing actually propagates
+                // all the way to the point where the core dispatch
+                // loop would call `stream_completion`.
+                let cfg = desktop_assistant_core::ports::llm::current_reasoning_config();
+                self.captured_reasoning.lock().unwrap().push(cfg);
+                Ok("ok".to_string())
+            }
+        }
+
+        fn local_ollama_cfg() -> DaemonConfig {
+            let mut cfg = config_with_connections(&[
+                ("local", ollama_local()),
+                ("aws", bedrock_work()),
+            ]);
+            cfg.purposes.interactive = Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("llama3".into()),
+                effort: None,
+            });
+            cfg
+        }
+
+        fn make_handler() -> (
+            Arc<RoutingConversationHandler<InMemoryConversationSelectionStore, CapturingInner>>,
+            Arc<CapturingInner>,
+            Arc<RegistryHandle>,
+            Arc<InMemoryConversationSelectionStore>,
+        ) {
+            let cfg = local_ollama_cfg();
+            let registry = make_handle_with(cfg);
+            let inner = Arc::new(CapturingInner::new());
+            let store = Arc::new(InMemoryConversationSelectionStore::default());
+            let routing = Arc::new(RoutingConversationHandler::new(
+                Arc::clone(&inner),
+                Arc::clone(&store),
+                Arc::clone(&registry),
+            ));
+            (routing, inner, registry, store)
+        }
+
+        fn noop_cb() -> (
+            desktop_assistant_core::ports::llm::ChunkCallback,
+            desktop_assistant_core::ports::llm::StatusCallback,
+        ) {
+            (
+                Box::new(|_: String| -> bool { true }),
+                Box::new(|_: String| {}),
+            )
+        }
+
+        #[tokio::test]
+        async fn send_prompt_unknown_override_connection_errors() {
+            let (routing, _inner, _reg, _store) = make_handler();
+            let (on_chunk, on_status) = noop_cb();
+            let err = routing
+                .send_prompt_with_override(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    Some(PromptSelectionOverride {
+                        connection_id: "does-not-exist".into(),
+                        model_id: "llama3".into(),
+                        effort: None,
+                    }),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("does-not-exist") || msg.contains("not a live"),
+                "expected error mentioning the unknown connection; got: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn interactive_purpose_reasoning_maps_to_local_connector_no_op() {
+            // interactive purpose: local/llama3 (ollama) with no effort →
+            // reasoning config stays empty, dispatch proceeds to inner.
+            let (routing, inner, _reg, _store) = make_handler();
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("dispatch should succeed via interactive purpose");
+            let captured = inner.captured_reasoning.lock().unwrap();
+            assert_eq!(captured.len(), 1);
+            assert_eq!(captured[0], ReasoningConfig::default());
+        }
+
+        #[tokio::test]
+        async fn bedrock_override_maps_effort_to_thinking_budget() {
+            // Configure an override pointing at the Bedrock connection
+            // with Effort::High; the routing wrapper must translate it
+            // to a `ReasoningConfig { thinking_budget_tokens: Some(24_000) }`
+            // and install it on the task-local observed by the inner.
+            let cfg = {
+                let mut c = local_ollama_cfg();
+                // Point interactive at aws/claude so override-less path
+                // still routes to a Claude-shape connector; override
+                // sets the Bedrock connection explicitly below to
+                // exercise the mapping.
+                c.purposes.interactive = Some(PurposeConfig {
+                    connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+                    model: ModelRef::Named(
+                        "us.anthropic.claude-sonnet-4-6".into(),
+                    ),
+                    effort: None,
+                });
+                c
+            };
+            let registry = make_handle_with(cfg);
+            let inner = Arc::new(CapturingInner::new());
+            let store = Arc::new(InMemoryConversationSelectionStore::default());
+            let routing = Arc::new(RoutingConversationHandler::new(
+                Arc::clone(&inner),
+                Arc::clone(&store),
+                Arc::clone(&registry),
+            ));
+
+            // The override connection/model must pass the `list_models`
+            // gate — for Bedrock this hits the AWS SDK, which is not
+            // available in the test env. Since validation would fail,
+            // exercise the effort-mapping function directly rather than
+            // the end-to-end path. (The end-to-end routing is covered
+            // above via `send_prompt` with the interactive purpose.)
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping(
+                "bedrock",
+                "us.anthropic.claude-sonnet-4-6",
+                Some(Effort::High),
+            );
+            assert_eq!(cfg.thinking_budget_tokens, Some(24_000));
+            assert!(cfg.reasoning_effort.is_none());
+
+            // Route routing is still used: prove the handler exists and
+            // its `send_prompt` path sets the default reasoning when no
+            // effort is supplied.
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("plain send_prompt should succeed via interactive purpose");
+        }
+
+        #[test]
+        fn effort_mapping_openai_path() {
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping("openai", "gpt-5", Some(Effort::Medium));
+            assert_eq!(
+                cfg.reasoning_effort,
+                Some(ReasoningLevel::Medium),
+                "Medium effort must map to ReasoningLevel::Medium for OpenAI"
+            );
+            assert!(cfg.thinking_budget_tokens.is_none());
+        }
+
+        #[test]
+        fn effort_mapping_low_anthropic_disables_thinking() {
+            // Low effort maps to budget=0 which disables the thinking
+            // block entirely, even though the caller asked for
+            // Effort::Low. Matches the Anthropic semantics where a
+            // zero budget means "extended thinking disabled".
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping("anthropic", "claude-sonnet-4-6", Some(Effort::Low));
+            assert!(cfg.thinking_budget_tokens.is_none());
+        }
+
+        #[test]
+        fn effort_mapping_ollama_is_noop() {
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping("ollama", "llama3", Some(Effort::High));
+            assert_eq!(cfg, ReasoningConfig::default());
+        }
+
+        #[test]
+        fn effort_mapping_unknown_connector_is_noop() {
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping("mystery-vendor", "m1", Some(Effort::High));
+            assert_eq!(cfg, ReasoningConfig::default());
+        }
+
+        #[test]
+        fn effort_mapping_no_effort_returns_default() {
+            let cfg = RoutingConversationHandler::<
+                InMemoryConversationSelectionStore,
+                CapturingInner,
+            >::apply_effort_mapping("anthropic", "claude-sonnet-4-6", None);
+            assert_eq!(cfg, ReasoningConfig::default());
+        }
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -16,6 +16,7 @@ mod config;
 mod connections;
 mod purposes;
 mod registry;
+mod routing_llm;
 mod settings_service;
 mod store;
 mod tls;
@@ -1154,6 +1155,15 @@ async fn main() -> Result<()> {
     };
     let conversation_store = SharedConversationStore(Arc::new(inner_store));
 
+    // Wrap the interactive-purpose client in a `RoutingLlmClient`. The
+    // routing wrapper (`api_surface::RoutingConversationHandler`) installs
+    // a task-local per turn; when present, dispatch picks the registry's
+    // client for the resolved connection id. When absent (backend tasks,
+    // legacy callers without an override), the routing client falls back
+    // to this interactive-purpose client — preserving pre-#18 behaviour.
+    let fallback_client = Arc::new(llm);
+    let llm =
+        routing_llm::RoutingLlmClient::new(Arc::clone(&fallback_client), llm_connector.clone());
     let llm = RetryingLlmClient::new(llm, 3);
     let llm = MaybeProfiled::from_config(
         llm,
@@ -1180,7 +1190,16 @@ async fn main() -> Result<()> {
             resolved_bt.connector,
             resolved_bt.model
         );
+        let bt_connector = resolved_bt.connector.clone();
         let bt_llm = build_llm_client(resolved_bt);
+        // Backend-tasks dispatch never sees a per-turn routing override —
+        // title generation and context summary are initiated server-side.
+        // Wrapping in `RoutingLlmClient` with no task-local installed
+        // always dispatches to this backend-tasks fallback, but keeps the
+        // concrete type uniform with the primary handler's `L` so
+        // `with_backend_llm` accepts it.
+        let bt_fallback = Arc::new(bt_llm);
+        let bt_llm = routing_llm::RoutingLlmClient::new(bt_fallback, bt_connector);
         let bt_llm = RetryingLlmClient::new(bt_llm, 3);
         let bt_llm = MaybeProfiled::from_config(
             bt_llm,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -6,7 +6,7 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role};
 use desktop_assistant_core::ports::embedding::{EmbedFn, EmbeddingClient};
 use desktop_assistant_core::ports::inbound::SettingsService;
-use desktop_assistant_core::ports::llm::{LlmClient, RetryingLlmClient};
+use desktop_assistant_core::ports::llm::{LlmClient, ReasoningConfig, RetryingLlmClient};
 use desktop_assistant_core::ports::llm_profiling::MaybeProfiled;
 use tracing_subscriber::EnvFilter;
 
@@ -1071,7 +1071,12 @@ async fn main() -> Result<()> {
                                 Message::new(Role::User, user_prompt),
                             ];
                             let response = llm
-                                .stream_completion(messages, &[], Box::new(|_| true))
+                                .stream_completion(
+                                    messages,
+                                    &[],
+                                    ReasoningConfig::default(),
+                                    Box::new(|_| true),
+                                )
                                 .await
                                 .map_err(|e| e.to_string())?;
                             Ok(response.text)

--- a/crates/daemon/src/registry.rs
+++ b/crates/daemon/src/registry.rs
@@ -22,7 +22,9 @@ use std::fmt;
 
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, ToolDefinition, ToolNamespace};
-use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, LlmResponse, ModelInfo};
+use desktop_assistant_core::ports::llm::{
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
+};
 use indexmap::IndexMap;
 
 use crate::config::{
@@ -93,13 +95,26 @@ impl LlmClient for AnyLlmClient {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         match self {
-            Self::Anthropic(c) => c.stream_completion(messages, tools, on_chunk).await,
-            Self::Bedrock(c) => c.stream_completion(messages, tools, on_chunk).await,
-            Self::OpenAi(c) => c.stream_completion(messages, tools, on_chunk).await,
-            Self::Ollama(c) => c.stream_completion(messages, tools, on_chunk).await,
+            Self::Anthropic(c) => {
+                c.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
+            Self::Bedrock(c) => {
+                c.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
+            Self::OpenAi(c) => {
+                c.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
+            Self::Ollama(c) => {
+                c.stream_completion(messages, tools, reasoning, on_chunk)
+                    .await
+            }
         }
     }
 
@@ -116,16 +131,21 @@ impl LlmClient for AnyLlmClient {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         match self {
             Self::Anthropic(c) => {
-                c.stream_completion_with_namespaces(messages, core_tools, namespaces, on_chunk)
-                    .await
+                c.stream_completion_with_namespaces(
+                    messages, core_tools, namespaces, reasoning, on_chunk,
+                )
+                .await
             }
             Self::OpenAi(c) => {
-                c.stream_completion_with_namespaces(messages, core_tools, namespaces, on_chunk)
-                    .await
+                c.stream_completion_with_namespaces(
+                    messages, core_tools, namespaces, reasoning, on_chunk,
+                )
+                .await
             }
             // Bedrock/Ollama: use default flattening behavior
             _ => {
@@ -133,7 +153,8 @@ impl LlmClient for AnyLlmClient {
                 for ns in namespaces {
                     all.extend(ns.tools.iter().cloned());
                 }
-                self.stream_completion(messages, &all, on_chunk).await
+                self.stream_completion(messages, &all, reasoning, on_chunk)
+                    .await
             }
         }
     }

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -1,0 +1,292 @@
+//! Per-turn dispatch client used by [`crate::api_surface::RoutingConversationHandler`]
+//! to swap the underlying [`AnyLlmClient`] based on the resolved
+//! `(connection_id, model_id, effort)` triple for each `send_prompt`.
+//!
+//! Rationale (issue #18): the core `ConversationHandler` owns a single
+//! `llm: L` field baked into its type parameters. Rebuilding the handler
+//! per turn is impractical (shared `namespace_cache`, non-`Clone`
+//! `id_generator`), and plumbing a per-call client argument through the
+//! ~450-line `send_prompt` would be a very invasive change.
+//!
+//! Instead we install this wrapper as the handler's `L`. It looks up the
+//! target `AnyLlmClient` on each call via a [`tokio::task_local!`] slot
+//! populated by the daemon-side routing wrapper. When the slot is unset
+//! (e.g. backend-tasks, background jobs), dispatch falls through to a
+//! statically-configured fallback — the interactive-purpose client at
+//! daemon startup.
+//!
+//! Concurrency: `tokio::task_local!` is per-task, so two concurrent
+//! `send_prompt` calls on different conversations each see their own
+//! routing target without coupling.
+
+use std::sync::Arc;
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Message, ToolDefinition, ToolNamespace};
+use desktop_assistant_core::ports::llm::{
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
+};
+
+use crate::connections::ConnectionId;
+use crate::registry::AnyLlmClient;
+
+tokio::task_local! {
+    /// Per-turn routing override. When set, dispatch uses the contained
+    /// `Arc<AnyLlmClient>` (resolved from the registry) instead of the
+    /// [`RoutingLlmClient`]'s static fallback. Populated by
+    /// [`with_active_client`] from inside the routing wrapper.
+    static ACTIVE_CLIENT: Arc<AnyLlmClient>;
+}
+
+/// Run `fut` with `client` installed as the current turn's active LLM
+/// client. All `stream_completion(_with_namespaces)` calls on the
+/// enclosing [`RoutingLlmClient`] observe `client` and dispatch to it.
+pub async fn with_active_client<F, T>(client: Arc<AnyLlmClient>, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    ACTIVE_CLIENT.scope(client, fut).await
+}
+
+/// The handler's LLM facade. Delegates to the per-turn active client when
+/// one is installed, or to the static fallback otherwise.
+///
+/// Note that `list_models`, capability flags, and default-model accessors
+/// always delegate to the fallback — they describe the handler's
+/// configured interactive model and are not meaningfully per-turn.
+#[derive(Clone)]
+pub struct RoutingLlmClient {
+    /// Client used when no task-local override is installed (e.g. title
+    /// generation run outside `send_prompt`, dreaming jobs that own
+    /// their own `llm` handle).
+    fallback: Arc<AnyLlmClient>,
+    /// Static fallback connector-type tag. Only used for diagnostics.
+    #[allow(dead_code)]
+    fallback_connector_type: String,
+}
+
+impl RoutingLlmClient {
+    pub fn new(fallback: Arc<AnyLlmClient>, fallback_connector_type: String) -> Self {
+        Self {
+            fallback,
+            fallback_connector_type,
+        }
+    }
+
+    /// Resolve the current turn's active client. Returns the task-local
+    /// override if set, or the static fallback otherwise.
+    fn resolve(&self) -> Arc<AnyLlmClient> {
+        ACTIVE_CLIENT
+            .try_with(|c| Arc::clone(c))
+            .unwrap_or_else(|_| Arc::clone(&self.fallback))
+    }
+}
+
+impl LlmClient for RoutingLlmClient {
+    fn get_default_model(&self) -> Option<&str> {
+        // `Option<&str>` borrows from `self`; we can't delegate through the
+        // task-local (which returns an Arc). Delegation to the fallback is
+        // correct since this accessor reports the statically configured
+        // default, not the per-turn model.
+        self.fallback.get_default_model()
+    }
+
+    fn get_default_base_url(&self) -> Option<&str> {
+        self.fallback.get_default_base_url()
+    }
+
+    fn max_context_tokens(&self) -> Option<u64> {
+        self.resolve().max_context_tokens()
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        // Callers of `list_models` are typically the connections-management
+        // API, which resolves clients directly from the registry — not
+        // through the routing wrapper. Keep this consistent with
+        // connector-level behaviour and delegate to whichever client is
+        // currently active (task-local or fallback).
+        self.resolve().list_models().await
+    }
+
+    async fn refresh_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        self.resolve().refresh_models().await
+    }
+
+    async fn stream_completion(
+        &self,
+        messages: Vec<Message>,
+        tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let client = self.resolve();
+        client
+            .stream_completion(messages, tools, reasoning, on_chunk)
+            .await
+    }
+
+    fn supports_hosted_tool_search(&self) -> bool {
+        // The flag gates how `ConversationHandler` assembles the tool
+        // list at the start of a turn, before any task-local is
+        // consulted. Report the fallback's capability so the handler's
+        // choice is consistent with what dispatch will actually support
+        // in the absence of per-turn routing.
+        self.fallback.supports_hosted_tool_search()
+    }
+
+    async fn stream_completion_with_namespaces(
+        &self,
+        messages: Vec<Message>,
+        core_tools: &[ToolDefinition],
+        namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let client = self.resolve();
+        client
+            .stream_completion_with_namespaces(
+                messages, core_tools, namespaces, reasoning, on_chunk,
+            )
+            .await
+    }
+}
+
+/// Look up a connection id's live client on the registry. Wraps the
+/// existing `RegistryHandle::client_for` so [`crate::api_surface`] can
+/// hand a concrete `Arc<AnyLlmClient>` into [`with_active_client`]
+/// without pulling the `crate::registry` internals into the public API.
+#[allow(dead_code)]
+pub fn resolve_client(
+    registry: &crate::api_surface::RegistryHandle,
+    id: &ConnectionId,
+) -> Option<Arc<AnyLlmClient>> {
+    registry.client_for(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connections::{ConnectionConfig, OllamaConnection};
+    use crate::registry::build_registry;
+    use desktop_assistant_core::CoreError;
+    use desktop_assistant_core::domain::Message;
+    use desktop_assistant_core::ports::llm::ReasoningConfig;
+    use indexmap::IndexMap;
+
+    fn build_ollama_registry() -> Arc<AnyLlmClient> {
+        let mut cfg = crate::config::DaemonConfig::default();
+        cfg.connections = IndexMap::from([(
+            "local".to_string(),
+            ConnectionConfig::Ollama(OllamaConnection {
+                base_url: Some("http://localhost:11434".into()),
+            }),
+        )]);
+        let registry = build_registry(&cfg);
+        let id = ConnectionId::new("local").unwrap();
+        registry.get(&id).unwrap()
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_static_when_no_task_local() {
+        let fallback = build_ollama_registry();
+        let client = RoutingLlmClient::new(Arc::clone(&fallback), "ollama".into());
+        // Without a task-local override, `resolve()` must equal the
+        // fallback pointer.
+        let resolved = client.resolve();
+        assert!(
+            Arc::ptr_eq(&resolved, &fallback),
+            "resolve() should return fallback when task-local is unset"
+        );
+    }
+
+    #[tokio::test]
+    async fn uses_task_local_override_when_set() {
+        let fallback = build_ollama_registry();
+        // Build a second distinct Ollama client so we can Arc-ptr compare.
+        let override_client = build_ollama_registry();
+        assert!(
+            !Arc::ptr_eq(&fallback, &override_client),
+            "test setup: fallback and override must be distinct"
+        );
+
+        let client = RoutingLlmClient::new(Arc::clone(&fallback), "ollama".into());
+
+        let override_clone = Arc::clone(&override_client);
+        let resolved = with_active_client(override_client, async move {
+            client.resolve()
+        })
+        .await;
+        assert!(
+            Arc::ptr_eq(&resolved, &override_clone),
+            "resolve() must return the task-local override when set"
+        );
+    }
+
+    /// A mock `AnyLlmClient` variant is overkill for this test; we simply
+    /// verify the dispatch does not panic and returns the fallback's
+    /// error (there's no real server), which proves the delegation
+    /// compiles and reaches the inner client.
+    #[tokio::test]
+    async fn stream_completion_delegates_to_resolved_client() {
+        let fallback = build_ollama_registry();
+        let client = RoutingLlmClient::new(fallback, "ollama".into());
+        let _ = client
+            .stream_completion(
+                vec![Message::new(
+                    desktop_assistant_core::domain::Role::User,
+                    "hi",
+                )],
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await;
+        // Result will be an `Err` (no ollama server), but the call
+        // path itself must complete without panicking.
+    }
+
+    fn _assert_llm_client_impl<L: LlmClient>() {}
+    fn _assert_routing_client_implements_llm_client() {
+        _assert_llm_client_impl::<RoutingLlmClient>();
+    }
+
+    #[test]
+    fn missing_connection_id_returns_none() {
+        let registry_handle = {
+            let mut cfg = crate::config::DaemonConfig::default();
+            cfg.connections = IndexMap::from([(
+                "local".to_string(),
+                ConnectionConfig::Ollama(OllamaConnection {
+                    base_url: Some("http://localhost:11434".into()),
+                }),
+            )]);
+            let reg = build_registry(&cfg);
+            Arc::new(crate::api_surface::RegistryHandle::new(cfg, reg))
+        };
+        let missing = ConnectionId::new("nonexistent").unwrap();
+        assert!(resolve_client(&registry_handle, &missing).is_none());
+    }
+
+    #[test]
+    fn existing_connection_id_resolves() {
+        let registry_handle = {
+            let mut cfg = crate::config::DaemonConfig::default();
+            cfg.connections = IndexMap::from([(
+                "local".to_string(),
+                ConnectionConfig::Ollama(OllamaConnection {
+                    base_url: Some("http://localhost:11434".into()),
+                }),
+            )]);
+            let reg = build_registry(&cfg);
+            Arc::new(crate::api_surface::RegistryHandle::new(cfg, reg))
+        };
+        let id = ConnectionId::new("local").unwrap();
+        assert!(resolve_client(&registry_handle, &id).is_some());
+    }
+
+    #[test]
+    fn unused_core_error_type_still_compiles() {
+        // Make sure the CoreError import isn't elided by mistake.
+        let _e: Option<CoreError> = None;
+    }
+}

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -174,13 +174,15 @@ mod tests {
     use indexmap::IndexMap;
 
     fn build_ollama_registry() -> Arc<AnyLlmClient> {
-        let mut cfg = crate::config::DaemonConfig::default();
-        cfg.connections = IndexMap::from([(
-            "local".to_string(),
-            ConnectionConfig::Ollama(OllamaConnection {
-                base_url: Some("http://localhost:11434".into()),
-            }),
-        )]);
+        let cfg = crate::config::DaemonConfig {
+            connections: IndexMap::from([(
+                "local".to_string(),
+                ConnectionConfig::Ollama(OllamaConnection {
+                    base_url: Some("http://localhost:11434".into()),
+                }),
+            )]),
+            ..crate::config::DaemonConfig::default()
+        };
         let registry = build_registry(&cfg);
         let id = ConnectionId::new("local").unwrap();
         registry.get(&id).unwrap()
@@ -250,36 +252,30 @@ mod tests {
         _assert_llm_client_impl::<RoutingLlmClient>();
     }
 
-    #[test]
-    fn missing_connection_id_returns_none() {
-        let registry_handle = {
-            let mut cfg = crate::config::DaemonConfig::default();
-            cfg.connections = IndexMap::from([(
+    fn build_local_ollama_handle() -> Arc<crate::api_surface::RegistryHandle> {
+        let cfg = crate::config::DaemonConfig {
+            connections: IndexMap::from([(
                 "local".to_string(),
                 ConnectionConfig::Ollama(OllamaConnection {
                     base_url: Some("http://localhost:11434".into()),
                 }),
-            )]);
-            let reg = build_registry(&cfg);
-            Arc::new(crate::api_surface::RegistryHandle::new(cfg, reg))
+            )]),
+            ..crate::config::DaemonConfig::default()
         };
+        let reg = build_registry(&cfg);
+        Arc::new(crate::api_surface::RegistryHandle::new(cfg, reg))
+    }
+
+    #[test]
+    fn missing_connection_id_returns_none() {
+        let registry_handle = build_local_ollama_handle();
         let missing = ConnectionId::new("nonexistent").unwrap();
         assert!(resolve_client(&registry_handle, &missing).is_none());
     }
 
     #[test]
     fn existing_connection_id_resolves() {
-        let registry_handle = {
-            let mut cfg = crate::config::DaemonConfig::default();
-            cfg.connections = IndexMap::from([(
-                "local".to_string(),
-                ConnectionConfig::Ollama(OllamaConnection {
-                    base_url: Some("http://localhost:11434".into()),
-                }),
-            )]);
-            let reg = build_registry(&cfg);
-            Arc::new(crate::api_surface::RegistryHandle::new(cfg, reg))
-        };
+        let registry_handle = build_local_ollama_handle();
         let id = ConnectionId::new("local").unwrap();
         assert!(resolve_client(&registry_handle, &id).is_some());
     }

--- a/crates/daemon/tests/conversation.rs
+++ b/crates/daemon/tests/conversation.rs
@@ -6,7 +6,7 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::ToolDefinition;
 use desktop_assistant_core::domain::{ConversationId, Message, Role};
 use desktop_assistant_core::ports::inbound::ConversationService;
-use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, LlmResponse};
+use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, LlmResponse, ReasoningConfig};
 use desktop_assistant_core::ports::store::ConversationStore;
 use desktop_assistant_core::service::ConversationHandler;
 use std::collections::HashMap;
@@ -126,6 +126,7 @@ impl LlmClient for TestLlm {
         &self,
         _messages: Vec<Message>,
         _tools: &[ToolDefinition],
+        _reasoning: ReasoningConfig,
         mut on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let mut full = String::new();

--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -1,7 +1,8 @@
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition, ToolNamespace};
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, TokenUsage,
+    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
+    TokenUsage,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -121,6 +122,29 @@ struct SystemBlock {
     cache_control: CacheControl,
 }
 
+/// Anthropic extended-thinking configuration block.
+///
+/// Serialized into the request body as `"thinking": { "type": "enabled",
+/// "budget_tokens": N }` when reasoning is requested. See the Anthropic
+/// Messages API reference for the exact schema; this client emits the
+/// `enabled` variant only — `disabled` is represented by omitting the
+/// field entirely.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+struct ThinkingConfig {
+    #[serde(rename = "type")]
+    mode: &'static str,
+    budget_tokens: u32,
+}
+
+impl ThinkingConfig {
+    fn enabled(budget: u32) -> Self {
+        Self {
+            mode: "enabled",
+            budget_tokens: budget,
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct MessagesRequest {
     model: String,
@@ -135,6 +159,8 @@ struct MessagesRequest {
     stream: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<AnthropicTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -231,6 +257,8 @@ struct MessagesRequestWithToolSearch {
     stream: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<AnthropicToolEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
 }
 
 /// Convert domain messages into Anthropic API messages, extracting the system prompt.
@@ -620,20 +648,25 @@ impl LlmClient for AnthropicClient {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let api_tools: Vec<AnthropicTool> = tools.iter().map(AnthropicTool::from).collect();
         let (system, api_messages) = convert_messages(&messages);
 
+        let thinking = thinking_for(reasoning);
+        let max_tokens = effective_max_tokens(self.max_tokens, thinking.as_ref());
+
         let request = MessagesRequest {
             model: self.model.clone(),
-            max_tokens: self.max_tokens,
+            max_tokens,
             temperature: self.temperature,
             top_p: self.top_p,
             system,
             messages: api_messages,
             stream: true,
             tools: api_tools,
+            thinking,
         };
 
         let request_json =
@@ -652,6 +685,7 @@ impl LlmClient for AnthropicClient {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let (system, api_messages) = convert_messages(&messages);
@@ -677,15 +711,19 @@ impl LlmClient for AnthropicClient {
             name: "tool_search_tool_regex".to_string(),
         }));
 
+        let thinking = thinking_for(reasoning);
+        let max_tokens = effective_max_tokens(self.max_tokens, thinking.as_ref());
+
         let request = MessagesRequestWithToolSearch {
             model: self.model.clone(),
-            max_tokens: self.max_tokens,
+            max_tokens,
             temperature: self.temperature,
             top_p: self.top_p,
             system,
             messages: api_messages,
             stream: true,
             tools: tool_entries,
+            thinking,
         };
 
         let request_json =
@@ -700,6 +738,40 @@ impl LlmClient for AnthropicClient {
         self.send_and_stream(&request_json, &request, on_chunk)
             .await
     }
+}
+
+/// Build a `ThinkingConfig` from the per-turn reasoning hint.
+///
+/// Rules:
+/// - `None` or `Some(0)` → no thinking block (omit the field).
+/// - `Some(N > 0)` → `{ type: "enabled", budget_tokens: N }`. The caller is
+///   responsible for ensuring `max_tokens > budget_tokens`; see
+///   [`effective_max_tokens`].
+fn thinking_for(reasoning: ReasoningConfig) -> Option<ThinkingConfig> {
+    match reasoning.thinking_budget_tokens {
+        Some(n) if n > 0 => Some(ThinkingConfig::enabled(n)),
+        _ => None,
+    }
+}
+
+/// Minimum headroom for the final visible response on top of the thinking
+/// budget. Anthropic requires `max_tokens > budget_tokens`, and real
+/// responses need enough room to emit both the thinking trace and the
+/// reply; we reserve 2048 tokens for the reply by default.
+const MIN_OUTPUT_HEADROOM_TOKENS: u32 = 2048;
+
+/// Compute the effective `max_tokens` for a request.
+///
+/// Anthropic's API rejects requests whose `budget_tokens` is not strictly
+/// less than `max_tokens`. When the configured `max_tokens` isn't large
+/// enough to host both the thinking budget and a non-trivial reply, bump
+/// it up to `budget + MIN_OUTPUT_HEADROOM_TOKENS`.
+fn effective_max_tokens(configured: u32, thinking: Option<&ThinkingConfig>) -> u32 {
+    let Some(t) = thinking else {
+        return configured;
+    };
+    let needed = t.budget_tokens.saturating_add(MIN_OUTPUT_HEADROOM_TOKENS);
+    configured.max(needed)
 }
 
 fn accumulate_usage(acc: &mut SseUsage, new: &SseUsage) {
@@ -962,6 +1034,7 @@ mod tests {
             messages: vec![],
             stream: true,
             tools: vec![],
+            thinking: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("tools"));
@@ -983,6 +1056,7 @@ mod tests {
             messages: vec![],
             stream: true,
             tools: vec![AnthropicTool::from(&def)],
+            thinking: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"tools\""));
@@ -1005,6 +1079,7 @@ mod tests {
             messages: vec![],
             stream: true,
             tools: vec![],
+            thinking: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"system\""));
@@ -1110,9 +1185,92 @@ mod tests {
             messages: vec![],
             stream: true,
             tools: vec![],
+            thinking: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("system"));
+    }
+
+    // --- Extended-thinking (reasoning) wiring ----------------------------
+
+    #[test]
+    fn thinking_for_omitted_when_no_budget() {
+        assert!(thinking_for(ReasoningConfig::default()).is_none());
+        assert!(
+            thinking_for(ReasoningConfig::with_thinking_budget(0)).is_none(),
+            "budget=0 should disable thinking"
+        );
+    }
+
+    #[test]
+    fn thinking_for_emits_enabled_block_for_positive_budget() {
+        let t = thinking_for(ReasoningConfig::with_thinking_budget(8_000)).unwrap();
+        assert_eq!(t.mode, "enabled");
+        assert_eq!(t.budget_tokens, 8_000);
+    }
+
+    #[test]
+    fn effective_max_tokens_unchanged_without_thinking() {
+        assert_eq!(effective_max_tokens(8_192, None), 8_192);
+    }
+
+    #[test]
+    fn effective_max_tokens_bumps_up_when_budget_exceeds_configured() {
+        let thinking = ThinkingConfig::enabled(24_000);
+        // Configured max_tokens (8_192) is LESS than budget (24_000); needs bump.
+        let mt = effective_max_tokens(8_192, Some(&thinking));
+        assert!(mt > 24_000, "max_tokens should strictly exceed budget");
+        assert_eq!(mt, 24_000 + MIN_OUTPUT_HEADROOM_TOKENS);
+    }
+
+    #[test]
+    fn effective_max_tokens_preserves_configured_when_large_enough() {
+        let thinking = ThinkingConfig::enabled(4_000);
+        // Configured max_tokens (16_000) already has >2k headroom above 4_000.
+        let mt = effective_max_tokens(16_000, Some(&thinking));
+        assert_eq!(mt, 16_000);
+    }
+
+    #[test]
+    fn request_includes_thinking_when_reasoning_enabled() {
+        let thinking = thinking_for(ReasoningConfig::with_thinking_budget(8_000));
+        let req = MessagesRequest {
+            model: "claude-sonnet-4-6-20260227".into(),
+            max_tokens: effective_max_tokens(8_192, thinking.as_ref()),
+            temperature: None,
+            top_p: None,
+            system: vec![],
+            messages: vec![],
+            stream: true,
+            tools: vec![],
+            thinking,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["thinking"]["type"], "enabled");
+        assert_eq!(parsed["thinking"]["budget_tokens"], 8_000);
+        assert!(parsed["max_tokens"].as_u64().unwrap() > 8_000);
+    }
+
+    #[test]
+    fn request_omits_thinking_when_reasoning_disabled() {
+        let thinking = thinking_for(ReasoningConfig::default());
+        let req = MessagesRequest {
+            model: "claude-sonnet-4-6-20260227".into(),
+            max_tokens: 8_192,
+            temperature: None,
+            top_p: None,
+            system: vec![],
+            messages: vec![],
+            stream: true,
+            tools: vec![],
+            thinking,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            !json.contains("thinking"),
+            "thinking field must be omitted when reasoning is off; got: {json}"
+        );
     }
 
     #[tokio::test]

--- a/crates/llm-bedrock/src/lib.rs
+++ b/crates/llm-bedrock/src/lib.rs
@@ -11,7 +11,8 @@ use aws_smithy_types::{Document, Number};
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition};
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, TokenUsage,
+    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
+    TokenUsage,
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -747,6 +748,7 @@ impl LlmClient for BedrockClient {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         mut on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let client = self.client().await?;
@@ -791,6 +793,14 @@ impl LlmClient for BedrockClient {
         }
         if let Some(cfg) = tool_config {
             request = request.tool_config(cfg);
+        }
+
+        // Extended-thinking reasoning for Claude-family Bedrock models.
+        // Passed via `additional_model_request_fields` with the same
+        // `thinking: { type: "enabled", budget_tokens: N }` shape as the
+        // Anthropic native API. For non-Claude models this is a no-op.
+        if let Some(extra) = build_additional_model_request_fields(&self.model, reasoning) {
+            request = request.additional_model_request_fields(extra);
         }
 
         let response = request.send().await.map_err(|e| {
@@ -872,6 +882,54 @@ impl LlmClient for BedrockClient {
     }
 }
 
+/// Recognize Claude-family Bedrock model ids. Only Claude models accept
+/// the `thinking` extended-thinking block via `additionalModelRequestFields`.
+///
+/// Matches both the legacy `anthropic.claude-*` names and the cross-region
+/// inference profile aliases (`us.anthropic.claude-*`, `eu.anthropic.claude-*`,
+/// `apac.anthropic.claude-*`).
+fn is_claude_bedrock_model(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("anthropic.claude")
+}
+
+/// Build the `additionalModelRequestFields` Document for a Bedrock
+/// Converse request, translating the per-turn reasoning hint into the
+/// per-vendor shape.
+///
+/// - Claude-family: `{"thinking": {"type": "enabled", "budget_tokens": N}}`
+/// - Others: `None` (unrecognized field would cause a 400).
+///
+/// Returns `None` when no reasoning is requested or when the model is
+/// not known to support extended thinking.
+fn build_additional_model_request_fields(
+    model: &str,
+    reasoning: ReasoningConfig,
+) -> Option<Document> {
+    use std::collections::HashMap;
+    let budget = match reasoning.thinking_budget_tokens {
+        Some(n) if n > 0 => n,
+        _ => return None,
+    };
+    if !is_claude_bedrock_model(model) {
+        tracing::debug!(
+            model,
+            budget,
+            "Bedrock reasoning requested but model is not Claude-family; dropping thinking field"
+        );
+        return None;
+    }
+    let mut thinking: HashMap<String, Document> = HashMap::new();
+    thinking.insert("type".to_string(), Document::String("enabled".to_string()));
+    thinking.insert(
+        "budget_tokens".to_string(),
+        Document::Number(Number::PosInt(u64::from(budget))),
+    );
+    let mut root: HashMap<String, Document> = HashMap::new();
+    root.insert("thinking".to_string(), Document::Object(thinking));
+    Some(Document::Object(root))
+}
+
 fn json_to_document(value: serde_json::Value) -> Document {
     match value {
         serde_json::Value::Null => Document::Null,
@@ -905,6 +963,59 @@ mod tests {
         ConverseStreamOutput, ToolUseBlockDelta, ToolUseBlockStart,
     };
     use std::sync::{Arc, Mutex};
+
+    // --- Extended-thinking (reasoning) wiring ----------------------------
+
+    #[test]
+    fn claude_bedrock_model_detection() {
+        assert!(is_claude_bedrock_model("anthropic.claude-opus-4-1"));
+        assert!(is_claude_bedrock_model("us.anthropic.claude-sonnet-4-6"));
+        assert!(is_claude_bedrock_model("eu.anthropic.claude-haiku-4-5"));
+        assert!(!is_claude_bedrock_model("amazon.titan-text-express-v1"));
+        assert!(!is_claude_bedrock_model("meta.llama3-70b"));
+    }
+
+    #[test]
+    fn additional_model_request_fields_none_when_no_budget() {
+        assert!(
+            build_additional_model_request_fields(
+                "us.anthropic.claude-sonnet-4-6",
+                ReasoningConfig::default(),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn additional_model_request_fields_none_for_non_claude_with_budget() {
+        let cfg = ReasoningConfig::with_thinking_budget(8_000);
+        assert!(
+            build_additional_model_request_fields("meta.llama3-70b", cfg).is_none(),
+            "thinking must not be forwarded to non-Claude Bedrock models"
+        );
+    }
+
+    #[test]
+    fn additional_model_request_fields_shape_matches_anthropic_native() {
+        let cfg = ReasoningConfig::with_thinking_budget(24_000);
+        let doc = build_additional_model_request_fields("us.anthropic.claude-opus-4-1", cfg)
+            .expect("thinking doc expected for Claude model");
+        let Document::Object(root) = doc else {
+            panic!("expected object at root");
+        };
+        let thinking = match root.get("thinking") {
+            Some(Document::Object(t)) => t,
+            _ => panic!("missing `thinking` key"),
+        };
+        assert!(
+            matches!(thinking.get("type"), Some(Document::String(s)) if s == "enabled"),
+            "thinking.type must be \"enabled\""
+        );
+        match thinking.get("budget_tokens") {
+            Some(Document::Number(Number::PosInt(n))) => assert_eq!(*n, 24_000),
+            other => panic!("budget_tokens shape unexpected: {other:?}"),
+        }
+    }
 
     #[test]
     fn region_parsing_supports_raw_region() {

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -1,7 +1,8 @@
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition};
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, TokenUsage,
+    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
+    TokenUsage,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -535,8 +536,18 @@ impl LlmClient for OllamaClient {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         mut on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
+        // Ollama exposes no standardized reasoning/thinking knob across
+        // community models; log at debug and otherwise ignore. See #18.
+        if !reasoning.is_empty() {
+            tracing::debug!(
+                model = %self.model,
+                ?reasoning,
+                "reasoning hint ignored on Ollama connector (no-op)"
+            );
+        }
         self.ensure_model_available().await?;
 
         let chat_tools: Vec<ChatTool> = tools.iter().map(ChatTool::from).collect();
@@ -929,6 +940,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "hi")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await
@@ -939,6 +951,7 @@ mod tests {
             .stream_completion(
                 vec![Message::new(Role::User, "again")],
                 &[],
+                ReasoningConfig::default(),
                 Box::new(|_| true),
             )
             .await

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition, ToolNamespace};
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, TokenUsage,
+    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
+    TokenUsage,
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -133,6 +134,16 @@ impl OpenAiClient {
 // Responses API – request serialization types
 // ---------------------------------------------------------------------------
 
+/// OpenAI Responses-API reasoning block (`{ "effort": "low|medium|high" }`).
+///
+/// Emitted only for reasoning-capable models (see
+/// [`model_supports_reasoning`]). For non-reasoning models the field is
+/// omitted entirely; sending it there causes a 400 from the API.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+struct ReasoningBlock {
+    effort: &'static str,
+}
+
 /// Unified request body for the Responses API (`POST /v1/responses`).
 #[derive(Serialize)]
 struct ResponsesRequest {
@@ -149,6 +160,8 @@ struct ResponsesRequest {
     top_p: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<ReasoningBlock>,
 }
 
 /// Heterogeneous input items for the Responses API.
@@ -629,6 +642,50 @@ impl OpenAiClient {
 /// (o1, o3, o4) and any GPT-5 variant that exposes reasoning traces.
 // TODO(#7): fetch `/v1/models` and merge with this table so newly
 // released models surface automatically.
+/// True when `model` is one of the curated OpenAI models flagged as
+/// reasoning-capable. Used to gate the `reasoning.effort` field on
+/// requests — sending it for non-reasoning models (e.g. `gpt-4o`) is a
+/// 400 from the API, so we silently drop it with a debug log.
+///
+/// Matches by exact id AND common prefixes (e.g. `gpt-5-mini-2025…`), so
+/// custom pinned versions resolve the same way as their family name.
+fn model_supports_reasoning(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    // Exact id match against the curated capabilities table.
+    if curated_openai_models()
+        .iter()
+        .any(|c| c.id.eq_ignore_ascii_case(model) && c.capabilities.reasoning)
+    {
+        return true;
+    }
+    // Prefix heuristics for pinned/versioned ids not in the curated table.
+    //   o-series: `o1`, `o1-mini`, `o3`, `o3-mini`, `o4-mini`, …
+    //   GPT-5 reasoning: `gpt-5`, `gpt-5-mini`, `gpt-5.4`, …
+    let is_o_series = m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4");
+    let is_gpt5 = m.starts_with("gpt-5");
+    is_o_series || is_gpt5
+}
+
+/// Build a `ReasoningBlock` from the per-turn reasoning hint, honoring
+/// the per-model capability gate. Returns `None` for non-reasoning
+/// models (debug-logged) and when no effort is requested.
+fn reasoning_for(model: &str, reasoning: ReasoningConfig) -> Option<ReasoningBlock> {
+    let Some(level) = reasoning.reasoning_effort else {
+        return None;
+    };
+    if !model_supports_reasoning(model) {
+        tracing::debug!(
+            model,
+            requested_effort = ?level,
+            "OpenAI reasoning_effort requested but model is not reasoning-capable; dropping field"
+        );
+        return None;
+    }
+    Some(ReasoningBlock {
+        effort: level.as_openai_effort(),
+    })
+}
+
 fn curated_openai_models() -> Vec<ModelInfo> {
     let chat_caps = ModelCapabilities {
         reasoning: false,
@@ -716,6 +773,7 @@ impl LlmClient for OpenAiClient {
         &self,
         messages: Vec<Message>,
         tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let (input, instructions) = convert_messages(&messages);
@@ -723,6 +781,8 @@ impl LlmClient for OpenAiClient {
             .iter()
             .map(|t| ToolEntry::Function(FunctionTool::from_definition(t)))
             .collect();
+
+        let reasoning_block = reasoning_for(&self.model, reasoning);
 
         let request = ResponsesRequest {
             model: self.model.clone(),
@@ -733,6 +793,7 @@ impl LlmClient for OpenAiClient {
             temperature: self.temperature,
             top_p: self.top_p,
             max_output_tokens: self.max_tokens,
+            reasoning: reasoning_block,
         };
 
         let request_json =
@@ -751,6 +812,7 @@ impl LlmClient for OpenAiClient {
         messages: Vec<Message>,
         core_tools: &[ToolDefinition],
         namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
         on_chunk: ChunkCallback,
     ) -> Result<LlmResponse, CoreError> {
         let (input, instructions) = convert_messages(&messages);
@@ -768,6 +830,8 @@ impl LlmClient for OpenAiClient {
             r#type: "tool_search".to_string(),
         }));
 
+        let reasoning_block = reasoning_for(&self.model, reasoning);
+
         let request = ResponsesRequest {
             model: self.model.clone(),
             input,
@@ -777,6 +841,7 @@ impl LlmClient for OpenAiClient {
             temperature: self.temperature,
             top_p: self.top_p,
             max_output_tokens: self.max_tokens,
+            reasoning: reasoning_block,
         };
 
         let request_json =
@@ -796,6 +861,7 @@ impl LlmClient for OpenAiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use desktop_assistant_core::ports::llm::ReasoningLevel;
 
     // --- convert_messages tests ---
 
@@ -970,6 +1036,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: Some(1024),
+            reasoning: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("max_output_tokens"));
@@ -987,6 +1054,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            reasoning: None,
         };
         let json: serde_json::Value = serde_json::to_value(&req).unwrap();
         assert_eq!(json["instructions"], "Be helpful.");
@@ -1003,6 +1071,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            reasoning: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("tools"));
@@ -1020,6 +1089,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            reasoning: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"tools\""));
@@ -1056,6 +1126,7 @@ mod tests {
             temperature: None,
             top_p: None,
             max_output_tokens: None,
+            reasoning: None,
         };
 
         let json: serde_json::Value = serde_json::to_value(&req).unwrap();
@@ -1064,6 +1135,91 @@ mod tests {
         assert_eq!(tools[0]["type"], "function");
         assert_eq!(tools[1]["type"], "namespace");
         assert_eq!(tools[2]["type"], "tool_search");
+    }
+
+    // --- Reasoning / effort tests ----------------------------------------
+
+    #[test]
+    fn model_supports_reasoning_curated_ids() {
+        assert!(model_supports_reasoning("gpt-5"));
+        assert!(model_supports_reasoning("gpt-5-mini"));
+        assert!(model_supports_reasoning("gpt-5.4"));
+        assert!(model_supports_reasoning("o3"));
+        assert!(model_supports_reasoning("o3-mini"));
+        assert!(model_supports_reasoning("o4-mini"));
+    }
+
+    #[test]
+    fn model_supports_reasoning_rejects_chat_models() {
+        assert!(!model_supports_reasoning("gpt-4o"));
+        assert!(!model_supports_reasoning("gpt-4o-mini"));
+        assert!(!model_supports_reasoning("gpt-4.1"));
+    }
+
+    #[test]
+    fn model_supports_reasoning_prefix_heuristic_versioned_ids() {
+        // Pinned versions not in the curated list still resolve correctly.
+        assert!(model_supports_reasoning("o1-2024-12-17"));
+        assert!(model_supports_reasoning("gpt-5-mini-2025-09-01"));
+        assert!(!model_supports_reasoning("gpt-4o-2024-11-20"));
+    }
+
+    #[test]
+    fn reasoning_for_omits_when_no_effort_requested() {
+        assert!(reasoning_for("gpt-5", ReasoningConfig::default()).is_none());
+    }
+
+    #[test]
+    fn reasoning_for_emits_block_on_reasoning_model() {
+        let cfg = ReasoningConfig::with_reasoning_effort(ReasoningLevel::High);
+        let block = reasoning_for("gpt-5.4", cfg).expect("reasoning block expected");
+        assert_eq!(block.effort, "high");
+    }
+
+    #[test]
+    fn reasoning_for_drops_block_on_non_reasoning_model() {
+        let cfg = ReasoningConfig::with_reasoning_effort(ReasoningLevel::High);
+        // gpt-4o does not support reasoning — field should be dropped, not sent.
+        assert!(reasoning_for("gpt-4o", cfg).is_none());
+    }
+
+    #[test]
+    fn request_includes_reasoning_for_supported_model() {
+        let cfg = ReasoningConfig::with_reasoning_effort(ReasoningLevel::Medium);
+        let block = reasoning_for("gpt-5", cfg);
+        let req = ResponsesRequest {
+            model: "gpt-5".into(),
+            input: vec![],
+            instructions: None,
+            stream: true,
+            tools: vec![],
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            reasoning: block,
+        };
+        let json: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["reasoning"]["effort"], "medium");
+    }
+
+    #[test]
+    fn request_omits_reasoning_field_when_none() {
+        let req = ResponsesRequest {
+            model: "gpt-4o".into(),
+            input: vec![],
+            instructions: None,
+            stream: true,
+            tools: vec![],
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            reasoning: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(
+            !json.contains("reasoning"),
+            "reasoning field must be omitted when None; got: {json}"
+        );
     }
 
     // --- Tool accumulator tests ---


### PR DESCRIPTION
## Summary

Closes the two deferred dispatch-path pieces from #11 / PR #17:

1. **Per-request client swap** — when a caller sets
   `SendMessage { override: { connection_id, model_id, effort } }` (or a
   conversation has a stored selection), the daemon now dispatches the
   turn through the resolved connection's live client. Previously the
   override was validated + persisted but dispatch still went through
   the interactive-purpose client.

2. **Effort threading** — the `Effort` knob is now translated per-connector
   into actual request-body fields:
   - **Anthropic**: `thinking: { type: "enabled", budget_tokens: N }`
     (plus a `max_tokens` bump to preserve the required headroom over
     `budget_tokens`).
   - **OpenAI (Responses API)**: `reasoning: { effort: "low|medium|high" }`
     for o-series / GPT-5 only; dropped with a debug log for chat models
     that would 400 on the field.
   - **Bedrock (Claude)**: same Anthropic-shape `thinking` block passed
     through `additionalModelRequestFields`. Non-Claude Bedrock models
     get a debug log and no field.
   - **Ollama**: no-op, debug log.

## Design

- `core::ports::llm` gains `ReasoningLevel` + `ReasoningConfig` and the
  `LlmClient` trait's `stream_completion(_with_namespaces)` gets a new
  `reasoning: ReasoningConfig` parameter. All existing call sites pass
  `ReasoningConfig::default()`.
- A new `tokio::task_local!` slot (`with_reasoning_config` /
  `current_reasoning_config`) carries the per-turn hint from the
  daemon-side routing wrapper into the core `ConversationHandler`'s
  dispatch loop without any coupling between core and daemon.
- A new daemon-side `routing_llm::RoutingLlmClient` wraps the handler's
  `L` type. It consults a second task-local on each
  `stream_completion`; when populated, it dispatches to the selected
  connection's client. When unset (backend-task paths that don't flow
  through the routing wrapper), it falls back to the interactive
  client — preserving pre-#18 behaviour.
- `RoutingConversationHandler` now:
  - hard-errors with a clean `CoreError::Llm` when the resolved
    connection is not live (previously silent fallback);
  - applies the same resolution to the plain `send_prompt` path so
    stored selections survive the legacy D-Bus/WS entry points;
  - maps `Effort` to the right `ReasoningConfig` per connector type
    (via the existing `apply_effort_mapping`, which now returns the
    config instead of only logging).

## Example request bodies

Before #18, `effort: High` with an Anthropic connection was ignored:

```json
// Anthropic request body (before):
{ "model": "claude-sonnet-4-6", "max_tokens": 8192, "messages": [...] }
```

After #18:

```json
// Anthropic, effort=High:
{
  "model": "claude-sonnet-4-6",
  "max_tokens": 26048,
  "messages": [...],
  "thinking": { "type": "enabled", "budget_tokens": 24000 }
}

// OpenAI Responses API, model=gpt-5 effort=Medium:
{
  "model": "gpt-5",
  "max_output_tokens": ...,
  "input": [...],
  "reasoning": { "effort": "medium" }
}

// OpenAI Responses API, model=gpt-4o effort=Medium:
// (gpt-4o does not support reasoning; field dropped with debug log)
{ "model": "gpt-4o", "input": [...] }

// Bedrock Converse, model=us.anthropic.claude-opus-4-1 effort=High:
// additionalModelRequestFields:
{ "thinking": { "type": "enabled", "budget_tokens": 24000 } }
```

## Test plan

- [x] Unit: Anthropic request serialization includes `thinking` block
      only when budget > 0; `max_tokens` bumps correctly.
- [x] Unit: OpenAI request serialization includes `reasoning.effort`
      only for reasoning-capable models.
- [x] Unit: Bedrock `additionalModelRequestFields` shape matches the
      Anthropic native `thinking` block; non-Claude models get `None`.
- [x] Unit: per-priority resolution in `RoutingConversationHandler`
      (override validation, stored fall-through) and clean error when
      the resolved connection is unavailable.
- [x] Unit: `Effort::{Low, Medium, High}` -> `ReasoningConfig` mapping
      for each connector type (Anthropic, OpenAI, Bedrock, Ollama,
      unknown-vendor no-op).
- [x] Unit: `RoutingLlmClient` picks task-local override when set and
      falls back to the static client when unset.
- [x] Full workspace test suite passes (`cargo test --workspace`).
- [x] `cargo clippy --workspace --tests` clean of new warnings.

## Commit graph

- `Thread per-turn ReasoningConfig through LlmClient trait` (core +
  connector impls + serialization tests)
- `Wire per-turn client + reasoning routing into the daemon dispatch
  path` (routing_llm + api_surface + main + routing-dispatch tests)
- `Clean up clippy warnings in routing_llm test helpers`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)