### PR TITLE
daemon: honor purposes.titling and thread effort through title/summary

### DIFF
--- a/crates/daemon/src/backend_reasoning.rs
+++ b/crates/daemon/src/backend_reasoning.rs
@@ -1,0 +1,277 @@
+//! Adapter that pins a fixed [`ReasoningConfig`] onto `stream_completion`
+//! calls when the wrapper was configured with a non-empty config (issue
+//! #28).
+//!
+//! Background tasks (title generation, context summary) call into the
+//! `LlmClient` trait with `ReasoningConfig::default()` because they live in
+//! the core service layer where the daemon's `purposes` concept doesn't
+//! exist. When the user has configured `[purposes.titling].effort`, the
+//! daemon needs to substitute that effort's mapped `ReasoningConfig` for
+//! the caller's default — without touching the core service code.
+//!
+//! ## Override semantics
+//!
+//! - When `configured.is_empty()` (i.e. `ReasoningConfig::default()`), the
+//!   wrapper is a transparent passthrough — the caller's reasoning is
+//!   forwarded verbatim. This is what we want for the *primary* (interactive)
+//!   client, which is wrapped purely for type-uniformity with the backend
+//!   stack and must not stomp on the per-turn task-local reasoning installed
+//!   by `RoutingConversationHandler`.
+//! - When `configured` has any field set, every `stream_completion` call
+//!   sees `configured` regardless of what the caller passed. This is the
+//!   override path for `[purposes.titling].effort`.
+//!
+//! Effort changes via `set_purpose` rebuild the daemon's clients on
+//! config reload, so the captured value is fixed for the lifetime of the
+//! wrapper.
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Message, ToolDefinition, ToolNamespace};
+use desktop_assistant_core::ports::llm::{
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
+};
+
+/// Wraps an [`LlmClient`] and substitutes a fixed [`ReasoningConfig`]
+/// for whatever the caller passes into `stream_completion`. See module
+/// docs.
+#[derive(Clone)]
+pub struct FixedReasoningLlmClient<L> {
+    inner: L,
+    reasoning: ReasoningConfig,
+}
+
+impl<L> FixedReasoningLlmClient<L> {
+    pub fn new(inner: L, reasoning: ReasoningConfig) -> Self {
+        Self { inner, reasoning }
+    }
+}
+
+impl<L: LlmClient> LlmClient for FixedReasoningLlmClient<L> {
+    fn get_default_model(&self) -> Option<&str> {
+        self.inner.get_default_model()
+    }
+
+    fn get_default_base_url(&self) -> Option<&str> {
+        self.inner.get_default_base_url()
+    }
+
+    fn max_context_tokens(&self) -> Option<u64> {
+        self.inner.max_context_tokens()
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        self.inner.list_models().await
+    }
+
+    async fn refresh_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        self.inner.refresh_models().await
+    }
+
+    async fn stream_completion(
+        &self,
+        messages: Vec<Message>,
+        tools: &[ToolDefinition],
+        caller_reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let effective = if self.reasoning.is_empty() {
+            caller_reasoning
+        } else {
+            self.reasoning
+        };
+        self.inner
+            .stream_completion(messages, tools, effective, on_chunk)
+            .await
+    }
+
+    fn supports_hosted_tool_search(&self) -> bool {
+        self.inner.supports_hosted_tool_search()
+    }
+
+    async fn stream_completion_with_namespaces(
+        &self,
+        messages: Vec<Message>,
+        core_tools: &[ToolDefinition],
+        namespaces: &[ToolNamespace],
+        caller_reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let effective = if self.reasoning.is_empty() {
+            caller_reasoning
+        } else {
+            self.reasoning
+        };
+        self.inner
+            .stream_completion_with_namespaces(messages, core_tools, namespaces, effective, on_chunk)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_core::domain::Role;
+    use desktop_assistant_core::ports::llm::{ReasoningLevel, TokenUsage};
+    use std::sync::Mutex;
+
+    /// Test double that records the `ReasoningConfig` it receives so we
+    /// can prove the wrapper substitutes its own value.
+    #[derive(Default)]
+    struct CapturingClient {
+        last_seen: Mutex<Option<ReasoningConfig>>,
+    }
+
+    impl CapturingClient {
+        fn last(&self) -> Option<ReasoningConfig> {
+            *self.last_seen.lock().unwrap()
+        }
+    }
+
+    impl LlmClient for CapturingClient {
+        fn get_default_model(&self) -> Option<&str> {
+            Some("captured")
+        }
+
+        fn get_default_base_url(&self) -> Option<&str> {
+            Some("http://captured")
+        }
+
+        fn max_context_tokens(&self) -> Option<u64> {
+            Some(8_000)
+        }
+
+        async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn refresh_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn stream_completion(
+            &self,
+            _messages: Vec<Message>,
+            _tools: &[ToolDefinition],
+            reasoning: ReasoningConfig,
+            _on_chunk: ChunkCallback,
+        ) -> Result<LlmResponse, CoreError> {
+            *self.last_seen.lock().unwrap() = Some(reasoning);
+            Ok(LlmResponse {
+                text: String::new(),
+                tool_calls: vec![],
+                usage: Some(TokenUsage::default()),
+            })
+        }
+
+        fn supports_hosted_tool_search(&self) -> bool {
+            false
+        }
+    }
+
+    fn user_msg(text: &str) -> Vec<Message> {
+        vec![Message::new(Role::User, text)]
+    }
+
+    #[tokio::test]
+    async fn substitutes_caller_reasoning_with_configured_value() {
+        // Caller passes default; wrapper must replace it with the
+        // configured (Anthropic-flavored) thinking budget.
+        let inner = CapturingClient::default();
+        let configured = ReasoningConfig::with_thinking_budget(8_000);
+        let wrapped = FixedReasoningLlmClient::new(inner, configured);
+
+        wrapped
+            .stream_completion(
+                user_msg("hi"),
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await
+            .expect("inner client returns Ok");
+
+        assert_eq!(wrapped.inner.last(), Some(configured));
+    }
+
+    #[tokio::test]
+    async fn fixed_default_reasoning_is_passthrough() {
+        // Construction with `ReasoningConfig::default()` means "no
+        // configured override". The wrapper must forward whatever the
+        // caller passes — this is what makes it safe to wrap the primary
+        // (interactive) client where the per-turn task-local reasoning
+        // is set by `RoutingConversationHandler` and arrives via the
+        // caller's `reasoning` argument. Stomping on it would erase the
+        // user's effort selection on every interactive turn.
+        let inner = CapturingClient::default();
+        let wrapped = FixedReasoningLlmClient::new(inner, ReasoningConfig::default());
+
+        let caller = ReasoningConfig::with_reasoning_effort(ReasoningLevel::High);
+        wrapped
+            .stream_completion(user_msg("hi"), &[], caller, Box::new(|_| true))
+            .await
+            .expect("inner client returns Ok");
+
+        assert_eq!(
+            wrapped.inner.last(),
+            Some(caller),
+            "default-configured wrapper must forward caller's reasoning untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn caller_reasoning_passes_through_when_not_configured_even_if_caller_is_default() {
+        // Symmetric case: caller is `default()`, configured is `default()`,
+        // inner observes `default()`. Confirms the wrapper doesn't wrongly
+        // synthesise a non-default value somewhere.
+        let inner = CapturingClient::default();
+        let wrapped = FixedReasoningLlmClient::new(inner, ReasoningConfig::default());
+
+        wrapped
+            .stream_completion(
+                user_msg("hi"),
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await
+            .expect("inner client returns Ok");
+
+        assert_eq!(wrapped.inner.last(), Some(ReasoningConfig::default()));
+    }
+
+    #[tokio::test]
+    async fn substitutes_for_with_namespaces_path_too() {
+        // The handler's tool-routing dispatch goes through
+        // `stream_completion_with_namespaces`. Backend tasks don't
+        // currently use namespaces, but the trait surface must stay
+        // consistent: the wrapper has to pin reasoning on both methods.
+        let inner = CapturingClient::default();
+        let configured = ReasoningConfig::with_reasoning_effort(ReasoningLevel::Medium);
+        let wrapped = FixedReasoningLlmClient::new(inner, configured);
+
+        // Default `stream_completion_with_namespaces` from the trait
+        // delegates to `stream_completion` for clients that haven't
+        // overridden it, so the same captured value applies.
+        wrapped
+            .stream_completion_with_namespaces(
+                user_msg("hi"),
+                &[],
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await
+            .expect("inner client returns Ok");
+
+        assert_eq!(wrapped.inner.last(), Some(configured));
+    }
+
+    #[test]
+    fn forwards_capability_flags_to_inner() {
+        let inner = CapturingClient::default();
+        let wrapped = FixedReasoningLlmClient::new(inner, ReasoningConfig::default());
+        assert!(!wrapped.supports_hosted_tool_search());
+        assert_eq!(wrapped.get_default_model(), Some("captured"));
+        assert_eq!(wrapped.max_context_tokens(), Some(8_000));
+    }
+}

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -6,12 +6,13 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role};
 use desktop_assistant_core::ports::embedding::{EmbedFn, EmbeddingClient};
 use desktop_assistant_core::ports::inbound::SettingsService;
-use desktop_assistant_core::ports::llm::{LlmClient, RetryingLlmClient};
+use desktop_assistant_core::ports::llm::{LlmClient, ReasoningConfig, RetryingLlmClient};
 use desktop_assistant_core::ports::llm_profiling::MaybeProfiled;
 use tracing_subscriber::EnvFilter;
 
 mod api_surface;
 mod app;
+mod backend_reasoning;
 mod config;
 mod connections;
 mod model_defaults;
@@ -1180,6 +1181,16 @@ async fn main() -> Result<()> {
     let fallback_client = Arc::new(llm);
     let llm =
         routing_llm::RoutingLlmClient::new(Arc::clone(&fallback_client), llm_connector.clone());
+    // Wrap the primary in a transparent `FixedReasoningLlmClient` whose
+    // override is `default()`. The interactive dispatch path goes through
+    // the per-turn task-local installed by `RoutingConversationHandler`,
+    // which calls `stream_completion` with its mapped `ReasoningConfig` —
+    // we must not stomp on that, hence the passthrough configuration.
+    // The wrapper exists here only so the primary and backend handlers
+    // share the same `L` type (issue #28: backend tasks need a non-default
+    // override, and `with_backend_llm(L)` requires both stacks to match).
+    let llm =
+        backend_reasoning::FixedReasoningLlmClient::new(llm, ReasoningConfig::default());
     let llm = RetryingLlmClient::new(llm, 3);
     let llm = MaybeProfiled::from_config(
         llm,
@@ -1194,17 +1205,46 @@ async fn main() -> Result<()> {
         Box::new(|| uuid::Uuid::now_v7().to_string()),
     );
 
-    // Build a separate LLM for backend tasks (title generation, context summary)
-    // if [backend_tasks.llm] is configured and differs from the primary.
-    let resolved_bt = config::resolve_backend_tasks_llm_config(daemon_config.as_ref());
+    // Build a separate LLM for backend tasks (title generation, context summary).
+    //
+    // Resolution order (issue #28):
+    //   1. `[purposes.titling]` — if set, always install the backend client
+    //      so the user's chosen connection / model / effort is honoured even
+    //      when it happens to coincide with the primary.
+    //   2. `[backend_tasks.llm]` legacy block — install only if it differs
+    //      from the primary (preserving pre-#28 behaviour for unmigrated
+    //      installs that haven't authored a `[purposes]` table).
+    //
+    // Effort threading: backend tasks call `stream_completion` from
+    // `core::service` with `ReasoningConfig::default()` baked in. We can't
+    // change that without touching the core service, so we wrap the backend
+    // client in `FixedReasoningLlmClient` to substitute the purpose's
+    // mapped reasoning at the daemon layer. For the legacy path we fix it
+    // to `default()` — a transparent passthrough.
+    let purpose_titling = api_surface::resolve_purpose_dispatch(
+        daemon_config.as_ref(),
+        purposes::PurposeKind::Titling,
+    );
     let resolved_primary = config::resolve_llm_config(daemon_config.as_ref());
-    if resolved_bt.connector != resolved_primary.connector
-        || resolved_bt.model != resolved_primary.model
-    {
+    let titling_setup = match purpose_titling {
+        Some((resolved, reasoning)) => Some((resolved, reasoning, "purposes.titling")),
+        None => {
+            let resolved = config::resolve_backend_tasks_llm_config(daemon_config.as_ref());
+            if resolved.connector != resolved_primary.connector
+                || resolved.model != resolved_primary.model
+            {
+                Some((resolved, ReasoningConfig::default(), "backend_tasks.llm"))
+            } else {
+                None
+            }
+        }
+    };
+    if let Some((resolved_bt, bt_reasoning, source)) = titling_setup {
         tracing::info!(
-            "backend-tasks LLM connector={}, model={}",
+            "backend-tasks LLM connector={}, model={}, source={}",
             resolved_bt.connector,
-            resolved_bt.model
+            resolved_bt.model,
+            source
         );
         let bt_connector = resolved_bt.connector.clone();
         let bt_llm = build_llm_client(resolved_bt);
@@ -1216,6 +1256,10 @@ async fn main() -> Result<()> {
         // `with_backend_llm` accepts it.
         let bt_fallback = Arc::new(bt_llm);
         let bt_llm = routing_llm::RoutingLlmClient::new(bt_fallback, bt_connector);
+        // Substitute the configured reasoning (purpose's mapped effort,
+        // or default for legacy installs) for whatever the core
+        // service's title/summary functions pass in.
+        let bt_llm = backend_reasoning::FixedReasoningLlmClient::new(bt_llm, bt_reasoning);
         let bt_llm = RetryingLlmClient::new(bt_llm, 3);
         let bt_llm = MaybeProfiled::from_config(
             bt_llm,


### PR DESCRIPTION
## Summary

Closes #28. Final piece of the purposes-not-being-honored series (#26, #27, #28).

- Add `backend_reasoning::FixedReasoningLlmClient<L>` — an `LlmClient` adapter that substitutes a configured `ReasoningConfig` for the caller's value on every dispatch, *unless* the configured value is `default()` (in which case the wrapper is a passthrough so the same wrapper can sit on the primary client without clobbering interactive's per-turn task-local reasoning).
- Prefer `api_surface::resolve_purpose_dispatch(..., Titling)` over `resolve_backend_tasks_llm_config` for the backend-tasks LLM. When a purpose is set we always install the backend client (the user explicitly chose it); otherwise we fall back to the legacy install-only-if-different rule.
- Wrap the primary llm in the same wrapper with a default-config (passthrough) so primary and backend stacks share `L` for `with_backend_llm`.
- Log the dispatch source.

## Why a wrapper, not core threading

`generate_conversation_title` / `generate_context_summary` in `core::service` pass `ReasoningConfig::default()` into `stream_completion` because they live below the daemon's purposes layer. Threading effort through them would require a core API change. The daemon-side adapter localises the override and keeps core unchanged.

## Test plan

- [x] `cargo test -p desktop-assistant-daemon` — 196 tests pass (190 daemon + 6 integration), with 5 new tests covering: caller reasoning passes through when configured is default (the safety property for the primary), substitution when configured is non-default, both `stream_completion` and `stream_completion_with_namespaces` paths, and capability flag forwarding.
- [x] `cargo check --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)