### PR TITLE
storage+daemon: builtin_conversation_search tool with Postgres FTS (#71)

### DIFF
--- a/crates/core/src/ports/conversation_search.rs
+++ b/crates/core/src/ports/conversation_search.rs
@@ -1,0 +1,86 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::CoreError;
+use crate::domain::Role;
+
+/// A single match returned by [`ConversationSearchStore::search_messages`].
+///
+/// Carries enough context for a tool result to render usefully without a
+/// follow-up fetch: the conversation id and title for grouping, the
+/// message ordinal for re-anchoring inside a conversation, the matched
+/// content with a highlighted snippet, and the rank score so callers can
+/// truncate or re-rank.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageHit {
+    pub conversation_id: String,
+    pub conversation_title: String,
+    pub ordinal: i32,
+    pub role: Role,
+    pub content: String,
+    /// `ts_headline`-formatted snippet around the matched terms.
+    pub snippet: String,
+    /// Postgres `ts_rank_cd` score; higher is more relevant.
+    pub rank: f32,
+    /// Conversation `updated_at` as an RFC3339 string for chronological
+    /// secondary sort / display.
+    pub updated_at: String,
+}
+
+/// Outbound port for full-text searching past conversations. Backed by
+/// the Postgres tsvector columns added in migration #013. The JSON store
+/// has no equivalent and intentionally omits this trait.
+pub trait ConversationSearchStore: Send + Sync {
+    /// Run a full-text query over message content (with conversation
+    /// title/summary contributing as a secondary axis). `role_filter`
+    /// scopes hits to a specific message role; `None` searches all
+    /// roles. Hits are ordered by `ts_rank_cd` descending.
+    fn search_messages(
+        &self,
+        query: &str,
+        limit: usize,
+        role_filter: Option<Role>,
+    ) -> impl Future<Output = Result<Vec<MessageHit>, CoreError>> + Send;
+}
+
+/// Boxed async closure for searching past conversations through
+/// non-generic boundaries (mirrors [`KnowledgeSearchFn`]).
+///
+/// [`KnowledgeSearchFn`]: super::knowledge::KnowledgeSearchFn
+pub type ConversationSearchFn = Arc<
+    dyn Fn(
+            String,
+            usize,
+            Option<Role>,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<MessageHit>, CoreError>> + Send>>
+        + Send
+        + Sync,
+>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockSearch;
+
+    impl ConversationSearchStore for MockSearch {
+        async fn search_messages(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _role_filter: Option<Role>,
+        ) -> Result<Vec<MessageHit>, CoreError> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_search_returns_empty() {
+        let s = MockSearch;
+        let hits = s.search_messages("hello", 10, None).await.unwrap();
+        assert!(hits.is_empty());
+    }
+
+    fn _assert_search_store<T: ConversationSearchStore>() {}
+}

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -28,6 +28,9 @@ pub mod tool_registry;
 /// Database query port — closure type for read-only SQL queries.
 pub mod database;
 
+/// Conversation search port — outbound trait for full-text search over past messages.
+pub mod conversation_search;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -891,6 +891,21 @@ async fn main() -> Result<()> {
                 desktop_assistant_storage::execute_database_query(&pool, &sql, limit).await
             })
         }));
+
+        // Issue #71: wire conversation full-text search.
+        let cs_store = Arc::new(desktop_assistant_storage::PgConversationSearchStore::new(
+            pool.clone(),
+        ));
+        tracing::info!("wiring conversation search into builtin tools");
+        use desktop_assistant_core::ports::conversation_search::ConversationSearchStore;
+        builtin_tools = builtin_tools.with_conversation_search(Arc::new(
+            move |query, limit, role_filter| {
+                let store = Arc::clone(&cs_store);
+                Box::pin(async move {
+                    store.search_messages(&query, limit, role_filter).await
+                })
+            },
+        ));
     }
 
     if let Some(tr) = &tool_registry_store {

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -4,7 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{Local, SecondsFormat, Utc};
 use desktop_assistant_core::CoreError;
-use desktop_assistant_core::domain::ToolDefinition;
+use desktop_assistant_core::domain::{Role, ToolDefinition};
+use desktop_assistant_core::ports::conversation_search::ConversationSearchFn;
 use desktop_assistant_core::ports::database::DbQueryFn;
 use desktop_assistant_core::ports::embedding::EmbedFn;
 use desktop_assistant_core::ports::knowledge::{
@@ -21,6 +22,7 @@ const TOOL_SEARCH: &str = "builtin_tool_search";
 const TOOL_SYS_PROPS: &str = "builtin_sys_props";
 const TOOL_DB_QUERY: &str = "builtin_db_query";
 const TOOL_MCP_CONTROL: &str = "builtin_mcp_control";
+const TOOL_CONV_SEARCH: &str = "builtin_conversation_search";
 
 fn now_ts() -> u64 {
     SystemTime::now()
@@ -39,6 +41,7 @@ pub struct BuiltinToolService {
     tool_definition_fn: Option<ToolDefinitionFn>,
     db_query_fn: Option<DbQueryFn>,
     mcp_handle: Option<McpControlHandle>,
+    conversation_search_fn: Option<ConversationSearchFn>,
 }
 
 impl Default for BuiltinToolService {
@@ -60,6 +63,7 @@ impl BuiltinToolService {
             tool_definition_fn: None,
             db_query_fn: None,
             mcp_handle: None,
+            conversation_search_fn: None,
         }
     }
 
@@ -96,6 +100,14 @@ impl BuiltinToolService {
     /// Configure database query closure for read-only SQL access.
     pub fn with_database(mut self, query_fn: DbQueryFn) -> Self {
         self.db_query_fn = Some(query_fn);
+        self
+    }
+
+    /// Configure the past-conversation full-text search closure (#71).
+    /// When unset, `builtin_conversation_search` returns a clear error
+    /// rather than silently no-op-ing.
+    pub fn with_conversation_search(mut self, search_fn: ConversationSearchFn) -> Self {
+        self.conversation_search_fn = Some(search_fn);
         self
     }
 
@@ -232,6 +244,40 @@ impl BuiltinToolService {
                 }),
             ),
             ToolDefinition::new(
+                TOOL_CONV_SEARCH,
+                "Search past conversations by full-text query. Useful for \
+                 recalling what was discussed, what decisions were made, or \
+                 finding a specific exchange. Returns matching messages \
+                 with conversation title, ordinal, role, content, a \
+                 highlighted snippet around the match, and a relevance \
+                 rank. Hits where the conversation title or summary \
+                 matches surface even if no individual message text does. \
+                 Use this when the user asks about prior conversations \
+                 (\"what did we discuss about X\", \"find where we talked \
+                 about Y\").",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Full-text search query (English tsvector). Multi-word phrases are AND-ed."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Max hits to return (default 10)."
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": ["user", "assistant"],
+                            "description": "Restrict matches to a specific role (omit to search all)."
+                        }
+                    },
+                    "required": ["query"]
+                }),
+            ),
+            ToolDefinition::new(
                 TOOL_MCP_CONTROL,
                 "Check status, start, stop, or restart MCP (Model Context Protocol) \
                  servers. Use this when a tool call fails because an MCP server is \
@@ -265,6 +311,7 @@ impl BuiltinToolService {
                 | TOOL_SYS_PROPS
                 | TOOL_DB_QUERY
                 | TOOL_MCP_CONTROL
+                | TOOL_CONV_SEARCH
         )
     }
 
@@ -281,6 +328,7 @@ impl BuiltinToolService {
             TOOL_SYS_PROPS => Ok(self.sys_props()),
             TOOL_DB_QUERY => self.db_query(arguments).await,
             TOOL_MCP_CONTROL => self.mcp_control(arguments).await,
+            TOOL_CONV_SEARCH => self.conversation_search(arguments).await,
             _ => Err(CoreError::ToolExecution(format!(
                 "unknown built-in tool: {name}"
             ))),
@@ -394,6 +442,64 @@ impl BuiltinToolService {
 
         tracing::info!(result_count = items.len(), "knowledge base search results");
         tracing::debug!(results = %serde_json::to_string(&items).unwrap_or_default(), "knowledge base search response");
+
+        Ok(serde_json::json!({
+            "ok": true,
+            "results": items,
+        })
+        .to_string())
+    }
+
+    async fn conversation_search(
+        &self,
+        arguments: serde_json::Value,
+    ) -> Result<String, CoreError> {
+        let search_fn = self.conversation_search_fn.as_ref().ok_or_else(|| {
+            CoreError::ToolExecution("conversation search not configured".to_string())
+        })?;
+
+        let query = required_string(&arguments, "query")?;
+        let limit = arguments
+            .get("limit")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(10) as usize;
+        let role_filter = arguments
+            .get("role")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|s| match s {
+                "user" => Some(Role::User),
+                "assistant" => Some(Role::Assistant),
+                // Reject other roles at the boundary so the SQL layer
+                // doesn't have to defend against arbitrary text.
+                _ => None,
+            });
+
+        tracing::info!(query = %query, limit, ?role_filter, "conversation search");
+
+        let hits = search_fn(query, limit, role_filter).await?;
+
+        let items: Vec<serde_json::Value> = hits
+            .into_iter()
+            .map(|h| {
+                serde_json::json!({
+                    "conversation_id": h.conversation_id,
+                    "conversation_title": h.conversation_title,
+                    "ordinal": h.ordinal,
+                    "role": match h.role {
+                        Role::User => "user",
+                        Role::Assistant => "assistant",
+                        Role::System => "system",
+                        Role::Tool => "tool",
+                    },
+                    "snippet": h.snippet,
+                    "content": h.content,
+                    "rank": h.rank,
+                    "updated_at": h.updated_at,
+                })
+            })
+            .collect();
+
+        tracing::info!(result_count = items.len(), "conversation search results");
 
         Ok(serde_json::json!({
             "ok": true,
@@ -757,6 +863,94 @@ mod tests {
         assert!(names.contains(&TOOL_SYS_PROPS.to_string()));
         assert!(names.contains(&TOOL_DB_QUERY.to_string()));
         assert!(names.contains(&TOOL_MCP_CONTROL.to_string()));
+        assert!(names.contains(&TOOL_CONV_SEARCH.to_string()));
+    }
+
+    #[tokio::test]
+    async fn conversation_search_without_store_returns_error() {
+        let service = BuiltinToolService::new();
+        let result = service
+            .execute_tool(TOOL_CONV_SEARCH, serde_json::json!({"query": "test"}))
+            .await;
+        assert!(matches!(result, Err(CoreError::ToolExecution(_))));
+    }
+
+    #[tokio::test]
+    async fn conversation_search_with_closure_returns_results() {
+        use desktop_assistant_core::ports::conversation_search::{
+            ConversationSearchFn, MessageHit,
+        };
+        use std::sync::Arc;
+
+        let search_fn: ConversationSearchFn =
+            Arc::new(move |query, limit, role_filter| {
+                let q = query.clone();
+                Box::pin(async move {
+                    assert_eq!(q, "deploy");
+                    assert_eq!(limit, 5);
+                    assert!(matches!(role_filter, Some(Role::Assistant)));
+                    Ok(vec![MessageHit {
+                        conversation_id: "c-1".into(),
+                        conversation_title: "Deploy timeline".into(),
+                        ordinal: 4,
+                        role: Role::Assistant,
+                        content: "We can deploy on Friday".into(),
+                        snippet: "We can <mark>deploy</mark> on Friday".into(),
+                        rank: 0.42,
+                        updated_at: "2026-05-02T13:00:00+00:00".into(),
+                    }])
+                })
+            });
+
+        let service = BuiltinToolService::new().with_conversation_search(search_fn);
+        let response = service
+            .execute_tool(
+                TOOL_CONV_SEARCH,
+                serde_json::json!({"query": "deploy", "limit": 5, "role": "assistant"}),
+            )
+            .await
+            .expect("search succeeds");
+
+        let json: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(json["ok"], serde_json::json!(true));
+        let results = json["results"].as_array().expect("results array");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["conversation_id"], "c-1");
+        assert_eq!(results[0]["ordinal"], 4);
+        assert_eq!(results[0]["role"], "assistant");
+        assert!(results[0]["snippet"].as_str().unwrap().contains("<mark>"));
+    }
+
+    #[tokio::test]
+    async fn conversation_search_rejects_unknown_role() {
+        // Unknown roles must not reach the search closure: the boundary
+        // strips them rather than passing through arbitrary text.
+        use desktop_assistant_core::ports::conversation_search::ConversationSearchFn;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let saw_role_filter = Arc::new(AtomicBool::new(false));
+        let saw_clone = Arc::clone(&saw_role_filter);
+        let search_fn: ConversationSearchFn =
+            Arc::new(move |_q, _l, role_filter| {
+                if role_filter.is_some() {
+                    saw_clone.store(true, Ordering::SeqCst);
+                }
+                Box::pin(async { Ok(Vec::new()) })
+            });
+
+        let service = BuiltinToolService::new().with_conversation_search(search_fn);
+        let _ = service
+            .execute_tool(
+                TOOL_CONV_SEARCH,
+                serde_json::json!({"query": "x", "role": "robot"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !saw_role_filter.load(Ordering::SeqCst),
+            "unknown role values must not propagate to the search closure"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/migrations/013_conversation_message_fts.sql
+++ b/crates/storage/migrations/013_conversation_message_fts.sql
@@ -1,0 +1,24 @@
+-- Issue #71: full-text search on past conversations.
+--
+-- Adds generated tsvector columns on `messages` (over content) and
+-- `conversations` (over title + context_summary). Postgres backfills
+-- generated-stored columns automatically on `ALTER TABLE`, so no
+-- separate backfill job is needed — but the table rewrite takes a
+-- write lock proportional to history size. Run during a quiet window
+-- on installs with large message tables.
+
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS tsv tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_messages_tsv
+    ON messages USING GIN(tsv);
+
+ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS tsv tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector('english', title || ' ' || COALESCE(context_summary, ''))
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_conversations_tsv
+    ON conversations USING GIN(tsv);

--- a/crates/storage/src/conversation_search.rs
+++ b/crates/storage/src/conversation_search.rs
@@ -1,0 +1,120 @@
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::Role;
+use desktop_assistant_core::ports::conversation_search::{ConversationSearchStore, MessageHit};
+use sqlx::PgPool;
+
+pub struct PgConversationSearchStore {
+    pool: PgPool,
+}
+
+impl PgConversationSearchStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Internal SQL row shape. We materialise role as the raw text Postgres
+/// stores (matches `messages.role` in the legacy schema) and parse it
+/// into [`Role`] when constructing the public hit.
+#[derive(sqlx::FromRow)]
+struct MessageHitRow {
+    conversation_id: String,
+    conversation_title: String,
+    ordinal: i32,
+    role: String,
+    content: String,
+    snippet: String,
+    rank: f32,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+fn parse_role(s: &str) -> Role {
+    // The DB column is unconstrained text; we map known values and fall
+    // back to `User` for anything unexpected so a corrupt row doesn't
+    // crash search. The role filter on inbound queries is enum-checked
+    // by the caller before reaching SQL, so this lossy fallback is
+    // confined to read-side display.
+    match s {
+        "user" => Role::User,
+        "assistant" => Role::Assistant,
+        "system" => Role::System,
+        "tool" => Role::Tool,
+        _ => Role::User,
+    }
+}
+
+fn role_to_db(role: Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::System => "system",
+        Role::Tool => "tool",
+    }
+}
+
+impl ConversationSearchStore for PgConversationSearchStore {
+    async fn search_messages(
+        &self,
+        query: &str,
+        limit: usize,
+        role_filter: Option<Role>,
+    ) -> Result<Vec<MessageHit>, CoreError> {
+        let role_db = role_filter.map(role_to_db);
+        let limit_i64 = limit as i64;
+
+        // Hits where the message itself matches OR the conversation
+        // title/summary matches; rank by message tsv when present, else
+        // by conversation tsv. Snippet runs over message content so the
+        // tool result has something concrete to show even when the
+        // match was on title/summary (an empty `ts_headline` is fine).
+        let rows: Vec<MessageHitRow> = sqlx::query_as(
+            "WITH q AS (
+                 SELECT plainto_tsquery('english', $1) AS query
+             )
+             SELECT m.conversation_id      AS conversation_id,
+                    c.title                AS conversation_title,
+                    m.ordinal              AS ordinal,
+                    m.role                 AS role,
+                    m.content              AS content,
+                    ts_headline(
+                        'english',
+                        m.content,
+                        (SELECT query FROM q),
+                        'StartSel=<mark>,StopSel=</mark>,MaxFragments=1,MaxWords=20,MinWords=5'
+                    )                      AS snippet,
+                    GREATEST(
+                        COALESCE(ts_rank_cd(m.tsv, (SELECT query FROM q)), 0.0),
+                        COALESCE(ts_rank_cd(c.tsv, (SELECT query FROM q)), 0.0)
+                    )::REAL                AS rank,
+                    c.updated_at           AS updated_at
+             FROM messages m
+             JOIN conversations c ON c.id = m.conversation_id
+             WHERE
+                 (m.tsv @@ (SELECT query FROM q)
+                  OR c.tsv @@ (SELECT query FROM q))
+                 AND ($2::text IS NULL OR m.role = $2)
+             ORDER BY rank DESC, c.updated_at DESC, m.ordinal ASC
+             LIMIT $3",
+        )
+        .bind(query)
+        .bind(role_db)
+        .bind(limit_i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| MessageHit {
+                conversation_id: r.conversation_id,
+                conversation_title: r.conversation_title,
+                ordinal: r.ordinal,
+                role: parse_role(&r.role),
+                content: r.content,
+                snippet: r.snippet,
+                rank: r.rank,
+                updated_at: r.updated_at.to_rfc3339(),
+            })
+            .collect())
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod conversation;
+pub mod conversation_search;
 pub mod database;
 pub mod dreaming;
 pub mod embedding_backfill;
@@ -8,6 +9,7 @@ pub mod pool;
 pub mod tool_registry;
 
 pub use conversation::PgConversationStore;
+pub use conversation_search::PgConversationSearchStore;
 pub use database::execute_database_query;
 pub use knowledge::PgKnowledgeBaseStore;
 pub use migrate_json::{

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -99,5 +99,16 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Conversation full-text search (issue #71) — generated tsvector
+    // columns + GIN indexes on `messages` and `conversations`. Generated-
+    // stored columns auto-backfill on `ALTER TABLE`; the rewrite takes a
+    // write lock proportional to message count, so first-run on large
+    // histories may take a moment.
+    sqlx::raw_sql(include_str!(
+        "../migrations/013_conversation_message_fts.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
Closes #71.

## Summary
- Adds generated \`tsvector\` columns on \`messages\` (content) and \`conversations\` (title + context_summary), each with a GIN index. Generated-stored columns auto-backfill on \`ALTER TABLE\` — no separate job.
- New \`ConversationSearchStore\` outbound port + \`PgConversationSearchStore\` impl. Hits where the conversation's title/summary matches surface even when no message text does.
- New \`builtin_conversation_search\` tool: \`{query, limit?, role?}\` → array of hits with conversation id/title, ordinal, role, content, \`ts_headline\` snippet, rank, updated_at. Wired in the daemon when a Postgres pool is configured.

## Migration note (callout)

\`013_conversation_message_fts.sql\` triggers a Postgres table rewrite to backfill the generated stored columns. The rewrite takes a write lock on \`messages\` proportional to row count. Run during a quiet window if the message table is large. JSON-store installs are unaffected.

## Test plan
- [x] \`cargo clippy --workspace --all-targets\` — no new warnings
- [x] \`cargo test --workspace\` — 30 suites pass, 0 failures
- [x] New unit tests in \`builtin.rs\`:
  - \`builtins_expose_expected_tools\` extended to assert \`TOOL_CONV_SEARCH\`
  - \`conversation_search_without_store_returns_error\` — clean error when no pg pool configured
  - \`conversation_search_with_closure_returns_results\` — tool input parsing + role filter + output JSON shape
  - \`conversation_search_rejects_unknown_role\` — boundary strips invalid role values before they hit SQL
- [ ] Manual: ask the assistant about a past conversation topic and confirm \`builtin_conversation_search\` is invoked and returns hits

## Out of scope (followups)
- Per-conversation date filters / archived toggle
- Embedding-augmented hybrid search
- Multi-language tsvector configs (\`'english'\` hard-coded, matches \`knowledge_base\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)