### PR TITLE
core+daemon+transports: knowledge base management API for clients (#73)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -131,6 +131,44 @@ pub enum Command {
         config: PurposeConfigView,
     },
 
+    // Knowledge base management (issue #73).
+    ListKnowledgeEntries {
+        #[serde(default = "default_kb_limit")]
+        limit: u32,
+        #[serde(default)]
+        offset: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tag_filter: Option<Vec<String>>,
+    },
+    GetKnowledgeEntry {
+        id: String,
+    },
+    SearchKnowledgeEntries {
+        query: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tag_filter: Option<Vec<String>>,
+        #[serde(default = "default_kb_limit")]
+        limit: u32,
+    },
+    CreateKnowledgeEntry {
+        content: String,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        metadata: serde_json::Value,
+    },
+    UpdateKnowledgeEntry {
+        id: String,
+        content: String,
+        #[serde(default)]
+        tags: Vec<String>,
+        #[serde(default)]
+        metadata: serde_json::Value,
+    },
+    DeleteKnowledgeEntry {
+        id: String,
+    },
+
     // MCP server management
     ListMcpServers,
     AddMcpServer {
@@ -161,6 +199,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_kb_limit() -> u32 {
+    50
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum CommandResult {
@@ -185,7 +227,25 @@ pub enum CommandResult {
     Models(Vec<ModelListing>),
     Purposes(PurposesView),
 
+    KnowledgeEntries(Vec<KnowledgeEntryView>),
+    KnowledgeEntry(Option<KnowledgeEntryView>),
+    KnowledgeEntryWritten(KnowledgeEntryView),
+
     Ack,
+}
+
+/// Wire-format view of a knowledge base entry. Mirrors
+/// `desktop_assistant_core::domain::KnowledgeEntry` but lives here so
+/// transports and clients depend only on `api-model`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct KnowledgeEntryView {
+    pub id: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -6,9 +6,10 @@
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
+use desktop_assistant_core::domain::KnowledgeEntry;
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
-    ConversationModelSelection, ConversationService, DispatchWarning, Effort,
+    ConversationModelSelection, ConversationService, DispatchWarning, Effort, KnowledgeService,
     PromptSelectionOverride, PurposeConfigPayload, PurposeKind, SettingsService,
 };
 use thiserror::Error;
@@ -73,37 +74,42 @@ pub trait EventSink: Send + Sync {
 
 const STREAM_EVENT_BUFFER: usize = 64;
 
-pub struct DefaultAssistantApiHandler<A, C, S, N>
+pub struct DefaultAssistantApiHandler<A, C, S, N, K>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
     N: ConnectionsService + 'static,
+    K: KnowledgeService + 'static,
 {
     assistant: Arc<A>,
     conversations: Arc<C>,
     settings: Arc<S>,
     connections: Arc<N>,
+    knowledge: Arc<K>,
 }
 
-impl<A, C, S, N> DefaultAssistantApiHandler<A, C, S, N>
+impl<A, C, S, N, K> DefaultAssistantApiHandler<A, C, S, N, K>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
     N: ConnectionsService + 'static,
+    K: KnowledgeService + 'static,
 {
     pub fn new(
         assistant: Arc<A>,
         conversations: Arc<C>,
         settings: Arc<S>,
         connections: Arc<N>,
+        knowledge: Arc<K>,
     ) -> Self {
         Self {
             assistant,
             conversations,
             settings,
             connections,
+            knowledge,
         }
     }
 
@@ -364,13 +370,25 @@ fn dispatch_warning_to_api(w: DispatchWarning) -> api::ConversationWarning {
     }
 }
 
+fn knowledge_entry_to_view(e: KnowledgeEntry) -> api::KnowledgeEntryView {
+    api::KnowledgeEntryView {
+        id: e.id,
+        content: e.content,
+        tags: e.tags,
+        metadata: e.metadata,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+    }
+}
+
 #[async_trait::async_trait]
-impl<A, C, S, N> AssistantApiHandler for DefaultAssistantApiHandler<A, C, S, N>
+impl<A, C, S, N, K> AssistantApiHandler for DefaultAssistantApiHandler<A, C, S, N, K>
 where
     A: AssistantService + 'static,
     C: ConversationService + 'static,
     S: SettingsService + 'static,
     N: ConnectionsService + 'static,
+    K: KnowledgeService + 'static,
 {
     async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
         match cmd {
@@ -587,6 +605,82 @@ where
             } => {
                 self.settings
                     .set_persistence_settings(enabled, remote_url, remote_name, push_on_update)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            // Knowledge base management (issue #73)
+            api::Command::ListKnowledgeEntries {
+                limit,
+                offset,
+                tag_filter,
+            } => {
+                let entries = self
+                    .knowledge
+                    .list_entries(limit as usize, offset as usize, tag_filter)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::KnowledgeEntries(
+                    entries.into_iter().map(knowledge_entry_to_view).collect(),
+                ))
+            }
+            api::Command::GetKnowledgeEntry { id } => {
+                let entry = self
+                    .knowledge
+                    .get_entry(id)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::KnowledgeEntry(
+                    entry.map(knowledge_entry_to_view),
+                ))
+            }
+            api::Command::SearchKnowledgeEntries {
+                query,
+                tag_filter,
+                limit,
+            } => {
+                let entries = self
+                    .knowledge
+                    .search_entries(query, tag_filter, limit as usize)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::KnowledgeEntries(
+                    entries.into_iter().map(knowledge_entry_to_view).collect(),
+                ))
+            }
+            api::Command::CreateKnowledgeEntry {
+                content,
+                tags,
+                metadata,
+            } => {
+                let entry = self
+                    .knowledge
+                    .create_entry(content, tags, metadata)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::KnowledgeEntryWritten(
+                    knowledge_entry_to_view(entry),
+                ))
+            }
+            api::Command::UpdateKnowledgeEntry {
+                id,
+                content,
+                tags,
+                metadata,
+            } => {
+                let entry = self
+                    .knowledge
+                    .update_entry(id, content, tags, metadata)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::KnowledgeEntryWritten(
+                    knowledge_entry_to_view(entry),
+                ))
+            }
+            api::Command::DeleteKnowledgeEntry { id } => {
+                self.knowledge
+                    .delete_entry(id)
                     .await
                     .map_err(Self::map_core_err)?;
                 Ok(api::CommandResult::Ack)
@@ -899,6 +993,56 @@ mod tests {
     use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct FakeKnowledge;
+    impl desktop_assistant_core::ports::inbound::KnowledgeService for FakeKnowledge {
+        async fn list_entries(
+            &self,
+            _limit: usize,
+            _offset: usize,
+            _tag_filter: Option<Vec<String>>,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            Ok(vec![])
+        }
+        async fn get_entry(
+            &self,
+            _id: String,
+        ) -> Result<Option<KnowledgeEntry>, CoreError> {
+            Ok(None)
+        }
+        async fn search_entries(
+            &self,
+            _query: String,
+            _tag_filter: Option<Vec<String>>,
+            _limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            Ok(vec![])
+        }
+        async fn create_entry(
+            &self,
+            content: String,
+            tags: Vec<String>,
+            metadata: serde_json::Value,
+        ) -> Result<KnowledgeEntry, CoreError> {
+            let mut e = KnowledgeEntry::new("kb-test", content, tags);
+            e.metadata = metadata;
+            Ok(e)
+        }
+        async fn update_entry(
+            &self,
+            id: String,
+            content: String,
+            tags: Vec<String>,
+            metadata: serde_json::Value,
+        ) -> Result<KnowledgeEntry, CoreError> {
+            let mut e = KnowledgeEntry::new(id, content, tags);
+            e.metadata = metadata;
+            Ok(e)
+        }
+        async fn delete_entry(&self, _id: String) -> Result<(), CoreError> {
+            Ok(())
+        }
+    }
 
     struct FakeConnections;
     impl ConnectionsService for FakeConnections {
@@ -1520,6 +1664,7 @@ mod tests {
             Arc::new(FakeConversations),
             Arc::new(FakeSettings),
             Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
         );
 
         let res = h.handle_command(api::Command::Ping).await.unwrap();
@@ -1538,6 +1683,7 @@ mod tests {
             Arc::new(FakeConversations),
             Arc::new(FakeSettings),
             Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
         );
 
         let sink = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
@@ -1561,6 +1707,7 @@ mod tests {
             }),
             Arc::new(FakeSettings),
             Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
         );
 
         h.handle_send_message("c1".into(), "hi".into(), "r1".into(), Arc::new(DropSink))
@@ -1578,6 +1725,7 @@ mod tests {
             Arc::new(FakeConversations),
             Arc::clone(&settings),
             Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
         );
 
         let res = h.handle_command(api::Command::GetConfig).await.unwrap();
@@ -1597,6 +1745,7 @@ mod tests {
             Arc::new(FakeConversations),
             Arc::clone(&settings),
             Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
         );
 
         let res = h

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use desktop_assistant_api_model as api;
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use zbus::Connection;
@@ -6,9 +7,44 @@ use zbus::Connection;
 use crate::signal::SignalEvent;
 use crate::types::{ChatMessage, ConversationDetail, ConversationSummary};
 
+/// Encode a tag filter for the JSON-string D-Bus argument. `None` and
+/// `Some(empty)` both serialise to `"null"`, matching the parsing on
+/// the server side (#73).
+fn tag_filter_to_json(filter: &Option<Vec<String>>) -> String {
+    match filter {
+        Some(tags) if !tags.is_empty() => {
+            serde_json::to_string(tags).unwrap_or_else(|_| "null".to_string())
+        }
+        _ => "null".to_string(),
+    }
+}
+
+fn decode_entries(raw: &str) -> Result<Vec<api::KnowledgeEntryView>> {
+    let envelope: api::CommandResult =
+        serde_json::from_str(raw).map_err(|e| anyhow::anyhow!("decoding entries: {e}"))?;
+    match envelope {
+        api::CommandResult::KnowledgeEntries(items) => Ok(items),
+        other => Err(anyhow::anyhow!(
+            "unexpected dbus response for knowledge entries: {other:?}"
+        )),
+    }
+}
+
+fn decode_entry_written(raw: &str) -> Result<api::KnowledgeEntryView> {
+    let envelope: api::CommandResult =
+        serde_json::from_str(raw).map_err(|e| anyhow::anyhow!("decoding entry: {e}"))?;
+    match envelope {
+        api::CommandResult::KnowledgeEntryWritten(entry) => Ok(entry),
+        other => Err(anyhow::anyhow!(
+            "unexpected dbus response for knowledge entry write: {other:?}"
+        )),
+    }
+}
+
 const DEFAULT_DBUS_SERVICE: &str = "org.desktopAssistant";
 const DBUS_CONVERSATIONS_PATH: &str = "/org/desktopAssistant/Conversations";
 const DBUS_SETTINGS_PATH: &str = "/org/desktopAssistant/Settings";
+const DBUS_KNOWLEDGE_PATH: &str = "/org/desktopAssistant/Knowledge";
 
 #[zbus::proxy(interface = "org.desktopAssistant.Conversations")]
 trait Conversations {
@@ -65,6 +101,42 @@ trait Settings {
     async fn generate_ws_jwt(&self, subject: &str) -> zbus::fdo::Result<String>;
 }
 
+#[zbus::proxy(interface = "org.desktopAssistant.Knowledge")]
+trait Knowledge {
+    async fn list_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter_json: &str,
+    ) -> zbus::fdo::Result<String>;
+
+    async fn get_entry(&self, id: &str) -> zbus::fdo::Result<String>;
+
+    async fn search_entries(
+        &self,
+        query: &str,
+        tag_filter_json: &str,
+        limit: u32,
+    ) -> zbus::fdo::Result<String>;
+
+    async fn create_entry(
+        &self,
+        content: &str,
+        tags_json: &str,
+        metadata_json: &str,
+    ) -> zbus::fdo::Result<String>;
+
+    async fn update_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags_json: &str,
+        metadata_json: &str,
+    ) -> zbus::fdo::Result<String>;
+
+    async fn delete_entry(&self, id: &str) -> zbus::fdo::Result<()>;
+}
+
 fn resolve_dbus_service_name() -> String {
     std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
         .ok()
@@ -87,6 +159,7 @@ pub async fn generate_ws_jwt(subject: &str) -> Result<String> {
 
 pub struct DbusClient {
     proxy: ConversationsProxy<'static>,
+    knowledge: KnowledgeProxy<'static>,
 }
 
 impl DbusClient {
@@ -94,11 +167,16 @@ impl DbusClient {
         let connection = Connection::session().await?;
         let service_name = resolve_dbus_service_name();
         let proxy = ConversationsProxy::builder(&connection)
-            .destination(service_name)?
+            .destination(service_name.clone())?
             .path(DBUS_CONVERSATIONS_PATH)?
             .build()
             .await?;
-        Ok(Self { proxy })
+        let knowledge = KnowledgeProxy::builder(&connection)
+            .destination(service_name)?
+            .path(DBUS_KNOWLEDGE_PATH)?
+            .build()
+            .await?;
+        Ok(Self { proxy, knowledge })
     }
 
     pub async fn list_conversations(&self) -> Result<Vec<ConversationSummary>> {
@@ -172,6 +250,89 @@ impl DbusClient {
     pub async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String> {
         let request_id = self.proxy.send_prompt(conversation_id, prompt).await?;
         Ok(request_id)
+    }
+
+    // --- Knowledge management (issue #73) -------------------------------
+
+    pub async fn list_knowledge_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        let raw = self
+            .knowledge
+            .list_entries(limit, offset, &tag_filter_to_json(&tag_filter))
+            .await?;
+        decode_entries(&raw)
+    }
+
+    pub async fn get_knowledge_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<api::KnowledgeEntryView>> {
+        let raw = self.knowledge.get_entry(id).await?;
+        let envelope: api::CommandResult = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("decoding get_entry response: {e}"))?;
+        match envelope {
+            api::CommandResult::KnowledgeEntry(entry) => Ok(entry),
+            other => Err(anyhow::anyhow!(
+                "unexpected dbus response for get_knowledge_entry: {other:?}"
+            )),
+        }
+    }
+
+    pub async fn search_knowledge_entries(
+        &self,
+        query: &str,
+        tag_filter: Option<Vec<String>>,
+        limit: u32,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        let raw = self
+            .knowledge
+            .search_entries(query, &tag_filter_to_json(&tag_filter), limit)
+            .await?;
+        decode_entries(&raw)
+    }
+
+    pub async fn create_knowledge_entry(
+        &self,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        let tags_json =
+            serde_json::to_string(&tags).map_err(|e| anyhow::anyhow!("encoding tags: {e}"))?;
+        let metadata_json = serde_json::to_string(&metadata)
+            .map_err(|e| anyhow::anyhow!("encoding metadata: {e}"))?;
+        let raw = self
+            .knowledge
+            .create_entry(content, &tags_json, &metadata_json)
+            .await?;
+        decode_entry_written(&raw)
+    }
+
+    pub async fn update_knowledge_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        let tags_json =
+            serde_json::to_string(&tags).map_err(|e| anyhow::anyhow!("encoding tags: {e}"))?;
+        let metadata_json = serde_json::to_string(&metadata)
+            .map_err(|e| anyhow::anyhow!("encoding metadata: {e}"))?;
+        let raw = self
+            .knowledge
+            .update_entry(id, content, &tags_json, &metadata_json)
+            .await?;
+        decode_entry_written(&raw)
+    }
+
+    pub async fn delete_knowledge_entry(&self, id: &str) -> Result<()> {
+        self.knowledge.delete_entry(id).await?;
+        Ok(())
     }
 
     pub async fn subscribe_signals(&self) -> Result<mpsc::UnboundedReceiver<SignalEvent>> {

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use desktop_assistant_api_model as api;
 use tokio::sync::mpsc;
 
 use crate::auth::resolve_ws_bearer_token;
@@ -19,6 +20,38 @@ pub trait AssistantClient: Send + Sync {
     async fn archive_conversation(&self, id: &str) -> Result<()>;
     async fn unarchive_conversation(&self, id: &str) -> Result<()>;
     async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String>;
+
+    // Knowledge management (#73)
+    async fn list_knowledge_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<api::KnowledgeEntryView>>;
+    async fn get_knowledge_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<api::KnowledgeEntryView>>;
+    async fn search_knowledge_entries(
+        &self,
+        query: &str,
+        tag_filter: Option<Vec<String>>,
+        limit: u32,
+    ) -> Result<Vec<api::KnowledgeEntryView>>;
+    async fn create_knowledge_entry(
+        &self,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView>;
+    async fn update_knowledge_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView>;
+    async fn delete_knowledge_entry(&self, id: &str) -> Result<()>;
 }
 
 pub enum TransportClient {
@@ -111,6 +144,94 @@ impl AssistantClient for TransportClient {
             #[cfg(feature = "dbus")]
             Self::Dbus(client) => client.send_prompt(conversation_id, prompt).await,
             Self::Ws(client) => client.send_prompt(conversation_id, prompt).await,
+        }
+    }
+
+    async fn list_knowledge_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => client
+                .list_knowledge_entries(limit, offset, tag_filter)
+                .await,
+            Self::Ws(client) => client
+                .list_knowledge_entries(limit, offset, tag_filter)
+                .await,
+        }
+    }
+
+    async fn get_knowledge_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<api::KnowledgeEntryView>> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => client.get_knowledge_entry(id).await,
+            Self::Ws(client) => client.get_knowledge_entry(id).await,
+        }
+    }
+
+    async fn search_knowledge_entries(
+        &self,
+        query: &str,
+        tag_filter: Option<Vec<String>>,
+        limit: u32,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => client
+                .search_knowledge_entries(query, tag_filter, limit)
+                .await,
+            Self::Ws(client) => client
+                .search_knowledge_entries(query, tag_filter, limit)
+                .await,
+        }
+    }
+
+    async fn create_knowledge_entry(
+        &self,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => client.create_knowledge_entry(content, tags, metadata).await,
+            Self::Ws(client) => client.create_knowledge_entry(content, tags, metadata).await,
+        }
+    }
+
+    async fn update_knowledge_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => {
+                client
+                    .update_knowledge_entry(id, content, tags, metadata)
+                    .await
+            }
+            Self::Ws(client) => {
+                client
+                    .update_knowledge_entry(id, content, tags, metadata)
+                    .await
+            }
+        }
+    }
+
+    async fn delete_knowledge_entry(&self, id: &str) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => client.delete_knowledge_entry(id).await,
+            Self::Ws(client) => client.delete_knowledge_entry(id).await,
         }
     }
 }

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -301,6 +301,121 @@ impl WsClient {
         };
         Ok(items)
     }
+
+    // --- Knowledge management (issue #73) -------------------------------
+
+    pub async fn list_knowledge_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        let result = self
+            .send_command(api::Command::ListKnowledgeEntries {
+                limit,
+                offset,
+                tag_filter,
+            })
+            .await?;
+        let api::CommandResult::KnowledgeEntries(items) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for list_knowledge_entries"
+            ));
+        };
+        Ok(items)
+    }
+
+    pub async fn get_knowledge_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<api::KnowledgeEntryView>> {
+        let result = self
+            .send_command(api::Command::GetKnowledgeEntry { id: id.to_string() })
+            .await?;
+        let api::CommandResult::KnowledgeEntry(entry) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for get_knowledge_entry"
+            ));
+        };
+        Ok(entry)
+    }
+
+    pub async fn search_knowledge_entries(
+        &self,
+        query: &str,
+        tag_filter: Option<Vec<String>>,
+        limit: u32,
+    ) -> Result<Vec<api::KnowledgeEntryView>> {
+        let result = self
+            .send_command(api::Command::SearchKnowledgeEntries {
+                query: query.to_string(),
+                tag_filter,
+                limit,
+            })
+            .await?;
+        let api::CommandResult::KnowledgeEntries(items) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for search_knowledge_entries"
+            ));
+        };
+        Ok(items)
+    }
+
+    pub async fn create_knowledge_entry(
+        &self,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        let result = self
+            .send_command(api::Command::CreateKnowledgeEntry {
+                content: content.to_string(),
+                tags,
+                metadata,
+            })
+            .await?;
+        let api::CommandResult::KnowledgeEntryWritten(entry) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for create_knowledge_entry"
+            ));
+        };
+        Ok(entry)
+    }
+
+    pub async fn update_knowledge_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<api::KnowledgeEntryView> {
+        let result = self
+            .send_command(api::Command::UpdateKnowledgeEntry {
+                id: id.to_string(),
+                content: content.to_string(),
+                tags,
+                metadata,
+            })
+            .await?;
+        let api::CommandResult::KnowledgeEntryWritten(entry) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for update_knowledge_entry"
+            ));
+        };
+        Ok(entry)
+    }
+
+    pub async fn delete_knowledge_entry(&self, id: &str) -> Result<()> {
+        let result = self
+            .send_command(api::Command::DeleteKnowledgeEntry { id: id.to_string() })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for delete_knowledge_entry"
+            ));
+        };
+        Ok(())
+    }
 }
 
 fn build_tls_connector(

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -1,5 +1,5 @@
 use crate::CoreError;
-use crate::domain::{Conversation, ConversationId, ConversationSummary};
+use crate::domain::{Conversation, ConversationId, ConversationSummary, KnowledgeEntry};
 use crate::ports::llm::{ChunkCallback, ModelInfo, StatusCallback};
 
 #[derive(Debug, Clone)]
@@ -571,6 +571,62 @@ pub trait SettingsService: Send + Sync {
     ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
 }
 
+/// Inbound port for client-facing knowledge base management (#73).
+///
+/// Distinct from the LLM-facing [`builtin_knowledge_base_*`][1] tools:
+/// adapters dispatch through this trait so client UIs (GTK browser, etc.)
+/// can browse, search, edit, and delete entries directly. Writes go
+/// through the same chunk-and-embed pipeline as the tool path so
+/// client-authored entries remain discoverable by the LLM.
+///
+/// `search_entries` is full-text only (no embedding round-trip on the
+/// client) — the LLM tool keeps the hybrid path.
+///
+/// [1]: crate::ports::knowledge::KnowledgeBaseStore
+pub trait KnowledgeService: Send + Sync {
+    fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+        tag_filter: Option<Vec<String>>,
+    ) -> impl std::future::Future<Output = Result<Vec<KnowledgeEntry>, CoreError>> + Send;
+
+    fn get_entry(
+        &self,
+        id: String,
+    ) -> impl std::future::Future<Output = Result<Option<KnowledgeEntry>, CoreError>> + Send;
+
+    fn search_entries(
+        &self,
+        query: String,
+        tag_filter: Option<Vec<String>>,
+        limit: usize,
+    ) -> impl std::future::Future<Output = Result<Vec<KnowledgeEntry>, CoreError>> + Send;
+
+    /// Create a new entry. The daemon assigns the id, embeds the
+    /// content, and records the embedding model used.
+    fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> impl std::future::Future<Output = Result<KnowledgeEntry, CoreError>> + Send;
+
+    /// Replace an existing entry's content/tags/metadata. Re-embeds.
+    fn update_entry(
+        &self,
+        id: String,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> impl std::future::Future<Output = Result<KnowledgeEntry, CoreError>> + Send;
+
+    fn delete_entry(
+        &self,
+        id: String,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -603,4 +659,5 @@ mod tests {
     // but we verify it's implementable via the service tests in service.rs.
     fn _assert_conversation_service<T: ConversationService>() {}
     fn _assert_settings_service<T: SettingsService>() {}
+    fn _assert_knowledge_service<T: KnowledgeService>() {}
 }

--- a/crates/core/src/ports/knowledge.rs
+++ b/crates/core/src/ports/knowledge.rs
@@ -26,6 +26,26 @@ pub trait KnowledgeBaseStore: Send + Sync {
         limit: usize,
     ) -> impl Future<Output = Result<Vec<KnowledgeEntry>, CoreError>> + Send;
 
+    /// Full-text search only (no vector similarity). Used by client-side
+    /// browsers that need responsive search without embedding round-trips
+    /// (#73). The LLM tool path keeps using [`Self::search`] for hybrid
+    /// semantic+lexical match.
+    fn search_text(
+        &self,
+        query: &str,
+        tags: Option<Vec<String>>,
+        limit: usize,
+    ) -> impl Future<Output = Result<Vec<KnowledgeEntry>, CoreError>> + Send;
+
+    /// Paginated listing of all entries, ordered by `updated_at DESC, id`.
+    /// Used by the management API (#73).
+    fn list(
+        &self,
+        limit: usize,
+        offset: usize,
+        tag_filter: Option<Vec<String>>,
+    ) -> impl Future<Output = Result<Vec<KnowledgeEntry>, CoreError>> + Send;
+
     /// Delete a knowledge entry by id.
     fn delete(&self, id: &str) -> impl Future<Output = Result<(), CoreError>> + Send;
 
@@ -86,6 +106,24 @@ mod tests {
             _query_embedding: Vec<f32>,
             _tags: Option<Vec<String>>,
             _limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn search_text(
+            &self,
+            _query: &str,
+            _tags: Option<Vec<String>>,
+            _limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn list(
+            &self,
+            _limit: usize,
+            _offset: usize,
+            _tag_filter: Option<Vec<String>>,
         ) -> Result<Vec<KnowledgeEntry>, CoreError> {
             Ok(vec![])
         }

--- a/crates/daemon/src/knowledge_service.rs
+++ b/crates/daemon/src/knowledge_service.rs
@@ -1,0 +1,471 @@
+//! Daemon-side [`KnowledgeService`] (#73).
+//!
+//! Adapts the [`KnowledgeBaseStore`] outbound port + the configured
+//! embedding closure into a client-facing inbound port. Mirrors the
+//! `builtin_knowledge_base_*` write path so client-authored entries
+//! remain discoverable via the LLM tool.
+//!
+//! When no Postgres pool is configured at startup, every method
+//! returns `CoreError::Storage("knowledge base not configured")` —
+//! same shape as the builtin tool's "no store wired" error so clients
+//! get a uniform message.
+
+use std::sync::Arc;
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::chunking::{CHUNK_MAX_CHARS, CHUNK_OVERLAP, chunk_text};
+use desktop_assistant_core::domain::KnowledgeEntry;
+use desktop_assistant_core::ports::embedding::EmbedFn;
+use desktop_assistant_core::ports::inbound::KnowledgeService;
+use desktop_assistant_core::ports::knowledge::KnowledgeBaseStore;
+
+/// Concrete [`KnowledgeService`] backed by a Postgres-backed
+/// [`KnowledgeBaseStore`] (or an in-memory test double).
+pub struct DaemonKnowledgeService<S>
+where
+    S: KnowledgeBaseStore + 'static,
+{
+    store: Arc<S>,
+    embed_fn: Option<EmbedFn>,
+    embedding_model: Option<String>,
+    id_generator: Box<dyn Fn() -> String + Send + Sync>,
+}
+
+impl<S> DaemonKnowledgeService<S>
+where
+    S: KnowledgeBaseStore + 'static,
+{
+    pub fn new(
+        store: Arc<S>,
+        embed_fn: Option<EmbedFn>,
+        embedding_model: Option<String>,
+    ) -> Self {
+        Self {
+            store,
+            embed_fn,
+            embedding_model,
+            id_generator: Box::new(|| uuid::Uuid::now_v7().to_string()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_id_generator(
+        mut self,
+        gen_fn: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        self.id_generator = Box::new(gen_fn);
+        self
+    }
+
+    /// Chunk + embed `content` using the configured embedding closure.
+    /// Returns `Ok(None)` when no embedding closure is wired (KB writes
+    /// still succeed, just without semantic search coverage — same
+    /// behaviour as the builtin tool's `embed_chunks` path).
+    async fn embed_chunks(
+        &self,
+        content: &str,
+    ) -> Result<Option<Vec<Vec<f32>>>, CoreError> {
+        let Some(embed_fn) = self.embed_fn.as_ref() else {
+            return Ok(None);
+        };
+        let chunks = chunk_text(content, CHUNK_MAX_CHARS, CHUNK_OVERLAP);
+        if chunks.is_empty() {
+            return Ok(None);
+        }
+        match embed_fn(chunks).await {
+            Ok(vecs) if !vecs.is_empty() => Ok(Some(vecs)),
+            Ok(_) => Ok(None),
+            Err(e) => {
+                tracing::warn!("knowledge service: embedding failed: {e}");
+                Ok(None)
+            }
+        }
+    }
+}
+
+impl<S> KnowledgeService for DaemonKnowledgeService<S>
+where
+    S: KnowledgeBaseStore + 'static,
+{
+    async fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        self.store.list(limit, offset, tag_filter).await
+    }
+
+    async fn get_entry(&self, id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        self.store.get(&id).await
+    }
+
+    async fn search_entries(
+        &self,
+        query: String,
+        tag_filter: Option<Vec<String>>,
+        limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        self.store.search_text(&query, tag_filter, limit).await
+    }
+
+    async fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let id = (self.id_generator)();
+        let mut entry = KnowledgeEntry::new(id, content, tags);
+        entry.metadata = metadata;
+        let embedding = self.embed_chunks(&entry.content).await?;
+        let model = embedding.as_ref().and(self.embedding_model.clone());
+        self.store.write(entry, embedding, model).await
+    }
+
+    async fn update_entry(
+        &self,
+        id: String,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let mut entry = KnowledgeEntry::new(id, content, tags);
+        entry.metadata = metadata;
+        let embedding = self.embed_chunks(&entry.content).await?;
+        let model = embedding.as_ref().and(self.embedding_model.clone());
+        // The store's `write` upserts on id collision, which is exactly
+        // the update semantics we want; created_at is preserved by the
+        // ON CONFLICT clause.
+        self.store.write(entry, embedding, model).await
+    }
+
+    async fn delete_entry(&self, id: String) -> Result<(), CoreError> {
+        self.store.delete(&id).await
+    }
+}
+
+/// Runtime dispatch wrapper. The `KnowledgeService` trait uses `impl
+/// Future` returns and so isn't dyn-compatible; the concrete type held
+/// by the API handler must therefore be fixed at compile time. Wrap the
+/// configured / unconfigured branches in this enum so the daemon can
+/// pick at runtime without infecting the handler's generics.
+pub enum AnyKnowledgeService<S>
+where
+    S: KnowledgeBaseStore + 'static,
+{
+    Configured(DaemonKnowledgeService<S>),
+    Unconfigured(UnconfiguredKnowledgeService),
+}
+
+impl<S> KnowledgeService for AnyKnowledgeService<S>
+where
+    S: KnowledgeBaseStore + 'static,
+{
+    async fn list_entries(
+        &self,
+        limit: usize,
+        offset: usize,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        match self {
+            Self::Configured(s) => s.list_entries(limit, offset, tag_filter).await,
+            Self::Unconfigured(s) => s.list_entries(limit, offset, tag_filter).await,
+        }
+    }
+
+    async fn get_entry(&self, id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        match self {
+            Self::Configured(s) => s.get_entry(id).await,
+            Self::Unconfigured(s) => s.get_entry(id).await,
+        }
+    }
+
+    async fn search_entries(
+        &self,
+        query: String,
+        tag_filter: Option<Vec<String>>,
+        limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        match self {
+            Self::Configured(s) => s.search_entries(query, tag_filter, limit).await,
+            Self::Unconfigured(s) => s.search_entries(query, tag_filter, limit).await,
+        }
+    }
+
+    async fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        match self {
+            Self::Configured(s) => s.create_entry(content, tags, metadata).await,
+            Self::Unconfigured(s) => s.create_entry(content, tags, metadata).await,
+        }
+    }
+
+    async fn update_entry(
+        &self,
+        id: String,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        match self {
+            Self::Configured(s) => s.update_entry(id, content, tags, metadata).await,
+            Self::Unconfigured(s) => s.update_entry(id, content, tags, metadata).await,
+        }
+    }
+
+    async fn delete_entry(&self, id: String) -> Result<(), CoreError> {
+        match self {
+            Self::Configured(s) => s.delete_entry(id).await,
+            Self::Unconfigured(s) => s.delete_entry(id).await,
+        }
+    }
+}
+
+/// No-op [`KnowledgeService`] used when no Postgres pool is configured.
+/// Every method returns a clear `not configured` error so the API
+/// surface is uniform regardless of backend availability.
+pub struct UnconfiguredKnowledgeService;
+
+const UNCONFIGURED_MSG: &str = "knowledge base not configured (Postgres required)";
+
+impl KnowledgeService for UnconfiguredKnowledgeService {
+    async fn list_entries(
+        &self,
+        _limit: usize,
+        _offset: usize,
+        _tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+
+    async fn get_entry(&self, _id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+
+    async fn search_entries(
+        &self,
+        _query: String,
+        _tag_filter: Option<Vec<String>>,
+        _limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+
+    async fn create_entry(
+        &self,
+        _content: String,
+        _tags: Vec<String>,
+        _metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+
+    async fn update_entry(
+        &self,
+        _id: String,
+        _content: String,
+        _tags: Vec<String>,
+        _metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+
+    async fn delete_entry(&self, _id: String) -> Result<(), CoreError> {
+        Err(CoreError::Storage(UNCONFIGURED_MSG.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct InMemoryStore {
+        entries: Mutex<Vec<(KnowledgeEntry, Option<Vec<Vec<f32>>>, Option<String>)>>,
+    }
+
+    impl KnowledgeBaseStore for InMemoryStore {
+        async fn write(
+            &self,
+            entry: KnowledgeEntry,
+            embedding: Option<Vec<Vec<f32>>>,
+            embedding_model: Option<String>,
+        ) -> Result<KnowledgeEntry, CoreError> {
+            let mut guard = self.entries.lock().unwrap();
+            // Upsert by id — drop any prior entry with the same id.
+            guard.retain(|(e, _, _)| e.id != entry.id);
+            guard.push((entry.clone(), embedding, embedding_model));
+            Ok(entry)
+        }
+
+        async fn search(
+            &self,
+            _query: &str,
+            _query_embedding: Vec<f32>,
+            _tags: Option<Vec<String>>,
+            _limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn search_text(
+            &self,
+            query: &str,
+            _tags: Option<Vec<String>>,
+            limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            // Naive contains-match; sufficient for unit tests.
+            let guard = self.entries.lock().unwrap();
+            let mut hits: Vec<KnowledgeEntry> = guard
+                .iter()
+                .filter(|(e, _, _)| e.content.contains(query))
+                .map(|(e, _, _)| e.clone())
+                .collect();
+            hits.truncate(limit);
+            Ok(hits)
+        }
+
+        async fn list(
+            &self,
+            limit: usize,
+            offset: usize,
+            _tag_filter: Option<Vec<String>>,
+        ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+            let guard = self.entries.lock().unwrap();
+            Ok(guard
+                .iter()
+                .map(|(e, _, _)| e.clone())
+                .skip(offset)
+                .take(limit)
+                .collect())
+        }
+
+        async fn delete(&self, id: &str) -> Result<(), CoreError> {
+            let mut guard = self.entries.lock().unwrap();
+            guard.retain(|(e, _, _)| e.id != id);
+            Ok(())
+        }
+
+        async fn get(&self, id: &str) -> Result<Option<KnowledgeEntry>, CoreError> {
+            let guard = self.entries.lock().unwrap();
+            Ok(guard
+                .iter()
+                .find(|(e, _, _)| e.id == id)
+                .map(|(e, _, _)| e.clone()))
+        }
+    }
+
+    #[tokio::test]
+    async fn create_assigns_id_and_persists() {
+        let store = Arc::new(InMemoryStore::default());
+        let service = DaemonKnowledgeService::new(Arc::clone(&store), None, None)
+            .with_id_generator(|| "fixed-id".into());
+
+        let entry = service
+            .create_entry(
+                "user prefers dark mode".into(),
+                vec!["preference".into()],
+                serde_json::json!({"scope": "global"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(entry.id, "fixed-id");
+        assert_eq!(entry.content, "user prefers dark mode");
+        assert_eq!(entry.tags, vec!["preference"]);
+
+        let fetched = service.get_entry("fixed-id".into()).await.unwrap();
+        assert!(fetched.is_some());
+    }
+
+    #[tokio::test]
+    async fn create_embeds_when_embed_fn_configured() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_closure = Arc::clone(&calls);
+        let embed_fn: EmbedFn = Arc::new(move |chunks| {
+            calls_for_closure.fetch_add(1, Ordering::SeqCst);
+            let n = chunks.len();
+            Box::pin(async move { Ok(vec![vec![0.1, 0.2]; n]) })
+        });
+
+        let store = Arc::new(InMemoryStore::default());
+        let service = DaemonKnowledgeService::new(
+            Arc::clone(&store),
+            Some(embed_fn),
+            Some("test-model".into()),
+        );
+
+        service
+            .create_entry("payload".into(), vec![], serde_json::json!({}))
+            .await
+            .unwrap();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "embed closure must be invoked exactly once"
+        );
+
+        let stored = store.entries.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].2.as_deref(), Some("test-model"));
+        assert!(stored[0].1.is_some(), "embedding must be persisted");
+    }
+
+    #[tokio::test]
+    async fn update_replaces_in_place_and_re_embeds() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_closure = Arc::clone(&calls);
+        let embed_fn: EmbedFn = Arc::new(move |chunks| {
+            calls_for_closure.fetch_add(1, Ordering::SeqCst);
+            let n = chunks.len();
+            Box::pin(async move { Ok(vec![vec![1.0]; n]) })
+        });
+
+        let store = Arc::new(InMemoryStore::default());
+        let service = DaemonKnowledgeService::new(
+            Arc::clone(&store),
+            Some(embed_fn),
+            Some("m".into()),
+        )
+        .with_id_generator(|| "kb-x".into());
+
+        service
+            .create_entry("orig".into(), vec![], serde_json::json!({}))
+            .await
+            .unwrap();
+        service
+            .update_entry(
+                "kb-x".into(),
+                "updated".into(),
+                vec!["t".into()],
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "create + update each embed once"
+        );
+        let stored = store.entries.lock().unwrap();
+        assert_eq!(stored.len(), 1, "update must not create a duplicate");
+        assert_eq!(stored[0].0.content, "updated");
+        assert_eq!(stored[0].0.tags, vec!["t"]);
+    }
+
+    #[tokio::test]
+    async fn unconfigured_service_returns_storage_error() {
+        let svc = UnconfiguredKnowledgeService;
+        let err = svc.list_entries(10, 0, None).await.unwrap_err();
+        assert!(matches!(err, CoreError::Storage(msg) if msg.contains("not configured")));
+    }
+}

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -15,6 +15,7 @@ mod app;
 mod backend_reasoning;
 mod config;
 mod connections;
+mod knowledge_service;
 mod model_defaults;
 mod purposes;
 mod registry;
@@ -844,6 +845,10 @@ async fn main() -> Result<()> {
 
     // Build the MCP tool executor with builtin tools
     let mut builtin_tools = BuiltinToolService::new();
+    // Hold an extra clone for the knowledge management service (#73) so
+    // both the LLM-tool path and the client-facing service embed via
+    // the same closure.
+    let embedding_fn_for_kb_service: Option<EmbedFn> = embedding_fn.clone();
     if let Some(embed_fn) = embedding_fn {
         tracing::info!(
             "enabling built-in vector search with model={}",
@@ -1334,6 +1339,29 @@ async fn main() -> Result<()> {
     let settings_service =
         Arc::new(DaemonSettingsService::new(config_path.clone()).with_mcp_control(mcp_handle));
 
+    // Knowledge management service (#73). When a Postgres pool is
+    // configured, wire the embedding closure so client-authored entries
+    // are discoverable by the LLM tool. Without a pool, every method
+    // surfaces a uniform "not configured" error.
+    let knowledge_service = Arc::new(match (&kb_store, embedding_fn_for_kb_service.clone()) {
+        (Some(store), embed_fn) => {
+            tracing::info!("knowledge management service ready");
+            knowledge_service::AnyKnowledgeService::Configured(
+                knowledge_service::DaemonKnowledgeService::new(
+                    Arc::clone(store),
+                    embed_fn,
+                    Some(embedding_model_id.clone()),
+                ),
+            )
+        }
+        (None, _) => {
+            tracing::info!("knowledge management service unavailable (no Postgres pool)");
+            knowledge_service::AnyKnowledgeService::Unconfigured(
+                knowledge_service::UnconfiguredKnowledgeService,
+            )
+        }
+    });
+
     // Construct the shared API handler up-front so both the D-Bus and WS
     // adapters can share it (the multi-connection D-Bus interface dispatches
     // through this handler, mirroring the WS adapter).
@@ -1343,6 +1371,7 @@ async fn main() -> Result<()> {
             Arc::clone(&conversation_service),
             Arc::clone(&settings_service),
             Arc::clone(&connections_service),
+            Arc::clone(&knowledge_service),
         ));
 
     let dbus_service_name = std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
@@ -1374,6 +1403,14 @@ async fn main() -> Result<()> {
                 b.serve_at(
                     "/org/desktopAssistant/Connections",
                     desktop_assistant_dbus::connections::DbusConnectionsAdapter::new(
+                        Arc::clone(&api_handler),
+                    ),
+                )
+            })
+            .and_then(|b| {
+                b.serve_at(
+                    "/org/desktopAssistant/Knowledge",
+                    desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(
                         Arc::clone(&api_handler),
                     ),
                 )

--- a/crates/dbus-interface/src/knowledge.rs
+++ b/crates/dbus-interface/src/knowledge.rs
@@ -1,0 +1,239 @@
+//! D-Bus adapter for the knowledge management API (#73).
+//!
+//! Each method translates D-Bus arguments into an [`api::Command`] and
+//! dispatches through the shared [`AssistantApiHandler`] (the same path
+//! the WebSocket adapter takes). Complex payloads — entry views,
+//! metadata blobs — are passed as JSON strings to keep the zbus
+//! marshaling minimal; clients re-parse with `serde_json` (or
+//! `QJsonDocument` on the Qt side).
+
+use std::sync::Arc;
+
+use desktop_assistant_application::AssistantApiHandler;
+use desktop_assistant_api_model::{self as api};
+use zbus::{fdo, interface};
+
+fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
+    fdo::Error::Failed(error.to_string())
+}
+
+pub struct DbusKnowledgeAdapter {
+    handler: Arc<dyn AssistantApiHandler>,
+}
+
+impl DbusKnowledgeAdapter {
+    pub fn new(handler: Arc<dyn AssistantApiHandler>) -> Self {
+        Self { handler }
+    }
+
+    async fn dispatch(&self, cmd: api::Command) -> fdo::Result<api::CommandResult> {
+        self.handler
+            .handle_command(cmd)
+            .await
+            .map_err(|e| fdo::Error::Failed(format!("{e:?}")))
+    }
+}
+
+#[interface(name = "org.desktopAssistant.Knowledge")]
+impl DbusKnowledgeAdapter {
+    /// Paginated entry list. Returns JSON `{"knowledge_entries": [...]}`
+    /// matching the WS surface. Pass `tag_filter_json="null"` (or `""`)
+    /// to disable the filter.
+    async fn list_entries(
+        &self,
+        limit: u32,
+        offset: u32,
+        tag_filter_json: &str,
+    ) -> fdo::Result<String> {
+        let tag_filter = parse_tag_filter(tag_filter_json)?;
+        let result = self
+            .dispatch(api::Command::ListKnowledgeEntries {
+                limit,
+                offset,
+                tag_filter,
+            })
+            .await?;
+        match &result {
+            api::CommandResult::KnowledgeEntries(_) => {
+                serde_json::to_string(&result).map_err(to_fdo_error)
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected ListKnowledgeEntries result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Fetch a single entry by id. Returns JSON `{"knowledge_entry": {...}}`
+    /// (or `{"knowledge_entry": null}` for unknown id) so callers always
+    /// see the same envelope.
+    async fn get_entry(&self, id: &str) -> fdo::Result<String> {
+        let result = self
+            .dispatch(api::Command::GetKnowledgeEntry {
+                id: id.to_string(),
+            })
+            .await?;
+        match &result {
+            api::CommandResult::KnowledgeEntry(_) => {
+                serde_json::to_string(&result).map_err(to_fdo_error)
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected GetKnowledgeEntry result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Full-text search. Same envelope as `list_entries` for callers
+    /// that swap between browse and search modes.
+    async fn search_entries(
+        &self,
+        query: &str,
+        tag_filter_json: &str,
+        limit: u32,
+    ) -> fdo::Result<String> {
+        let tag_filter = parse_tag_filter(tag_filter_json)?;
+        let result = self
+            .dispatch(api::Command::SearchKnowledgeEntries {
+                query: query.to_string(),
+                tag_filter,
+                limit,
+            })
+            .await?;
+        match &result {
+            api::CommandResult::KnowledgeEntries(_) => {
+                serde_json::to_string(&result).map_err(to_fdo_error)
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected SearchKnowledgeEntries result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Create a new entry; daemon assigns the id and embeds. Returns
+    /// JSON `{"knowledge_entry_written": {...}}` carrying the persisted
+    /// view (with the assigned id + timestamps).
+    async fn create_entry(
+        &self,
+        content: &str,
+        tags_json: &str,
+        metadata_json: &str,
+    ) -> fdo::Result<String> {
+        let tags = parse_tags(tags_json)?;
+        let metadata = parse_metadata(metadata_json)?;
+        let result = self
+            .dispatch(api::Command::CreateKnowledgeEntry {
+                content: content.to_string(),
+                tags,
+                metadata,
+            })
+            .await?;
+        match &result {
+            api::CommandResult::KnowledgeEntryWritten(_) => {
+                serde_json::to_string(&result).map_err(to_fdo_error)
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected CreateKnowledgeEntry result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Replace an existing entry's content/tags/metadata. Re-embeds.
+    async fn update_entry(
+        &self,
+        id: &str,
+        content: &str,
+        tags_json: &str,
+        metadata_json: &str,
+    ) -> fdo::Result<String> {
+        let tags = parse_tags(tags_json)?;
+        let metadata = parse_metadata(metadata_json)?;
+        let result = self
+            .dispatch(api::Command::UpdateKnowledgeEntry {
+                id: id.to_string(),
+                content: content.to_string(),
+                tags,
+                metadata,
+            })
+            .await?;
+        match &result {
+            api::CommandResult::KnowledgeEntryWritten(_) => {
+                serde_json::to_string(&result).map_err(to_fdo_error)
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected UpdateKnowledgeEntry result: {other:?}"
+            ))),
+        }
+    }
+
+    async fn delete_entry(&self, id: &str) -> fdo::Result<()> {
+        let result = self
+            .dispatch(api::Command::DeleteKnowledgeEntry {
+                id: id.to_string(),
+            })
+            .await?;
+        match result {
+            api::CommandResult::Ack => Ok(()),
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected DeleteKnowledgeEntry result: {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Parse the wire-format tag filter. Empty string and `"null"` both map
+/// to `None`. Anything else must be a JSON array of strings.
+fn parse_tag_filter(raw: &str) -> fdo::Result<Option<Vec<String>>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "null" {
+        return Ok(None);
+    }
+    serde_json::from_str(trimmed).map_err(to_fdo_error)
+}
+
+/// Parse a JSON array of tag strings; empty string maps to no tags.
+fn parse_tags(raw: &str) -> fdo::Result<Vec<String>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str(trimmed).map_err(to_fdo_error)
+}
+
+/// Parse a JSON metadata blob; empty string maps to `null`.
+fn parse_metadata(raw: &str) -> fdo::Result<serde_json::Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
+    serde_json::from_str(trimmed).map_err(to_fdo_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tag_filter_handles_empty_and_null() {
+        assert!(parse_tag_filter("").unwrap().is_none());
+        assert!(parse_tag_filter("null").unwrap().is_none());
+        assert!(parse_tag_filter("  null  ").unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_tag_filter_parses_array() {
+        let tags = parse_tag_filter("[\"a\",\"b\"]").unwrap().unwrap();
+        assert_eq!(tags, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn parse_metadata_empty_is_null() {
+        assert_eq!(parse_metadata("").unwrap(), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_metadata_parses_object() {
+        assert_eq!(
+            parse_metadata("{\"k\":1}").unwrap(),
+            serde_json::json!({"k": 1})
+        );
+    }
+}

--- a/crates/dbus-interface/src/lib.rs
+++ b/crates/dbus-interface/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod connections;
 pub mod conversation;
+pub mod knowledge;
 pub mod settings;
 
 use desktop_assistant_core::ports::inbound::AssistantService;

--- a/crates/storage/src/knowledge.rs
+++ b/crates/storage/src/knowledge.rs
@@ -111,6 +111,58 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         Ok(rows.into_iter().map(|r| r.into_entry()).collect())
     }
 
+    async fn search_text(
+        &self,
+        query: &str,
+        tags: Option<Vec<String>>,
+        limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        let result_limit = limit as i64;
+        let rows: Vec<KbRow> = sqlx::query_as(
+            "WITH q AS (SELECT plainto_tsquery('english', $1) AS query)
+             SELECT id, content, tags, metadata, created_at, updated_at
+             FROM knowledge_base
+             WHERE tsv @@ (SELECT query FROM q)
+               AND ($2::text[] IS NULL OR tags && $2)
+             ORDER BY ts_rank_cd(tsv, (SELECT query FROM q)) DESC,
+                      updated_at DESC
+             LIMIT $3",
+        )
+        .bind(query)
+        .bind(&tags)
+        .bind(result_limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        Ok(rows.into_iter().map(|r| r.into_entry()).collect())
+    }
+
+    async fn list(
+        &self,
+        limit: usize,
+        offset: usize,
+        tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        let limit_i64 = limit as i64;
+        let offset_i64 = offset as i64;
+        let rows: Vec<KbRow> = sqlx::query_as(
+            "SELECT id, content, tags, metadata, created_at, updated_at
+             FROM knowledge_base
+             WHERE ($1::text[] IS NULL OR tags && $1)
+             ORDER BY updated_at DESC, id
+             LIMIT $2 OFFSET $3",
+        )
+        .bind(&tag_filter)
+        .bind(limit_i64)
+        .bind(offset_i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        Ok(rows.into_iter().map(|r| r.into_entry()).collect())
+    }
+
     async fn delete(&self, id: &str) -> Result<(), CoreError> {
         sqlx::query("DELETE FROM knowledge_base WHERE id = $1")
             .bind(id)

--- a/crates/ws-interface/tests/ping.rs
+++ b/crates/ws-interface/tests/ping.rs
@@ -13,16 +13,65 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tower::ServiceExt;
 
 use desktop_assistant_core::CoreError;
-use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationSummary};
+use desktop_assistant_core::domain::{
+    Conversation, ConversationId, ConversationSummary, KnowledgeEntry,
+};
 use desktop_assistant_core::ports::inbound::{
     AssistantService, BackendTasksSettingsView, ConnectionConfigPayload,
     ConnectionView as CoreConnectionView, ConnectorDefaultsView, ConversationService,
-    ConnectionsService, DatabaseSettingsView, EmbeddingsSettingsView, LlmSettingsView,
-    ModelListing as CoreModelListing, PersistenceSettingsView, PurposeConfigPayload,
-    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SettingsService,
-    WsAuthSettingsView,
+    ConnectionsService, DatabaseSettingsView, EmbeddingsSettingsView, KnowledgeService,
+    LlmSettingsView, ModelListing as CoreModelListing, PersistenceSettingsView,
+    PurposeConfigPayload, PurposeKind as CorePurposeKind, PurposesView as CorePurposesView,
+    SettingsService, WsAuthSettingsView,
 };
 use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
+
+struct FakeKnowledge;
+impl KnowledgeService for FakeKnowledge {
+    async fn list_entries(
+        &self,
+        _limit: usize,
+        _offset: usize,
+        _tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_entry(&self, _id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        Ok(None)
+    }
+    async fn search_entries(
+        &self,
+        _query: String,
+        _tag_filter: Option<Vec<String>>,
+        _limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let mut e = KnowledgeEntry::new("kb-test", content, tags);
+        e.metadata = metadata;
+        Ok(e)
+    }
+    async fn update_entry(
+        &self,
+        id: String,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let mut e = KnowledgeEntry::new(id, content, tags);
+        e.metadata = metadata;
+        Ok(e)
+    }
+    async fn delete_entry(&self, _id: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
 
 struct FakeConnections;
 impl ConnectionsService for FakeConnections {
@@ -647,6 +696,7 @@ async fn ws_ping_roundtrip() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -701,6 +751,7 @@ async fn ws_rejects_missing_bearer_token() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -736,6 +787,7 @@ async fn ws_rejects_invalid_bearer_token() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -771,6 +823,7 @@ async fn login_issues_token_for_basic_auth_username() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router_with_login(
@@ -807,6 +860,7 @@ async fn login_rejects_invalid_basic_credentials() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router_with_login(
@@ -836,6 +890,7 @@ async fn ws_get_status_roundtrip() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -890,6 +945,7 @@ async fn ws_set_config_roundtrip_emits_config_changed() {
         Arc::new(FakeConversations),
         Arc::new(StatefulSettings::new()),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -961,6 +1017,7 @@ async fn ws_send_message_ack_then_streaming_events() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -1071,6 +1128,7 @@ async fn ws_send_message_cancels_when_client_disconnects() {
         }),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router(handler, Arc::new(StaticJwtAuth));
@@ -1132,6 +1190,7 @@ async fn ws_serve_with_shutdown_exits() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
@@ -1180,6 +1239,7 @@ async fn ws_allows_native_client_without_origin() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     // Empty allowlist — but no Origin header means native client, should be allowed.
@@ -1222,6 +1282,7 @@ async fn ws_rejects_browser_origin_when_allowlist_empty() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let app = router_full(handler, Arc::new(StaticJwtAuth), None, None, vec![]);
@@ -1261,6 +1322,7 @@ async fn ws_allows_configured_origin() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let allowed = vec!["https://daystrom.lab.spadea.tech".to_string()];
@@ -1305,6 +1367,7 @@ async fn ws_rejects_non_matching_origin() {
         Arc::new(FakeConversations),
         Arc::new(FakeSettings),
         Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
     ));
 
     let allowed = vec!["https://daystrom.lab.spadea.tech".to_string()];


### PR DESCRIPTION
Closes #73. Backend half of #74 (GTK browser).

## Summary

- Storage: \`PgKnowledgeBaseStore::{list, search_text}\` for paginated browse + FTS-only client search.
- Core: \`KnowledgeBaseStore\` trait extended; new \`inbound::KnowledgeService\` trait for adapters.
- api-model: \`KnowledgeEntryView\` + 6 \`Command\` variants + 3 \`CommandResult\` variants.
- Application: 5th generic on \`DefaultAssistantApiHandler\` (\`K: KnowledgeService\`); routing \`match\` arms.
- Daemon: \`DaemonKnowledgeService\` (chunks + embeds writes via the same closure as the LLM tool path), \`UnconfiguredKnowledgeService\` (clean error when no Postgres pool), \`AnyKnowledgeService\` enum (concrete type for the API handler since \`KnowledgeService\` isn't dyn-compatible).
- Both transports covered: \`org.desktopAssistant.Knowledge\` D-Bus interface (mirrors \`Connections\` pattern, JSON-string complex payloads); WS uses the default-arm dispatch (zero changes there).
- client-common: \`WsClient\` + \`DbusClient\` methods, \`AssistantClient\` trait + \`TransportClient\` dispatch — GTK can pick a transport without caring.

## Design highlights

- **FTS-only client search**: \`search_entries\` skips the embedding round-trip for UI responsiveness. The LLM tool keeps hybrid search; the UI search box trades paraphrase coverage for latency.
- **Writes embed**: \`create_entry\`/\`update_entry\` chunk + embed before persisting, so client-authored entries are immediately discoverable by the LLM's hybrid search.
- **No PG = clean error**: \`UnconfiguredKnowledgeService\` returns \`CoreError::Storage(\"knowledge base not configured\")\` uniformly so the API surface looks the same regardless of backend.

## Test plan

- [x] \`cargo clippy --workspace --all-targets\` — only pre-existing warnings
- [x] \`cargo test --workspace\` — 30 suites pass
- [x] New unit tests:
  - \`DaemonKnowledgeService\`: id assignment, embed-on-create, embed-on-update, upsert-in-place semantics
  - \`UnconfiguredKnowledgeService\`: returns storage error
  - D-Bus argument parsers: tag filter / metadata round-trip empty/null/JSON
  - Stub services added to \`application\` and \`ws-interface\` test harnesses
- [ ] Manual smoke (after merge): D-Bus introspect at \`/org/desktopAssistant/Knowledge\`; WS \`list_knowledge_entries\` round-trip

## Out of scope (followups)

- Pagination cursors instead of offset
- Tag autocomplete API
- Bulk import/export
- Embedding-augmented search in the client API (LLM tool keeps it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)