### PR TITLE
daemon: remove vestigial #[allow(dead_code)] cluster (#49)

### DIFF
--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -23,7 +23,7 @@
 //! See the ticket body on #11 for the full priority table
 //! (override → stored → interactive).
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationSummary};
@@ -906,54 +906,6 @@ where
     }
 }
 
-// --- In-memory ConversationSelectionStore (for tests) ----------------------
-
-/// Trivial in-memory store used by the daemon test suite. Production code
-/// uses the Postgres-backed store via the storage crate.
-#[allow(dead_code)]
-pub struct InMemoryConversationSelectionStore {
-    inner: Mutex<std::collections::HashMap<String, ConversationModelSelection>>,
-}
-
-impl Default for InMemoryConversationSelectionStore {
-    fn default() -> Self {
-        Self {
-            inner: Mutex::new(std::collections::HashMap::new()),
-        }
-    }
-}
-
-impl ConversationSelectionStore for InMemoryConversationSelectionStore {
-    async fn get_selection(
-        &self,
-        id: &ConversationId,
-    ) -> Result<Option<ConversationModelSelection>, CoreError> {
-        Ok(self
-            .inner
-            .lock()
-            .expect("selection store poisoned")
-            .get(&id.0)
-            .cloned())
-    }
-
-    async fn set_selection(
-        &self,
-        id: &ConversationId,
-        selection: Option<&ConversationModelSelection>,
-    ) -> Result<(), CoreError> {
-        let mut map = self.inner.lock().expect("selection store poisoned");
-        match selection {
-            Some(sel) => {
-                map.insert(id.0.clone(), sel.clone());
-            }
-            None => {
-                map.remove(&id.0);
-            }
-        }
-        Ok(())
-    }
-}
-
 // --- Effort → per-connector param mapping ----------------------------------
 
 /// Anthropic extended-thinking `budget_tokens`. Defaults: Low = off (0, no
@@ -967,19 +919,17 @@ pub fn map_anthropic_thinking_budget(e: Effort) -> u32 {
     }
 }
 
-/// OpenAI `reasoning_effort` literal. Pass through verbatim.
+/// OpenAI `reasoning_effort` wire literal for an effort hint.
 ///
-/// Retained as the canonical Effort → wire-token table even after the
-/// main dispatch path switched to [`map_effort_to_reasoning_level`] +
-/// the connector's own per-model capability gate; keeps the mapping
-/// truth-source documented in one place for future providers.
+/// Composed from [`map_effort_to_reasoning_level`] +
+/// [`ReasoningLevel::as_openai_effort`] so the Effort → wire-token
+/// mapping has exactly one source of truth and the two paths cannot
+/// drift. Currently only used by tests; kept on the public surface
+/// because future connectors that surface `reasoning_effort` directly
+/// (vs going through `ReasoningConfig`) will want it.
 #[allow(dead_code)]
 pub fn map_openai_reasoning_effort(e: Effort) -> &'static str {
-    match e {
-        Effort::Low => "low",
-        Effort::Medium => "medium",
-        Effort::High => "high",
-    }
+    map_effort_to_reasoning_level(e).as_openai_effort()
 }
 
 /// `Effort` → core-level [`ReasoningLevel`], used when threading the
@@ -1114,6 +1064,54 @@ fn purposes_referencing(purposes: &crate::purposes::Purposes, id: &ConnectionId)
 mod tests {
     use super::*;
     use crate::connections::{BedrockConnection, ConnectionConfig, OllamaConnection};
+
+    use std::sync::Mutex;
+
+    /// Trivial in-memory `ConversationSelectionStore` for the daemon test
+    /// suite. Production code uses the Postgres-backed store via the
+    /// storage crate.
+    pub struct InMemoryConversationSelectionStore {
+        inner: Mutex<std::collections::HashMap<String, ConversationModelSelection>>,
+    }
+
+    impl Default for InMemoryConversationSelectionStore {
+        fn default() -> Self {
+            Self {
+                inner: Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+    }
+
+    impl ConversationSelectionStore for InMemoryConversationSelectionStore {
+        async fn get_selection(
+            &self,
+            id: &ConversationId,
+        ) -> Result<Option<ConversationModelSelection>, CoreError> {
+            Ok(self
+                .inner
+                .lock()
+                .expect("selection store poisoned")
+                .get(&id.0)
+                .cloned())
+        }
+
+        async fn set_selection(
+            &self,
+            id: &ConversationId,
+            selection: Option<&ConversationModelSelection>,
+        ) -> Result<(), CoreError> {
+            let mut map = self.inner.lock().expect("selection store poisoned");
+            match selection {
+                Some(sel) => {
+                    map.insert(id.0.clone(), sel.clone());
+                }
+                None => {
+                    map.remove(&id.0);
+                }
+            }
+            Ok(())
+        }
+    }
 
     fn tmp_config_path() -> std::path::PathBuf {
         let mut p = std::env::temp_dir();

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1212,8 +1212,7 @@ async fn main() -> Result<()> {
     // legacy callers without an override), the routing client falls back
     // to this interactive-purpose client — preserving pre-#18 behaviour.
     let fallback_client = Arc::new(llm);
-    let llm =
-        routing_llm::RoutingLlmClient::new(Arc::clone(&fallback_client), llm_connector.clone());
+    let llm = routing_llm::RoutingLlmClient::new(Arc::clone(&fallback_client));
     // Wrap the primary in a transparent `FixedReasoningLlmClient` whose
     // override is `default()`. The interactive dispatch path goes through
     // the per-turn task-local installed by `RoutingConversationHandler`,
@@ -1302,10 +1301,9 @@ async fn main() -> Result<()> {
                 resolved_bt.connector,
                 resolved_bt.model
             );
-            let bt_connector = resolved_bt.connector.clone();
             let bt_llm = build_llm_client(resolved_bt);
             let bt_fallback = Arc::new(bt_llm);
-            let bt_llm = routing_llm::RoutingLlmClient::new(bt_fallback, bt_connector);
+            let bt_llm = routing_llm::RoutingLlmClient::new(bt_fallback);
             let bt_llm = backend_reasoning::FixedReasoningLlmClient::new(
                 bt_llm,
                 ReasoningConfig::default(),

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -19,11 +19,6 @@
 //!   budget, OpenAI `reasoning_effort`, etc.) at dispatch time. See the TODO
 //!   on [`Effort`] below.
 //!
-//! Several accessors here are not yet called from the daemon binary (the
-//! registry lands in #9 and the API surface lands in #11). `#[allow(dead_code)]`
-//! keeps this module reviewable on its own.
-#![allow(dead_code)]
-
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
@@ -64,6 +59,12 @@ impl PurposeKind {
     }
 
     /// Parse a canonical key back into a [`PurposeKind`].
+    ///
+    /// Inverse of [`Self::as_key`]; kept as public API surface for
+    /// adapters that round-trip key strings (the WS protocol uses
+    /// `as_key` on the way out and would symmetrically use this on the
+    /// way in once we expose a free-form purpose endpoint).
+    #[allow(dead_code)]
     pub fn from_key(key: &str) -> Option<Self> {
         match key {
             "interactive" => Some(Self::Interactive),
@@ -233,7 +234,11 @@ impl Purposes {
     }
 
     /// Iterate (kind, config) pairs in [`PurposeKind::all`] order, skipping
-    /// absent slots.
+    /// absent slots. Used by [`resolve_all`] and tests; kept on the
+    /// public surface because the daemon's purpose-config introspection
+    /// path will need this once we expose a "show me everything that's
+    /// configured" command.
+    #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = (PurposeKind, &PurposeConfig)> {
         PurposeKind::all()
             .into_iter()
@@ -299,13 +304,6 @@ pub enum PurposeError {
          in `[connections]`"
     )]
     DanglingInteractiveConnection { connection: String },
-    #[error("invalid connection id {raw:?} in purpose {purpose:?}: {source}")]
-    InvalidConnectionId {
-        purpose: &'static str,
-        raw: String,
-        #[source]
-        source: ConnectionIdError,
-    },
 }
 
 /// Resolve a single purpose to a [`ResolvedPurpose`] against a validated
@@ -410,6 +408,12 @@ pub fn resolve_purpose(
 /// Resolve every configured purpose. Returns a map keyed by [`PurposeKind`].
 /// Missing purposes are simply absent from the output; it is up to call sites
 /// to decide whether a given absence is a hard error.
+///
+/// Currently only exercised by tests — the daemon resolves purposes
+/// per-call via `resolve_purpose` rather than batching at startup —
+/// but kept as part of the public surface for diagnostic and
+/// configuration-introspection use cases.
+#[allow(dead_code)]
 pub fn resolve_all(
     purposes: &Purposes,
     connections: &ConnectionsMap,

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -28,7 +28,6 @@ use desktop_assistant_core::ports::llm::{
 };
 
 use crate::api_surface::RegistryHandle;
-use crate::connections::ConnectionId;
 use crate::purposes::PurposeKind;
 use crate::registry::AnyLlmClient;
 
@@ -68,12 +67,7 @@ pub enum FallbackMode {
     /// Static client captured at construction. Used by the primary
     /// (interactive) slot — dispatch reads `ACTIVE_CLIENT` first, then
     /// falls back to this client for legacy callers without an override.
-    Static {
-        client: Arc<AnyLlmClient>,
-        /// Connector-type tag retained for diagnostics.
-        #[allow(dead_code)]
-        connector_type: String,
-    },
+    Static { client: Arc<AnyLlmClient> },
     /// Resolve the target client from a [`RegistryHandle`] on every
     /// dispatch by re-reading the named purpose's config. Used by the
     /// backend-tasks slot so titling/dreaming pick up control-panel edits
@@ -103,12 +97,9 @@ pub struct RoutingLlmClient {
 impl RoutingLlmClient {
     /// Static-fallback constructor. Used by the primary (interactive)
     /// slot.
-    pub fn new(fallback: Arc<AnyLlmClient>, fallback_connector_type: String) -> Self {
+    pub fn new(fallback: Arc<AnyLlmClient>) -> Self {
         Self {
-            fallback: FallbackMode::Static {
-                client: fallback,
-                connector_type: fallback_connector_type,
-            },
+            fallback: FallbackMode::Static { client: fallback },
         }
     }
 
@@ -343,22 +334,11 @@ impl LlmClient for RoutingLlmClient {
     }
 }
 
-/// Look up a connection id's live client on the registry. Wraps the
-/// existing `RegistryHandle::client_for` so [`crate::api_surface`] can
-/// hand a concrete `Arc<AnyLlmClient>` into [`with_active_client`]
-/// without pulling the `crate::registry` internals into the public API.
-#[allow(dead_code)]
-pub fn resolve_client(
-    registry: &crate::api_surface::RegistryHandle,
-    id: &ConnectionId,
-) -> Option<Arc<AnyLlmClient>> {
-    registry.client_for(id)
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connections::{ConnectionConfig, OllamaConnection};
+    use crate::connections::{ConnectionConfig, ConnectionId, OllamaConnection};
     use crate::registry::build_registry;
     use desktop_assistant_core::CoreError;
     use desktop_assistant_core::domain::Message;
@@ -383,7 +363,7 @@ mod tests {
     #[tokio::test]
     async fn falls_back_to_static_when_no_task_local() {
         let fallback = build_ollama_registry();
-        let client = RoutingLlmClient::new(Arc::clone(&fallback), "ollama".into());
+        let client = RoutingLlmClient::new(Arc::clone(&fallback));
         // Without a task-local override, `resolve()` must equal the
         // fallback pointer.
         let resolved = client.resolve_static();
@@ -403,7 +383,7 @@ mod tests {
             "test setup: fallback and override must be distinct"
         );
 
-        let client = RoutingLlmClient::new(Arc::clone(&fallback), "ollama".into());
+        let client = RoutingLlmClient::new(Arc::clone(&fallback));
 
         let override_clone = Arc::clone(&override_client);
         let resolved = with_active_client(override_client, async move {
@@ -423,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn stream_completion_delegates_to_resolved_client() {
         let fallback = build_ollama_registry();
-        let client = RoutingLlmClient::new(fallback, "ollama".into());
+        let client = RoutingLlmClient::new(fallback);
         let _ = client
             .stream_completion(
                 vec![Message::new(
@@ -462,14 +442,14 @@ mod tests {
     fn missing_connection_id_returns_none() {
         let registry_handle = build_local_ollama_handle();
         let missing = ConnectionId::new("nonexistent").unwrap();
-        assert!(resolve_client(&registry_handle, &missing).is_none());
+        assert!(registry_handle.client_for(&missing).is_none());
     }
 
     #[test]
     fn existing_connection_id_resolves() {
         let registry_handle = build_local_ollama_handle();
         let id = ConnectionId::new("local").unwrap();
-        assert!(resolve_client(&registry_handle, &id).is_some());
+        assert!(registry_handle.client_for(&id).is_some());
     }
 
     #[test]
@@ -490,7 +470,7 @@ mod tests {
         // delegation to the resolved client — no overlay, no tier
         // fallback. Ollama returns `None`; the wrapper must too.
         let fallback = build_ollama_registry();
-        let client = RoutingLlmClient::new(fallback, "ollama".into());
+        let client = RoutingLlmClient::new(fallback);
         assert_eq!(client.max_context_tokens(), None);
     }
 


### PR DESCRIPTION
Closes #49 (5/6 items; #6 deferred — see commit message).

## Summary

- \`purposes.rs\`: blanket \`#![allow(dead_code)]\` removed. Three \`pub fn\`s without current callers (\`from_key\`, \`Purposes::iter\`, \`resolve_all\`) get item-level allows + short rationale. Truly-dead \`PurposeError::InvalidConnectionId\` deleted (zero constructors anywhere in the workspace).
- \`routing_llm.rs\`: drop the diagnostic-only \`fallback_connector_type\` field — stored, never read. Constructor simplifies to \`new(client)\`. Drop the \`pub fn resolve_client\` thin wrapper around \`RegistryHandle::client_for\`; only tests called it and tests now call \`client_for\` directly.
- \`api_surface.rs\`: chain \`map_openai_reasoning_effort\` through \`map_effort_to_reasoning_level\` + \`ReasoningLevel::as_openai_effort\` so the Effort → wire-token mapping has one source of truth. Move \`InMemoryConversationSelectionStore\` into \`mod tests\` so it stops being a public production type.

## Deferred

\`BackendTasksConfig.llm\` is still actively read by \`resolve_backend_tasks_llm_config\` as the legacy fallback when \`[purposes.titling]\` isn't configured — not vestigial. Closing the migration window is a judgment call I'd rather punt to a follow-up.

## Test plan
- [x] \`cargo build --workspace\` clean (no new warnings, two preexisting unused-import warnings I introduced earlier are now gone)
- [x] \`cargo test --workspace\` — 30 suites pass
- [x] \`cargo clippy --workspace --all-targets\` — only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)