### PR TITLE
daemon: sweep PR/issue-narrating comments (#48)

### DIFF
--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -1,8 +1,8 @@
 //! Daemon-side implementation of the connection/purpose management API
-//! (issue #11) plus the wrapper that threads per-send overrides through
-//! the core `ConversationHandler`.
+//! plus the wrapper that threads per-send overrides through the core
+//! `ConversationHandler`.
 //!
-//! Architecture notes:
+//! Architecture:
 //!
 //! - [`DaemonConnectionsService`] wraps a shared [`ConnectionRegistry`]
 //!   (plus the on-disk config) and implements the
@@ -20,8 +20,10 @@
 //!   Stored-but-dangling selections are detected, cleared, and surfaced
 //!   via a one-time [`DispatchWarning::DanglingModelSelection`].
 //!
-//! See the ticket body on #11 for the full priority table
-//! (override → stored → interactive).
+//! Per-send model selection priority is `override → stored → interactive`:
+//! the explicit override on the request wins; if none, fall back to the
+//! conversation's last stored selection; if neither is usable, dispatch
+//! through the interactive purpose's default.
 
 use std::sync::{Arc, RwLock};
 
@@ -525,8 +527,8 @@ where
 }
 
 /// Resolve a purpose's full dispatch config — `(ResolvedLlmConfig,
-/// ReasoningConfig)` — for use by background tasks that want to honour
-/// `[purposes.<kind>]` end-to-end (issue #27 dreaming, #28 titling).
+/// ReasoningConfig)` — for background tasks that want to honour
+/// `[purposes.<kind>]` end-to-end (dreaming, titling, etc.).
 ///
 /// Returns `None` when no purpose is configured for `kind` so callers
 /// can fall back to the legacy resolvers without an extra branch on a
@@ -701,11 +703,12 @@ where
         //   2. stored conversation selection (validate; warn + fallback if dangling)
         //   3. interactive purpose
         //
-        // We track *user_driven* separately from *effective* (issue #33):
-        // the user-driven path (override / live stored) routes through the
-        // registry's per-connection client; the interactive-fallback path
-        // routes through the handler's static primary llm, which is
-        // already built with the interactive purpose's model baked in.
+        // We track *user_driven* separately from *effective*: the
+        // user-driven path (override / live stored) routes through the
+        // registry's per-connection client, while the
+        // interactive-fallback path routes through the handler's static
+        // primary llm, which is already built with the interactive
+        // purpose's model baked in.
         // Without this split, interactive_selection's `model_id` would be
         // dropped at dispatch — connector clients have no per-call model
         // knob, so the registry client always uses the connection's
@@ -778,8 +781,8 @@ where
         //     `RoutingLlmClient` falls through to the primary llm (which
         //     was built with the interactive purpose's model).
         //   - `model_override`: the resolved `model_id` to inject into the
-        //     connector's request body via the `MODEL_OVERRIDE` task-local
-        //     (issue #34). Set whenever we install an `active_client` so
+        //     connector's request body via the `MODEL_OVERRIDE` task-local.
+        //     Set whenever we install an `active_client` so
         //     dispatch is deterministic — even if the user picked the
         //     connector's default model, we still pin it explicitly rather
         //     than relying on `self.model`. For the interactive-purpose
@@ -830,11 +833,11 @@ where
                 Self::apply_effort_mapping(&connector_type, &sel.model_id, sel.effort.map(Effort::from));
         }
 
-        // Resolve the per-turn context budget once at dispatch entry
-        // (issue #63). Tier 1 is the user's `purposes.interactive.
-        // max_context_tokens`; tier 2 is the connector's curated table for
-        // the configured (or active) client; tier 3 is the universal 200K
-        // fallback. Resolving once here freezes the value for the whole
+        // Resolve the per-turn context budget once at dispatch entry.
+        // Tier 1 is the user's `purposes.interactive.max_context_tokens`;
+        // tier 2 is the connector's curated table for the configured
+        // (or active) client; tier 3 is the universal 200K fallback.
+        // Resolving once here freezes the value for the whole
         // `send_prompt` call so the dispatch loop's token-pressure check
         // doesn't re-query the LLM trait on every iteration.
         let purpose_override = crate::config::purpose_max_context_override(
@@ -874,9 +877,9 @@ where
         //     token-pressure compaction.
         //   - `current_reasoning_config()` surfaces `reasoning` into the
         //     connector's request body.
-        //   - `current_model_override()` (issue #34) surfaces the resolved
-        //     `model_id` so connectors send the user-chosen model rather
-        //     than `self.model` (the connection's startup default).
+        //   - `current_model_override()` surfaces the resolved `model_id`
+        //     so connectors send the user-chosen model rather than
+        //     `self.model` (the connection's startup default).
         let inner = Arc::clone(&self.inner);
         let conv_id = conversation_id.clone();
         let response = {
@@ -1317,7 +1320,7 @@ mod tests {
 
     // ----- RoutingConversationHandler dispatch-routing tests -----------
     //
-    // These tests cover the per-turn routing logic added in #18:
+    // These tests cover the per-turn routing logic:
     // - priority resolution across override/stored/interactive
     // - task-local reasoning config installation
     // - per-connector effort mapping into ReasoningConfig
@@ -1340,13 +1343,11 @@ mod tests {
             /// Whether the routing wrapper installed an `ACTIVE_CLIENT`
             /// task-local on each `send_prompt`. `false` means dispatch
             /// would fall through to the primary llm — the expected
-            /// behaviour for the interactive-purpose fallback path
-            /// (issue #33).
+            /// behaviour for the interactive-purpose fallback path.
             captured_active_client_set: StdMutex<Vec<bool>>,
             /// Snapshot of the `MODEL_OVERRIDE` task-local at each
             /// `send_prompt`. `None` means no override was installed —
-            /// connectors will fall back to their baked-in `self.model`
-            /// (issue #34).
+            /// connectors will fall back to their baked-in `self.model`.
             captured_model_override: StdMutex<Vec<Option<String>>>,
         }
 
@@ -1726,11 +1727,10 @@ mod tests {
 
         #[tokio::test]
         async fn interactive_purpose_dispatch_does_not_install_model_override() {
-            // Issue #34 negative case: when no user-driven selection exists
+            // Negative case: when no user-driven selection exists
             // (override is None, no stored selection), `send_prompt` must
             // NOT install `MODEL_OVERRIDE`. Connectors then fall back to
-            // their baked-in `self.model` — preserving the pre-#34
-            // dispatch shape for this fallback path.
+            // their baked-in `self.model` for this fallback path.
             let (routing, inner, _reg, _store) = make_handler();
             let (on_chunk, on_status) = noop_cb();
             routing
@@ -1814,8 +1814,9 @@ mod tests {
                         connection_id: "local".into(),
                         // Pick a model that differs from the connection's
                         // baked-in default (`llama3.2`) so the assertion
-                        // is meaningful — pre-#34 the connector would
-                        // dispatch `self.model` and silently drop this.
+                        // is meaningful — without `MODEL_OVERRIDE` the
+                        // connector would dispatch `self.model` and
+                        // silently drop this.
                         model_id: "qwen3".into(),
                         effort: None,
                     }),

--- a/crates/daemon/src/backend_reasoning.rs
+++ b/crates/daemon/src/backend_reasoning.rs
@@ -1,6 +1,5 @@
 //! Adapter that pins a fixed [`ReasoningConfig`] onto `stream_completion`
-//! calls when the wrapper was configured with a non-empty config (issue
-//! #28).
+//! calls when the wrapper was configured with a non-empty config.
 //!
 //! Background tasks (title generation, context summary) call into the
 //! `LlmClient` trait with `ReasoningConfig::default()` because they live in

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -31,10 +31,6 @@ pub struct DaemonConfig {
     /// re-wraps the map as a validated [`ConnectionsMap`], rejecting invalid
     /// or duplicate ids.
     ///
-    /// Note for #9/#10: this map is intentionally not yet wired into
-    /// `build_llm_client` or `resolve_*` — those call sites still read
-    /// `[llm]` / `[backend_tasks.llm]`. See the migration path in
-    /// [`load_daemon_config`] and the deprecation warning emitted there.
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub connections: IndexMap<String, ConnectionConfig>,
     #[serde(default)]
@@ -46,14 +42,14 @@ pub struct DaemonConfig {
     /// Backend-tasks (dreaming / titling) overrides. The legacy `llm` field
     /// is reshaped into `[purposes]` during migration; see
     /// [`maybe_migrate_legacy_purposes`]. Consumers that still read
-    /// `backend_tasks.llm` will see `None` after migration and fall back to
-    /// the primary LLM — #11 rewires dispatch to consult `[purposes]`.
+    /// `backend_tasks.llm` see `None` after migration and fall back to
+    /// the primary LLM.
     #[serde(default)]
     pub backend_tasks: BackendTasksConfig,
-    /// Per-purpose LLM configs (issue #10). Each purpose picks a connection
-    /// + model (possibly inherited from `interactive`) and an optional effort
-    /// level. Empty on fresh installs; synthesized by migration when a legacy
-    /// `[llm]` / `[backend_tasks.llm]` pair is present.
+    /// Per-purpose LLM configs. Each purpose picks a connection + model
+    /// (possibly inherited from `interactive`) and an optional effort
+    /// level. Empty on fresh installs; synthesized by migration when a
+    /// legacy `[llm]` / `[backend_tasks.llm]` pair is present.
     #[serde(default, skip_serializing_if = "Purposes::is_empty")]
     pub purposes: Purposes,
     #[serde(default)]
@@ -552,9 +548,10 @@ pub fn load_daemon_config(path: &Path) -> anyhow::Result<Option<DaemonConfig>> {
     let explicit_connections_table = file_has_top_level_table(&content, "connections");
     let explicit_purposes_table = file_has_top_level_table(&content, "purposes");
     // Purpose migration runs only when the file is in a legacy shape:
-    // either `[llm]` (pre-#8) or `[backend_tasks.llm]` (pre-#10) is present.
-    // Pure new-format configs (connections + no legacy markers) are left alone
-    // so first-run users are not forced to accept synthesized purposes.
+    // either `[llm]` or `[backend_tasks.llm]` is present. Pure
+    // new-format configs (connections + no legacy markers) are left
+    // alone so first-run users are not forced to accept synthesized
+    // purposes.
     let legacy_shape_present = file_has_top_level_table(&content, "llm")
         || file_has_top_level_table(&content, "backend_tasks.llm");
     let parsed = maybe_migrate_legacy_connections(path, parsed, &content)?;
@@ -1460,15 +1457,14 @@ pub fn resolve_purpose_llm_config(
     Some(llm)
 }
 
-/// Universal fallback for purpose-aware context-window resolution
-/// (issue #51). Used when no purpose override is set and the connector's
-/// curated table reports nothing for the model. Most modern frontier
-/// models meet or exceed this; under-stating is safe (we compact slightly
+/// Universal fallback for purpose-aware context-window resolution.
+/// Used when no purpose override is set and the connector's curated
+/// table reports nothing for the model. Most modern frontier models
+/// meet or exceed this; under-stating is safe (we compact slightly
 /// earlier than necessary), over-stating is not (the LLM rejects).
 pub const DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS: u64 = 200_000;
 
 /// Three-tier resolution for "what's the context window for this purpose?"
-/// (issue #51, refined in #63).
 ///
 /// Resolution order:
 ///   1. The purpose's `max_context_tokens` override, if explicitly set —
@@ -3124,7 +3120,7 @@ mod tests {
         std::fs::remove_dir_all(&test_dir).ok();
     }
 
-    // --- Named-connections schema + migration (issue #8) -------------------
+    // --- Named-connections schema + migration -------------------
 
     fn unique_test_dir(prefix: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
@@ -3780,7 +3776,7 @@ y = 2
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // Purpose-aware LLM config resolution (issue #26)
+    // Purpose-aware LLM config resolution
     // ─────────────────────────────────────────────────────────────────────
 
     /// Build a config with an `ollama` interactive connection at the given
@@ -3977,9 +3973,9 @@ y = 2
 
     #[test]
     fn resolve_embeddings_uses_purposes_embedding_when_configured() {
-        // The whole point of issue #26: a user who has set `[purposes.embedding]`
-        // gets *that* connection/model back from `resolve_embeddings_config`,
-        // not whatever the legacy `[embeddings]` block (or `[llm]` fallback)
+        // A user who has set `[purposes.embedding]` gets *that*
+        // connection/model back from `resolve_embeddings_config`, not
+        // whatever the legacy `[embeddings]` block (or `[llm]` fallback)
         // would have inferred.
         let config: DaemonConfig = toml::from_str(
             r#"
@@ -4016,11 +4012,10 @@ y = 2
 
     #[test]
     fn resolve_embeddings_falls_back_to_legacy_when_no_purpose() {
-        // When `[purposes.embedding]` is *not* set, we keep the pre-#26
-        // behaviour byte-for-byte: legacy `[embeddings]` overrides win, then
-        // the `[llm].connector` default. This ensures the bug fix is
-        // additive — installs without a purposes block see no behaviour
-        // change at all.
+        // When `[purposes.embedding]` is *not* set, the legacy resolver
+        // path runs unchanged: `[embeddings]` overrides win, then the
+        // `[llm].connector` default. Installs without a purposes block
+        // see no behaviour change.
         let config: DaemonConfig = toml::from_str(
             r#"
             [llm]
@@ -4216,10 +4211,10 @@ y = 2
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // Purpose-aware max_context_tokens resolution (issue #51)
+    // Purpose-aware max_context_tokens resolution
     // ─────────────────────────────────────────────────────────────────────
 
-    // --- resolve_context_budget three-tier resolution (issue #51 / #63) -
+    // --- resolve_context_budget three-tier resolution -------------------
 
     #[test]
     fn resolve_context_budget_purpose_override_wins() {

--- a/crates/daemon/src/connections.rs
+++ b/crates/daemon/src/connections.rs
@@ -1,23 +1,14 @@
 //! Named-connection config schema.
 //!
-//! Introduces a `connections` map keyed by a user-chosen slug ([`ConnectionId`]).
+//! A `connections` map keyed by a user-chosen slug ([`ConnectionId`]).
 //! Each connection owns its own credentials/endpoint and declares its connector
-//! type via a `#[serde(tag = "type")]` payload. This replaces the legacy single
+//! type via a `#[serde(tag = "type")]` payload, replacing the legacy single
 //! `[llm]` block which hard-coded one global connector.
 //!
-//! See issue #8. Downstream tickets:
-//! - #9 (registry) wires this into `build_llm_client`.
-//! - #10 reshapes `backend_tasks.llm` into purpose configs.
-//! - #11 exposes connections over the API.
-//!
-//! This module is intentionally schema-only: migration lives in
-//! [`super::config`] so it can share I/O helpers with the wider config layer.
-//!
-//! The `ConnectionsMap` accessors and the `connector_type` shortcut are wired
-//! into the registry (`crates/daemon/src/registry.rs`) under #9; a few
-//! accessors remain exposed for symmetry even though no call site uses them
-//! yet, so `#[allow(dead_code)]` stays on this module until #11 consumes
-//! them.
+//! Schema-only: migration lives in [`super::config`] so it can share I/O
+//! helpers with the wider config layer. The blanket `#[allow(dead_code)]`
+//! covers a handful of `ConnectionsMap` accessors that are exposed for
+//! symmetry but have no current call site.
 #![allow(dead_code)]
 
 use std::fmt;

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -431,10 +431,9 @@ impl api_surface::ConversationSelectionStore for SharedConversationStore {
     }
 }
 
-// Per-conversation model selection (#11). Only the Postgres backend
-// persists selections across restarts; the JSON backend keeps them
-// in-memory and drops them on shutdown (matches pre-#11 behavior for
-// installs without a database).
+// Per-conversation model selection. Only the Postgres backend persists
+// selections across restarts; the JSON backend keeps them in-memory and
+// drops them on shutdown (the same shape as installs without a database).
 impl api_surface::ConversationSelectionStore for AnyConversationStore {
     async fn get_selection(
         &self,
@@ -604,13 +603,13 @@ async fn main() -> Result<()> {
     // HTTP client allocation — the registry clients stay live for the
     // connection-listing and model-listing APIs.
     // Build the primary llm via the shared `resolve_purpose_llm_config`
-    // helper (issue #33) so the interactive purpose's `model` actually
-    // lands on the resolved config — connector clients have no per-call
-    // model knob, so a dispatch via the registry's per-connection client
-    // would otherwise silently use the connection's construction-time
-    // model and ignore the user's choice. Using the same helper as the
-    // background-task purposes (#26 / #27 / #28) keeps the model-override
-    // logic in one place.
+    // helper so the interactive purpose's `model` actually lands on the
+    // resolved config — connector clients have no per-call model knob,
+    // so a dispatch via the registry's per-connection client would
+    // otherwise silently use the connection's construction-time model
+    // and ignore the user's choice. Using the same helper for primary
+    // and background-task purposes keeps the model-override logic in
+    // one place.
     let primary_resolved = config::resolve_purpose_llm_config(
         daemon_config.as_ref(),
         purposes::PurposeKind::Interactive,
@@ -1061,9 +1060,9 @@ async fn main() -> Result<()> {
             &pg_pool,
             !matches!(embedding_client.as_ref(), AnyEmbeddingClient::Unavailable),
         ) {
-            // Prefer `[purposes.dreaming]` (issue #27) when configured; fall
-            // back to the legacy `[backend_tasks.llm]` block otherwise so
-            // installs that haven't migrated still work. Effort threading is
+            // Prefer `[purposes.dreaming]` when configured; fall back to
+            // the legacy `[backend_tasks.llm]` block otherwise so installs
+            // that haven't migrated still work. Effort threading is
             // computed once at startup and copied into the closure — the
             // resolved purpose is fixed for this daemon run, and
             // `ReasoningConfig` is `Copy`.
@@ -1210,7 +1209,7 @@ async fn main() -> Result<()> {
     // a task-local per turn; when present, dispatch picks the registry's
     // client for the resolved connection id. When absent (backend tasks,
     // legacy callers without an override), the routing client falls back
-    // to this interactive-purpose client — preserving pre-#18 behaviour.
+    // to this interactive-purpose client.
     let fallback_client = Arc::new(llm);
     let llm = routing_llm::RoutingLlmClient::new(Arc::clone(&fallback_client));
     // Wrap the primary in a transparent `FixedReasoningLlmClient` whose
@@ -1219,8 +1218,8 @@ async fn main() -> Result<()> {
     // which calls `stream_completion` with its mapped `ReasoningConfig` —
     // we must not stomp on that, hence the passthrough configuration.
     // The wrapper exists here only so the primary and backend handlers
-    // share the same `L` type (issue #28: backend tasks need a non-default
-    // override, and `with_backend_llm(L)` requires both stacks to match).
+    // share the same `L` type (backend tasks need a non-default override,
+    // and `with_backend_llm(L)` requires both stacks to match).
     let llm =
         backend_reasoning::FixedReasoningLlmClient::new(llm, ReasoningConfig::default());
     let llm = RetryingLlmClient::new(llm, 3);
@@ -1256,13 +1255,12 @@ async fn main() -> Result<()> {
     // Resolution order:
     //   1. `[purposes.titling]` — if set, install a dynamic-purpose client
     //      that resolves the connection/model/effort from the live config
-    //      on every call (#68). Control-panel edits take effect on the next
+    //      on every call. Control-panel edits take effect on the next
     //      backend dispatch with no daemon restart.
     //   2. `[backend_tasks.llm]` legacy block — install a static client
-    //      only if it differs from the primary (preserving pre-#28
-    //      behaviour for unmigrated installs that haven't authored a
-    //      `[purposes]` table). The legacy path remains static — migrating
-    //      it dynamic is unnecessary as authors are expected to move to
+    //      only if it differs from the primary, so unmigrated installs
+    //      that haven't authored a `[purposes]` table still work. The
+    //      legacy path stays static; authors are expected to move to
     //      `[purposes.titling]`.
     let resolved_primary = config::resolve_llm_config(daemon_config.as_ref());
     let titling_configured = daemon_config

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -1,24 +1,20 @@
-//! Purpose configs (issue #10).
+//! Purpose configs.
 //!
 //! Each LLM *purpose* (interactive chat, dreaming, embedding, titling)
 //! references a named connection by id and picks a model from that connection,
-//! optionally with an effort level. This replaces the legacy
-//! `[backend_tasks.llm]` block, which duplicated credentials for every extra
-//! purpose and did not scale past two call sites.
+//! optionally with an effort level. Replaces the legacy `[backend_tasks.llm]`
+//! block, which duplicated credentials for every extra purpose and didn't
+//! scale past two call sites.
 //!
-//! The schema deliberately keeps the wire format narrow: a `connection`
-//! reference, a `model` reference, and an optional `effort` hint. Both refs
-//! support a literal `"primary"` sentinel that inherits from the `interactive`
-//! purpose at load time. Resolution is one level deep (we explicitly forbid
-//! `primary -> primary` chains beyond the single inherit step) so cycles are
-//! structurally impossible, not just rejected.
+//! The wire format is narrow on purpose: a `connection` reference, a `model`
+//! reference, and an optional `effort` hint. Both refs support a literal
+//! `"primary"` sentinel that inherits from the `interactive` purpose at load
+//! time. Resolution is one level deep — `primary -> primary` chains are
+//! explicitly forbidden — so cycles are structurally impossible, not just
+//! rejected.
 //!
-//! This module is intentionally schema + resolution only:
-//! - Issue #9 wires the registry that actually instantiates connections.
-//! - Issue #11 maps [`Effort`] onto per-connector knobs (Anthropic thinking
-//!   budget, OpenAI `reasoning_effort`, etc.) at dispatch time. See the TODO
-//!   on [`Effort`] below.
-//!
+//! Schema + resolution only: registry instantiation lives in `registry.rs`,
+//! and `Effort → ReasoningConfig` mapping lives in `api_surface.rs`.
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
@@ -119,14 +115,10 @@ pub enum ModelRef {
 /// Reserved sentinel that represents the `primary` inherit token.
 const PRIMARY_SENTINEL: &str = "primary";
 
-/// Effort level hint for a purpose.
-///
-/// Mapped per-connector at request dispatch time (issue #11):
-// TODO(#11): map `Effort` onto concrete per-connector parameters at dispatch
-// time — Anthropic's thinking/extended-thinking budget_tokens, OpenAI's
-// `reasoning_effort`, Bedrock's per-model parameters, and Ollama's keep-alive/
-// num_predict. Purpose configs default the level; per-request overrides come
-// from the per-conversation selector in #11.
+/// Effort level hint for a purpose. Mapped to concrete per-connector
+/// parameters by `api_surface::map_effort_to_reasoning_config` at
+/// dispatch time (Anthropic `thinking.budget_tokens`, OpenAI
+/// `reasoning_effort`, Bedrock per-model knobs; Ollama ignores it).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Effort {
@@ -148,9 +140,9 @@ pub enum Effort {
 ///
 /// `max_context_tokens` is a user-supplied override for the model's context
 /// window in tokens. When set, it takes priority over the connector's
-/// curated table (issue #51). Leaving it unset (the default) lets the
-/// daemon-side resolver consult the connector's per-model table and fall
-/// back to a conservative universal default.
+/// curated table. Leaving it unset (the default) lets the daemon-side
+/// resolver consult the connector's per-model table and fall back to a
+/// conservative universal default.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PurposeConfig {

--- a/crates/daemon/src/registry.rs
+++ b/crates/daemon/src/registry.rs
@@ -266,11 +266,9 @@ impl ConnectionRegistry {
 
     /// Move the active client out of the registry.
     ///
-    /// Used by pre-#11 daemon startup (before purpose-based dispatch) to
-    /// hand the active connection's client to the `ConversationHandler`.
-    /// Under #11 dispatch is purpose-driven and callers use
-    /// [`ConnectionRegistry::get`] instead; this accessor is retained for
-    /// diagnostics and legacy tests.
+    /// Legacy accessor from before purpose-based dispatch landed —
+    /// production callers use [`ConnectionRegistry::get`] now. Retained
+    /// for diagnostics and legacy tests.
     pub fn take_active(&mut self) -> Option<(ConnectionId, std::sync::Arc<AnyLlmClient>)> {
         let id = self.active.clone()?;
         let client = self.clients.shift_remove(&id)?;

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -2,16 +2,16 @@
 //! to swap the underlying [`AnyLlmClient`] based on the resolved
 //! `(connection_id, model_id, effort)` triple for each `send_prompt`.
 //!
-//! Rationale (issue #18): the core `ConversationHandler` owns a single
-//! `llm: L` field baked into its type parameters. Rebuilding the handler
-//! per turn is impractical (shared `namespace_cache`, non-`Clone`
-//! `id_generator`), and plumbing a per-call client argument through the
-//! ~450-line `send_prompt` would be a very invasive change.
+//! Rationale: the core `ConversationHandler` owns a single `llm: L` field
+//! baked into its type parameters. Rebuilding the handler per turn is
+//! impractical (shared `namespace_cache`, non-`Clone` `id_generator`), and
+//! plumbing a per-call client argument through the ~450-line `send_prompt`
+//! would be a very invasive change.
 //!
 //! Instead we install this wrapper as the handler's `L`. It looks up the
 //! target `AnyLlmClient` on each call via a [`tokio::task_local!`] slot
 //! populated by the daemon-side routing wrapper. When the slot is unset
-//! (e.g. backend-tasks, background jobs), dispatch falls through to a
+//! (e.g. backend tasks, background jobs), dispatch falls through to a
 //! statically-configured fallback — the interactive-purpose client at
 //! daemon startup.
 //!
@@ -52,8 +52,8 @@ where
 /// Whether an [`ACTIVE_CLIENT`] task-local is set for the current
 /// scope. Used by tests in the api_surface dispatch module to assert
 /// that interactive-purpose fallbacks correctly *do not* install an
-/// override (issue #33: dispatch should fall through to the primary
-/// llm in that case so the interactive purpose's model takes effect).
+/// override — dispatch should fall through to the primary llm in that
+/// case so the interactive purpose's model takes effect.
 #[cfg(test)]
 pub(crate) fn active_client_is_set() -> bool {
     ACTIVE_CLIENT.try_with(|_| ()).is_ok()
@@ -70,11 +70,10 @@ pub enum FallbackMode {
     Static { client: Arc<AnyLlmClient> },
     /// Resolve the target client from a [`RegistryHandle`] on every
     /// dispatch by re-reading the named purpose's config. Used by the
-    /// backend-tasks slot so titling/dreaming pick up control-panel edits
-    /// without a daemon restart (issue #68). Always ignores
-    /// `ACTIVE_CLIENT` — backend tasks must not inherit the user's
-    /// per-turn model override even when invoked inside a `send_prompt`
-    /// scope.
+    /// backend-tasks slot so titling/dreaming pick up control-panel
+    /// edits without a daemon restart. Always ignores `ACTIVE_CLIENT`
+    /// — backend tasks must not inherit the user's per-turn model
+    /// override even when invoked inside a `send_prompt` scope.
     DynamicPurpose {
         registry: Arc<RegistryHandle>,
         purpose: PurposeKind,
@@ -220,12 +219,12 @@ impl LlmClient for RoutingLlmClient {
 
     fn max_context_tokens(&self) -> Option<u64> {
         // The dispatch loop reads token-pressure budgets from the
-        // `CONTEXT_BUDGET` task-local installed by the daemon's wrapper
-        // (issue #63), not from this trait method, so the resolution
-        // chain no longer lives here. Static-mode delegates to the
-        // resolved client; dynamic-purpose mode has no single client to
-        // ask without a config snapshot, and callers (capability probes,
-        // debug paths) tolerate `None`.
+        // `CONTEXT_BUDGET` task-local installed by the daemon's wrapper,
+        // not from this trait method, so the resolution chain no longer
+        // lives here. Static-mode delegates to the resolved client;
+        // dynamic-purpose mode has no single client to ask without a
+        // config snapshot, and callers (capability probes, debug paths)
+        // tolerate `None`.
         match &self.fallback {
             FallbackMode::Static { .. } => self.resolve_static().max_context_tokens(),
             FallbackMode::DynamicPurpose { .. } => None,
@@ -458,23 +457,19 @@ mod tests {
         let _e: Option<CoreError> = None;
     }
 
-    // The three-tier `max_context_tokens` resolution previously tested
-    // here moved to `crate::config::resolve_context_budget` (issue #63).
-    // Tests against that resolver live in `crates/daemon/src/config.rs`.
-    // The task-local accessor is exercised in
-    // `crates/core/src/ports/llm.rs` against `current_context_budget`.
-
     #[tokio::test]
     async fn max_context_delegates_to_resolved_client() {
-        // After #63 `RoutingLlmClient::max_context_tokens` is plain
-        // delegation to the resolved client — no overlay, no tier
-        // fallback. Ollama returns `None`; the wrapper must too.
+        // `RoutingLlmClient::max_context_tokens` is plain delegation to
+        // the resolved client — no overlay, no tier fallback (the
+        // three-tier budget resolution lives in
+        // `config::resolve_context_budget`). Ollama returns `None`;
+        // the wrapper must too.
         let fallback = build_ollama_registry();
         let client = RoutingLlmClient::new(fallback);
         assert_eq!(client.max_context_tokens(), None);
     }
 
-    // --- DynamicPurpose mode (issue #68) ---------------------------------
+    // --- DynamicPurpose mode -------------------------------------------------
 
     /// Build a `RegistryHandle` with `[purposes.titling]` pointed at the
     /// "local" Ollama connection — exercises the full purpose-resolution


### PR DESCRIPTION
Closes #48.

Strip standalone \`(issue #N)\` qualifiers, \"pre-#N behaviour\" notes, \"in #N this changed\" references, and completed \`TODO(#N)\` markers across all 8 daemon source files. Where the surrounding prose already explained the rationale, the issue number was dead weight; where it didn't, the prose was expanded so the why is in the comment instead of behind a ticket link.

No behaviour change. ~30 lines lighter. Restores compliance with AGENTS.md (\"Reference issues only when the comment captures a non-obvious WHY tied to that issue\").

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 30 suites pass
- [x] \`grep -rn 'issue #[0-9]\\|TODO(#[0-9]\\|pre-#[0-9]\\|after #[0-9]\\|(issue \\|in #[0-9]' crates/daemon/src/\` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)