### PR TITLE
chore: apply cargo fmt across the workspace (#52)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -653,17 +653,9 @@ pub struct WsRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum WsFrame {
-    Result {
-        id: String,
-        result: CommandResult,
-    },
-    Error {
-        id: String,
-        error: String,
-    },
-    Event {
-        event: Event,
-    },
+    Result { id: String, result: CommandResult },
+    Error { id: String, error: String },
+    Event { event: Event },
 }
 
 #[cfg(test)]
@@ -751,8 +743,7 @@ mod tests {
         assert_eq!(cmd, back);
 
         // Missing force flag defaults to false.
-        let cmd2: Command =
-            serde_json::from_str(r#"{"delete_connection":{"id":"old"}}"#).unwrap();
+        let cmd2: Command = serde_json::from_str(r#"{"delete_connection":{"id":"old"}}"#).unwrap();
         assert_eq!(
             cmd2,
             Command::DeleteConnection {
@@ -830,10 +821,9 @@ mod tests {
     #[test]
     fn send_message_override_is_optional() {
         // Without override.
-        let cmd: Command = serde_json::from_str(
-            r#"{"send_message":{"conversation_id":"c1","content":"hi"}}"#,
-        )
-        .unwrap();
+        let cmd: Command =
+            serde_json::from_str(r#"{"send_message":{"conversation_id":"c1","content":"hi"}}"#)
+                .unwrap();
         match &cmd {
             Command::SendMessage {
                 override_selection, ..
@@ -902,9 +892,7 @@ mod tests {
         let ok = ConnectionAvailability::Ok;
         let json = serde_json::to_string(&ok).unwrap();
         assert!(json.contains("\"status\":\"ok\""));
-        let un = ConnectionAvailability::Unavailable {
-            reason: "x".into(),
-        };
+        let un = ConnectionAvailability::Unavailable { reason: "x".into() };
         let json2 = serde_json::to_string(&un).unwrap();
         assert!(json2.contains("\"status\":\"unavailable\""));
         let back: ConnectionAvailability = serde_json::from_str(&json2).unwrap();

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -442,8 +442,7 @@ where
             }
 
             api::Command::GetConversation { id } => {
-                let conv_id =
-                    desktop_assistant_core::domain::ConversationId::from(id.as_str());
+                let conv_id = desktop_assistant_core::domain::ConversationId::from(id.as_str());
                 let conv = self
                     .conversations
                     .get_conversation(&conv_id)
@@ -523,7 +522,6 @@ where
             }
 
             // Settings
-
             api::Command::SetApiKey { api_key } => {
                 self.settings
                     .set_api_key(api_key)
@@ -807,7 +805,10 @@ where
                     .await
                     .map_err(Self::map_core_err)?;
                 Ok(api::CommandResult::Models(
-                    listings.into_iter().map(core_model_listing_to_api).collect(),
+                    listings
+                        .into_iter()
+                        .map(core_model_listing_to_api)
+                        .collect(),
                 ))
             }
 
@@ -1004,10 +1005,7 @@ mod tests {
         ) -> Result<Vec<KnowledgeEntry>, CoreError> {
             Ok(vec![])
         }
-        async fn get_entry(
-            &self,
-            _id: String,
-        ) -> Result<Option<KnowledgeEntry>, CoreError> {
+        async fn get_entry(&self, _id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
             Ok(None)
         }
         async fn search_entries(
@@ -1048,10 +1046,8 @@ mod tests {
     impl ConnectionsService for FakeConnections {
         async fn list_connections(
             &self,
-        ) -> Result<
-            Vec<desktop_assistant_core::ports::inbound::ConnectionView>,
-            CoreError,
-        > {
+        ) -> Result<Vec<desktop_assistant_core::ports::inbound::ConnectionView>, CoreError>
+        {
             Ok(vec![])
         }
         async fn create_connection(
@@ -1068,11 +1064,7 @@ mod tests {
         ) -> Result<(), CoreError> {
             Ok(())
         }
-        async fn delete_connection(
-            &self,
-            _id: String,
-            _force: bool,
-        ) -> Result<(), CoreError> {
+        async fn delete_connection(&self, _id: String, _force: bool) -> Result<(), CoreError> {
             Ok(())
         }
         async fn list_available_models(

--- a/crates/client-common/src/config.rs
+++ b/crates/client-common/src/config.rs
@@ -12,7 +12,10 @@ pub fn default_ca_cert_path() -> PathBuf {
                 .join(".local")
                 .join("share")
         });
-    data_home.join("desktop-assistant").join("tls").join("ca.pem")
+    data_home
+        .join("desktop-assistant")
+        .join("tls")
+        .join("ca.pem")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -267,10 +267,7 @@ impl DbusClient {
         decode_entries(&raw)
     }
 
-    pub async fn get_knowledge_entry(
-        &self,
-        id: &str,
-    ) -> Result<Option<api::KnowledgeEntryView>> {
+    pub async fn get_knowledge_entry(&self, id: &str) -> Result<Option<api::KnowledgeEntryView>> {
         let raw = self.knowledge.get_entry(id).await?;
         let envelope: api::CommandResult = serde_json::from_str(&raw)
             .map_err(|e| anyhow::anyhow!("decoding get_entry response: {e}"))?;

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -28,10 +28,7 @@ pub trait AssistantClient: Send + Sync {
         offset: u32,
         tag_filter: Option<Vec<String>>,
     ) -> Result<Vec<api::KnowledgeEntryView>>;
-    async fn get_knowledge_entry(
-        &self,
-        id: &str,
-    ) -> Result<Option<api::KnowledgeEntryView>>;
+    async fn get_knowledge_entry(&self, id: &str) -> Result<Option<api::KnowledgeEntryView>>;
     async fn search_knowledge_entries(
         &self,
         query: &str,
@@ -155,19 +152,20 @@ impl AssistantClient for TransportClient {
     ) -> Result<Vec<api::KnowledgeEntryView>> {
         match self {
             #[cfg(feature = "dbus")]
-            Self::Dbus(client) => client
-                .list_knowledge_entries(limit, offset, tag_filter)
-                .await,
-            Self::Ws(client) => client
-                .list_knowledge_entries(limit, offset, tag_filter)
-                .await,
+            Self::Dbus(client) => {
+                client
+                    .list_knowledge_entries(limit, offset, tag_filter)
+                    .await
+            }
+            Self::Ws(client) => {
+                client
+                    .list_knowledge_entries(limit, offset, tag_filter)
+                    .await
+            }
         }
     }
 
-    async fn get_knowledge_entry(
-        &self,
-        id: &str,
-    ) -> Result<Option<api::KnowledgeEntryView>> {
+    async fn get_knowledge_entry(&self, id: &str) -> Result<Option<api::KnowledgeEntryView>> {
         match self {
             #[cfg(feature = "dbus")]
             Self::Dbus(client) => client.get_knowledge_entry(id).await,
@@ -183,12 +181,16 @@ impl AssistantClient for TransportClient {
     ) -> Result<Vec<api::KnowledgeEntryView>> {
         match self {
             #[cfg(feature = "dbus")]
-            Self::Dbus(client) => client
-                .search_knowledge_entries(query, tag_filter, limit)
-                .await,
-            Self::Ws(client) => client
-                .search_knowledge_entries(query, tag_filter, limit)
-                .await,
+            Self::Dbus(client) => {
+                client
+                    .search_knowledge_entries(query, tag_filter, limit)
+                    .await
+            }
+            Self::Ws(client) => {
+                client
+                    .search_knowledge_entries(query, tag_filter, limit)
+                    .await
+            }
         }
     }
 

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use desktop_assistant_api_model as api;
 use api::{WsFrame, WsRequest};
+use desktop_assistant_api_model as api;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message;
@@ -38,13 +38,9 @@ impl WsClient {
             None
         };
 
-        let (socket, _response) = tokio_tungstenite::connect_async_tls_with_config(
-            request,
-            None,
-            false,
-            connector,
-        )
-        .await?;
+        let (socket, _response) =
+            tokio_tungstenite::connect_async_tls_with_config(request, None, false, connector)
+                .await?;
         let (mut ws_tx, mut ws_rx) = socket.split();
 
         let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<Message>();
@@ -325,10 +321,7 @@ impl WsClient {
         Ok(items)
     }
 
-    pub async fn get_knowledge_entry(
-        &self,
-        id: &str,
-    ) -> Result<Option<api::KnowledgeEntryView>> {
+    pub async fn get_knowledge_entry(&self, id: &str) -> Result<Option<api::KnowledgeEntryView>> {
         let result = self
             .send_command(api::Command::GetKnowledgeEntry { id: id.to_string() })
             .await?;
@@ -418,9 +411,7 @@ impl WsClient {
     }
 }
 
-fn build_tls_connector(
-    ca_cert_path: Option<&Path>,
-) -> Result<tokio_tungstenite::Connector> {
+fn build_tls_connector(ca_cert_path: Option<&Path>) -> Result<tokio_tungstenite::Connector> {
     let mut root_store = rustls::RootCertStore::empty();
 
     if let Some(ca_path) = ca_cert_path {

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -167,10 +167,7 @@ pub(crate) fn llm_messages_for_turn(
     let threshold = (max_input_tokens as f64 * COMPACTION_TOKEN_RATIO) as u64;
 
     for _ in 0..MAX_PREFLIGHT_SHRINK_ITERATIONS {
-        let assembled_tokens: u64 = assembled
-            .iter()
-            .map(|m| estimate(&m.content))
-            .sum();
+        let assembled_tokens: u64 = assembled.iter().map(|m| estimate(&m.content)).sum();
         if assembled_tokens <= threshold {
             return assembled;
         }
@@ -327,8 +324,7 @@ fn assemble_messages_inner(
             ratio = (system_tokens_before as f64 / b.max_input_tokens as f64),
             "system block size"
         );
-        let threshold =
-            (b.max_input_tokens as f64 * SYSTEM_BLOCK_BUDGET_RATIO) as u64;
+        let threshold = (b.max_input_tokens as f64 * SYSTEM_BLOCK_BUDGET_RATIO) as u64;
         if system_tokens_before > threshold {
             let demoted_note = build_demoted_tool_note(tool_defs, deferred_namespaces);
             let demoted_system = assemble_system_instruction(demoted_note);
@@ -401,10 +397,7 @@ fn assemble_messages_inner(
         let many_tool_rounds = tool_rounds_since_anchor > ACTIVE_TASK_ROUND_THRESHOLD;
 
         if !anchor_visible || many_tool_rounds {
-            messages.push(Message::new(
-                Role::System,
-                format!("[Current task] {task}"),
-            ));
+            messages.push(Message::new(Role::System, format!("[Current task] {task}")));
         }
     }
 
@@ -436,10 +429,9 @@ fn assemble_messages_inner(
                         }
                     }
                     let body = match (first, last) {
-                        (Some(f), Some(l)) => format!(
-                            "[Summary of messages {}\u{2013}{}] {}",
-                            f, l, s.summary
-                        ),
+                        (Some(f), Some(l)) => {
+                            format!("[Summary of messages {}\u{2013}{}] {}", f, l, s.summary)
+                        }
                         _ => format!("[Summary of earlier messages] {}", s.summary),
                     };
                     messages.push(Message::new(Role::System, body));
@@ -1011,7 +1003,9 @@ mod tests {
         assert!(notice.contains("12345 bytes"));
         assert!(notice.contains("203524"));
         assert!(notice.contains("200000"));
-        assert!(notice.contains("narrower") || notice.contains("chunk") || notice.contains("smaller"));
+        assert!(
+            notice.contains("narrower") || notice.contains("chunk") || notice.contains("smaller")
+        );
     }
 
     #[test]
@@ -1035,7 +1029,18 @@ mod tests {
             })
             .collect();
 
-        let result = llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
         // System message + all 10 conversation messages
         assert_eq!(result.len(), 11);
         assert_eq!(result[0].role, Role::System);
@@ -1058,7 +1063,18 @@ mod tests {
             })
             .collect();
 
-        let result = llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
         // The tentative start is count - MAX_CONTEXT_MESSAGES = 20, which is
         // a User message (even index), so the window starts exactly there.
         // Result: 1 system + MAX_CONTEXT_MESSAGES conversation messages.
@@ -1091,7 +1107,18 @@ mod tests {
         msgs.push(Message::new(Role::User, "final-user"));
         msgs.push(Message::new(Role::Assistant, "final-reply"));
 
-        let result = llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
 
         // The first conversation message (after System) must be a User message.
         assert_eq!(result[0].role, Role::System);
@@ -1322,7 +1349,18 @@ mod tests {
             })
             .collect();
 
-        let result = llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
 
         // System prompt directly followed by windowed messages — no summary
         assert_eq!(result[0].role, Role::System);
@@ -1439,20 +1477,43 @@ mod tests {
     #[test]
     fn active_task_not_injected_when_none() {
         let msgs = vec![Message::new(Role::User, "hello")];
-        let result =
-            llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
 
         let any_anchor = result
             .iter()
             .any(|m| m.role == Role::System && m.content.starts_with("[Current task]"));
-        assert!(!any_anchor, "no anchor should be injected when active_task is None");
+        assert!(
+            !any_anchor,
+            "no anchor should be injected when active_task is None"
+        );
     }
 
     #[test]
     fn active_task_not_injected_when_empty_string() {
         let msgs = vec![Message::new(Role::User, "hello")];
-        let result =
-            llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, Some(""), 99, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            Some(""),
+            99,
+            None,
+            &default_estimate,
+        );
 
         let any_anchor = result
             .iter()
@@ -1528,8 +1589,18 @@ mod tests {
             summary: "Assistant performed steps 1-3.".to_string(),
         }];
 
-        let result =
-            llm_messages_for_turn(&msgs, &summaries, &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &summaries,
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
 
         // System + "start" + summary injection + "follow up" + "final" = 5
         assert_eq!(result.len(), 5);
@@ -1549,7 +1620,18 @@ mod tests {
             Message::new(Role::Assistant, "hello"),
         ];
 
-        let result = llm_messages_for_turn(&msgs, &[], &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
         // System + 2 messages
         assert_eq!(result.len(), 3);
         assert_eq!(result[1].content, "hi");
@@ -1583,8 +1665,18 @@ mod tests {
             },
         ];
 
-        let result =
-            llm_messages_for_turn(&msgs, &summaries, &[], &[], "", MAX_CONTEXT_MESSAGES, None, 0, None, &default_estimate);
+        let result = llm_messages_for_turn(
+            &msgs,
+            &summaries,
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            0,
+            None,
+            &default_estimate,
+        );
         // System + "start" + summary1 + "middle" + summary2 + "end" = 6
         assert_eq!(result.len(), 6);
         assert!(result[2].content.contains("Summary of messages 1\u{2013}2"));
@@ -1829,13 +1921,17 @@ mod tests {
             .find(|m| m.role == Role::System)
             .expect("system message must be present");
         assert!(
-            system.content.contains(&format!("There are {} tools across", tools.len())),
+            system
+                .content
+                .contains(&format!("There are {} tools across", tools.len())),
             "demoted system block must include 'There are <N> tools' wording, \
              got: {:?}",
             system.content
         );
         assert!(
-            !system.content.contains(&format!("Available tools in this turn: {}", tools[0].name)),
+            !system
+                .content
+                .contains(&format!("Available tools in this turn: {}", tools[0].name)),
             "demoted system block must not enumerate every tool name, got: {:?}",
             system.content
         );
@@ -1875,7 +1971,9 @@ mod tests {
             .find(|m| m.role == Role::System)
             .expect("system message must be present");
         assert!(
-            system.content.contains("Available tools in this turn: ping."),
+            system
+                .content
+                .contains("Available tools in this turn: ping."),
             "full enumeration must be preserved, got: {:?}",
             system.content
         );
@@ -1920,7 +2018,9 @@ mod tests {
             "full enumeration must be present when no budget installed"
         );
         assert!(
-            !system.content.contains(&format!("There are {} tools across", tools.len())),
+            !system
+                .content
+                .contains(&format!("There are {} tools across", tools.len())),
             "demoted summary must not appear when no budget installed"
         );
     }

--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -66,9 +66,7 @@ where
 /// Current task-local reasoning config, or `ReasoningConfig::default()`
 /// (all `None`) when not set. Safe to call from any async context.
 pub fn current_reasoning_config() -> ReasoningConfig {
-    REASONING_CONFIG
-        .try_with(|c| *c)
-        .unwrap_or_default()
+    REASONING_CONFIG.try_with(|c| *c).unwrap_or_default()
 }
 
 /// Run `fut` with `model` installed as the current turn's model override.
@@ -1012,10 +1010,8 @@ mod tests {
 
     #[tokio::test]
     async fn current_model_override_observes_scope() {
-        let observed = with_model_override("gpt-5-mini".to_string(), async {
-            current_model_override()
-        })
-        .await;
+        let observed =
+            with_model_override("gpt-5-mini".to_string(), async { current_model_override() }).await;
         assert_eq!(observed, Some("gpt-5-mini".to_string()));
         // After the scope exits the task-local is unset again.
         assert_eq!(current_model_override(), None);

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -1,11 +1,10 @@
 use crate::CoreError;
 use crate::context::{
-    MAX_CONTEXT_MESSAGES, MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES, COMPACTION_TOKEN_RATIO,
+    COMPACTION_TOKEN_RATIO, MAX_CONTEXT_MESSAGES, MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES,
     compaction_range, generate_context_summary, llm_messages_for_turn, recover_from_overflow,
 };
 use crate::domain::{
-    Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition,
-    ToolNamespace,
+    Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition, ToolNamespace,
 };
 use crate::ports::inbound::ConversationService;
 use crate::ports::llm::{
@@ -14,7 +13,9 @@ use crate::ports::llm::{
 use crate::ports::store::ConversationStore;
 use crate::ports::tools::ToolExecutor;
 use crate::sanitize::{sanitize_assistant_text, sanitize_assistant_text_for_stream};
-use crate::tools::{NoopToolExecutor, categorize_tool_namespaces, tool_set_hash, tool_status_message};
+use crate::tools::{
+    NoopToolExecutor, categorize_tool_namespaces, tool_set_hash, tool_status_message,
+};
 use chrono::{Duration, Local};
 
 /// Maximum number of tool-calling rounds before giving up.
@@ -94,7 +95,12 @@ async fn generate_conversation_title<L: LlmClient>(initial_prompt: &str, llm: &L
         ),
     ];
     match llm
-        .stream_completion(messages, &[], ReasoningConfig::default(), Box::new(|_| true))
+        .stream_completion(
+            messages,
+            &[],
+            ReasoningConfig::default(),
+            Box::new(|_| true),
+        )
         .await
     {
         Ok(response) => sanitize_generated_title(&response.text),
@@ -412,73 +418,70 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             // empty config, matching the pre-issue-18 behaviour.
             let reasoning = crate::ports::llm::current_reasoning_config();
 
-            let response =
-                match if use_hosted_search && !namespaces.is_empty() && !hosted_search_demoted {
-                    self.llm
-                        .stream_completion_with_namespaces(
-                            llm_messages,
-                            &tool_defs,
-                            &namespaces,
-                            reasoning,
-                            filtered_chunk_callback,
-                        )
-                        .await
-                } else {
-                    self.llm
-                        .stream_completion(
-                            llm_messages,
-                            &tool_defs,
-                            reasoning,
-                            filtered_chunk_callback,
-                        )
-                        .await
-                } {
-                    Ok(r) => r,
-                    Err(CoreError::ContextOverflow {
+            let response = match if use_hosted_search
+                && !namespaces.is_empty()
+                && !hosted_search_demoted
+            {
+                self.llm
+                    .stream_completion_with_namespaces(
+                        llm_messages,
+                        &tool_defs,
+                        &namespaces,
+                        reasoning,
+                        filtered_chunk_callback,
+                    )
+                    .await
+            } else {
+                self.llm
+                    .stream_completion(llm_messages, &tool_defs, reasoning, filtered_chunk_callback)
+                    .await
+            } {
+                Ok(r) => r,
+                Err(CoreError::ContextOverflow {
+                    prompt_tokens,
+                    max_tokens,
+                    detail: _,
+                }) if overflow_retries < MAX_OVERFLOW_RETRIES => {
+                    // The provider rejected this turn's prompt for
+                    // exceeding its context window. Run the recovery
+                    // ladder (truncate large tool result → trim old
+                    // pairs → summarise-and-shrink) and retry. The
+                    // counter bounds total attempts across all steps
+                    // so persistently-oversized requests can't loop.
+                    overflow_retries += 1;
+                    tracing::warn!(
+                        attempt = overflow_retries,
+                        max_attempts = MAX_OVERFLOW_RETRIES,
+                        prompt_tokens = ?prompt_tokens,
+                        max_tokens = ?max_tokens,
+                        "context overflow — running recovery ladder"
+                    );
+                    recover_from_overflow(
+                        &mut conv,
                         prompt_tokens,
                         max_tokens,
-                        detail: _,
-                    }) if overflow_retries < MAX_OVERFLOW_RETRIES => {
-                        // The provider rejected this turn's prompt for
-                        // exceeding its context window. Run the recovery
-                        // ladder (truncate large tool result → trim old
-                        // pairs → summarise-and-shrink) and retry. The
-                        // counter bounds total attempts across all steps
-                        // so persistently-oversized requests can't loop.
-                        overflow_retries += 1;
-                        tracing::warn!(
-                            attempt = overflow_retries,
-                            max_attempts = MAX_OVERFLOW_RETRIES,
-                            prompt_tokens = ?prompt_tokens,
-                            max_tokens = ?max_tokens,
-                            "context overflow — running recovery ladder"
-                        );
-                        recover_from_overflow(
-                            &mut conv,
-                            prompt_tokens,
-                            max_tokens,
-                            &mut target_window,
-                            self.task_llm(),
-                            &estimate,
-                        )
-                        .await;
-                        on_chunk = Box::new(|_| true);
-                        continue;
-                    }
-                    Err(e) => {
-                        // Anything else — including exhausted overflow
-                        // retries — surfaces as a user-visible message.
-                        // Non-context errors are no longer trimmed-and-prayed
-                        // through old path C; that swallowed transient
-                        // failures (rate limits, server errors, malformed
-                        // tool calls) by mutating conversation state.
-                        let friendly = user_visible_llm_error_message(&e);
-                        conv.messages.push(Message::new(Role::Assistant, &friendly));
-                        conv.updated_at = now_timestamp();
-                        self.store.update(conv).await?;
-                        return Ok(friendly);
-                    }
-                };
+                        &mut target_window,
+                        self.task_llm(),
+                        &estimate,
+                    )
+                    .await;
+                    on_chunk = Box::new(|_| true);
+                    continue;
+                }
+                Err(e) => {
+                    // Anything else — including exhausted overflow
+                    // retries — surfaces as a user-visible message.
+                    // Non-context errors are no longer trimmed-and-prayed
+                    // through old path C; that swallowed transient
+                    // failures (rate limits, server errors, malformed
+                    // tool calls) by mutating conversation state.
+                    let friendly = user_visible_llm_error_message(&e);
+                    conv.messages.push(Message::new(Role::Assistant, &friendly));
+                    conv.updated_at = now_timestamp();
+                    self.store.update(conv).await?;
+                    return Ok(friendly);
+                }
+            };
 
             // Token-pressure check: if the provider reports input tokens
             // above COMPACTION_TOKEN_RATIO of its context window, shrink the
@@ -492,8 +495,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             // wrapper), token-based compaction skips — same behaviour as
             // when the connector previously returned `None` from
             // `max_context_tokens()`.
-            if let (Some(budget), Some(usage)) =
-                (current_context_budget(), response.usage.as_ref())
+            if let (Some(budget), Some(usage)) = (current_context_budget(), response.usage.as_ref())
                 && let Some(input_tokens) = usage.input_tokens
             {
                 let max_tokens = budget.max_input_tokens;
@@ -1591,8 +1593,7 @@ mod tests {
             MockStore::new(),
             FailingLlm::new(responses, 1).with_error_variant(|| CoreError::RateLimited {
                 retry_after: None,
-                detail: "Anthropic API error (HTTP 429 Too Many Requests): rate_limit_error"
-                    .into(),
+                detail: "Anthropic API error (HTTP 429 Too Many Requests): rate_limit_error".into(),
             }),
             MockToolExecutor::new(tools, tool_results),
             Box::new(move || {
@@ -2311,7 +2312,9 @@ mod tests {
             .push(Message::assistant_with_tool_calls(vec![ToolCall::new(
                 "c3", "big", "{}",
             )]));
-        stored.messages.push(Message::tool_result("c3", &big_content));
+        stored
+            .messages
+            .push(Message::tool_result("c3", &big_content));
         handler.store.update(stored).await.unwrap();
 
         let result = handler
@@ -2357,7 +2360,10 @@ mod tests {
             "expected truncation notice, got: {:?}",
             &big.content
         );
-        assert!(big.content.contains(&format!("{} bytes", big_content.len())));
+        assert!(
+            big.content
+                .contains(&format!("{} bytes", big_content.len()))
+        );
     }
 
     #[tokio::test]
@@ -2518,12 +2524,7 @@ mod tests {
             .clone();
 
         let result = handler
-            .send_prompt(
-                &conv.id,
-                "follow-up".into(),
-                noop_callback(),
-                noop_status(),
-            )
+            .send_prompt(&conv.id, "follow-up".into(), noop_callback(), noop_status())
             .await
             .unwrap();
         assert_eq!(result, "done");
@@ -2588,12 +2589,10 @@ mod tests {
             .push(Message::assistant_with_tool_calls(vec![ToolCall::new(
                 "c1", "t", "{}",
             )]));
-        stored
-            .messages
-            .push(Message::tool_result(
-                "c1",
-                "x".repeat((MIN_TRUNCATION_TOKENS * 8) as usize),
-            ));
+        stored.messages.push(Message::tool_result(
+            "c1",
+            "x".repeat((MIN_TRUNCATION_TOKENS * 8) as usize),
+        ));
         handler.store.update(stored).await.unwrap();
 
         let result = handler
@@ -2723,10 +2722,7 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn tool_definition(
-            &self,
-            _name: &str,
-        ) -> Result<Option<ToolDefinition>, CoreError> {
+        async fn tool_definition(&self, _name: &str) -> Result<Option<ToolDefinition>, CoreError> {
             Ok(None)
         }
 
@@ -2964,5 +2960,4 @@ mod tests {
             "categorizer must run once when the raw listing exceeds the budget threshold"
         );
     }
-
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -139,7 +139,12 @@ pub(crate) async fn categorize_tool_namespaces<L: LlmClient>(
     ];
 
     let response = match llm
-        .stream_completion(messages, &[], ReasoningConfig::default(), Box::new(|_| true))
+        .stream_completion(
+            messages,
+            &[],
+            ReasoningConfig::default(),
+            Box::new(|_| true),
+        )
         .await
     {
         Ok(r) => r,

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -37,8 +37,8 @@ use desktop_assistant_core::ports::inbound::{
     PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SerdeEffort,
 };
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback,
-    with_context_budget, with_model_override, with_reasoning_config,
+    ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
+    with_model_override, with_reasoning_config,
 };
 
 use crate::config::{
@@ -229,7 +229,8 @@ impl ConnectionsService for DaemonConnectionsService {
             if cfg.connections.contains_key(id_valid.as_str()) {
                 return Err(format!("connection id {:?} already exists", id_valid));
             }
-            cfg.connections.insert(id_valid.as_str().to_string(), new_conn);
+            cfg.connections
+                .insert(id_valid.as_str().to_string(), new_conn);
             Ok(())
         })
     }
@@ -262,8 +263,7 @@ impl ConnectionsService for DaemonConnectionsService {
             // Check whether any purpose references this id.
             let referenced_by: Vec<PurposeKind> = purposes_referencing(&cfg.purposes, &id_valid);
             if !referenced_by.is_empty() && !force {
-                let names: Vec<&'static str> =
-                    referenced_by.iter().map(|k| k.as_key()).collect();
+                let names: Vec<&'static str> = referenced_by.iter().map(|k| k.as_key()).collect();
                 return Err(format!(
                     "connection {:?} is referenced by purposes {:?}; pass force=true to cascade",
                     id_valid, names
@@ -319,11 +319,7 @@ impl ConnectionsService for DaemonConnectionsService {
             String,
             std::sync::Arc<crate::registry::AnyLlmClient>,
         )> = {
-            let state = self
-                .registry
-                .state
-                .read()
-                .expect("registry state poisoned");
+            let state = self.registry.state.read().expect("registry state poisoned");
             if let Some(id_raw) = &connection_id {
                 let id = ConnectionId::new(id_raw.clone())
                     .map_err(|e| CoreError::Llm(format!("invalid connection id: {e}")))?;
@@ -428,9 +424,7 @@ impl ConnectionsService for DaemonConnectionsService {
 
         self.registry.mutate_config(|cfg| {
             cfg.purposes.set(purpose_kind, Some(new_cfg));
-            cfg.purposes
-                .validate()
-                .map_err(|e| format!("{e}"))
+            cfg.purposes.validate().map_err(|e| format!("{e}"))
         })
     }
 }
@@ -444,9 +438,7 @@ pub trait ConversationSelectionStore: Send + Sync {
     fn get_selection(
         &self,
         id: &ConversationId,
-    ) -> impl std::future::Future<
-        Output = Result<Option<ConversationModelSelection>, CoreError>,
-    > + Send;
+    ) -> impl std::future::Future<Output = Result<Option<ConversationModelSelection>, CoreError>> + Send;
 
     fn set_selection(
         &self,
@@ -503,14 +495,13 @@ where
     /// Check a stored selection against the live registry. Returns
     /// `(is_still_valid)`. When invalid, the caller is responsible for
     /// clearing the stored selection and emitting a warning.
-    async fn selection_is_live(
-        &self,
-        sel: &ConversationModelSelection,
-    ) -> Result<bool, CoreError> {
+    async fn selection_is_live(&self, sel: &ConversationModelSelection) -> Result<bool, CoreError> {
         let Ok(id) = ConnectionId::new(sel.connection_id.clone()) else {
             return Ok(false);
         };
-        self.registry.connection_lists_model(&id, &sel.model_id).await
+        self.registry
+            .connection_lists_model(&id, &sel.model_id)
+            .await
     }
 
     /// Translate the effort hint into the per-connector
@@ -631,7 +622,9 @@ where
         max_age_days: Option<u32>,
         include_archived: bool,
     ) -> Result<Vec<ConversationSummary>, CoreError> {
-        self.inner.list_conversations(max_age_days, include_archived).await
+        self.inner
+            .list_conversations(max_age_days, include_archived)
+            .await
     }
 
     async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
@@ -825,12 +818,12 @@ where
                     sel.connection_id
                 ))
             })?;
-            let connector_type = self
-                .registry
-                .connector_type_for(&id)
-                .unwrap_or_default();
-            reasoning =
-                Self::apply_effort_mapping(&connector_type, &sel.model_id, sel.effort.map(Effort::from));
+            let connector_type = self.registry.connector_type_for(&id).unwrap_or_default();
+            reasoning = Self::apply_effort_mapping(
+                &connector_type,
+                &sel.model_id,
+                sel.effort.map(Effort::from),
+            );
         }
 
         // Resolve the per-turn context budget once at dispatch entry.
@@ -902,10 +895,7 @@ where
                 (None, _) => dispatch.await,
             }
         }?;
-        Ok(PromptDispatchOutcome {
-            response,
-            warnings,
-        })
+        Ok(PromptDispatchOutcome { response, warnings })
     }
 }
 
@@ -1050,7 +1040,10 @@ fn core_to_internal_purpose(k: CorePurposeKind) -> PurposeKind {
     }
 }
 
-fn purposes_referencing(purposes: &crate::purposes::Purposes, id: &ConnectionId) -> Vec<PurposeKind> {
+fn purposes_referencing(
+    purposes: &crate::purposes::Purposes,
+    id: &ConnectionId,
+) -> Vec<PurposeKind> {
     let mut out = Vec::new();
     for kind in PurposeKind::all() {
         if let Some(p) = purposes.get(kind)
@@ -1154,10 +1147,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_connections_returns_declared_order() {
-        let cfg = config_with_connections(&[
-            ("local", ollama_local()),
-            ("aws", bedrock_work()),
-        ]);
+        let cfg = config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
         let svc = DaemonConnectionsService::new(make_handle_with(cfg));
         let views = svc.list_connections().await.unwrap();
         assert_eq!(views.len(), 2);
@@ -1198,10 +1188,8 @@ mod tests {
 
     #[tokio::test]
     async fn delete_connection_refuses_when_referenced_without_force() {
-        let mut cfg = config_with_connections(&[
-            ("local", ollama_local()),
-            ("aws", bedrock_work()),
-        ]);
+        let mut cfg =
+            config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
         cfg.purposes.interactive = Some(PurposeConfig {
             connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
             model: ModelRef::Named("llama3".into()),
@@ -1225,10 +1213,8 @@ mod tests {
 
     #[tokio::test]
     async fn delete_connection_force_cascades_to_primary() {
-        let mut cfg = config_with_connections(&[
-            ("local", ollama_local()),
-            ("aws", bedrock_work()),
-        ]);
+        let mut cfg =
+            config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
         cfg.purposes.interactive = Some(PurposeConfig {
             connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
             model: ModelRef::Named("llama3".into()),
@@ -1244,7 +1230,9 @@ mod tests {
 
         let handle = make_handle_with(cfg);
         let svc = DaemonConnectionsService::new(Arc::clone(&handle));
-        svc.delete_connection("aws".to_string(), true).await.unwrap();
+        svc.delete_connection("aws".to_string(), true)
+            .await
+            .unwrap();
 
         let cfg = handle.snapshot_config();
         assert!(!cfg.connections.contains_key("aws"));
@@ -1308,10 +1296,8 @@ mod tests {
         // we just verify the dispatch path runs without panicking and
         // filters unhealthy entries. A full integration test with mocked
         // list_models lives in `send_prompt_override_tests` below.
-        let cfg = config_with_connections(&[
-            ("local1", ollama_local()),
-            ("local2", ollama_local()),
-        ]);
+        let cfg =
+            config_with_connections(&[("local1", ollama_local()), ("local2", ollama_local())]);
         let svc = DaemonConnectionsService::new(make_handle_with(cfg));
         // Either the network fails (empty list) or succeeds — both are OK
         // since we're just checking we don't hard-error when aggregating.
@@ -1362,10 +1348,7 @@ mod tests {
         }
 
         impl ConversationService for CapturingInner {
-            async fn create_conversation(
-                &self,
-                title: String,
-            ) -> Result<Conversation, CoreError> {
+            async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
                 Ok(Conversation::new("c1", title))
             }
             async fn list_conversations(
@@ -1381,10 +1364,7 @@ mod tests {
             ) -> Result<Conversation, CoreError> {
                 Ok(Conversation::new(id.as_str(), "t"))
             }
-            async fn delete_conversation(
-                &self,
-                _id: &ConversationId,
-            ) -> Result<(), CoreError> {
+            async fn delete_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
                 Ok(())
             }
             async fn rename_conversation(
@@ -1394,16 +1374,10 @@ mod tests {
             ) -> Result<(), CoreError> {
                 Ok(())
             }
-            async fn archive_conversation(
-                &self,
-                _id: &ConversationId,
-            ) -> Result<(), CoreError> {
+            async fn archive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
                 Ok(())
             }
-            async fn unarchive_conversation(
-                &self,
-                _id: &ConversationId,
-            ) -> Result<(), CoreError> {
+            async fn unarchive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
                 Ok(())
             }
             async fn clear_all_history(&self) -> Result<u32, CoreError> {
@@ -1425,18 +1399,15 @@ mod tests {
                 self.captured_reasoning.lock().unwrap().push(cfg);
                 let active = crate::routing_llm::active_client_is_set();
                 self.captured_active_client_set.lock().unwrap().push(active);
-                let model =
-                    desktop_assistant_core::ports::llm::current_model_override();
+                let model = desktop_assistant_core::ports::llm::current_model_override();
                 self.captured_model_override.lock().unwrap().push(model);
                 Ok("ok".to_string())
             }
         }
 
         fn local_ollama_cfg() -> DaemonConfig {
-            let mut cfg = config_with_connections(&[
-                ("local", ollama_local()),
-                ("aws", bedrock_work()),
-            ]);
+            let mut cfg =
+                config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
             cfg.purposes.interactive = Some(PurposeConfig {
                 connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
                 model: ModelRef::Named("llama3".into()),
@@ -1533,9 +1504,7 @@ mod tests {
                 // exercise the mapping.
                 c.purposes.interactive = Some(PurposeConfig {
                     connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
-                    model: ModelRef::Named(
-                        "us.anthropic.claude-sonnet-4-6".into(),
-                    ),
+                    model: ModelRef::Named("us.anthropic.claude-sonnet-4-6".into()),
                     effort: None,
                     max_context_tokens: None,
                 });
@@ -1605,7 +1574,9 @@ mod tests {
             let cfg = RoutingConversationHandler::<
                 InMemoryConversationSelectionStore,
                 CapturingInner,
-            >::apply_effort_mapping("anthropic", "claude-sonnet-4-6", Some(Effort::Low));
+            >::apply_effort_mapping(
+                "anthropic", "claude-sonnet-4-6", Some(Effort::Low)
+            );
             assert!(cfg.thinking_budget_tokens.is_none());
         }
 
@@ -1623,7 +1594,9 @@ mod tests {
             let cfg = RoutingConversationHandler::<
                 InMemoryConversationSelectionStore,
                 CapturingInner,
-            >::apply_effort_mapping("mystery-vendor", "m1", Some(Effort::High));
+            >::apply_effort_mapping(
+                "mystery-vendor", "m1", Some(Effort::High)
+            );
             assert_eq!(cfg, ReasoningConfig::default());
         }
 

--- a/crates/daemon/src/backend_reasoning.rs
+++ b/crates/daemon/src/backend_reasoning.rs
@@ -101,7 +101,9 @@ impl<L: LlmClient> LlmClient for FixedReasoningLlmClient<L> {
             self.reasoning
         };
         self.inner
-            .stream_completion_with_namespaces(messages, core_tools, namespaces, effective, on_chunk)
+            .stream_completion_with_namespaces(
+                messages, core_tools, namespaces, effective, on_chunk,
+            )
             .await
     }
 }

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -573,12 +573,8 @@ pub fn load_daemon_config(path: &Path) -> anyhow::Result<Option<DaemonConfig>> {
     // the synthesized `[connections.default]`. It also rewrites the config
     // file on first contact — only when a legacy shape was present and no
     // `[purposes]` table has been authored yet.
-    let parsed = maybe_migrate_legacy_purposes(
-        path,
-        parsed,
-        explicit_purposes_table,
-        legacy_shape_present,
-    )?;
+    let parsed =
+        maybe_migrate_legacy_purposes(path, parsed, explicit_purposes_table, legacy_shape_present)?;
 
     // Validate purposes: structural checks (interactive required when set,
     // no `Primary` in interactive) happen here so misconfigurations surface
@@ -718,12 +714,9 @@ fn maybe_migrate_legacy_purposes(
             .cloned()
             .expect("connections non-empty")
     };
-    let interactive_conn = ConnectionId::new(interactive_conn_id.clone())
-        .with_context(|| {
-            format!(
-                "cannot migrate purposes: connection id {interactive_conn_id:?} is invalid"
-            )
-        })?;
+    let interactive_conn = ConnectionId::new(interactive_conn_id.clone()).with_context(|| {
+        format!("cannot migrate purposes: connection id {interactive_conn_id:?} is invalid")
+    })?;
 
     // Model for interactive: take from [llm].model, else use the connector's
     // built-in default so the resolved purpose always has a concrete model.
@@ -765,9 +758,7 @@ fn maybe_migrate_legacy_purposes(
             // Case C: different connector. Synthesize a new connection.
             let synthesized = connection_from_legacy_llm(bt_llm);
             let backend_id = pick_free_connection_id(&parsed.connections, "backend");
-            parsed
-                .connections
-                .insert(backend_id.clone(), synthesized);
+            parsed.connections.insert(backend_id.clone(), synthesized);
             let id = ConnectionId::new(backend_id).expect("pick_free returns a valid slug");
             (ConnectionRef::Named(id), bt_model)
         }
@@ -839,10 +830,7 @@ fn maybe_migrate_legacy_purposes(
 
 /// Find a `ConnectionId`-valid slug that is not already in use. Starts with
 /// `base` (e.g. `backend`) and appends `_2`, `_3`, ... as needed.
-fn pick_free_connection_id(
-    existing: &IndexMap<String, ConnectionConfig>,
-    base: &str,
-) -> String {
+fn pick_free_connection_id(existing: &IndexMap<String, ConnectionConfig>, base: &str) -> String {
     if !existing.contains_key(base) {
         return base.to_string();
     }
@@ -860,7 +848,10 @@ fn pick_free_connection_id(
 /// `<path>.bak.3`, ... when earlier slots are taken. Never overwrites.
 fn pick_backup_path(path: &Path) -> PathBuf {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("config");
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("config");
 
     let primary = parent.join(format!("{file_name}.bak"));
     if !primary.exists() {
@@ -1271,7 +1262,9 @@ pub fn resolve_embeddings_config(config: Option<&DaemonConfig>) -> EmbeddingsSet
 /// Build an `EmbeddingsSettingsView` from `purposes.embedding` if it is
 /// configured, otherwise return `None`. Centralises the purpose-aware
 /// short-circuit so the legacy resolver can skip the rest of its work.
-fn resolve_purpose_embeddings_view(config: Option<&DaemonConfig>) -> Option<EmbeddingsSettingsView> {
+fn resolve_purpose_embeddings_view(
+    config: Option<&DaemonConfig>,
+) -> Option<EmbeddingsSettingsView> {
     let resolved = resolve_purpose_llm_config(config, PurposeKind::Embedding)?;
     let available = resolved.connector != "anthropic";
     let has_api_key = !resolved.api_key.trim().is_empty();
@@ -1621,12 +1614,7 @@ pub fn resolve_connection_llm_config(
             base_url,
             api_key_env,
             secret,
-        }) => (
-            base_url.clone(),
-            api_key_env.clone(),
-            secret.clone(),
-            None,
-        ),
+        }) => (base_url.clone(), api_key_env.clone(), secret.clone(), None),
         ConnectionConfig::Ollama(OllamaConnection { base_url }) => {
             (base_url.clone(), None, None, None)
         }
@@ -1686,12 +1674,11 @@ pub fn resolve_connection_llm_config(
         .map(|c| (c.temperature, c.top_p, c.max_tokens, c.hosted_tool_search))
         .unwrap_or((None, None, None, None));
 
-    let aws_profile = conn_aws_profile
-        .or_else(|| {
-            fallback_llm
-                .filter(|c| c.connector.trim().to_lowercase() == connector)
-                .and_then(|c| c.aws_profile.clone())
-        });
+    let aws_profile = conn_aws_profile.or_else(|| {
+        fallback_llm
+            .filter(|c| c.connector.trim().to_lowercase() == connector)
+            .and_then(|c| c.aws_profile.clone())
+    });
 
     ResolvedLlmConfig {
         connector,
@@ -1818,19 +1805,15 @@ fn write_common_file_secret(account: &str, value: &str) -> anyhow::Result<()> {
             .truncate(true)
             .mode(0o600)
             .open(&path)
-            .map_err(|error| {
-                anyhow!("failed to write secret file {}: {error}", path.display())
-            })?;
-        file.write_all(value.as_bytes()).map_err(|error| {
-            anyhow!("failed to write secret file {}: {error}", path.display())
-        })?;
+            .map_err(|error| anyhow!("failed to write secret file {}: {error}", path.display()))?;
+        file.write_all(value.as_bytes())
+            .map_err(|error| anyhow!("failed to write secret file {}: {error}", path.display()))?;
     }
 
     #[cfg(not(unix))]
     {
-        std::fs::write(&path, value).map_err(|error| {
-            anyhow!("failed to write secret file {}: {error}", path.display())
-        })?;
+        std::fs::write(&path, value)
+            .map_err(|error| anyhow!("failed to write secret file {}: {error}", path.display()))?;
     }
 
     Ok(())
@@ -2821,11 +2804,8 @@ mod tests {
     fn oidc_require_https_rejects_non_loopback_http() {
         // Plaintext JWKS lets a network attacker swap the keys and forge
         // tokens — must reject.
-        let err = OidcValidator::require_https_or_loopback(
-            "http://idp.example.com",
-            "issuer_url",
-        )
-        .expect_err("plaintext IdP rejected");
+        let err = OidcValidator::require_https_or_loopback("http://idp.example.com", "issuer_url")
+            .expect_err("plaintext IdP rejected");
         assert!(err.to_string().contains("https://"));
 
         OidcValidator::require_https_or_loopback("ftp://idp.example.com", "issuer_url")
@@ -2840,9 +2820,9 @@ mod tests {
         assert_eq!(bucket_secret_len(8), "<16");
         assert_eq!(bucket_secret_len(15), "<16");
         assert_eq!(bucket_secret_len(16), "16-31");
-        assert_eq!(bucket_secret_len(32), "32-47");  // typical OpenAI sk- key
+        assert_eq!(bucket_secret_len(32), "32-47"); // typical OpenAI sk- key
         assert_eq!(bucket_secret_len(47), "32-47");
-        assert_eq!(bucket_secret_len(51), "48-79");  // typical Anthropic key
+        assert_eq!(bucket_secret_len(51), "48-79"); // typical Anthropic key
         assert_eq!(bucket_secret_len(79), "48-79");
         assert_eq!(bucket_secret_len(80), ">=80");
         assert_eq!(bucket_secret_len(2048), ">=80");
@@ -3147,7 +3127,10 @@ base_url = "http://localhost:11434"
 "#;
         let parsed: DaemonConfig = toml::from_str(content).unwrap();
         let validated = parsed.validated_connections().expect("should validate");
-        let ids: Vec<_> = validated.iter().map(|(id, _)| id.as_str().to_owned()).collect();
+        let ids: Vec<_> = validated
+            .iter()
+            .map(|(id, _)| id.as_str().to_owned())
+            .collect();
         assert_eq!(ids, vec!["work_openai", "home_bedrock", "laptop_ollama"]);
         assert_eq!(
             validated
@@ -3180,8 +3163,10 @@ region = "us-west-2"
     #[test]
     fn validated_connections_rejects_invalid_slug() {
         let mut cfg = DaemonConfig::default();
-        cfg.connections
-            .insert("Bad Id".to_string(), ConnectionConfig::OpenAi(Default::default()));
+        cfg.connections.insert(
+            "Bad Id".to_string(),
+            ConnectionConfig::OpenAi(Default::default()),
+        );
         let err = cfg.validated_connections().unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Bad Id"), "error should cite bad id: {msg}");
@@ -3250,10 +3235,7 @@ type = "openai"
 
         let err = load_daemon_config(&path).unwrap_err();
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("Bad Id"),
-            "error should cite bad id: {msg}"
-        );
+        assert!(msg.contains("Bad Id"), "error should cite bad id: {msg}");
         assert!(
             msg.contains("connection id"),
             "error should mention 'connection id': {msg}"
@@ -3309,7 +3291,10 @@ dreaming_enabled = true
             "aws-bedrock" => "bedrock",
             other => other,
         };
-        assert_eq!(type_tag, expected, "connector type mismatch for {connector}");
+        assert_eq!(
+            type_tag, expected,
+            "connector type mismatch for {connector}"
+        );
 
         // Backup written alongside original.
         let bak = dir.join("daemon.toml.bak");
@@ -3372,18 +3357,12 @@ aws_profile = "home""#,
     fn migration_aws_bedrock_alias() {
         // Legacy users of the `aws-bedrock` connector alias migrate to the
         // canonical `bedrock` variant.
-        load_migrates_legacy_for_connector(
-            "aws-bedrock",
-            r#"base_url = "us-east-1""#,
-        );
+        load_migrates_legacy_for_connector("aws-bedrock", r#"base_url = "us-east-1""#);
     }
 
     #[test]
     fn migration_ollama() {
-        load_migrates_legacy_for_connector(
-            "ollama",
-            r#"base_url = "http://localhost:11434""#,
-        );
+        load_migrates_legacy_for_connector("ollama", r#"base_url = "http://localhost:11434""#);
     }
 
     #[test]
@@ -3661,12 +3640,10 @@ effort = "high"
         // `[backend_tasks.llm]` targets a different connector than `[llm]`.
         // Exercises: new `backend` connection synthesis, dreaming/titling
         // pointed at it, backend_tasks.llm removed from serialized form.
-        let legacy = include_str!(
-            "../tests/fixtures/purposes_migration/legacy_anthropic_backend.toml"
-        );
-        let expected_new = include_str!(
-            "../tests/fixtures/purposes_migration/migrated_anthropic_backend.toml"
-        );
+        let legacy =
+            include_str!("../tests/fixtures/purposes_migration/legacy_anthropic_backend.toml");
+        let expected_new =
+            include_str!("../tests/fixtures/purposes_migration/migrated_anthropic_backend.toml");
 
         let dir = unique_test_dir("da-test-golden-purposes");
         let path = dir.join("daemon.toml");
@@ -3688,12 +3665,9 @@ effort = "high"
     fn migration_golden_file_openai() {
         // Golden-file test: a representative legacy config migrates to the
         // expected new form byte-for-byte (modulo trailing whitespace).
-        let legacy = include_str!(
-            "../tests/fixtures/connections_migration/legacy_openai.toml"
-        );
-        let expected_new = include_str!(
-            "../tests/fixtures/connections_migration/migrated_openai.toml"
-        );
+        let legacy = include_str!("../tests/fixtures/connections_migration/legacy_openai.toml");
+        let expected_new =
+            include_str!("../tests/fixtures/connections_migration/migrated_openai.toml");
 
         let dir = unique_test_dir("da-test-golden-openai");
         let path = dir.join("daemon.toml");
@@ -4077,8 +4051,10 @@ y = 2
         // resolver when connectors match. Use a clearly-marked env var so
         // we can assert the value flows end-to-end without depending on
         // ambient OPENAI_API_KEY.
-        let env_var =
-            format!("DA_TEST_PURPOSE_LEGACY_KEY_{}", uuid::Uuid::new_v4().simple());
+        let env_var = format!(
+            "DA_TEST_PURPOSE_LEGACY_KEY_{}",
+            uuid::Uuid::new_v4().simple()
+        );
         // SAFETY: unique name, single-threaded test scope.
         unsafe {
             std::env::set_var(&env_var, "legacy-secret");
@@ -4110,8 +4086,7 @@ y = 2
         // the api_key from the purpose's connection's secret/env reaches the
         // view (not just `has_api_key`), so `main.rs` can hand it to the
         // OpenAI-compatible embedding client without an extra round-trip.
-        let env_var =
-            format!("DA_TEST_PURPOSE_KEY_{}", uuid::Uuid::new_v4().simple());
+        let env_var = format!("DA_TEST_PURPOSE_KEY_{}", uuid::Uuid::new_v4().simple());
         // SAFETY: unique name, single-threaded test scope.
         unsafe {
             std::env::set_var(&env_var, "purpose-secret");
@@ -4248,10 +4223,7 @@ y = 2
         // disabling for non-curated providers. Tag explicitly identifies
         // the silent floor so operators can grep logs.
         let budget = resolve_context_budget(None, None);
-        assert_eq!(
-            budget.max_input_tokens,
-            DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS
-        );
+        assert_eq!(budget.max_input_tokens, DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS);
         assert_eq!(budget.source, BudgetSource::UniversalFallback);
         assert_eq!(budget.max_input_tokens, 200_000);
     }
@@ -4321,7 +4293,12 @@ model = "llama3.2"
 "#;
         let legacy: DaemonConfig = toml::from_str(legacy_toml).expect("legacy parses");
         assert_eq!(
-            legacy.purposes.interactive.as_ref().unwrap().max_context_tokens,
+            legacy
+                .purposes
+                .interactive
+                .as_ref()
+                .unwrap()
+                .max_context_tokens,
             None
         );
         let reserialized = toml::to_string(&legacy).unwrap();

--- a/crates/daemon/src/connections.rs
+++ b/crates/daemon/src/connections.rs
@@ -284,11 +284,7 @@ pub(crate) fn connection_from_legacy_llm(llm: &LlmConfig) -> ConnectionConfig {
                 .as_ref()
                 .filter(|v| !v.trim().is_empty() && !v.contains("://"))
                 .cloned(),
-            base_url: llm
-                .base_url
-                .as_ref()
-                .filter(|v| v.contains("://"))
-                .cloned(),
+            base_url: llm.base_url.as_ref().filter(|v| v.contains("://")).cloned(),
         }),
         // Anything else (including the legacy default "openai") maps to OpenAI.
         _ => ConnectionConfig::OpenAi(OpenAiConnection {
@@ -378,8 +374,14 @@ mod tests {
     fn connections_map_rejects_duplicate_ids() {
         let id = ConnectionId::new("default").unwrap();
         let pairs = vec![
-            (id.clone(), ConnectionConfig::OpenAi(OpenAiConnection::default())),
-            (id.clone(), ConnectionConfig::OpenAi(OpenAiConnection::default())),
+            (
+                id.clone(),
+                ConnectionConfig::OpenAi(OpenAiConnection::default()),
+            ),
+            (
+                id.clone(),
+                ConnectionConfig::OpenAi(OpenAiConnection::default()),
+            ),
         ];
         let err = ConnectionsMap::from_pairs(pairs).unwrap_err();
         assert_eq!(err, ConnectionsError::DuplicateId("default".to_string()));

--- a/crates/daemon/src/knowledge_service.rs
+++ b/crates/daemon/src/knowledge_service.rs
@@ -35,11 +35,7 @@ impl<S> DaemonKnowledgeService<S>
 where
     S: KnowledgeBaseStore + 'static,
 {
-    pub fn new(
-        store: Arc<S>,
-        embed_fn: Option<EmbedFn>,
-        embedding_model: Option<String>,
-    ) -> Self {
+    pub fn new(store: Arc<S>, embed_fn: Option<EmbedFn>, embedding_model: Option<String>) -> Self {
         Self {
             store,
             embed_fn,
@@ -61,10 +57,7 @@ where
     /// Returns `Ok(None)` when no embedding closure is wired (KB writes
     /// still succeed, just without semantic search coverage — same
     /// behaviour as the builtin tool's `embed_chunks` path).
-    async fn embed_chunks(
-        &self,
-        content: &str,
-    ) -> Result<Option<Vec<Vec<f32>>>, CoreError> {
+    async fn embed_chunks(&self, content: &str) -> Result<Option<Vec<Vec<f32>>>, CoreError> {
         let Some(embed_fn) = self.embed_fn.as_ref() else {
             return Ok(None);
         };
@@ -430,12 +423,9 @@ mod tests {
         });
 
         let store = Arc::new(InMemoryStore::default());
-        let service = DaemonKnowledgeService::new(
-            Arc::clone(&store),
-            Some(embed_fn),
-            Some("m".into()),
-        )
-        .with_id_generator(|| "kb-x".into());
+        let service =
+            DaemonKnowledgeService::new(Arc::clone(&store), Some(embed_fn), Some("m".into()))
+                .with_id_generator(|| "kb-x".into());
 
         service
             .create_entry("orig".into(), vec![], serde_json::json!({}))

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -407,10 +407,8 @@ impl api_surface::ConversationSelectionStore for SharedConversationStore {
     async fn get_selection(
         &self,
         id: &desktop_assistant_core::domain::ConversationId,
-    ) -> Result<
-        Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>,
-        CoreError,
-    > {
+    ) -> Result<Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>, CoreError>
+    {
         <AnyConversationStore as api_surface::ConversationSelectionStore>::get_selection(
             &self.0, id,
         )
@@ -420,9 +418,7 @@ impl api_surface::ConversationSelectionStore for SharedConversationStore {
     async fn set_selection(
         &self,
         id: &desktop_assistant_core::domain::ConversationId,
-        selection: Option<
-            &desktop_assistant_core::ports::inbound::ConversationModelSelection,
-        >,
+        selection: Option<&desktop_assistant_core::ports::inbound::ConversationModelSelection>,
     ) -> Result<(), CoreError> {
         <AnyConversationStore as api_surface::ConversationSelectionStore>::set_selection(
             &self.0, id, selection,
@@ -438,10 +434,8 @@ impl api_surface::ConversationSelectionStore for AnyConversationStore {
     async fn get_selection(
         &self,
         id: &desktop_assistant_core::domain::ConversationId,
-    ) -> Result<
-        Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>,
-        CoreError,
-    > {
+    ) -> Result<Option<desktop_assistant_core::ports::inbound::ConversationModelSelection>, CoreError>
+    {
         match self {
             Self::Postgres(s) => s.get_conversation_model_selection(id).await,
             Self::Json(_) => {
@@ -562,11 +556,9 @@ async fn main() -> Result<()> {
     connection_registry.spawn_ollama_warmups();
     for status in connection_registry.status() {
         match &status.health {
-            ConnectionHealth::Ok => tracing::info!(
-                "connection {} ({}) ready",
-                status.id,
-                status.connector_type
-            ),
+            ConnectionHealth::Ok => {
+                tracing::info!("connection {} ({}) ready", status.id, status.connector_type)
+            }
             ConnectionHealth::Unavailable { reason } => tracing::warn!(
                 "connection {} ({}) unavailable: {reason}",
                 status.id,
@@ -627,9 +619,7 @@ async fn main() -> Result<()> {
 
     let (active_id, llm) = match primary_resolved {
         Some((id, resolved)) => {
-            tracing::info!(
-                "primary dispatch via interactive purpose → connection {id}"
-            );
+            tracing::info!("primary dispatch via interactive purpose → connection {id}");
             (Some(id), build_llm_client(resolved))
         }
         None => {
@@ -902,14 +892,11 @@ async fn main() -> Result<()> {
         ));
         tracing::info!("wiring conversation search into builtin tools");
         use desktop_assistant_core::ports::conversation_search::ConversationSearchStore;
-        builtin_tools = builtin_tools.with_conversation_search(Arc::new(
-            move |query, limit, role_filter| {
+        builtin_tools =
+            builtin_tools.with_conversation_search(Arc::new(move |query, limit, role_filter| {
                 let store = Arc::clone(&cs_store);
-                Box::pin(async move {
-                    store.search_messages(&query, limit, role_filter).await
-                })
-            },
-        ));
+                Box::pin(async move { store.search_messages(&query, limit, role_filter).await })
+            }));
     }
 
     if let Some(tr) = &tool_registry_store {
@@ -1121,12 +1108,7 @@ async fn main() -> Result<()> {
                                 Message::new(Role::User, user_prompt),
                             ];
                             let response = llm
-                                .stream_completion(
-                                    messages,
-                                    &[],
-                                    reasoning,
-                                    Box::new(|_| true),
-                                )
+                                .stream_completion(messages, &[], reasoning, Box::new(|_| true))
                                 .await
                                 .map_err(|e| e.to_string())?;
                             Ok(response.text)
@@ -1220,8 +1202,7 @@ async fn main() -> Result<()> {
     // The wrapper exists here only so the primary and backend handlers
     // share the same `L` type (backend tasks need a non-default override,
     // and `with_backend_llm(L)` requires both stacks to match).
-    let llm =
-        backend_reasoning::FixedReasoningLlmClient::new(llm, ReasoningConfig::default());
+    let llm = backend_reasoning::FixedReasoningLlmClient::new(llm, ReasoningConfig::default());
     let llm = RetryingLlmClient::new(llm, 3);
     let llm = MaybeProfiled::from_config(
         llm,
@@ -1268,9 +1249,7 @@ async fn main() -> Result<()> {
         .and_then(|c| c.purposes.titling.as_ref())
         .is_some();
     if titling_configured {
-        tracing::info!(
-            "backend-tasks LLM source=purposes.titling (dynamic resolution per call)"
-        );
+        tracing::info!("backend-tasks LLM source=purposes.titling (dynamic resolution per call)");
         let bt_llm = routing_llm::RoutingLlmClient::new_dynamic_purpose(
             Arc::clone(&registry_handle),
             purposes::PurposeKind::Titling,
@@ -1280,7 +1259,8 @@ async fn main() -> Result<()> {
         // `with_backend_llm(L)` requires both to be the same type. The
         // dynamic-purpose dispatch path overrides reasoning internally,
         // so the wrapper is a transparent passthrough here.
-        let bt_llm = backend_reasoning::FixedReasoningLlmClient::new(bt_llm, ReasoningConfig::default());
+        let bt_llm =
+            backend_reasoning::FixedReasoningLlmClient::new(bt_llm, ReasoningConfig::default());
         let bt_llm = RetryingLlmClient::new(bt_llm, 3);
         let bt_llm = MaybeProfiled::from_config(
             bt_llm,
@@ -1302,10 +1282,8 @@ async fn main() -> Result<()> {
             let bt_llm = build_llm_client(resolved_bt);
             let bt_fallback = Arc::new(bt_llm);
             let bt_llm = routing_llm::RoutingLlmClient::new(bt_fallback);
-            let bt_llm = backend_reasoning::FixedReasoningLlmClient::new(
-                bt_llm,
-                ReasoningConfig::default(),
-            );
+            let bt_llm =
+                backend_reasoning::FixedReasoningLlmClient::new(bt_llm, ReasoningConfig::default());
             let bt_llm = RetryingLlmClient::new(bt_llm, 3);
             let bt_llm = MaybeProfiled::from_config(
                 bt_llm,
@@ -1328,9 +1306,9 @@ async fn main() -> Result<()> {
     ));
     let conversation_service = routing_conv;
 
-    let connections_service = Arc::new(api_surface::DaemonConnectionsService::new(
-        Arc::clone(&registry_handle),
-    ));
+    let connections_service = Arc::new(api_surface::DaemonConnectionsService::new(Arc::clone(
+        &registry_handle,
+    )));
 
     let settings_service =
         Arc::new(DaemonSettingsService::new(config_path.clone()).with_mcp_control(mcp_handle));
@@ -1398,17 +1376,17 @@ async fn main() -> Result<()> {
             .and_then(|b| {
                 b.serve_at(
                     "/org/desktopAssistant/Connections",
-                    desktop_assistant_dbus::connections::DbusConnectionsAdapter::new(
-                        Arc::clone(&api_handler),
-                    ),
+                    desktop_assistant_dbus::connections::DbusConnectionsAdapter::new(Arc::clone(
+                        &api_handler,
+                    )),
                 )
             })
             .and_then(|b| {
                 b.serve_at(
                     "/org/desktopAssistant/Knowledge",
-                    desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(
-                        Arc::clone(&api_handler),
-                    ),
+                    desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(Arc::clone(
+                        &api_handler,
+                    )),
                 )
             }) {
             Ok(builder) => match builder.build().await {
@@ -1537,7 +1515,9 @@ async fn main() -> Result<()> {
         .map(|c| c.allowed_origins.clone())
         .unwrap_or_default();
     if allowed_origins.is_empty() {
-        tracing::info!("WebSocket origin policy: browser clients blocked (no allowed_origins configured)");
+        tracing::info!(
+            "WebSocket origin policy: browser clients blocked (no allowed_origins configured)"
+        );
     } else {
         tracing::info!("WebSocket allowed origins: {allowed_origins:?}");
     }
@@ -1576,7 +1556,9 @@ async fn main() -> Result<()> {
 
     let (ws_shutdown_tx, ws_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let ws_task = tokio::spawn(async move {
-        let shutdown = async { let _ = ws_shutdown_rx.await; };
+        let shutdown = async {
+            let _ = ws_shutdown_rx.await;
+        };
         let result = if let Some(acceptor) = tls_acceptor {
             tracing::info!("WebSocket listening on wss://{ws_addr} (/ws, /auth/config)");
             ws::serve_full_tls(

--- a/crates/daemon/src/model_defaults.rs
+++ b/crates/daemon/src/model_defaults.rs
@@ -123,9 +123,11 @@ mod tests {
 
     #[test]
     fn merge_keeps_live_metadata() {
-        let live = vec![ModelInfo::new("llama3.2:3b")
-            .with_display_name("LIVE override")
-            .with_context_limit(100)];
+        let live = vec![
+            ModelInfo::new("llama3.2:3b")
+                .with_display_name("LIVE override")
+                .with_context_limit(100),
+        ];
         let merged = merge_with_defaults("ollama", live);
         let llama = merged.iter().find(|m| m.id == "llama3.2:3b").unwrap();
         assert_eq!(llama.display_name, "LIVE override");

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -565,10 +565,7 @@ mod tests {
 
     #[test]
     fn model_ref_parses_primary_and_named() {
-        assert_eq!(
-            ModelRef::from_str("primary").unwrap(),
-            ModelRef::Primary
-        );
+        assert_eq!(ModelRef::from_str("primary").unwrap(), ModelRef::Primary);
         assert_eq!(
             ModelRef::from_str("gpt-5.4").unwrap(),
             ModelRef::Named("gpt-5.4".to_string())
@@ -583,7 +580,10 @@ model = "gpt-5.4"
 effort = "medium"
 "#;
         let parsed: PurposeConfig = toml::from_str(toml_src).unwrap();
-        assert_eq!(parsed.connection, ConnectionRef::Named(conn_id("work_openai")));
+        assert_eq!(
+            parsed.connection,
+            ConnectionRef::Named(conn_id("work_openai"))
+        );
         assert_eq!(parsed.model, ModelRef::Named("gpt-5.4".to_string()));
         assert_eq!(parsed.effort, Some(Effort::Medium));
 
@@ -755,7 +755,12 @@ mystery = "x"
         let p = Purposes::default();
         let conns = connections_with(&["work"]);
         let err = resolve_purpose(PurposeKind::Interactive, &p, &conns).unwrap_err();
-        assert!(matches!(err, PurposeError::Missing { purpose: "interactive" }));
+        assert!(matches!(
+            err,
+            PurposeError::Missing {
+                purpose: "interactive"
+            }
+        ));
     }
 
     #[test]

--- a/crates/daemon/src/registry.rs
+++ b/crates/daemon/src/registry.rs
@@ -546,8 +546,8 @@ pub fn build_registry(config: &DaemonConfig) -> ConnectionRegistry {
 mod tests {
     use super::*;
     use crate::connections::{
-        AnthropicConnection, BedrockConnection, ConnectionConfig, ConnectionsMap,
-        OllamaConnection, OpenAiConnection,
+        AnthropicConnection, BedrockConnection, ConnectionConfig, ConnectionsMap, OllamaConnection,
+        OpenAiConnection,
     };
     use indexmap::IndexMap;
 
@@ -596,7 +596,10 @@ mod tests {
         let registry = build_registry(&config);
 
         let id = ConnectionId::new("local").unwrap();
-        assert!(registry.get(&id).is_some(), "expected live client for local");
+        assert!(
+            registry.get(&id).is_some(),
+            "expected live client for local"
+        );
         assert_eq!(registry.live_count(), 1);
         assert_eq!(registry.declared_count(), 1);
 
@@ -622,7 +625,10 @@ mod tests {
             std::env::remove_var(&unused);
         }
 
-        let pairs = vec![(ConnectionId::new("cloud").unwrap(), openai_with_key(&unused))];
+        let pairs = vec![(
+            ConnectionId::new("cloud").unwrap(),
+            openai_with_key(&unused),
+        )];
         let config = config_from_pairs(pairs);
         let registry = build_registry(&config);
 
@@ -677,7 +683,10 @@ mod tests {
         let statuses = registry.status();
         assert_eq!(statuses.len(), 2);
         assert_eq!(statuses[0].id, bad_id);
-        assert!(matches!(statuses[0].health, ConnectionHealth::Unavailable { .. }));
+        assert!(matches!(
+            statuses[0].health,
+            ConnectionHealth::Unavailable { .. }
+        ));
         assert_eq!(statuses[1].id, good_id);
         assert!(matches!(statuses[1].health, ConnectionHealth::Ok));
     }
@@ -724,10 +733,7 @@ mod tests {
         // Declaration order: x (ok), y (ok). Active must be x.
         let x = ConnectionId::new("x").unwrap();
         let y = ConnectionId::new("y").unwrap();
-        let pairs = vec![
-            (x.clone(), ollama_local()),
-            (y.clone(), ollama_local()),
-        ];
+        let pairs = vec![(x.clone(), ollama_local()), (y.clone(), ollama_local())];
         let config = config_from_pairs(pairs);
         let registry = build_registry(&config);
         assert_eq!(registry.active_connection(), Some(&x));
@@ -857,11 +863,8 @@ mod tests {
         // assert the daemon-startup invariants: at least one healthy client,
         // deterministic active id, unavailable connections surfaced without
         // aborting.
-        let fixture = include_str!(
-            "../tests/fixtures/connections_migration/multi_connection.toml"
-        );
-        let config: DaemonConfig =
-            toml::from_str(fixture).expect("fixture is valid TOML");
+        let fixture = include_str!("../tests/fixtures/connections_migration/multi_connection.toml");
+        let config: DaemonConfig = toml::from_str(fixture).expect("fixture is valid TOML");
 
         // The fixture relies on one env var being unset so the openai
         // connection resolves with no key. Clear it defensively.
@@ -878,7 +881,10 @@ mod tests {
         let aws = ConnectionId::new("aws").unwrap();
 
         // `local` (ollama) and `aws` (bedrock) are expected healthy.
-        assert!(registry.get(&local).is_some(), "local ollama should be live");
+        assert!(
+            registry.get(&local).is_some(),
+            "local ollama should be live"
+        );
         assert!(matches!(
             registry.status_of(&local).unwrap().health,
             ConnectionHealth::Ok
@@ -890,7 +896,10 @@ mod tests {
         ));
 
         // `cloud` (openai) has no key; expected unavailable.
-        assert!(registry.get(&cloud).is_none(), "cloud openai should be unavailable");
+        assert!(
+            registry.get(&cloud).is_none(),
+            "cloud openai should be unavailable"
+        );
         match &registry.status_of(&cloud).unwrap().health {
             ConnectionHealth::Unavailable { reason } => {
                 assert!(reason.contains("api key"), "reason: {reason}");

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -168,14 +168,13 @@ impl RoutingLlmClient {
                 purpose.as_key()
             ))
         })?;
-        let resolved =
-            crate::purposes::resolve_purpose(*purpose, &config.purposes, &connections)
-                .map_err(|e| {
-                    CoreError::Llm(format!(
-                        "purpose {:?} resolution failed: {e}",
-                        purpose.as_key()
-                    ))
-                })?;
+        let resolved = crate::purposes::resolve_purpose(*purpose, &config.purposes, &connections)
+            .map_err(|e| {
+            CoreError::Llm(format!(
+                "purpose {:?} resolution failed: {e}",
+                purpose.as_key()
+            ))
+        })?;
         let connection = connections.get(&resolved.connection_id).ok_or_else(|| {
             CoreError::Llm(format!(
                 "purpose {:?} resolved connection {:?} is missing from \
@@ -188,15 +187,19 @@ impl RoutingLlmClient {
         let reasoning = crate::api_surface::map_effort_to_reasoning_config(
             &connector_type,
             &resolved.model_id,
-            resolved.effort.map(crate::api_surface::purpose_effort_to_core),
+            resolved
+                .effort
+                .map(crate::api_surface::purpose_effort_to_core),
         );
-        let client = registry.client_for(&resolved.connection_id).ok_or_else(|| {
-            CoreError::Llm(format!(
-                "purpose {:?} references connection {:?} which is not present in the registry",
-                purpose.as_key(),
-                resolved.connection_id
-            ))
-        })?;
+        let client = registry
+            .client_for(&resolved.connection_id)
+            .ok_or_else(|| {
+                CoreError::Llm(format!(
+                    "purpose {:?} references connection {:?} which is not present in the registry",
+                    purpose.as_key(),
+                    resolved.connection_id
+                ))
+            })?;
         with_model_override(resolved.model_id, op(client, reasoning)).await
     }
 }
@@ -306,11 +309,7 @@ impl LlmClient for RoutingLlmClient {
                 let client = self.resolve_static();
                 client
                     .stream_completion_with_namespaces(
-                        messages,
-                        core_tools,
-                        namespaces,
-                        reasoning,
-                        on_chunk,
+                        messages, core_tools, namespaces, reasoning, on_chunk,
                     )
                     .await
             }
@@ -332,7 +331,6 @@ impl LlmClient for RoutingLlmClient {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -385,10 +383,8 @@ mod tests {
         let client = RoutingLlmClient::new(Arc::clone(&fallback));
 
         let override_clone = Arc::clone(&override_client);
-        let resolved = with_active_client(override_client, async move {
-            client.resolve_static()
-        })
-        .await;
+        let resolved =
+            with_active_client(override_client, async move { client.resolve_static() }).await;
         assert!(
             Arc::ptr_eq(&resolved, &override_clone),
             "resolve() must return the task-local override when set"
@@ -566,10 +562,8 @@ mod tests {
         // distinct strings ("local" vs "ollama") so a regression that
         // confuses the two would fail here.
         let handle = build_handle_with_titling("titling-model");
-        let client = RoutingLlmClient::new_dynamic_purpose(
-            Arc::clone(&handle),
-            PurposeKind::Titling,
-        );
+        let client =
+            RoutingLlmClient::new_dynamic_purpose(Arc::clone(&handle), PurposeKind::Titling);
         let result = client
             .stream_completion(
                 vec![Message::new(
@@ -609,10 +603,8 @@ mod tests {
         use crate::api_surface::resolve_purpose_dispatch;
 
         let handle = build_handle_with_titling("model-v1");
-        let _client = RoutingLlmClient::new_dynamic_purpose(
-            Arc::clone(&handle),
-            PurposeKind::Titling,
-        );
+        let _client =
+            RoutingLlmClient::new_dynamic_purpose(Arc::clone(&handle), PurposeKind::Titling);
 
         let cfg = handle.snapshot_config();
         let (resolved, _) = resolve_purpose_dispatch(Some(&cfg), PurposeKind::Titling)
@@ -624,9 +616,7 @@ mod tests {
         // persistence (covered by the connections-management API tests).
         let mut new_cfg = handle.snapshot_config();
         new_cfg.purposes.titling = Some(crate::purposes::PurposeConfig {
-            connection: crate::purposes::ConnectionRef::Named(
-                ConnectionId::new("local").unwrap(),
-            ),
+            connection: crate::purposes::ConnectionRef::Named(ConnectionId::new("local").unwrap()),
             model: crate::purposes::ModelRef::Named("model-v2".to_string()),
             effort: None,
             max_context_tokens: None,

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -42,13 +42,13 @@ pub fn setup(
         (Some(cert), Some(key)) => {
             let cert_pem = std::fs::read(cert)
                 .with_context(|| format!("reading TLS cert {}", cert.display()))?;
-            let key_pem = std::fs::read(key)
-                .with_context(|| format!("reading TLS key {}", key.display()))?;
+            let key_pem =
+                std::fs::read(key).with_context(|| format!("reading TLS key {}", key.display()))?;
             build_server_config(&cert_pem, &key_pem)
         }
-        (Some(_), None) | (None, Some(_)) => {
-            Err(anyhow!("both tls.cert_file and tls.key_file must be set together"))
-        }
+        (Some(_), None) | (None, Some(_)) => Err(anyhow!(
+            "both tls.cert_file and tls.key_file must be set together"
+        )),
         (None, None) => {
             let tls_dir = default_tls_dir();
             let (ca_cert_pem, ca_key_pem) = ensure_ca(&tls_dir)?;
@@ -70,8 +70,8 @@ fn ensure_ca(tls_dir: &Path) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
     if cert_path.exists() && key_path.exists() {
         let cert_pem = std::fs::read(&cert_path)
             .with_context(|| format!("reading {}", cert_path.display()))?;
-        let key_pem = std::fs::read(&key_path)
-            .with_context(|| format!("reading {}", key_path.display()))?;
+        let key_pem =
+            std::fs::read(&key_path).with_context(|| format!("reading {}", key_path.display()))?;
         return Ok((cert_pem, key_pem));
     }
 
@@ -144,8 +144,7 @@ fn ensure_server_cert(
         .unwrap()
         .as_secs();
     params.not_before = time::OffsetDateTime::from_unix_timestamp(now as i64)?;
-    params.not_after =
-        time::OffsetDateTime::from_unix_timestamp(now as i64 + 365 * 24 * 3600)?;
+    params.not_after = time::OffsetDateTime::from_unix_timestamp(now as i64 + 365 * 24 * 3600)?;
 
     let cert = params.signed_by(&server_key, &ca_issuer)?;
     let cert_pem = cert.pem().into_bytes();
@@ -245,8 +244,7 @@ fn parse_not_after_expired(der: &[u8]) -> bool {
             365 * (y - 1970) + ((y - 1969) / 4) - ((y - 1901) / 100) + ((y - 1601) / 400)
         };
         let days_in_months: [u32; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-        let is_leap =
-            (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+        let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
         let mut day_of_year: u32 = 0;
         for m in 0..(month - 1) as usize {
             day_of_year += days_in_months[m];
@@ -353,15 +351,13 @@ fn write_secret_file(path: &Path, data: &[u8]) -> anyhow::Result<()> {
     }
     #[cfg(not(unix))]
     {
-        std::fs::write(path, data)
-            .with_context(|| format!("writing {}", path.display()))?;
+        std::fs::write(path, data).with_context(|| format!("writing {}", path.display()))?;
     }
     Ok(())
 }
 
 fn write_public_file(path: &Path, data: &[u8]) -> anyhow::Result<()> {
-    std::fs::write(path, data)
-        .with_context(|| format!("writing {}", path.display()))?;
+    std::fs::write(path, data).with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }
 
@@ -415,7 +411,11 @@ mod tests {
         let mut chain = server_cert;
         chain.extend_from_slice(&ca_cert);
         let config = build_server_config(&chain, &server_key);
-        assert!(config.is_ok(), "should build valid ServerConfig: {:?}", config.err());
+        assert!(
+            config.is_ok(),
+            "should build valid ServerConfig: {:?}",
+            config.err()
+        );
     }
 
     #[test]
@@ -440,7 +440,10 @@ mod tests {
     fn not_after_check_detects_valid_cert() {
         let dir = tempfile::tempdir().unwrap();
         let (ca_cert, _) = ensure_ca(dir.path()).unwrap();
-        assert!(!is_pem_cert_expired(&ca_cert), "fresh CA should not be expired");
+        assert!(
+            !is_pem_cert_expired(&ca_cert),
+            "fresh CA should not be expired"
+        );
     }
 
     #[test]
@@ -455,10 +458,8 @@ mod tests {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
-        params.not_before =
-            time::OffsetDateTime::from_unix_timestamp(now - 3600).unwrap();
-        params.not_after =
-            time::OffsetDateTime::from_unix_timestamp(now - 1).unwrap();
+        params.not_before = time::OffsetDateTime::from_unix_timestamp(now - 3600).unwrap();
+        params.not_after = time::OffsetDateTime::from_unix_timestamp(now - 1).unwrap();
         let cert = params.self_signed(&key).unwrap();
         let pem = cert.pem().into_bytes();
 

--- a/crates/dbus-interface/src/connections.rs
+++ b/crates/dbus-interface/src/connections.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use desktop_assistant_application::AssistantApiHandler;
 use desktop_assistant_api_model::{self as api};
+use desktop_assistant_application::AssistantApiHandler;
 use zbus::{fdo, interface};
 
 fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
@@ -136,9 +136,7 @@ impl DbusConnectionsAdapter {
     async fn get_purposes(&self) -> fdo::Result<String> {
         let result = self.dispatch(api::Command::GetPurposes).await?;
         match &result {
-            api::CommandResult::Purposes(_) => {
-                serde_json::to_string(&result).map_err(to_fdo_error)
-            }
+            api::CommandResult::Purposes(_) => serde_json::to_string(&result).map_err(to_fdo_error),
             other => Err(fdo::Error::Failed(format!(
                 "unexpected GetPurposes result: {other:?}"
             ))),

--- a/crates/dbus-interface/src/knowledge.rs
+++ b/crates/dbus-interface/src/knowledge.rs
@@ -9,8 +9,8 @@
 
 use std::sync::Arc;
 
-use desktop_assistant_application::AssistantApiHandler;
 use desktop_assistant_api_model::{self as api};
+use desktop_assistant_application::AssistantApiHandler;
 use zbus::{fdo, interface};
 
 fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
@@ -68,9 +68,7 @@ impl DbusKnowledgeAdapter {
     /// see the same envelope.
     async fn get_entry(&self, id: &str) -> fdo::Result<String> {
         let result = self
-            .dispatch(api::Command::GetKnowledgeEntry {
-                id: id.to_string(),
-            })
+            .dispatch(api::Command::GetKnowledgeEntry { id: id.to_string() })
             .await?;
         match &result {
             api::CommandResult::KnowledgeEntry(_) => {
@@ -166,9 +164,7 @@ impl DbusKnowledgeAdapter {
 
     async fn delete_entry(&self, id: &str) -> fdo::Result<()> {
         let result = self
-            .dispatch(api::Command::DeleteKnowledgeEntry {
-                id: id.to_string(),
-            })
+            .dispatch(api::Command::DeleteKnowledgeEntry { id: id.to_string() })
             .await?;
         match result {
             api::CommandResult::Ack => Ok(()),

--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -494,9 +494,7 @@ impl AnthropicClient {
             // body shaped like `{ "type": "error", "error": { "type":
             // "invalid_request_error", "message": "prompt is too long:
             // 203524 tokens > 200000 maximum" } }`.
-            if let Some((prompt_tokens, max_tokens)) =
-                detect_anthropic_context_overflow(&body)
-            {
+            if let Some((prompt_tokens, max_tokens)) = detect_anthropic_context_overflow(&body) {
                 tracing::warn!(
                     prompt_tokens = ?prompt_tokens,
                     max_tokens = ?max_tokens,
@@ -941,7 +939,10 @@ fn parse_prompt_too_long(message: &str) -> (Option<u64>, Option<u64>) {
 /// "no hint" rather than substituting a default.
 fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<std::time::Duration> {
     let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
-    raw.trim().parse::<u64>().ok().map(std::time::Duration::from_secs)
+    raw.trim()
+        .parse::<u64>()
+        .ok()
+        .map(std::time::Duration::from_secs)
 }
 
 #[cfg(test)]
@@ -1443,10 +1444,7 @@ mod tests {
         assert!(models.iter().any(|m| m.id == "claude-haiku-4-5"));
 
         // 4.x models are tagged as supporting extended thinking.
-        let sonnet = models
-            .iter()
-            .find(|m| m.id == "claude-sonnet-4-6")
-            .unwrap();
+        let sonnet = models.iter().find(|m| m.id == "claude-sonnet-4-6").unwrap();
         assert!(sonnet.capabilities.reasoning);
 
         // 3.x Haiku is not flagged as a reasoning model.
@@ -1462,8 +1460,7 @@ mod tests {
     /// Helper that drains a one-event SSE stream into a complete-but-empty
     /// response — just enough to make `send_and_stream` return `Ok` so the
     /// test can focus on the *request* body.
-    const STUB_SSE_BODY: &str =
-        "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"m\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"x\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\ndata: [DONE]\n\n";
+    const STUB_SSE_BODY: &str = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"m\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"x\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\ndata: [DONE]\n\n";
 
     #[tokio::test]
     async fn stream_completion_uses_self_model_when_override_unset() {
@@ -1524,10 +1521,7 @@ mod tests {
 
     #[test]
     fn context_limit_for_known_models() {
-        assert_eq!(
-            context_limit_for_model("claude-opus-4-5"),
-            Some(200_000)
-        );
+        assert_eq!(context_limit_for_model("claude-opus-4-5"), Some(200_000));
         assert_eq!(
             context_limit_for_model("claude-sonnet-4-6-20260227"),
             Some(200_000)

--- a/crates/llm-bedrock/src/lib.rs
+++ b/crates/llm-bedrock/src/lib.rs
@@ -690,7 +690,8 @@ pub fn context_limit_for_model(model_id: &str) -> Option<u64> {
     let base = strip_region_prefix(model_id);
 
     // Anthropic Claude on Bedrock: 3.x and 4.x all ship with 200K context.
-    if base.starts_with("anthropic.claude-3") || base.starts_with("anthropic.claude-sonnet-4")
+    if base.starts_with("anthropic.claude-3")
+        || base.starts_with("anthropic.claude-sonnet-4")
         || base.starts_with("anthropic.claude-opus-4")
         || base.starts_with("anthropic.claude-haiku-4")
     {
@@ -703,7 +704,11 @@ pub fn context_limit_for_model(model_id: &str) -> Option<u64> {
 /// Heuristic capability inference from a model id. Operates on the *base*
 /// id (region-prefix already stripped) so it works for both bare foundation
 /// model ids and inference-profile ids.
-fn infer_capabilities_from_id(base_id: &str, vision: bool, is_embedding: bool) -> ModelCapabilities {
+fn infer_capabilities_from_id(
+    base_id: &str,
+    vision: bool,
+    is_embedding: bool,
+) -> ModelCapabilities {
     let lc = base_id.to_ascii_lowercase();
 
     let tools = lc.contains("anthropic.claude")
@@ -789,11 +794,11 @@ fn document_to_json_string(doc: &Document) -> String {
                     .unwrap_or(serde_json::Value::Null),
             },
             Document::String(s) => serde_json::Value::String(s.clone()),
-            Document::Array(a) => {
-                serde_json::Value::Array(a.iter().map(doc_to_value).collect())
-            }
+            Document::Array(a) => serde_json::Value::Array(a.iter().map(doc_to_value).collect()),
             Document::Object(o) => serde_json::Value::Object(
-                o.iter().map(|(k, v)| (k.clone(), doc_to_value(v))).collect(),
+                o.iter()
+                    .map(|(k, v)| (k.clone(), doc_to_value(v)))
+                    .collect(),
             ),
         }
     }
@@ -938,9 +943,8 @@ impl BedrockClient {
 
         let (foundation_res, profiles_res) = tokio::join!(foundation_fut, profiles_fut);
 
-        let foundation = foundation_res.map_err(|e| {
-            CoreError::Llm(format!("Bedrock ListFoundationModels failed: {e:#}"))
-        })?;
+        let foundation = foundation_res
+            .map_err(|e| CoreError::Llm(format!("Bedrock ListFoundationModels failed: {e:#}")))?;
 
         let mut models: Vec<ModelInfo> = foundation
             .model_summaries()
@@ -1058,10 +1062,7 @@ impl LlmClient for BedrockClient {
             system,
             tool_config,
             inference_cfg: self.build_inference_config(),
-            additional_request_fields: build_additional_model_request_fields(
-                &model,
-                reasoning,
-            ),
+            additional_request_fields: build_additional_model_request_fields(&model, reasoning),
         };
 
         // Path selection (#67):
@@ -1091,10 +1092,7 @@ impl LlmClient for BedrockClient {
 
         match self.dispatch_streaming(&client, &inputs, on_chunk).await {
             Ok(response) => Ok(response),
-            Err(StreamingDispatchError::StreamingToolsUnsupported {
-                on_chunk,
-                detail,
-            }) => {
+            Err(StreamingDispatchError::StreamingToolsUnsupported { on_chunk, detail }) => {
                 tracing::warn!(
                     model = %model,
                     detail,
@@ -1144,8 +1142,7 @@ impl BedrockClient {
         if self.temperature.is_none() && self.top_p.is_none() && self.max_tokens.is_none() {
             return None;
         }
-        let mut inference_cfg =
-            aws_sdk_bedrockruntime::types::InferenceConfiguration::builder();
+        let mut inference_cfg = aws_sdk_bedrockruntime::types::InferenceConfiguration::builder();
         if let Some(t) = self.temperature {
             inference_cfg = inference_cfg.temperature(t as f32);
         }
@@ -1825,8 +1822,7 @@ mod tests {
 
     impl ModelClock for MockClock {
         fn now(&self) -> Instant {
-            self.origin
-                + Duration::from_secs(self.offset.load(std::sync::atomic::Ordering::SeqCst))
+            self.origin + Duration::from_secs(self.offset.load(std::sync::atomic::Ordering::SeqCst))
         }
     }
 
@@ -1959,10 +1955,7 @@ mod tests {
         client.__set_models_cache_for_test(cached.clone()).await;
 
         // Cache is still within TTL.
-        assert_eq!(
-            client.list_models().await.expect("within ttl"),
-            cached,
-        );
+        assert_eq!(client.list_models().await.expect("within ttl"), cached,);
 
         // Advance past TTL → next call bypasses cache and will attempt a
         // network fetch. We just verify the call path diverges (either
@@ -2070,7 +2063,11 @@ mod tests {
         assert_eq!(info.id, "anthropic.claude-3-haiku-20240307-v1:0");
     }
 
-    fn make_profile(id: &str, name: &str, status: InferenceProfileStatus) -> InferenceProfileSummary {
+    fn make_profile(
+        id: &str,
+        name: &str,
+        status: InferenceProfileStatus,
+    ) -> InferenceProfileSummary {
         // The builder requires `models` to be set (the underlying foundation
         // models the profile routes to). The conversion code doesn't read
         // them — we infer capabilities from the profile id — so a single
@@ -2079,7 +2076,9 @@ mod tests {
             .model_arn("arn:aws:bedrock:us-east-1::foundation-model/test")
             .build();
         InferenceProfileSummary::builder()
-            .inference_profile_arn(format!("arn:aws:bedrock:us-east-1:0:inference-profile/{id}"))
+            .inference_profile_arn(format!(
+                "arn:aws:bedrock:us-east-1:0:inference-profile/{id}"
+            ))
             .inference_profile_id(id)
             .inference_profile_name(name)
             .status(status)
@@ -2197,8 +2196,8 @@ mod tests {
             .build();
         let svc_err = ConverseStreamError::ThrottlingException(exc);
 
-        let mapped = map_converse_stream_service_error(&svc_err)
-            .expect("throttling has dedicated mapping");
+        let mapped =
+            map_converse_stream_service_error(&svc_err).expect("throttling has dedicated mapping");
         match mapped {
             CoreError::RateLimited {
                 retry_after,
@@ -2277,9 +2276,15 @@ mod tests {
         // Llama 3 / 4 reject tools in streaming mode; everything else
         // is currently assumed safe (and the runtime fallback covers
         // mis-classifications).
-        assert!(!supports_streaming_with_tools("meta.llama4-maverick-17b-instruct-v1:0"));
-        assert!(!supports_streaming_with_tools("meta.llama4-scout-17b-instruct-v1:0"));
-        assert!(!supports_streaming_with_tools("meta.llama3-70b-instruct-v1:0"));
+        assert!(!supports_streaming_with_tools(
+            "meta.llama4-maverick-17b-instruct-v1:0"
+        ));
+        assert!(!supports_streaming_with_tools(
+            "meta.llama4-scout-17b-instruct-v1:0"
+        ));
+        assert!(!supports_streaming_with_tools(
+            "meta.llama3-70b-instruct-v1:0"
+        ));
 
         // Claude is the canonical safe case.
         assert!(supports_streaming_with_tools("anthropic.claude-sonnet-4-6"));
@@ -2327,10 +2332,7 @@ mod tests {
         inner.insert("count".to_string(), Document::Number(Number::PosInt(42)));
         inner.insert(
             "items".to_string(),
-            Document::Array(vec![
-                Document::String("a".to_string()),
-                Document::Null,
-            ]),
+            Document::Array(vec![Document::String("a".to_string()), Document::Null]),
         );
         let doc = Document::Object(inner);
 

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -695,9 +695,7 @@ impl LlmClient for OllamaClient {
             // so we match a small set of substrings (case-insensitive)
             // and emit `ContextOverflow` with `None` measurements.
             if detect_ollama_context_overflow(&body) {
-                tracing::warn!(
-                    "Ollama rejected request for context overflow"
-                );
+                tracing::warn!("Ollama rejected request for context overflow");
                 return Err(CoreError::ContextOverflow {
                     prompt_tokens: None,
                     max_tokens: None,
@@ -1382,7 +1380,9 @@ mod tests {
     async fn warm_context_length_populates_cache() {
         let server = MockServer::start();
         let show = server.mock(|when, then| {
-            when.method(POST).path("/api/show").body_includes("llama3.2");
+            when.method(POST)
+                .path("/api/show")
+                .body_includes("llama3.2");
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
@@ -1415,7 +1415,9 @@ mod tests {
 
         let server = MockServer::start();
         server.mock(|when, then| {
-            when.method(POST).path("/api/show").body_includes("llama3.2");
+            when.method(POST)
+                .path("/api/show")
+                .body_includes("llama3.2");
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
@@ -1437,10 +1439,8 @@ mod tests {
         let _ = client.warm_context_length_for("qwen2:latest").await;
 
         assert_eq!(client.max_context_tokens(), Some(131_072));
-        let observed = with_model_override("qwen2:latest".into(), async {
-            client.max_context_tokens()
-        })
-        .await;
+        let observed =
+            with_model_override("qwen2:latest".into(), async { client.max_context_tokens() }).await;
         assert_eq!(observed, Some(32_768));
     }
 
@@ -1450,7 +1450,9 @@ mod tests {
 
         let server = MockServer::start();
         server.mock(|when, then| {
-            when.method(POST).path("/api/show").body_includes("llama3.2");
+            when.method(POST)
+                .path("/api/show")
+                .body_includes("llama3.2");
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
@@ -1461,10 +1463,8 @@ mod tests {
 
         // Override targets a model that hasn't been warmed: returns None
         // (cache miss is the safe answer).
-        let observed = with_model_override("never-warmed".into(), async {
-            client.max_context_tokens()
-        })
-        .await;
+        let observed =
+            with_model_override("never-warmed".into(), async { client.max_context_tokens() }).await;
         assert_eq!(observed, None);
     }
 
@@ -1593,9 +1593,7 @@ mod tests {
         assert!(detect_ollama_model_loading(
             r#"{"error":"downloading layer"}"#
         ));
-        assert!(detect_ollama_model_loading(
-            r#"{"error":"no such file"}"#
-        ));
+        assert!(detect_ollama_model_loading(r#"{"error":"no such file"}"#));
     }
 
     #[test]

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -538,9 +538,7 @@ impl OpenAiClient {
             // retry. OpenAI returns HTTP 400 with a body shaped like
             // `{ "error": { "code": "context_length_exceeded", "type":
             // "invalid_request_error", "message": "..." } }`.
-            if let Some((prompt_tokens, max_tokens)) =
-                detect_openai_context_overflow(&body)
-            {
+            if let Some((prompt_tokens, max_tokens)) = detect_openai_context_overflow(&body) {
                 tracing::warn!(
                     prompt_tokens = ?prompt_tokens,
                     max_tokens = ?max_tokens,
@@ -776,7 +774,10 @@ fn detect_openai_insufficient_quota(body: &str) -> bool {
 /// "no hint" rather than substituting a default.
 fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<std::time::Duration> {
     let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
-    raw.trim().parse::<u64>().ok().map(std::time::Duration::from_secs)
+    raw.trim()
+        .parse::<u64>()
+        .ok()
+        .map(std::time::Duration::from_secs)
 }
 
 /// Parse OpenAI's `"This model's maximum context length is 128000
@@ -1523,8 +1524,7 @@ mod tests {
 
     /// Minimal SSE body that lets `send_and_stream` reach `break` on
     /// `response.completed` — empty `response` object is enough.
-    const STUB_SSE_BODY: &str =
-        "event: response.completed\ndata: {\"response\":{}}\n\n";
+    const STUB_SSE_BODY: &str = "event: response.completed\ndata: {\"response\":{}}\n\n";
 
     #[tokio::test]
     async fn stream_completion_uses_self_model_when_override_unset() {
@@ -1641,8 +1641,7 @@ mod tests {
         let client = OpenAiClient::new("k".into()).with_model("totally-fake-model");
         assert_eq!(client.max_context_tokens(), None);
         let observed =
-            with_model_override("gpt-4o-mini".into(), async { client.max_context_tokens() })
-                .await;
+            with_model_override("gpt-4o-mini".into(), async { client.max_context_tokens() }).await;
         assert_eq!(observed, Some(128_000));
     }
 

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -450,10 +450,7 @@ impl BuiltinToolService {
         .to_string())
     }
 
-    async fn conversation_search(
-        &self,
-        arguments: serde_json::Value,
-    ) -> Result<String, CoreError> {
+    async fn conversation_search(&self, arguments: serde_json::Value) -> Result<String, CoreError> {
         let search_fn = self.conversation_search_fn.as_ref().ok_or_else(|| {
             CoreError::ToolExecution("conversation search not configured".to_string())
         })?;
@@ -882,25 +879,24 @@ mod tests {
         };
         use std::sync::Arc;
 
-        let search_fn: ConversationSearchFn =
-            Arc::new(move |query, limit, role_filter| {
-                let q = query.clone();
-                Box::pin(async move {
-                    assert_eq!(q, "deploy");
-                    assert_eq!(limit, 5);
-                    assert!(matches!(role_filter, Some(Role::Assistant)));
-                    Ok(vec![MessageHit {
-                        conversation_id: "c-1".into(),
-                        conversation_title: "Deploy timeline".into(),
-                        ordinal: 4,
-                        role: Role::Assistant,
-                        content: "We can deploy on Friday".into(),
-                        snippet: "We can <mark>deploy</mark> on Friday".into(),
-                        rank: 0.42,
-                        updated_at: "2026-05-02T13:00:00+00:00".into(),
-                    }])
-                })
-            });
+        let search_fn: ConversationSearchFn = Arc::new(move |query, limit, role_filter| {
+            let q = query.clone();
+            Box::pin(async move {
+                assert_eq!(q, "deploy");
+                assert_eq!(limit, 5);
+                assert!(matches!(role_filter, Some(Role::Assistant)));
+                Ok(vec![MessageHit {
+                    conversation_id: "c-1".into(),
+                    conversation_title: "Deploy timeline".into(),
+                    ordinal: 4,
+                    role: Role::Assistant,
+                    content: "We can deploy on Friday".into(),
+                    snippet: "We can <mark>deploy</mark> on Friday".into(),
+                    rank: 0.42,
+                    updated_at: "2026-05-02T13:00:00+00:00".into(),
+                }])
+            })
+        });
 
         let service = BuiltinToolService::new().with_conversation_search(search_fn);
         let response = service
@@ -931,13 +927,12 @@ mod tests {
 
         let saw_role_filter = Arc::new(AtomicBool::new(false));
         let saw_clone = Arc::clone(&saw_role_filter);
-        let search_fn: ConversationSearchFn =
-            Arc::new(move |_q, _l, role_filter| {
-                if role_filter.is_some() {
-                    saw_clone.store(true, Ordering::SeqCst);
-                }
-                Box::pin(async { Ok(Vec::new()) })
-            });
+        let search_fn: ConversationSearchFn = Arc::new(move |_q, _l, role_filter| {
+            if role_filter.is_some() {
+                saw_clone.store(true, Ordering::SeqCst);
+            }
+            Box::pin(async { Ok(Vec::new()) })
+        });
 
         let service = BuiltinToolService::new().with_conversation_search(search_fn);
         let _ = service

--- a/crates/mcp-client/src/config.rs
+++ b/crates/mcp-client/src/config.rs
@@ -129,9 +129,7 @@ pub fn default_secrets_path() -> PathBuf {
             let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
             PathBuf::from(home).join(".config")
         });
-    config_dir
-        .join("desktop-assistant")
-        .join("secrets.toml")
+    config_dir.join("desktop-assistant").join("secrets.toml")
 }
 
 /// Load secrets from a TOML file.
@@ -147,13 +145,11 @@ pub fn load_secrets(path: &std::path::Path) -> Result<HashMap<String, String>, M
 
     enforce_permissions(path)?;
 
-    let contents = std::fs::read_to_string(path).map_err(|e| {
-        McpError::UnexpectedResponse(format!("failed to read secrets file: {e}"))
-    })?;
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| McpError::UnexpectedResponse(format!("failed to read secrets file: {e}")))?;
 
-    let config: SecretsConfig = toml::from_str(&contents).map_err(|e| {
-        McpError::UnexpectedResponse(format!("failed to parse secrets file: {e}"))
-    })?;
+    let config: SecretsConfig = toml::from_str(&contents)
+        .map_err(|e| McpError::UnexpectedResponse(format!("failed to parse secrets file: {e}")))?;
 
     tracing::info!(
         "loaded {} secret(s) from {}",
@@ -184,7 +180,10 @@ args = ["--config", "/path/to/config.toml"]
         assert_eq!(config.servers[0].name, "fileio");
         assert_eq!(config.servers[0].command, "fileio-mcp");
         assert!(config.servers[0].args.is_empty());
-        assert!(config.servers[0].env.is_empty(), "env should default to empty");
+        assert!(
+            config.servers[0].env.is_empty(),
+            "env should default to empty"
+        );
         assert_eq!(config.servers[1].name, "genmcp");
         assert_eq!(config.servers[1].args.len(), 2);
     }
@@ -206,7 +205,10 @@ OTHER_VAR = "value"
         assert_eq!(config.servers[0].name, "github");
         assert_eq!(config.servers[0].env.len(), 2);
         assert_eq!(
-            config.servers[0].env.get("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap(),
+            config.servers[0]
+                .env
+                .get("GITHUB_PERSONAL_ACCESS_TOKEN")
+                .unwrap(),
             "my-token"
         );
         assert_eq!(config.servers[0].env.get("OTHER_VAR").unwrap(), "value");
@@ -287,7 +289,10 @@ GITHUB_PERSONAL_ACCESS_TOKEN = "github_pat"
         let config: McpConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.servers.len(), 1);
         assert_eq!(
-            config.servers[0].env_secrets.get("GITHUB_PERSONAL_ACCESS_TOKEN").unwrap(),
+            config.servers[0]
+                .env_secrets
+                .get("GITHUB_PERSONAL_ACCESS_TOKEN")
+                .unwrap(),
             "github_pat"
         );
         assert!(config.servers[0].env.is_empty());
@@ -308,8 +313,14 @@ SOME_PUBLIC_VAR = "public-value"
 SECRET_VAR = "my_secret_id"
 "#;
         let config: McpConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.servers[0].env.get("SOME_PUBLIC_VAR").unwrap(), "public-value");
-        assert_eq!(config.servers[0].env_secrets.get("SECRET_VAR").unwrap(), "my_secret_id");
+        assert_eq!(
+            config.servers[0].env.get("SOME_PUBLIC_VAR").unwrap(),
+            "public-value"
+        );
+        assert_eq!(
+            config.servers[0].env_secrets.get("SECRET_VAR").unwrap(),
+            "my_secret_id"
+        );
     }
 
     #[test]

--- a/crates/mcp-client/src/lib.rs
+++ b/crates/mcp-client/src/lib.rs
@@ -443,11 +443,13 @@ mod tests {
     fn validate_command_accepts_safe_commands() {
         assert!(validate_command("fileio-mcp", &[]).is_ok());
         assert!(validate_command("/usr/bin/fileio-mcp", &[]).is_ok());
-        assert!(validate_command(
-            "genmcp",
-            &["--config".into(), "/path/to/config.toml".into()]
-        )
-        .is_ok());
+        assert!(
+            validate_command(
+                "genmcp",
+                &["--config".into(), "/path/to/config.toml".into()]
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/storage/src/conversation.rs
+++ b/crates/storage/src/conversation.rs
@@ -52,22 +52,19 @@ impl PgConversationStore {
         &self,
         conversation_id: &ConversationId,
     ) -> Result<Option<ConversationModelSelection>, CoreError> {
-        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
-            "SELECT last_model_selection FROM conversations WHERE id = $1",
-        )
-        .bind(&conversation_id.0)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let row: Option<(Option<serde_json::Value>,)> =
+            sqlx::query_as("SELECT last_model_selection FROM conversations WHERE id = $1")
+                .bind(&conversation_id.0)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         let row = row.ok_or_else(|| CoreError::ConversationNotFound(conversation_id.0.clone()))?;
         let Some(json) = row.0 else {
             return Ok(None);
         };
         let sel: ConversationModelSelection = serde_json::from_value(json).map_err(|e| {
-            CoreError::Storage(format!(
-                "last_model_selection JSON in DB is malformed: {e}"
-            ))
+            CoreError::Storage(format!("last_model_selection JSON in DB is malformed: {e}"))
         })?;
         Ok(Some(sel))
     }

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -77,11 +77,9 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
 
     // Repair damage from pre-idempotent runs of migration 007 on existing
     // databases. No-op on fresh installs.
-    sqlx::raw_sql(include_str!(
-        "../migrations/010_fix_damaged_embeddings.sql"
-    ))
-    .execute(pool)
-    .await?;
+    sqlx::raw_sql(include_str!("../migrations/010_fix_damaged_embeddings.sql"))
+        .execute(pool)
+        .await?;
 
     // Per-conversation model selection (issue #11) — nullable JSONB column
     // on `conversations`.

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -68,7 +68,13 @@ pub fn router_with_auth(
     login_service: Option<Arc<dyn WsLoginService>>,
     auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
 ) -> Router {
-    router_full(handler, auth_validator, login_service, auth_discovery, vec![])
+    router_full(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        vec![],
+    )
 }
 
 pub fn router_full(
@@ -448,7 +454,16 @@ pub async fn serve_with_shutdown_and_auth<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    serve_full(handler, auth_validator, login_service, auth_discovery, vec![], bind, shutdown).await
+    serve_full(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        vec![],
+        bind,
+        shutdown,
+    )
+    .await
 }
 
 pub async fn serve_full<F>(
@@ -463,7 +478,13 @@ pub async fn serve_full<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let app = router_full(handler, auth_validator, login_service, auth_discovery, allowed_origins);
+    let app = router_full(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        allowed_origins,
+    );
     let listener = tokio::net::TcpListener::bind(bind).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
@@ -489,7 +510,13 @@ where
     use hyper_util::server::conn::auto::Builder as ConnBuilder;
     use hyper_util::service::TowerToHyperService;
 
-    let app = router_full(handler, auth_validator, login_service, auth_discovery, allowed_origins);
+    let app = router_full(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        allowed_origins,
+    );
     let listener = tokio::net::TcpListener::bind(bind).await?;
 
     tokio::pin!(shutdown);

--- a/crates/ws-interface/tests/ping.rs
+++ b/crates/ws-interface/tests/ping.rs
@@ -18,8 +18,8 @@ use desktop_assistant_core::domain::{
 };
 use desktop_assistant_core::ports::inbound::{
     AssistantService, BackendTasksSettingsView, ConnectionConfigPayload,
-    ConnectionView as CoreConnectionView, ConnectorDefaultsView, ConversationService,
-    ConnectionsService, DatabaseSettingsView, EmbeddingsSettingsView, KnowledgeService,
+    ConnectionView as CoreConnectionView, ConnectionsService, ConnectorDefaultsView,
+    ConversationService, DatabaseSettingsView, EmbeddingsSettingsView, KnowledgeService,
     LlmSettingsView, ModelListing as CoreModelListing, PersistenceSettingsView,
     PurposeConfigPayload, PurposeKind as CorePurposeKind, PurposesView as CorePurposesView,
     SettingsService, WsAuthSettingsView,
@@ -92,11 +92,7 @@ impl ConnectionsService for FakeConnections {
     ) -> Result<(), CoreError> {
         Ok(())
     }
-    async fn delete_connection(
-        &self,
-        _id: String,
-        _force: bool,
-    ) -> Result<(), CoreError> {
+    async fn delete_connection(&self, _id: String, _force: bool) -> Result<(), CoreError> {
         Ok(())
     }
     async fn list_available_models(
@@ -992,7 +988,10 @@ async fn ws_set_config_roundtrip_emits_config_changed() {
         other => panic!("unexpected frame: {other:?}"),
     };
 
-    assert_eq!(config_from_result.embeddings.model, "text-embedding-3-small");
+    assert_eq!(
+        config_from_result.embeddings.model,
+        "text-embedding-3-small"
+    );
     assert_eq!(config_from_result.persistence.remote_name, "upstream");
 
     let event_frame =
@@ -1224,10 +1223,9 @@ fn ws_request_with_origin(
         );
     }
     if let Some(origin) = origin {
-        request.headers_mut().insert(
-            "origin",
-            origin.parse().unwrap(),
-        );
+        request
+            .headers_mut()
+            .insert("origin", origin.parse().unwrap());
     }
     request
 }


### PR DESCRIPTION
Closes #52.

Mechanical reformat — \`cargo fmt --all\` with default rustfmt settings. No code or behaviour changes.

## Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 30 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)