### PR TITLE
daemon: replace Purposes named-fields struct with map keyed by PurposeKind (#42)

### DIFF
--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -278,7 +278,7 @@ impl ConnectionsService for DaemonConnectionsService {
                     // Pick a replacement: first remaining connection, if any.
                     if let Some((new_interactive_id, _)) = cfg.connections.iter().next() {
                         let new_id = new_interactive_id.clone();
-                        if let Some(p) = cfg.purposes.interactive.as_mut() {
+                        if let Some(p) = cfg.purposes.get_mut(PurposeKind::Interactive) {
                             p.connection = ConnectionRef::Named(
                                 ConnectionId::new(new_id)
                                     .expect("existing key was already validated"),
@@ -286,17 +286,11 @@ impl ConnectionsService for DaemonConnectionsService {
                         }
                     } else {
                         // No connections left — clear interactive entirely.
-                        cfg.purposes.interactive = None;
+                        cfg.purposes.set(PurposeKind::Interactive, None);
                     }
                     continue;
                 }
-                let slot = match kind {
-                    PurposeKind::Dreaming => cfg.purposes.dreaming.as_mut(),
-                    PurposeKind::Embedding => cfg.purposes.embedding.as_mut(),
-                    PurposeKind::Titling => cfg.purposes.titling.as_mut(),
-                    PurposeKind::Interactive => unreachable!(),
-                };
-                if let Some(p) = slot {
+                if let Some(p) = cfg.purposes.get_mut(kind) {
                     p.connection = ConnectionRef::Primary;
                 }
             }
@@ -390,10 +384,22 @@ impl ConnectionsService for DaemonConnectionsService {
     async fn get_purposes(&self) -> Result<CorePurposesView, CoreError> {
         let config = self.registry.snapshot_config();
         Ok(CorePurposesView {
-            interactive: config.purposes.interactive.as_ref().map(purpose_to_payload),
-            dreaming: config.purposes.dreaming.as_ref().map(purpose_to_payload),
-            embedding: config.purposes.embedding.as_ref().map(purpose_to_payload),
-            titling: config.purposes.titling.as_ref().map(purpose_to_payload),
+            interactive: config
+                .purposes
+                .get(PurposeKind::Interactive)
+                .map(purpose_to_payload),
+            dreaming: config
+                .purposes
+                .get(PurposeKind::Dreaming)
+                .map(purpose_to_payload),
+            embedding: config
+                .purposes
+                .get(PurposeKind::Embedding)
+                .map(purpose_to_payload),
+            titling: config
+                .purposes
+                .get(PurposeKind::Titling)
+                .map(purpose_to_payload),
         })
     }
 
@@ -475,7 +481,7 @@ where
     /// valid stored selection exists.
     fn interactive_selection(&self) -> Option<ConversationModelSelection> {
         let cfg = self.registry.snapshot_config();
-        cfg.purposes.interactive.as_ref().and_then(|p| {
+        cfg.purposes.get(PurposeKind::Interactive).and_then(|p| {
             let connection_id = match &p.connection {
                 ConnectionRef::Named(id) => id.as_str().to_string(),
                 ConnectionRef::Primary => return None,
@@ -1190,18 +1196,24 @@ mod tests {
     async fn delete_connection_refuses_when_referenced_without_force() {
         let mut cfg =
             config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
-        cfg.purposes.interactive = Some(PurposeConfig {
-            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-            model: ModelRef::Named("llama3".into()),
-            effort: None,
-            max_context_tokens: None,
-        });
-        cfg.purposes.dreaming = Some(PurposeConfig {
-            connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
-            model: ModelRef::Named("claude".into()),
-            effort: None,
-            max_context_tokens: None,
-        });
+        cfg.purposes.set(
+            PurposeKind::Interactive,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("llama3".into()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
+        cfg.purposes.set(
+            PurposeKind::Dreaming,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+                model: ModelRef::Named("claude".into()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
 
         let svc = DaemonConnectionsService::new(make_handle_with(cfg));
         let err = svc
@@ -1215,18 +1227,24 @@ mod tests {
     async fn delete_connection_force_cascades_to_primary() {
         let mut cfg =
             config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
-        cfg.purposes.interactive = Some(PurposeConfig {
-            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-            model: ModelRef::Named("llama3".into()),
-            effort: None,
-            max_context_tokens: None,
-        });
-        cfg.purposes.dreaming = Some(PurposeConfig {
-            connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
-            model: ModelRef::Named("claude".into()),
-            effort: None,
-            max_context_tokens: None,
-        });
+        cfg.purposes.set(
+            PurposeKind::Interactive,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("llama3".into()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
+        cfg.purposes.set(
+            PurposeKind::Dreaming,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+                model: ModelRef::Named("claude".into()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
 
         let handle = make_handle_with(cfg);
         let svc = DaemonConnectionsService::new(Arc::clone(&handle));
@@ -1236,7 +1254,10 @@ mod tests {
 
         let cfg = handle.snapshot_config();
         assert!(!cfg.connections.contains_key("aws"));
-        let dreaming = cfg.purposes.dreaming.as_ref().expect("dreaming still set");
+        let dreaming = cfg
+            .purposes
+            .get(PurposeKind::Dreaming)
+            .expect("dreaming still set");
         assert!(matches!(dreaming.connection, ConnectionRef::Primary));
     }
 
@@ -1262,12 +1283,15 @@ mod tests {
     #[tokio::test]
     async fn get_purposes_returns_current_config() {
         let mut cfg = config_with_connections(&[("local", ollama_local())]);
-        cfg.purposes.interactive = Some(PurposeConfig {
-            connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-            model: ModelRef::Named("llama3".into()),
-            effort: Some(PurposeEffort::Medium),
-            max_context_tokens: None,
-        });
+        cfg.purposes.set(
+            PurposeKind::Interactive,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("llama3".into()),
+                effort: Some(PurposeEffort::Medium),
+                max_context_tokens: None,
+            }),
+        );
         let svc = DaemonConnectionsService::new(make_handle_with(cfg));
         let view = svc.get_purposes().await.unwrap();
         let i = view.interactive.expect("interactive set");
@@ -1408,12 +1432,15 @@ mod tests {
         fn local_ollama_cfg() -> DaemonConfig {
             let mut cfg =
                 config_with_connections(&[("local", ollama_local()), ("aws", bedrock_work())]);
-            cfg.purposes.interactive = Some(PurposeConfig {
-                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                model: ModelRef::Named("llama3".into()),
-                effort: None,
-                max_context_tokens: None,
-            });
+            cfg.purposes.set(
+                PurposeKind::Interactive,
+                Some(PurposeConfig {
+                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                    model: ModelRef::Named("llama3".into()),
+                    effort: None,
+                    max_context_tokens: None,
+                }),
+            );
             cfg
         }
 
@@ -1502,12 +1529,15 @@ mod tests {
                 // still routes to a Claude-shape connector; override
                 // sets the Bedrock connection explicitly below to
                 // exercise the mapping.
-                c.purposes.interactive = Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
-                    model: ModelRef::Named("us.anthropic.claude-sonnet-4-6".into()),
-                    effort: None,
-                    max_context_tokens: None,
-                });
+                c.purposes.set(
+                    PurposeKind::Interactive,
+                    Some(PurposeConfig {
+                        connection: ConnectionRef::Named(ConnectionId::new("aws").unwrap()),
+                        model: ModelRef::Named("us.anthropic.claude-sonnet-4-6".into()),
+                        effort: None,
+                        max_context_tokens: None,
+                    }),
+                );
                 c
             };
             let registry = make_handle_with(cfg);
@@ -1660,12 +1690,15 @@ mod tests {
             // so the bedrock-effort case is covered by the unit test on
             // `apply_effort_mapping` above.
             let mut cfg = local_ollama_cfg();
-            cfg.purposes.interactive = Some(PurposeConfig {
-                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                model: ModelRef::Named("llama3".into()),
-                effort: Some(PurposeEffort::High),
-                max_context_tokens: None,
-            });
+            cfg.purposes.set(
+                PurposeKind::Interactive,
+                Some(PurposeConfig {
+                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                    model: ModelRef::Named("llama3".into()),
+                    effort: Some(PurposeEffort::High),
+                    max_context_tokens: None,
+                }),
+            );
             let registry = make_handle_with(cfg);
             let inner = Arc::new(CapturingInner::new());
             let store = Arc::new(InMemoryConversationSelectionStore::default());
@@ -1761,12 +1794,15 @@ mod tests {
                         base_url: Some(server.url("")),
                     }),
                 )]);
-                c.purposes.interactive = Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                    model: ModelRef::Named("llama3.2".into()),
-                    effort: None,
-                    max_context_tokens: None,
-                });
+                c.purposes.set(
+                    PurposeKind::Interactive,
+                    Some(PurposeConfig {
+                        connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                        model: ModelRef::Named("llama3.2".into()),
+                        effort: None,
+                        max_context_tokens: None,
+                    }),
+                );
                 c
             };
             let registry = make_handle_with(cfg);
@@ -1840,12 +1876,15 @@ mod tests {
                         base_url: Some(server.url("")),
                     }),
                 )]);
-                c.purposes.interactive = Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                    model: ModelRef::Named("llama3.2".into()),
-                    effort: None,
-                    max_context_tokens: None,
-                });
+                c.purposes.set(
+                    PurposeKind::Interactive,
+                    Some(PurposeConfig {
+                        connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                        model: ModelRef::Named("llama3.2".into()),
+                        effort: None,
+                        max_context_tokens: None,
+                    }),
+                );
                 c
             };
             let registry = make_handle_with(cfg);

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -768,12 +768,15 @@ fn maybe_migrate_legacy_purposes(
     };
 
     // Build the purposes set.
-    parsed.purposes.interactive = Some(PurposeConfig {
-        connection: ConnectionRef::Named(interactive_conn),
-        model: ModelRef::Named(interactive_model),
-        effort: None,
-        max_context_tokens: None,
-    });
+    parsed.purposes.set(
+        PurposeKind::Interactive,
+        Some(PurposeConfig {
+            connection: ConnectionRef::Named(interactive_conn),
+            model: ModelRef::Named(interactive_model),
+            effort: None,
+            max_context_tokens: None,
+        }),
+    );
 
     let dreaming_model = match (&backend_conn_ref, &backend_model_opt) {
         (ConnectionRef::Primary, Some(m)) => ModelRef::Named(m.clone()),
@@ -789,28 +792,37 @@ fn maybe_migrate_legacy_purposes(
         }
     };
 
-    parsed.purposes.dreaming = Some(PurposeConfig {
-        connection: backend_conn_ref.clone(),
-        model: dreaming_model.clone(),
-        effort: None,
-        max_context_tokens: None,
-    });
-    parsed.purposes.titling = Some(PurposeConfig {
-        connection: backend_conn_ref,
-        model: dreaming_model,
-        effort: None,
-        max_context_tokens: None,
-    });
+    parsed.purposes.set(
+        PurposeKind::Dreaming,
+        Some(PurposeConfig {
+            connection: backend_conn_ref.clone(),
+            model: dreaming_model.clone(),
+            effort: None,
+            max_context_tokens: None,
+        }),
+    );
+    parsed.purposes.set(
+        PurposeKind::Titling,
+        Some(PurposeConfig {
+            connection: backend_conn_ref,
+            model: dreaming_model,
+            effort: None,
+            max_context_tokens: None,
+        }),
+    );
     // Embeddings always inherit from the primary connection: the embedding
     // model lives in `[embeddings]`, not in `backend_tasks.llm`, so there is
     // nothing connector-specific to carry over. Users with a dedicated
     // embeddings connector keep their `[embeddings]` config unchanged.
-    parsed.purposes.embedding = Some(PurposeConfig {
-        connection: ConnectionRef::Primary,
-        model: ModelRef::Primary,
-        effort: None,
-        max_context_tokens: None,
-    });
+    parsed.purposes.set(
+        PurposeKind::Embedding,
+        Some(PurposeConfig {
+            connection: ConnectionRef::Primary,
+            model: ModelRef::Primary,
+            effort: None,
+            max_context_tokens: None,
+        }),
+    );
 
     // Drop `backend_tasks.llm` from the serialized shape. The field remains
     // in memory so existing consumers (main.rs, settings views) can still
@@ -3453,21 +3465,30 @@ model = "gpt-4o-mini"
         assert!(loaded.connections.contains_key("default"));
 
         // Interactive → default connection, primary model preserved.
-        let interactive = loaded.purposes.interactive.as_ref().expect("interactive");
+        let interactive = loaded
+            .purposes
+            .get(PurposeKind::Interactive)
+            .expect("interactive");
         assert_eq!(interactive.connection.to_string(), "default");
         assert_eq!(interactive.model.to_string(), "gpt-5.4");
 
         // Dreaming/titling → primary connection, backend model.
-        let dreaming = loaded.purposes.dreaming.as_ref().expect("dreaming");
+        let dreaming = loaded
+            .purposes
+            .get(PurposeKind::Dreaming)
+            .expect("dreaming");
         assert_eq!(dreaming.connection.to_string(), "primary");
         assert_eq!(dreaming.model.to_string(), "gpt-4o-mini");
-        let titling = loaded.purposes.titling.as_ref().expect("titling");
+        let titling = loaded.purposes.get(PurposeKind::Titling).expect("titling");
         assert_eq!(titling.connection.to_string(), "primary");
         assert_eq!(titling.model.to_string(), "gpt-4o-mini");
 
         // Embedding always inherits both (the legacy `[llm]` didn't carry an
         // embedding model — that lives in `[embeddings]`, untouched here).
-        let embedding = loaded.purposes.embedding.as_ref().expect("embedding");
+        let embedding = loaded
+            .purposes
+            .get(PurposeKind::Embedding)
+            .expect("embedding");
         assert_eq!(embedding.connection.to_string(), "primary");
         assert_eq!(embedding.model.to_string(), "primary");
 
@@ -3515,22 +3536,22 @@ model = "claude-haiku-4-5-20251001"
             "anthropic"
         );
 
-        let interactive = loaded.purposes.interactive.as_ref().unwrap();
+        let interactive = loaded.purposes.get(PurposeKind::Interactive).unwrap();
         assert_eq!(interactive.connection.to_string(), "default");
         assert_eq!(interactive.model.to_string(), "gpt-5.4");
 
         // Dreaming/titling → named `backend`, with the backend model.
-        let dreaming = loaded.purposes.dreaming.as_ref().unwrap();
+        let dreaming = loaded.purposes.get(PurposeKind::Dreaming).unwrap();
         assert_eq!(dreaming.connection.to_string(), "backend");
         assert_eq!(dreaming.model.to_string(), "claude-haiku-4-5-20251001");
-        let titling = loaded.purposes.titling.as_ref().unwrap();
+        let titling = loaded.purposes.get(PurposeKind::Titling).unwrap();
         assert_eq!(titling.connection.to_string(), "backend");
 
         // Embedding → always `primary`/`primary`, because embedding models
         // live in `[embeddings]`, not in `backend_tasks.llm`. Users with a
         // cross-connector embeddings config keep that config; the purpose
-        // entry is just there so #11 has a uniform lookup point.
-        let embedding = loaded.purposes.embedding.as_ref().unwrap();
+        // entry is just there for a uniform lookup point.
+        let embedding = loaded.purposes.get(PurposeKind::Embedding).unwrap();
         assert_eq!(embedding.connection.to_string(), "primary");
         assert_eq!(embedding.model.to_string(), "primary");
 
@@ -3553,15 +3574,15 @@ api_key_env = "OPENAI_API_KEY"
         let loaded = load_daemon_config(&path).unwrap().unwrap();
         assert_eq!(loaded.connections.len(), 1);
 
-        let interactive = loaded.purposes.interactive.as_ref().unwrap();
+        let interactive = loaded.purposes.get(PurposeKind::Interactive).unwrap();
         assert_eq!(interactive.connection.to_string(), "default");
         // Model falls back to the connector default when none was set.
         assert_eq!(interactive.model.to_string(), "gpt-5.4");
 
         for p in [
-            loaded.purposes.dreaming.as_ref().unwrap(),
-            loaded.purposes.titling.as_ref().unwrap(),
-            loaded.purposes.embedding.as_ref().unwrap(),
+            loaded.purposes.get(PurposeKind::Dreaming).unwrap(),
+            loaded.purposes.get(PurposeKind::Titling).unwrap(),
+            loaded.purposes.get(PurposeKind::Embedding).unwrap(),
         ] {
             assert_eq!(p.connection.to_string(), "primary");
             assert_eq!(p.model.to_string(), "primary");
@@ -3599,7 +3620,7 @@ api_key_env = "OPENAI_WORK_KEY"
         assert!(!dir.join("daemon.toml.bak").exists());
 
         // Purposes synthesized, pointing at the user-authored connection.
-        let interactive = loaded.purposes.interactive.as_ref().unwrap();
+        let interactive = loaded.purposes.get(PurposeKind::Interactive).unwrap();
         assert_eq!(interactive.connection.to_string(), "work");
 
         std::fs::remove_dir_all(&dir).ok();
@@ -3622,10 +3643,10 @@ effort = "high"
         std::fs::write(&path, content).unwrap();
 
         let loaded = load_daemon_config(&path).unwrap().unwrap();
-        let interactive = loaded.purposes.interactive.as_ref().unwrap();
+        let interactive = loaded.purposes.get(PurposeKind::Interactive).unwrap();
         assert_eq!(interactive.effort, Some(crate::purposes::Effort::High));
         // No other purposes synthesized.
-        assert!(loaded.purposes.dreaming.is_none());
+        assert!(loaded.purposes.get(PurposeKind::Dreaming).is_none());
 
         // File unchanged (no legacy shape, no purpose migration).
         let on_disk = std::fs::read_to_string(&path).unwrap();
@@ -4295,8 +4316,7 @@ model = "llama3.2"
         assert_eq!(
             legacy
                 .purposes
-                .interactive
-                .as_ref()
+                .get(PurposeKind::Interactive)
                 .unwrap()
                 .max_context_tokens,
             None
@@ -4322,8 +4342,7 @@ max_context_tokens = 1000000
         assert_eq!(
             parsed
                 .purposes
-                .interactive
-                .as_ref()
+                .get(PurposeKind::Interactive)
                 .unwrap()
                 .max_context_tokens,
             Some(1_000_000)

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -609,7 +609,7 @@ async fn main() -> Result<()> {
     .and_then(|resolved| {
         let id = daemon_config
             .as_ref()
-            .and_then(|c| c.purposes.interactive.as_ref())
+            .and_then(|c| c.purposes.get(purposes::PurposeKind::Interactive))
             .and_then(|p| match &p.connection {
                 purposes::ConnectionRef::Named(id) => Some(id.clone()),
                 purposes::ConnectionRef::Primary => None,
@@ -1246,7 +1246,7 @@ async fn main() -> Result<()> {
     let resolved_primary = config::resolve_llm_config(daemon_config.as_ref());
     let titling_configured = daemon_config
         .as_ref()
-        .and_then(|c| c.purposes.titling.as_ref())
+        .and_then(|c| c.purposes.get(purposes::PurposeKind::Titling))
         .is_some();
     if titling_configured {
         tracing::info!("backend-tasks LLM source=purposes.titling (dynamic resolution per call)");

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -26,10 +26,10 @@ use crate::connections::{ConnectionId, ConnectionIdError, ConnectionsMap};
 
 /// Which LLM purpose a [`PurposeConfig`] applies to.
 ///
-/// The variants are extensible: adding a new purpose is a breaking schema
-/// change, not an API one. When adding a variant, update:
+/// Adding a new purpose is a breaking schema change, not an API one.
+/// When adding a variant, update:
 /// - [`PurposeKind::as_key`] / [`PurposeKind::from_key`]
-/// - [`Purposes`] to add a slot
+/// - [`PurposeKind::all`] (the iteration order)
 /// - the migration logic in `config::maybe_migrate_legacy_purposes`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PurposeKind {
@@ -184,44 +184,43 @@ pub struct PurposeConfig {
 /// Empty / absent `[purposes]` is represented by `Purposes::default()` and is
 /// a valid state (first-run, no migration) — [`load_daemon_config`] decides
 /// whether to synthesize a set.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-pub struct Purposes {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub interactive: Option<PurposeConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dreaming: Option<PurposeConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub embedding: Option<PurposeConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub titling: Option<PurposeConfig>,
-}
+///
+/// Internally a `BTreeMap<PurposeKind, PurposeConfig>` so adding a new
+/// variant doesn't require editing four named-field arms. Custom
+/// serde implementations preserve the existing TOML named-table shape
+/// (`[purposes.interactive]`, `[purposes.dreaming]`, ...) so on-disk
+/// configs stay byte-compatible.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Purposes(BTreeMap<PurposeKind, PurposeConfig>);
 
 impl Purposes {
     /// Whether any purpose is configured.
     pub fn is_empty(&self) -> bool {
-        self.interactive.is_none()
-            && self.dreaming.is_none()
-            && self.embedding.is_none()
-            && self.titling.is_none()
+        self.0.is_empty()
     }
 
     /// Get the raw [`PurposeConfig`] for a given kind, if present.
     pub fn get(&self, kind: PurposeKind) -> Option<&PurposeConfig> {
-        match kind {
-            PurposeKind::Interactive => self.interactive.as_ref(),
-            PurposeKind::Dreaming => self.dreaming.as_ref(),
-            PurposeKind::Embedding => self.embedding.as_ref(),
-            PurposeKind::Titling => self.titling.as_ref(),
-        }
+        self.0.get(&kind)
     }
 
-    /// Mutably set the raw [`PurposeConfig`] for a given kind.
+    /// Mutable accessor used by config-mutation paths (delete-cascade,
+    /// purpose editing) that need to tweak fields on an existing entry
+    /// without going through the full `set` round-trip.
+    pub fn get_mut(&mut self, kind: PurposeKind) -> Option<&mut PurposeConfig> {
+        self.0.get_mut(&kind)
+    }
+
+    /// Mutably set the raw [`PurposeConfig`] for a given kind. Passing
+    /// `None` clears the slot.
     pub fn set(&mut self, kind: PurposeKind, cfg: Option<PurposeConfig>) {
-        match kind {
-            PurposeKind::Interactive => self.interactive = cfg,
-            PurposeKind::Dreaming => self.dreaming = cfg,
-            PurposeKind::Embedding => self.embedding = cfg,
-            PurposeKind::Titling => self.titling = cfg,
+        match cfg {
+            Some(c) => {
+                self.0.insert(kind, c);
+            }
+            None => {
+                self.0.remove(&kind);
+            }
         }
     }
 
@@ -232,9 +231,23 @@ impl Purposes {
     /// configured" command.
     #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = (PurposeKind, &PurposeConfig)> {
+        // Drive iteration order from `PurposeKind::all` rather than
+        // `BTreeMap`'s natural ordering so the public iter contract is
+        // independent of how `PurposeKind` happens to derive `Ord`.
         PurposeKind::all()
             .into_iter()
             .filter_map(|k| self.get(k).map(|c| (k, c)))
+    }
+
+    /// Build a `Purposes` from a list of `(kind, config)` pairs. Used
+    /// by tests; the daemon paths build incrementally via `set`.
+    /// Duplicate keys overwrite — last write wins, matching `set`.
+    pub fn from_pairs<I: IntoIterator<Item = (PurposeKind, PurposeConfig)>>(pairs: I) -> Self {
+        let mut out = Self::default();
+        for (kind, cfg) in pairs {
+            out.set(kind, Some(cfg));
+        }
+        out
     }
 
     /// Validate the set at load time. Currently enforces:
@@ -247,7 +260,7 @@ impl Purposes {
         if self.is_empty() {
             return Ok(());
         }
-        let Some(interactive) = self.interactive.as_ref() else {
+        let Some(interactive) = self.get(PurposeKind::Interactive) else {
             return Err(PurposeError::MissingInteractive);
         };
         if matches!(interactive.connection, ConnectionRef::Primary) {
@@ -257,6 +270,68 @@ impl Purposes {
             return Err(PurposeError::InteractivePrimaryModel);
         }
         Ok(())
+    }
+}
+
+/// Custom serde: preserve the existing TOML named-table shape on the
+/// wire (so user configs and tests don't need to change) while letting
+/// the in-memory representation be a single map. Serializes only the
+/// purposes that are present, in [`PurposeKind::all`] order; deserializes
+/// any subset of `interactive` / `dreaming` / `embedding` / `titling`
+/// keys. Unknown keys are rejected so typos surface at parse time.
+mod purposes_serde {
+    use super::{PurposeConfig, PurposeKind, Purposes};
+    use serde::de::{Error as DeError, MapAccess, Visitor};
+    use serde::ser::SerializeMap;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt;
+
+    impl Serialize for Purposes {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut map = serializer.serialize_map(Some(self.0.len()))?;
+            for kind in PurposeKind::all() {
+                if let Some(cfg) = self.get(kind) {
+                    map.serialize_entry(kind.as_key(), cfg)?;
+                }
+            }
+            map.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Purposes {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            struct PurposesVisitor;
+
+            impl<'de> Visitor<'de> for PurposesVisitor {
+                type Value = Purposes;
+
+                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("a `[purposes]` table with known purpose keys")
+                }
+
+                fn visit_map<M: MapAccess<'de>>(self, mut access: M) -> Result<Purposes, M::Error> {
+                    let mut out = Purposes::default();
+                    while let Some(key) = access.next_key::<String>()? {
+                        let Some(kind) = PurposeKind::from_key(&key) else {
+                            return Err(M::Error::custom(format!(
+                                "unknown purpose `{key}`; expected one of \
+                                 `interactive`, `dreaming`, `embedding`, `titling`"
+                            )));
+                        };
+                        if out.get(kind).is_some() {
+                            return Err(M::Error::custom(format!(
+                                "duplicate purpose `{key}` in `[purposes]`"
+                            )));
+                        }
+                        let cfg: PurposeConfig = access.next_value()?;
+                        out.set(kind, Some(cfg));
+                    }
+                    Ok(out)
+                }
+            }
+
+            deserializer.deserialize_map(PurposesVisitor)
+        }
     }
 }
 
@@ -323,8 +398,7 @@ pub fn resolve_purpose(
         });
     };
     let interactive = purposes
-        .interactive
-        .as_ref()
+        .get(PurposeKind::Interactive)
         .ok_or(PurposeError::MissingInteractive)?;
 
     // Resolve connection (depth 1 max).
@@ -648,29 +722,29 @@ mystery = "x"
 
     #[test]
     fn validate_requires_interactive_when_any_purpose_set() {
-        let p = Purposes {
-            dreaming: Some(PurposeConfig {
+        let p = Purposes::from_pairs([(
+            PurposeKind::Dreaming,
+            PurposeConfig {
                 connection: ConnectionRef::Primary,
                 model: ModelRef::Primary,
                 effort: None,
                 max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+            },
+        )]);
         assert_eq!(p.validate().unwrap_err(), PurposeError::MissingInteractive);
     }
 
     #[test]
     fn validate_rejects_primary_in_interactive_connection() {
-        let p = Purposes {
-            interactive: Some(PurposeConfig {
+        let p = Purposes::from_pairs([(
+            PurposeKind::Interactive,
+            PurposeConfig {
                 connection: ConnectionRef::Primary,
                 model: ModelRef::Named("gpt-5.4".to_string()),
                 effort: None,
                 max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+            },
+        )]);
         assert_eq!(
             p.validate().unwrap_err(),
             PurposeError::InteractivePrimaryConnection
@@ -679,15 +753,15 @@ mystery = "x"
 
     #[test]
     fn validate_rejects_primary_in_interactive_model() {
-        let p = Purposes {
-            interactive: Some(PurposeConfig {
+        let p = Purposes::from_pairs([(
+            PurposeKind::Interactive,
+            PurposeConfig {
                 connection: ConnectionRef::Named(conn_id("work")),
                 model: ModelRef::Primary,
                 effort: None,
                 max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+            },
+        )]);
         assert_eq!(
             p.validate().unwrap_err(),
             PurposeError::InteractivePrimaryModel
@@ -698,10 +772,8 @@ mystery = "x"
 
     #[test]
     fn resolve_concrete_interactive() {
-        let p = Purposes {
-            interactive: Some(interactive_for("work", "gpt-5.4")),
-            ..Purposes::default()
-        };
+        let p =
+            Purposes::from_pairs([(PurposeKind::Interactive, interactive_for("work", "gpt-5.4"))]);
         let conns = connections_with(&["work"]);
 
         let r = resolve_purpose(PurposeKind::Interactive, &p, &conns).unwrap();
@@ -712,16 +784,18 @@ mystery = "x"
 
     #[test]
     fn resolve_primary_inherits_from_interactive() {
-        let p = Purposes {
-            interactive: Some(interactive_for("work", "gpt-5.4")),
-            dreaming: Some(PurposeConfig {
-                connection: ConnectionRef::Primary,
-                model: ModelRef::Primary,
-                effort: Some(Effort::Low),
-                max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+        let p = Purposes::from_pairs([
+            (PurposeKind::Interactive, interactive_for("work", "gpt-5.4")),
+            (
+                PurposeKind::Dreaming,
+                PurposeConfig {
+                    connection: ConnectionRef::Primary,
+                    model: ModelRef::Primary,
+                    effort: Some(Effort::Low),
+                    max_context_tokens: None,
+                },
+            ),
+        ]);
         let conns = connections_with(&["work"]);
 
         let r = resolve_purpose(PurposeKind::Dreaming, &p, &conns).unwrap();
@@ -733,16 +807,18 @@ mystery = "x"
 
     #[test]
     fn resolve_partial_primary_keeps_named_model() {
-        let p = Purposes {
-            interactive: Some(interactive_for("work", "gpt-5.4")),
-            dreaming: Some(PurposeConfig {
-                connection: ConnectionRef::Primary,
-                model: ModelRef::Named("claude-haiku-4-5".to_string()),
-                effort: None,
-                max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+        let p = Purposes::from_pairs([
+            (PurposeKind::Interactive, interactive_for("work", "gpt-5.4")),
+            (
+                PurposeKind::Dreaming,
+                PurposeConfig {
+                    connection: ConnectionRef::Primary,
+                    model: ModelRef::Named("claude-haiku-4-5".to_string()),
+                    effort: None,
+                    max_context_tokens: None,
+                },
+            ),
+        ]);
         let conns = connections_with(&["work"]);
 
         let r = resolve_purpose(PurposeKind::Dreaming, &p, &conns).unwrap();
@@ -765,16 +841,18 @@ mystery = "x"
 
     #[test]
     fn resolve_dangling_nonprimary_falls_back_to_interactive() {
-        let p = Purposes {
-            interactive: Some(interactive_for("work", "gpt-5.4")),
-            dreaming: Some(PurposeConfig {
-                connection: ConnectionRef::Named(conn_id("ghost")),
-                model: ModelRef::Named("claude-haiku-4-5".to_string()),
-                effort: None,
-                max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+        let p = Purposes::from_pairs([
+            (PurposeKind::Interactive, interactive_for("work", "gpt-5.4")),
+            (
+                PurposeKind::Dreaming,
+                PurposeConfig {
+                    connection: ConnectionRef::Named(conn_id("ghost")),
+                    model: ModelRef::Named("claude-haiku-4-5".to_string()),
+                    effort: None,
+                    max_context_tokens: None,
+                },
+            ),
+        ]);
         let conns = connections_with(&["work"]);
 
         let r = resolve_purpose(PurposeKind::Dreaming, &p, &conns).unwrap();
@@ -786,10 +864,10 @@ mystery = "x"
 
     #[test]
     fn resolve_dangling_interactive_connection_errors() {
-        let p = Purposes {
-            interactive: Some(interactive_for("ghost", "gpt-5.4")),
-            ..Purposes::default()
-        };
+        let p = Purposes::from_pairs([(
+            PurposeKind::Interactive,
+            interactive_for("ghost", "gpt-5.4"),
+        )]);
         let conns = connections_with(&["work"]);
         let err = resolve_purpose(PurposeKind::Interactive, &p, &conns).unwrap_err();
         match err {
@@ -802,16 +880,18 @@ mystery = "x"
 
     #[test]
     fn resolve_all_skips_absent_purposes() {
-        let p = Purposes {
-            interactive: Some(interactive_for("work", "gpt-5.4")),
-            titling: Some(PurposeConfig {
-                connection: ConnectionRef::Primary,
-                model: ModelRef::Primary,
-                effort: None,
-                max_context_tokens: None,
-            }),
-            ..Purposes::default()
-        };
+        let p = Purposes::from_pairs([
+            (PurposeKind::Interactive, interactive_for("work", "gpt-5.4")),
+            (
+                PurposeKind::Titling,
+                PurposeConfig {
+                    connection: ConnectionRef::Primary,
+                    model: ModelRef::Primary,
+                    effort: None,
+                    max_context_tokens: None,
+                },
+            ),
+        ]);
         let conns = connections_with(&["work"]);
         let resolved = resolve_all(&p, &conns).unwrap();
         assert_eq!(resolved.len(), 2);
@@ -837,10 +917,10 @@ connection = "primary"
 model = "primary"
 "#;
         let parsed: Purposes = toml::from_str(toml_src).unwrap();
-        assert!(parsed.interactive.is_some());
-        assert!(parsed.dreaming.is_some());
-        assert!(parsed.titling.is_some());
-        assert!(parsed.embedding.is_none());
+        assert!(parsed.get(PurposeKind::Interactive).is_some());
+        assert!(parsed.get(PurposeKind::Dreaming).is_some());
+        assert!(parsed.get(PurposeKind::Titling).is_some());
+        assert!(parsed.get(PurposeKind::Embedding).is_none());
         parsed.validate().expect("valid");
 
         let reserialized = toml::to_string(&parsed).unwrap();

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -472,6 +472,25 @@ mod tests {
     /// path used by the backend slot.
     fn build_handle_with_titling(model: &str) -> Arc<crate::api_surface::RegistryHandle> {
         use crate::purposes::{ConnectionRef, ModelRef, PurposeConfig, Purposes};
+        let mut purposes = Purposes::default();
+        purposes.set(
+            PurposeKind::Interactive,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("interactive-model".to_string()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
+        purposes.set(
+            PurposeKind::Titling,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named(model.to_string()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
         let cfg = crate::config::DaemonConfig {
             connections: IndexMap::from([(
                 "local".to_string(),
@@ -479,21 +498,7 @@ mod tests {
                     base_url: Some("http://localhost:11434".into()),
                 }),
             )]),
-            purposes: Purposes {
-                interactive: Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                    model: ModelRef::Named("interactive-model".to_string()),
-                    effort: None,
-                    max_context_tokens: None,
-                }),
-                titling: Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                    model: ModelRef::Named(model.to_string()),
-                    effort: None,
-                    max_context_tokens: None,
-                }),
-                ..Purposes::default()
-            },
+            purposes,
             ..crate::config::DaemonConfig::default()
         };
         let reg = build_registry(&cfg);
@@ -508,6 +513,17 @@ mod tests {
         // validation — which is a separate path covered by config-level
         // tests.)
         use crate::purposes::{ConnectionRef, ModelRef, PurposeConfig, Purposes};
+        let mut purposes = Purposes::default();
+        purposes.set(
+            PurposeKind::Interactive,
+            Some(PurposeConfig {
+                connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
+                model: ModelRef::Named("interactive-model".to_string()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
+        // Note: titling intentionally absent.
         let cfg = crate::config::DaemonConfig {
             connections: IndexMap::from([(
                 "local".to_string(),
@@ -515,16 +531,7 @@ mod tests {
                     base_url: Some("http://localhost:11434".into()),
                 }),
             )]),
-            purposes: Purposes {
-                interactive: Some(PurposeConfig {
-                    connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-                    model: ModelRef::Named("interactive-model".to_string()),
-                    effort: None,
-                    max_context_tokens: None,
-                }),
-                // Note: titling intentionally absent.
-                ..Purposes::default()
-            },
+            purposes,
             ..crate::config::DaemonConfig::default()
         };
         let reg = build_registry(&cfg);
@@ -615,12 +622,17 @@ mod tests {
         // after the control panel writes a new value, minus the disk
         // persistence (covered by the connections-management API tests).
         let mut new_cfg = handle.snapshot_config();
-        new_cfg.purposes.titling = Some(crate::purposes::PurposeConfig {
-            connection: crate::purposes::ConnectionRef::Named(ConnectionId::new("local").unwrap()),
-            model: crate::purposes::ModelRef::Named("model-v2".to_string()),
-            effort: None,
-            max_context_tokens: None,
-        });
+        new_cfg.purposes.set(
+            PurposeKind::Titling,
+            Some(crate::purposes::PurposeConfig {
+                connection: crate::purposes::ConnectionRef::Named(
+                    ConnectionId::new("local").unwrap(),
+                ),
+                model: crate::purposes::ModelRef::Named("model-v2".to_string()),
+                effort: None,
+                max_context_tokens: None,
+            }),
+        );
         handle.replace_config_for_test(new_cfg);
 
         let cfg2 = handle.snapshot_config();


### PR DESCRIPTION
Closes #42 (daemon side).

## Summary
- \`daemon::purposes::Purposes\` is now a single \`BTreeMap<PurposeKind, PurposeConfig>\` instead of four named \`Option<PurposeConfig>\` fields.
- Custom serde preserves the existing TOML / JSON named-table shape (\`[purposes.interactive]\`, etc.) so on-disk configs and wire output are byte-compatible. Unknown keys reject at parse time so typos surface fast.
- Adds \`get_mut\` + \`from_pairs\` for ergonomic call sites and tests.
- Removes parallel 4-arm matches in \`api_surface::delete_connection\`'s force-cascade.
- Updates call sites across \`api_surface\`, \`config\`, \`routing_llm\`, \`main\`, and the daemon test suite.

Adding a fifth purpose now means editing \`PurposeKind\` (variant + 3 small functions) + the migration synthesis. No more 4-arm matches in \`get\` / \`set\` / \`is_empty\` / \`validate\`.

## Out of scope
\`api_model::PurposesView\` and \`core::ports::inbound::PurposesView\` are the same named-fields shape and would benefit from the same conversion. Left for a focused follow-up — \`PurposesView\` participates in the JSON wire format and serializing it as a map (preserving JSON shape) wants its own review pass rather than being bundled here.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 30 suites pass
- [x] \`cargo fmt --all --check\` clean
- [x] On-disk TOML round-trip test (\`purposes_toml_roundtrip_full\`) covers serde compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)