### PR TITLE
llm-shared: extract ToolCallAccumulator into core (#45)

### DIFF
--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -439,6 +439,97 @@ pub fn is_retryable_error(e: &CoreError) -> bool {
     matches!(e, CoreError::RateLimited { .. })
 }
 
+// --- Tool-call accumulator -------------------------------------------------
+
+/// Stream-time accumulator for assembling [`ToolCall`]s from a sequence
+/// of provider-specific events.
+///
+/// The shape is the same across every connector: each tool call has a
+/// stable per-stream index, an `id`, a `name`, and an `arguments` JSON
+/// string that may arrive in pieces (Anthropic / Bedrock / OpenAI all
+/// stream `arguments` as concatenated partial JSON deltas, with OpenAI
+/// also emitting a final `done` event carrying the full string).
+///
+/// Generic over the index type — Anthropic uses `usize` (zero-based
+/// content-block index), Bedrock uses `i32` (signed by the SDK),
+/// OpenAI uses `usize` (`output_index`). All three need `Ord` so
+/// [`Self::into_tool_calls`] can return calls in stable, ascending
+/// order regardless of arrival order.
+#[derive(Debug, Clone, Default)]
+pub struct ToolCallAccumulator<K> {
+    entries: std::collections::BTreeMap<K, ToolCallEntry>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ToolCallEntry {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl<K: Ord + Copy> ToolCallAccumulator<K> {
+    pub fn new() -> Self {
+        Self {
+            entries: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Register a new tool call at `key`. If a call already exists at
+    /// `key`, its `id` and `name` are overwritten and any
+    /// already-accumulated arguments are preserved — providers that
+    /// emit `start` for the same index twice (none seen in practice)
+    /// will get last-write-wins on the metadata without losing
+    /// streamed argument bytes.
+    pub fn start(&mut self, key: K, id: impl Into<String>, name: impl Into<String>) {
+        let entry = self.entries.entry(key).or_default();
+        entry.id = id.into();
+        entry.name = name.into();
+    }
+
+    /// Append a partial-JSON chunk to the arguments string at `key`.
+    /// Silently dropped when no `start` was emitted for `key` first
+    /// (defensive against malformed event sequences). Use this for
+    /// providers that stream `arguments` deltas (Anthropic
+    /// `input_json_delta`, Bedrock `ContentBlockDelta::ToolUse`,
+    /// OpenAI `response.function_call_arguments.delta`).
+    pub fn append(&mut self, key: K, partial_json: &str) {
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.arguments.push_str(partial_json);
+        }
+    }
+
+    /// Replace the arguments string at `key` with the full final
+    /// payload. Used by OpenAI's `response.function_call_arguments.done`
+    /// event, which carries the canonical full JSON; the deltas are a
+    /// preview the SDK doesn't promise are byte-equivalent. No-op for
+    /// connectors that don't emit a finalize event — they just keep
+    /// the accumulated deltas as-is.
+    pub fn finalize(&mut self, key: K, arguments: impl Into<String>) {
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.arguments = arguments.into();
+        }
+    }
+
+    /// Drain into [`ToolCall`]s in ascending key order. Entries with
+    /// empty `id` *and* empty `name` are filtered out — they're zombies
+    /// from a stream that emitted `append` without a matching `start`
+    /// (Bedrock's older shape did this; the new `append` guards against
+    /// it but the filter is kept as belt-and-braces).
+    pub fn into_tool_calls(self) -> Vec<ToolCall> {
+        self.entries
+            .into_values()
+            .filter(|e| !e.id.is_empty() || !e.name.is_empty())
+            .map(|e| ToolCall::new(e.id, e.name, e.arguments))
+            .collect()
+    }
+
+    /// Number of registered tool calls. Test-only.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
 /// Decorator that wraps any `LlmClient` and retries on transient rate-limit errors
 /// with exponential backoff.
 pub struct RetryingLlmClient<L> {
@@ -1065,5 +1156,74 @@ mod tests {
         })
         .await;
         assert_eq!(observed, Some(inner_budget));
+    }
+
+    // --- ToolCallAccumulator (#45) ----------------------------------------
+
+    #[test]
+    fn tool_call_accumulator_assembles_streamed_deltas() {
+        let mut acc = ToolCallAccumulator::<usize>::new();
+        acc.start(0, "call_a", "search");
+        acc.append(0, "{\"q\":");
+        acc.append(0, "\"hello\"}");
+        let calls = acc.into_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_a");
+        assert_eq!(calls[0].name, "search");
+        assert_eq!(calls[0].arguments, "{\"q\":\"hello\"}");
+    }
+
+    #[test]
+    fn tool_call_accumulator_orders_by_key_ascending() {
+        let mut acc = ToolCallAccumulator::<i32>::new();
+        // Insert out of order — output must still be sorted by key.
+        acc.start(2, "call_z", "zebra");
+        acc.append(2, "{}");
+        acc.start(0, "call_a", "alpha");
+        acc.append(0, "{}");
+        acc.start(1, "call_m", "middle");
+        acc.append(1, "{}");
+        let calls = acc.into_tool_calls();
+        let names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "middle", "zebra"]);
+    }
+
+    #[test]
+    fn tool_call_accumulator_finalize_replaces_partial_arguments() {
+        let mut acc = ToolCallAccumulator::<usize>::new();
+        acc.start(0, "call_a", "search");
+        acc.append(0, "{\"part");
+        // OpenAI emits a `done` event with the full canonical JSON;
+        // finalize must replace whatever deltas have accumulated.
+        acc.finalize(0, "{\"q\":\"final\"}");
+        let calls = acc.into_tool_calls();
+        assert_eq!(calls[0].arguments, "{\"q\":\"final\"}");
+    }
+
+    #[test]
+    fn tool_call_accumulator_append_without_start_is_dropped() {
+        let mut acc = ToolCallAccumulator::<usize>::new();
+        acc.append(0, "lost data");
+        assert!(acc.into_tool_calls().is_empty());
+    }
+
+    #[test]
+    fn tool_call_accumulator_filters_zombie_entries() {
+        // An entry whose id and name are both empty (from a hypothetical
+        // mis-sequenced provider) is filtered out — see method doc for the
+        // belt-and-braces rationale.
+        let mut acc = ToolCallAccumulator::<usize>::new();
+        acc.entries.insert(
+            0,
+            ToolCallEntry {
+                id: String::new(),
+                name: String::new(),
+                arguments: "garbage".into(),
+            },
+        );
+        acc.start(1, "real", "real");
+        let calls = acc.into_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "real");
     }
 }

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -242,6 +242,7 @@ impl Purposes {
     /// Build a `Purposes` from a list of `(kind, config)` pairs. Used
     /// by tests; the daemon paths build incrementally via `set`.
     /// Duplicate keys overwrite — last write wins, matching `set`.
+    #[cfg(test)]
     pub fn from_pairs<I: IntoIterator<Item = (PurposeKind, PurposeConfig)>>(pairs: I) -> Self {
         let mut out = Self::default();
         for (kind, cfg) in pairs {

--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -1,5 +1,7 @@
 use desktop_assistant_core::CoreError;
-use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition, ToolNamespace};
+#[cfg(test)]
+use desktop_assistant_core::domain::ToolCall;
+use desktop_assistant_core::domain::{Message, Role, ToolDefinition, ToolNamespace};
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
@@ -407,42 +409,9 @@ enum SseDelta {
     InputJsonDelta { partial_json: String },
 }
 
-/// Accumulator for building tool calls from streaming content blocks.
-#[derive(Default)]
-struct ToolCallAccumulator {
-    entries: Vec<ToolCallEntry>,
-}
-
-#[derive(Default)]
-struct ToolCallEntry {
-    id: String,
-    name: String,
-    arguments: String,
-}
-
-impl ToolCallAccumulator {
-    fn start_tool_use(&mut self, index: usize, id: String, name: String) {
-        while self.entries.len() <= index {
-            self.entries.push(ToolCallEntry::default());
-        }
-        let entry = &mut self.entries[index];
-        entry.id = id;
-        entry.name = name;
-    }
-
-    fn append_json(&mut self, index: usize, partial_json: &str) {
-        if let Some(entry) = self.entries.get_mut(index) {
-            entry.arguments.push_str(partial_json);
-        }
-    }
-
-    fn into_tool_calls(self) -> Vec<ToolCall> {
-        self.entries
-            .into_iter()
-            .map(|e| ToolCall::new(e.id, e.name, e.arguments))
-            .collect()
-    }
-}
+/// Anthropic SSE indexes content blocks with `usize`. Use the shared
+/// accumulator from core (#45).
+type ToolCallAccumulator = desktop_assistant_core::ports::llm::ToolCallAccumulator<usize>;
 
 impl AnthropicClient {
     /// Send a request and parse the SSE stream into an LlmResponse.
@@ -560,7 +529,7 @@ impl AnthropicClient {
                                         let tool_idx = tool_block_count;
                                         tool_block_count += 1;
                                         block_to_tool.insert(index, tool_idx);
-                                        tool_acc.start_tool_use(tool_idx, id.clone(), name.clone());
+                                        tool_acc.start(tool_idx, id.clone(), name.clone());
                                     }
                                     SseContentBlock::Text { .. } => {}
                                 }
@@ -580,7 +549,7 @@ impl AnthropicClient {
                                         if let Some(index) = event.index
                                             && let Some(&tool_idx) = block_to_tool.get(&index)
                                         {
-                                            tool_acc.append_json(tool_idx, partial_json);
+                                            tool_acc.append(tool_idx, partial_json);
                                         }
                                     }
                                 }
@@ -1136,36 +1105,8 @@ mod tests {
         assert_eq!(usage.cache_read_input_tokens, Some(20));
     }
 
-    #[test]
-    fn tool_call_accumulator_builds_from_blocks() {
-        let mut acc = ToolCallAccumulator::default();
-
-        acc.start_tool_use(0, "toolu_1".into(), "read_file".into());
-        acc.append_json(0, "{\"pa");
-        acc.append_json(0, "th\": \"/tmp\"}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].id, "toolu_1");
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[0].arguments, r#"{"path": "/tmp"}"#);
-    }
-
-    #[test]
-    fn tool_call_accumulator_multiple_tools() {
-        let mut acc = ToolCallAccumulator::default();
-
-        acc.start_tool_use(0, "t1".into(), "tool_a".into());
-        acc.append_json(0, "{}");
-
-        acc.start_tool_use(1, "t2".into(), "tool_b".into());
-        acc.append_json(1, "{}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].name, "tool_a");
-        assert_eq!(calls[1].name, "tool_b");
-    }
+    // Standalone accumulator unit tests moved to
+    // `desktop_assistant_core::ports::llm` (#45).
 
     #[test]
     fn request_without_tools_omits_field() {

--- a/crates/llm-bedrock/src/lib.rs
+++ b/crates/llm-bedrock/src/lib.rs
@@ -14,7 +14,7 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, OnceCell};
@@ -481,41 +481,9 @@ fn convert_tools(tools: &[ToolDefinition]) -> Result<Option<ToolConfiguration>, 
     Ok(Some(cfg))
 }
 
-#[derive(Default)]
-struct ToolCallAccumulator {
-    entries: BTreeMap<i32, ToolCallEntry>,
-}
-
-#[derive(Default)]
-struct ToolCallEntry {
-    id: String,
-    name: String,
-    arguments: String,
-}
-
-impl ToolCallAccumulator {
-    fn start_tool_use(&mut self, index: i32, id: impl Into<String>, name: impl Into<String>) {
-        let entry = self.entries.entry(index).or_default();
-        entry.id = id.into();
-        entry.name = name.into();
-    }
-
-    fn append_arguments(&mut self, index: i32, chunk: &str) {
-        self.entries
-            .entry(index)
-            .or_default()
-            .arguments
-            .push_str(chunk);
-    }
-
-    fn into_tool_calls(self) -> Vec<ToolCall> {
-        self.entries
-            .into_values()
-            .filter(|entry| !entry.id.is_empty() || !entry.name.is_empty())
-            .map(|entry| ToolCall::new(entry.id, entry.name, entry.arguments))
-            .collect()
-    }
-}
+/// Bedrock indexes streamed content blocks with `i32`. Use the shared
+/// accumulator from core (#45).
+type ToolCallAccumulator = desktop_assistant_core::ports::llm::ToolCallAccumulator<i32>;
 
 fn apply_stream_event(
     event: aws_sdk_bedrockruntime::types::ConverseStreamOutput,
@@ -530,7 +498,7 @@ fn apply_stream_event(
                 && let aws_sdk_bedrockruntime::types::ContentBlockStart::ToolUse(tool_use) =
                     content_start
             {
-                tool_acc.start_tool_use(
+                tool_acc.start(
                     start.content_block_index(),
                     tool_use.tool_use_id(),
                     tool_use.name(),
@@ -548,7 +516,7 @@ fn apply_stream_event(
                         }
                     }
                     aws_sdk_bedrockruntime::types::ContentBlockDelta::ToolUse(tool_delta) => {
-                        tool_acc.append_arguments(delta.content_block_index(), tool_delta.input());
+                        tool_acc.append(delta.content_block_index(), tool_delta.input());
                     }
                     _ => {}
                 }
@@ -1627,38 +1595,10 @@ mod tests {
         assert_eq!(creds.session_token(), Some("token789"));
     }
 
-    #[test]
-    fn tool_call_accumulator_builds_single_call_from_deltas() {
-        let mut acc = ToolCallAccumulator::default();
-
-        acc.start_tool_use(0, "call_1", "read_file");
-        acc.append_arguments(0, "{\"path\":\"/tmp");
-        acc.append_arguments(0, "/a\"}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].id, "call_1");
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[0].arguments, "{\"path\":\"/tmp/a\"}");
-    }
-
-    #[test]
-    fn tool_call_accumulator_orders_calls_by_block_index() {
-        let mut acc = ToolCallAccumulator::default();
-
-        acc.start_tool_use(2, "call_2", "tool_b");
-        acc.append_arguments(2, "{}");
-
-        acc.start_tool_use(1, "call_1", "tool_a");
-        acc.append_arguments(1, "{}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].id, "call_1");
-        assert_eq!(calls[0].name, "tool_a");
-        assert_eq!(calls[1].id, "call_2");
-        assert_eq!(calls[1].name, "tool_b");
-    }
+    // The standalone accumulator unit tests moved to
+    // `desktop_assistant_core::ports::llm` (#45) where the type now
+    // lives. The Bedrock-specific stream-event integration test below
+    // still exercises the connector's wiring of the accumulator.
 
     #[test]
     fn stream_event_processing_handles_mixed_text_and_tool_calls() {

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
-
 use desktop_assistant_core::CoreError;
-use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition, ToolNamespace};
+#[cfg(test)]
+use desktop_assistant_core::domain::ToolCall;
+use desktop_assistant_core::domain::{Message, Role, ToolDefinition, ToolNamespace};
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
@@ -382,53 +382,9 @@ struct ResponseUsage {
     output_tokens: Option<u64>,
 }
 
-/// Entry in the tool call accumulator, keyed by `output_index`.
-#[derive(Debug, Default)]
-struct ResponseToolEntry {
-    call_id: String,
-    name: String,
-    arguments: String,
-}
-
-/// Accumulator for building tool calls from Responses API streaming events.
-#[derive(Debug, Default)]
-struct ResponseToolAccumulator {
-    entries: HashMap<usize, ResponseToolEntry>,
-}
-
-impl ResponseToolAccumulator {
-    fn register(&mut self, output_index: usize, call_id: String, name: String) {
-        self.entries.insert(
-            output_index,
-            ResponseToolEntry {
-                call_id,
-                name,
-                arguments: String::new(),
-            },
-        );
-    }
-
-    fn append_arguments(&mut self, output_index: usize, delta: &str) {
-        if let Some(entry) = self.entries.get_mut(&output_index) {
-            entry.arguments.push_str(delta);
-        }
-    }
-
-    fn finalize_arguments(&mut self, output_index: usize, arguments: &str) {
-        if let Some(entry) = self.entries.get_mut(&output_index) {
-            entry.arguments = arguments.to_string();
-        }
-    }
-
-    fn into_tool_calls(self) -> Vec<ToolCall> {
-        let mut pairs: Vec<(usize, ResponseToolEntry)> = self.entries.into_iter().collect();
-        pairs.sort_by_key(|(idx, _)| *idx);
-        pairs
-            .into_iter()
-            .map(|(_, e)| ToolCall::new(e.call_id, e.name, e.arguments))
-            .collect()
-    }
-}
+/// OpenAI Responses-API events index tool calls with `output_index`
+/// (`usize`). Use the shared accumulator from core (#45).
+type ResponseToolAccumulator = desktop_assistant_core::ports::llm::ToolCallAccumulator<usize>;
 
 // ---------------------------------------------------------------------------
 // Message conversion: domain Messages → Responses API InputItems
@@ -623,7 +579,7 @@ impl OpenAiClient {
                     Some("response.output_item.added") => {
                         if let Ok(added) = serde_json::from_str::<OutputItemAdded>(data) {
                             if added.item.r#type == "function_call" {
-                                tool_acc.register(
+                                tool_acc.start(
                                     added.output_index,
                                     added.item.call_id.unwrap_or_default(),
                                     added.item.name.unwrap_or_default(),
@@ -633,12 +589,12 @@ impl OpenAiClient {
                     }
                     Some("response.function_call_arguments.delta") => {
                         if let Ok(d) = serde_json::from_str::<FunctionArgsDelta>(data) {
-                            tool_acc.append_arguments(d.output_index, &d.delta);
+                            tool_acc.append(d.output_index, &d.delta);
                         }
                     }
                     Some("response.function_call_arguments.done") => {
                         if let Ok(d) = serde_json::from_str::<FunctionArgsDone>(data) {
-                            tool_acc.finalize_arguments(d.output_index, &d.arguments);
+                            tool_acc.finalize(d.output_index, &d.arguments);
                         }
                     }
                     Some("response.tool_search_call.searching") => {
@@ -1409,63 +1365,8 @@ mod tests {
         );
     }
 
-    // --- Tool accumulator tests ---
-
-    #[test]
-    fn response_tool_accumulator_register_and_finalize() {
-        let mut acc = ResponseToolAccumulator::default();
-        acc.register(0, "call_1".into(), "read_file".into());
-        acc.append_arguments(0, r#"{"pa"#);
-        acc.append_arguments(0, r#"th": "/tmp"}"#);
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].id, "call_1");
-        assert_eq!(calls[0].name, "read_file");
-        assert_eq!(calls[0].arguments, r#"{"path": "/tmp"}"#);
-    }
-
-    #[test]
-    fn response_tool_accumulator_finalize_replaces_partial() {
-        let mut acc = ResponseToolAccumulator::default();
-        acc.register(0, "c1".into(), "tool_a".into());
-        acc.append_arguments(0, "partial");
-        acc.finalize_arguments(0, r#"{"complete": true}"#);
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls[0].arguments, r#"{"complete": true}"#);
-    }
-
-    #[test]
-    fn response_tool_accumulator_multiple_tools() {
-        let mut acc = ResponseToolAccumulator::default();
-        acc.register(0, "c1".into(), "tool_a".into());
-        acc.register(1, "c2".into(), "tool_b".into());
-        acc.finalize_arguments(0, "{}");
-        acc.finalize_arguments(1, "{}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].name, "tool_a");
-        assert_eq!(calls[1].name, "tool_b");
-    }
-
-    #[test]
-    fn response_tool_accumulator_sorted_by_index() {
-        let mut acc = ResponseToolAccumulator::default();
-        // Insert out of order
-        acc.register(2, "c3".into(), "tool_c".into());
-        acc.register(0, "c1".into(), "tool_a".into());
-        acc.register(1, "c2".into(), "tool_b".into());
-        acc.finalize_arguments(0, "{}");
-        acc.finalize_arguments(1, "{}");
-        acc.finalize_arguments(2, "{}");
-
-        let calls = acc.into_tool_calls();
-        assert_eq!(calls[0].name, "tool_a");
-        assert_eq!(calls[1].name, "tool_b");
-        assert_eq!(calls[2].name, "tool_c");
-    }
+    // Tool accumulator unit tests moved to
+    // `desktop_assistant_core::ports::llm` (#45) along with the type.
 
     // --- Client builder test ---
 


### PR DESCRIPTION
Closes #45.

## Summary
Hoist a generic \`ToolCallAccumulator<K: Ord + Copy>\` to \`crates/core/src/ports/llm.rs\` with four operations: \`start\`, \`append\`, \`finalize\`, \`into_tool_calls\`. Each connector replaces its private accumulator + redundant unit tests with a type alias plus method renames.

- Anthropic uses \`<usize>\` (content block index)
- Bedrock uses \`<i32>\` (SDK signed index)
- OpenAI uses \`<usize>\` (\`output_index\`)

\`finalize\` is OpenAI-specific (the API emits a \`done\` event with the canonical full-JSON arguments); other providers leave it unused. Output ordering is BTreeMap-natural (ascending by key) so all three providers get a deterministic order without each sorting at the end.

Net: ~130 LoC removed, three near-identical test bodies consolidated into one canonical set in core (5 new tests covering: streaming-delta assembly, ascending-order output, finalize-replaces-deltas, append-without-start drop, zombie-entry filtering).

## Test plan
- [x] \`cargo build --workspace\` clean (no new warnings)
- [x] \`cargo test --workspace\` — 30 suites pass, 5 new tests in core, redundant tests in connectors deleted
- [x] \`cargo fmt --all --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)