### PR TITLE
core: collapse Effort + SerdeEffort (#43 partial)

### DIFF
--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -214,7 +214,11 @@ pub trait ConversationService: Send + Sync {
 
 /// Effort hint passed to connectors and mapped to per-connector request
 /// parameters at dispatch time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializes as the lowercase variant name (`"low"`, `"medium"`,
+/// `"high"`) for JSON columns and wire payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Effort {
     Low,
     Medium,
@@ -237,36 +241,7 @@ pub struct ConversationModelSelection {
     pub connection_id: String,
     pub model_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<SerdeEffort>,
-}
-
-/// Serde-friendly `Effort` that maps to lowercase strings in JSON.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SerdeEffort {
-    Low,
-    Medium,
-    High,
-}
-
-impl From<SerdeEffort> for Effort {
-    fn from(e: SerdeEffort) -> Self {
-        match e {
-            SerdeEffort::Low => Effort::Low,
-            SerdeEffort::Medium => Effort::Medium,
-            SerdeEffort::High => Effort::High,
-        }
-    }
-}
-
-impl From<Effort> for SerdeEffort {
-    fn from(e: Effort) -> Self {
-        match e {
-            Effort::Low => SerdeEffort::Low,
-            Effort::Medium => SerdeEffort::Medium,
-            Effort::High => SerdeEffort::High,
-        }
-    }
+    pub effort: Option<Effort>,
 }
 
 /// Advisory attached to a `send_prompt_with_override` result. Returned

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -34,7 +34,7 @@ use desktop_assistant_core::ports::inbound::{
     ConnectionView as CoreConnectionView, ConnectionsService, ConversationModelSelection,
     ConversationService, DispatchWarning, Effort, ModelListing as CoreModelListing,
     PromptDispatchOutcome, PromptSelectionOverride, PurposeConfigPayload,
-    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView, SerdeEffort,
+    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView,
 };
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
@@ -493,7 +493,7 @@ where
             Some(ConversationModelSelection {
                 connection_id,
                 model_id,
-                effort: p.effort.map(effort_internal_to_serde),
+                effort: p.effort.map(purpose_effort_to_core),
             })
         })
     }
@@ -734,7 +734,7 @@ where
             let sel = ConversationModelSelection {
                 connection_id: override_sel.connection_id,
                 model_id: override_sel.model_id,
-                effort: override_sel.effort.map(SerdeEffort::from),
+                effort: override_sel.effort,
             };
             // Persist before dispatch so a crash mid-call doesn't lose the
             // user's choice.
@@ -1026,14 +1026,6 @@ fn core_effort_to_purpose(e: Effort) -> PurposeEffort {
         Effort::Low => PurposeEffort::Low,
         Effort::Medium => PurposeEffort::Medium,
         Effort::High => PurposeEffort::High,
-    }
-}
-
-fn effort_internal_to_serde(e: PurposeEffort) -> SerdeEffort {
-    match e {
-        PurposeEffort::Low => SerdeEffort::Low,
-        PurposeEffort::Medium => SerdeEffort::Medium,
-        PurposeEffort::High => SerdeEffort::High,
     }
 }
 


### PR DESCRIPTION
Partial close on #43.

## Why partial
The cross-crate \`PurposeKind\` and \`Effort\` triplets (daemon / core / api-model) need either an \`api-model → core\` dep (which inverts the \"api-model has no deps\" contract) or a new shared types crate to deduplicate. That's an architectural call worth its own thread. This PR ships the unambiguous within-crate win.

## Summary
\`core::ports::inbound::Effort\` (no serde, trait-param shape) and \`SerdeEffort\` (serde-derived, used in the JSON-stored \`ConversationModelSelection.effort\` field) were variant-for-variant identical with bidirectional \`From\` impls. Collapse them: add serde derives to \`Effort\`, drop \`SerdeEffort\`. Drop the now-redundant \`effort_internal_to_serde\` in \`api_surface.rs\`.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\` — 30 suites pass (no behaviour change; \`SerdeEffort\` and \`Effort\` had identical wire shape via the From impls)
- [x] \`cargo fmt --all --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)