### PR TITLE
workspace: unify duplicated PurposeKind / Effort enums (#43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
+ "desktop-assistant-core",
  "serde",
  "serde_json",
 ]

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+desktop-assistant-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -535,34 +535,12 @@ pub struct ModelCapabilitiesView {
 
 // --- Purpose views (#10 + #11) --------------------------------------------
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum PurposeKindApi {
-    Interactive,
-    Dreaming,
-    Embedding,
-    Titling,
-}
-
-impl PurposeKindApi {
-    pub fn as_key(self) -> &'static str {
-        match self {
-            Self::Interactive => "interactive",
-            Self::Dreaming => "dreaming",
-            Self::Embedding => "embedding",
-            Self::Titling => "titling",
-        }
-    }
-}
-
-/// Effort hint passed to connectors (mapped at dispatch time).
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum EffortLevel {
-    Low,
-    Medium,
-    High,
-}
+// `PurposeKindApi` and `EffortLevel` are re-exports of the canonical
+// types in `desktop_assistant_core::ports::inbound` (#43). The aliases
+// are kept so existing callers keep compiling without churn; new code
+// can use either name.
+pub use desktop_assistant_core::ports::inbound::Effort as EffortLevel;
+pub use desktop_assistant_core::ports::inbound::PurposeKind as PurposeKindApi;
 
 /// Protocol-neutral purpose config. String `"primary"` in the connection or
 /// model field means "inherit from interactive" — the daemon resolves this

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -9,8 +9,8 @@ use desktop_assistant_api_model as api;
 use desktop_assistant_core::domain::KnowledgeEntry;
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
-    ConversationModelSelection, ConversationService, DispatchWarning, Effort, KnowledgeService,
-    PromptSelectionOverride, PurposeConfigPayload, PurposeKind, SettingsService,
+    ConversationModelSelection, ConversationService, DispatchWarning, KnowledgeService,
+    PromptSelectionOverride, PurposeConfigPayload, SettingsService,
 };
 use thiserror::Error;
 use tracing::warn;
@@ -303,7 +303,7 @@ fn core_purpose_to_api(p: PurposeConfigPayload) -> api::PurposeConfigView {
     api::PurposeConfigView {
         connection: p.connection,
         model: p.model,
-        effort: p.effort.map(effort_to_api),
+        effort: p.effort,
         max_context_tokens: p.max_context_tokens,
     }
 }
@@ -312,33 +312,8 @@ fn api_purpose_to_core(p: api::PurposeConfigView) -> PurposeConfigPayload {
     PurposeConfigPayload {
         connection: p.connection,
         model: p.model,
-        effort: p.effort.map(effort_from_api),
+        effort: p.effort,
         max_context_tokens: p.max_context_tokens,
-    }
-}
-
-fn effort_to_api(e: Effort) -> api::EffortLevel {
-    match e {
-        Effort::Low => api::EffortLevel::Low,
-        Effort::Medium => api::EffortLevel::Medium,
-        Effort::High => api::EffortLevel::High,
-    }
-}
-
-fn effort_from_api(e: api::EffortLevel) -> Effort {
-    match e {
-        api::EffortLevel::Low => Effort::Low,
-        api::EffortLevel::Medium => Effort::Medium,
-        api::EffortLevel::High => Effort::High,
-    }
-}
-
-fn api_purpose_kind_to_core(k: api::PurposeKindApi) -> PurposeKind {
-    match k {
-        api::PurposeKindApi::Interactive => PurposeKind::Interactive,
-        api::PurposeKindApi::Dreaming => PurposeKind::Dreaming,
-        api::PurposeKindApi::Embedding => PurposeKind::Embedding,
-        api::PurposeKindApi::Titling => PurposeKind::Titling,
     }
 }
 
@@ -346,7 +321,7 @@ fn model_selection_to_view(sel: ConversationModelSelection) -> api::Conversation
     api::ConversationModelSelectionView {
         connection_id: sel.connection_id,
         model_id: sel.model_id,
-        effort: sel.effort.map(|e| effort_to_api(Effort::from(e))),
+        effort: sel.effort,
     }
 }
 
@@ -359,12 +334,12 @@ fn dispatch_warning_to_api(w: DispatchWarning) -> api::ConversationWarning {
             previous_selection: api::ConversationModelSelectionView {
                 connection_id: previous.connection_id,
                 model_id: previous.model_id,
-                effort: previous.effort.map(|e| effort_to_api(Effort::from(e))),
+                effort: previous.effort,
             },
             fallback_to: api::ConversationModelSelectionView {
                 connection_id: fallback_to.connection_id,
                 model_id: fallback_to.model_id,
-                effort: fallback_to.effort.map(|e| effort_to_api(Effort::from(e))),
+                effort: fallback_to.effort,
             },
         },
     }
@@ -828,10 +803,7 @@ where
 
             api::Command::SetPurpose { purpose, config } => {
                 self.connections
-                    .set_purpose(
-                        api_purpose_kind_to_core(purpose),
-                        api_purpose_to_core(config),
-                    )
+                    .set_purpose(purpose, api_purpose_to_core(config))
                     .await
                     .map_err(Self::map_core_err)?;
                 Ok(api::CommandResult::Ack)
@@ -907,7 +879,7 @@ where
         let override_for_core = override_selection.map(|o| PromptSelectionOverride {
             connection_id: o.connection_id,
             model_id: o.model_id,
-            effort: o.effort.map(effort_from_api),
+            effort: o.effort,
         });
 
         let outcome = self
@@ -989,7 +961,7 @@ mod tests {
     use desktop_assistant_core::ports::inbound::{
         BackendTasksSettingsView, ConnectorDefaultsView, DatabaseSettingsView,
         EmbeddingsSettingsView, LlmSettingsView, ModelListing as CoreModelListing,
-        PersistenceSettingsView, PurposesView as CorePurposesView,
+        PersistenceSettingsView, PurposeKind, PurposesView as CorePurposesView,
     };
     use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
     use std::sync::Mutex;

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -323,17 +323,31 @@ pub struct ModelListing {
     pub model: ModelInfo,
 }
 
-/// Purpose kind identifiers — mirrors
-/// `crates/daemon/src/purposes.rs::PurposeKind` via string keys.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Purpose kind identifiers. Canonical home for the enum that used to
+/// live in three places (this crate, `daemon::purposes`, and api-model
+/// as `PurposeKindApi`); see #43. The other crates re-export from here.
+///
+/// Wire format (`serde`) is `snake_case` so JSON / settings payloads
+/// produce `"interactive"`, `"dreaming"`, etc. The TOML config in the
+/// daemon does not derive serde on this type — it builds its own
+/// keyed map via [`Self::as_key`] / [`Self::from_key`].
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
 pub enum PurposeKind {
+    /// The user-facing chat LLM. Cannot inherit (nothing to inherit from).
     Interactive,
+    /// Periodic fact extraction (the "dreaming" background task).
     Dreaming,
+    /// Vector embeddings for memory and retrieval.
     Embedding,
+    /// Short-title generation for conversations.
     Titling,
 }
 
 impl PurposeKind {
+    /// Canonical lowercase key used in TOML and error messages.
     pub fn as_key(self) -> &'static str {
         match self {
             Self::Interactive => "interactive",
@@ -341,6 +355,37 @@ impl PurposeKind {
             Self::Embedding => "embedding",
             Self::Titling => "titling",
         }
+    }
+
+    /// Parse a canonical key back into a [`PurposeKind`]. Inverse of
+    /// [`Self::as_key`]; used by adapters that round-trip key strings.
+    pub fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "interactive" => Some(Self::Interactive),
+            "dreaming" => Some(Self::Dreaming),
+            "embedding" => Some(Self::Embedding),
+            "titling" => Some(Self::Titling),
+            _ => None,
+        }
+    }
+
+    /// Every purpose kind, in a stable order. Useful for iteration in
+    /// tests and serialization round-trips. Order matches the schema
+    /// migration order (interactive first because every other purpose
+    /// can inherit from it).
+    pub fn all() -> [Self; 4] {
+        [
+            Self::Interactive,
+            Self::Dreaming,
+            Self::Embedding,
+            Self::Titling,
+        ]
+    }
+}
+
+impl std::fmt::Display for PurposeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_key())
     }
 }
 

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -32,9 +32,8 @@ use desktop_assistant_core::domain::{Conversation, ConversationId, ConversationS
 use desktop_assistant_core::ports::inbound::{
     ConnectionAvailability as CoreConnectionAvailability, ConnectionConfigPayload,
     ConnectionView as CoreConnectionView, ConnectionsService, ConversationModelSelection,
-    ConversationService, DispatchWarning, Effort, ModelListing as CoreModelListing,
-    PromptDispatchOutcome, PromptSelectionOverride, PurposeConfigPayload,
-    PurposeKind as CorePurposeKind, PurposesView as CorePurposesView,
+    ConversationService, DispatchWarning, ModelListing as CoreModelListing, PromptDispatchOutcome,
+    PromptSelectionOverride, PurposeConfigPayload, PurposesView as CorePurposesView,
 };
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
@@ -48,9 +47,7 @@ use crate::connections::{
     AnthropicConnection, BedrockConnection, ConnectionConfig, ConnectionId, OllamaConnection,
     OpenAiConnection,
 };
-use crate::purposes::{
-    ConnectionRef, Effort as PurposeEffort, ModelRef, PurposeConfig, PurposeKind,
-};
+use crate::purposes::{ConnectionRef, Effort, ModelRef, PurposeConfig, PurposeKind};
 use crate::registry::{ConnectionHealth, ConnectionRegistry, build_registry};
 
 /// Shared, mutable handle to the registry + current config. Writes acquire
@@ -405,10 +402,10 @@ impl ConnectionsService for DaemonConnectionsService {
 
     async fn set_purpose(
         &self,
-        purpose: CorePurposeKind,
+        purpose: PurposeKind,
         config: PurposeConfigPayload,
     ) -> Result<(), CoreError> {
-        let purpose_kind = core_to_internal_purpose(purpose);
+        let purpose_kind = purpose;
         let new_cfg = payload_to_purpose(config)
             .map_err(|e| CoreError::Llm(format!("invalid purpose config: {e}")))?;
 
@@ -493,7 +490,7 @@ where
             Some(ConversationModelSelection {
                 connection_id,
                 model_id,
-                effort: p.effort.map(purpose_effort_to_core),
+                effort: p.effort,
             })
         })
     }
@@ -547,8 +544,7 @@ pub(crate) fn resolve_purpose_dispatch(
     // `ResolvedLlmConfig` doesn't carry (it's connector/model/credentials).
     let effort = config
         .and_then(|c| c.purposes.get(kind))
-        .and_then(|p| p.effort)
-        .map(purpose_effort_to_core);
+        .and_then(|p| p.effort);
     let reasoning = map_effort_to_reasoning_config(&resolved.connector, &resolved.model, effort);
     Some((resolved, reasoning))
 }
@@ -986,7 +982,7 @@ fn purpose_to_payload(p: &PurposeConfig) -> PurposeConfigPayload {
             ModelRef::Named(m) => m.clone(),
             ModelRef::Primary => "primary".to_string(),
         },
-        effort: p.effort.map(purpose_effort_to_core),
+        effort: p.effort,
         max_context_tokens: p.max_context_tokens,
     }
 }
@@ -1008,34 +1004,9 @@ fn payload_to_purpose(p: PurposeConfigPayload) -> Result<PurposeConfig, String> 
     Ok(PurposeConfig {
         connection,
         model,
-        effort: p.effort.map(core_effort_to_purpose),
+        effort: p.effort,
         max_context_tokens: p.max_context_tokens,
     })
-}
-
-pub(crate) fn purpose_effort_to_core(e: PurposeEffort) -> Effort {
-    match e {
-        PurposeEffort::Low => Effort::Low,
-        PurposeEffort::Medium => Effort::Medium,
-        PurposeEffort::High => Effort::High,
-    }
-}
-
-fn core_effort_to_purpose(e: Effort) -> PurposeEffort {
-    match e {
-        Effort::Low => PurposeEffort::Low,
-        Effort::Medium => PurposeEffort::Medium,
-        Effort::High => PurposeEffort::High,
-    }
-}
-
-fn core_to_internal_purpose(k: CorePurposeKind) -> PurposeKind {
-    match k {
-        CorePurposeKind::Interactive => PurposeKind::Interactive,
-        CorePurposeKind::Dreaming => PurposeKind::Dreaming,
-        CorePurposeKind::Embedding => PurposeKind::Embedding,
-        CorePurposeKind::Titling => PurposeKind::Titling,
-    }
 }
 
 fn purposes_referencing(
@@ -1259,7 +1230,7 @@ mod tests {
         let svc = DaemonConnectionsService::new(make_handle_with(cfg));
         let err = svc
             .set_purpose(
-                CorePurposeKind::Interactive,
+                PurposeKind::Interactive,
                 PurposeConfigPayload {
                     connection: "primary".into(),
                     model: "llama3".into(),
@@ -1280,7 +1251,7 @@ mod tests {
             Some(PurposeConfig {
                 connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
                 model: ModelRef::Named("llama3".into()),
-                effort: Some(PurposeEffort::Medium),
+                effort: Some(Effort::Medium),
                 max_context_tokens: None,
             }),
         );
@@ -1687,7 +1658,7 @@ mod tests {
                 Some(PurposeConfig {
                     connection: ConnectionRef::Named(ConnectionId::new("local").unwrap()),
                     model: ModelRef::Named("llama3".into()),
-                    effort: Some(PurposeEffort::High),
+                    effort: Some(Effort::High),
                     max_context_tokens: None,
                 }),
             );

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -22,72 +22,12 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+// `PurposeKind` is the canonical enum in `core::ports::inbound` (#43).
+// Re-exported here so the daemon can reach it through the same path it
+// always has (`crate::purposes::PurposeKind`).
+pub use desktop_assistant_core::ports::inbound::PurposeKind;
+
 use crate::connections::{ConnectionId, ConnectionIdError, ConnectionsMap};
-
-/// Which LLM purpose a [`PurposeConfig`] applies to.
-///
-/// Adding a new purpose is a breaking schema change, not an API one.
-/// When adding a variant, update:
-/// - [`PurposeKind::as_key`] / [`PurposeKind::from_key`]
-/// - [`PurposeKind::all`] (the iteration order)
-/// - the migration logic in `config::maybe_migrate_legacy_purposes`
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum PurposeKind {
-    /// The user-facing chat LLM. Cannot inherit (nothing to inherit from).
-    Interactive,
-    /// Periodic fact extraction (the "dreaming" background task).
-    Dreaming,
-    /// Vector embeddings for memory and retrieval.
-    Embedding,
-    /// Short-title generation for conversations.
-    Titling,
-}
-
-impl PurposeKind {
-    /// Canonical lowercase key used in TOML and error messages.
-    pub fn as_key(self) -> &'static str {
-        match self {
-            Self::Interactive => "interactive",
-            Self::Dreaming => "dreaming",
-            Self::Embedding => "embedding",
-            Self::Titling => "titling",
-        }
-    }
-
-    /// Parse a canonical key back into a [`PurposeKind`].
-    ///
-    /// Inverse of [`Self::as_key`]; kept as public API surface for
-    /// adapters that round-trip key strings (the WS protocol uses
-    /// `as_key` on the way out and would symmetrically use this on the
-    /// way in once we expose a free-form purpose endpoint).
-    #[allow(dead_code)]
-    pub fn from_key(key: &str) -> Option<Self> {
-        match key {
-            "interactive" => Some(Self::Interactive),
-            "dreaming" => Some(Self::Dreaming),
-            "embedding" => Some(Self::Embedding),
-            "titling" => Some(Self::Titling),
-            _ => None,
-        }
-    }
-
-    /// Every purpose kind, in a stable order. Useful for iteration in tests
-    /// and for serialization round-trips.
-    pub fn all() -> [Self; 4] {
-        [
-            Self::Interactive,
-            Self::Dreaming,
-            Self::Embedding,
-            Self::Titling,
-        ]
-    }
-}
-
-impl fmt::Display for PurposeKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_key())
-    }
-}
 
 /// A reference to a [`ConnectionId`] as it appears in a purpose config.
 ///
@@ -115,17 +55,12 @@ pub enum ModelRef {
 /// Reserved sentinel that represents the `primary` inherit token.
 const PRIMARY_SENTINEL: &str = "primary";
 
-/// Effort level hint for a purpose. Mapped to concrete per-connector
-/// parameters by `api_surface::map_effort_to_reasoning_config` at
-/// dispatch time (Anthropic `thinking.budget_tokens`, OpenAI
-/// `reasoning_effort`, Bedrock per-model knobs; Ollama ignores it).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Effort {
-    Low,
-    Medium,
-    High,
-}
+// `Effort` is the canonical enum in `core::ports::inbound` (#43).
+// Re-exported so the daemon's purpose configs can keep referring to
+// `crate::purposes::Effort`. Maps to per-connector knobs at dispatch
+// time (Anthropic `thinking.budget_tokens`, OpenAI `reasoning_effort`,
+// Bedrock per-model; Ollama ignores).
+pub use desktop_assistant_core::ports::inbound::Effort;
 
 /// Raw config for a single purpose, as parsed from TOML.
 ///

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -187,9 +187,7 @@ impl RoutingLlmClient {
         let reasoning = crate::api_surface::map_effort_to_reasoning_config(
             &connector_type,
             &resolved.model_id,
-            resolved
-                .effort
-                .map(crate::api_surface::purpose_effort_to_core),
+            resolved.effort,
         );
         let client = registry
             .client_for(&resolved.connection_id)


### PR DESCRIPTION
## Summary
- Three parallel `PurposeKind` enums (daemon, core, api-model `PurposeKindApi`) and three parallel `Effort` enums collapse to one canonical pair in `core::ports::inbound`. The daemon and api-model re-export from core.
- Conversion glue removed:
  - `api_surface::purpose_effort_to_core` / `core_effort_to_purpose` / `core_to_internal_purpose`
  - `application::effort_to_api` / `effort_from_api` / `api_purpose_kind_to_core`
- Plus the redundant `Effort::from(e)` calls left over from the earlier `SerdeEffort` collapse (#86).
- api-model now depends on core; both crates sit below the adapters in the hex layering, and api-model has no consumers outside this workspace today.

Net ~99 lines of pure boilerplate gone.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace` (all suites green; api-model wire-format tests still pass)
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo fmt --all`

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)