### PR TITLE
llm: extract HTTP error helper into llm-http crate (#46)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,11 +1105,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-assistant-llm-http"
+version = "0.1.0"
+dependencies = [
+ "desktop-assistant-core",
+ "httpmock",
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "desktop-assistant-llm-ollama"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "desktop-assistant-core",
+ "desktop-assistant-llm-http",
  "httpmock",
  "reqwest",
  "serde",
@@ -1126,6 +1137,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "desktop-assistant-core",
+ "desktop-assistant-llm-http",
  "httpmock",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/llm-bedrock",
     "crates/llm-anthropic",
     "crates/llm-ollama",
+    "crates/llm-http",
     "crates/mcp-client",
     "crates/storage",
     "crates/client-common",
@@ -32,6 +33,7 @@ desktop-assistant-llm-anthropic = { path = "crates/llm-anthropic" }
 desktop-assistant-llm-openai = { path = "crates/llm-openai" }
 desktop-assistant-llm-ollama = { path = "crates/llm-ollama" }
 desktop-assistant-llm-bedrock = { path = "crates/llm-bedrock" }
+desktop-assistant-llm-http = { path = "crates/llm-http" }
 desktop-assistant-mcp-client = { path = "crates/mcp-client" }
 desktop-assistant-storage = { path = "crates/storage" }
 desktop-assistant-client-common = { path = "crates/client-common" }

--- a/crates/llm-http/Cargo.toml
+++ b/crates/llm-http/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "desktop-assistant-llm-http"
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-or-later"
+
+[dependencies]
+desktop-assistant-core.workspace = true
+reqwest = { version = "0.13", default-features = false }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }
+httpmock = "0.8"
+reqwest = { version = "0.13" }

--- a/crates/llm-http/src/lib.rs
+++ b/crates/llm-http/src/lib.rs
@@ -1,0 +1,88 @@
+//! Shared HTTP error-handling helpers for the LLM connector crates.
+//!
+//! Issue #46. Every reqwest-based connector (`llm-anthropic`,
+//! `llm-openai`, `llm-ollama`) repeated the same "if non-success, read
+//! the body and bail with a formatted message" idiom at every endpoint.
+//! This crate centralises that pattern.
+//!
+//! Out of scope: the streaming dispatch sites that need
+//! provider-specific routing on the error (context-overflow detection,
+//! rate-limit / quota classification, etc.) keep their bespoke arms —
+//! those produce structured `CoreError` variants
+//! (`ContextOverflow`, `RateLimited`, `QuotaExceeded`, `ModelLoading`,
+//! `ToolsUnsupported`) and aren't worth shoehorning into one helper.
+
+use desktop_assistant_core::CoreError;
+use reqwest::Response;
+
+/// Return `Ok(response)` when the status is 2xx; otherwise consume the
+/// body and return `CoreError::Llm` with a uniform
+/// `"{context} (HTTP {status}): {body}"` detail string.
+///
+/// `context` is a short label like `"OpenAI embeddings API error"` or
+/// `"Ollama model pull API error for 'llama3'"` — i.e. include the
+/// provider name and (when relevant) the endpoint or resource. Body
+/// read failures are surfaced as the literal `"unable to read body"`
+/// so the error message still names the status code even when the
+/// transport drops mid-frame.
+pub async fn bail_for_status(response: Response, context: &str) -> Result<Response, CoreError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|_| "unable to read body".into());
+    Err(CoreError::Llm(format!("{context} (HTTP {status}): {body}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+
+    #[tokio::test]
+    async fn bail_for_status_passes_through_2xx() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/ok");
+            then.status(200).body("hello");
+        });
+
+        let response = reqwest::get(format!("{}/ok", server.base_url()))
+            .await
+            .unwrap();
+        let response = bail_for_status(response, "Test API error").await.unwrap();
+        assert_eq!(response.text().await.unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn bail_for_status_formats_non_2xx_with_context() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/bad");
+            then.status(503).body("upstream gave up");
+        });
+
+        let response = reqwest::get(format!("{}/bad", server.base_url()))
+            .await
+            .unwrap();
+        let err = bail_for_status(response, "Sample API error")
+            .await
+            .unwrap_err();
+        let CoreError::Llm(detail) = err else {
+            panic!("expected CoreError::Llm, got {err:?}");
+        };
+        assert!(
+            detail.contains("Sample API error"),
+            "context label missing: {detail}"
+        );
+        assert!(detail.contains("503"), "status missing: {detail}");
+        assert!(
+            detail.contains("upstream gave up"),
+            "body missing: {detail}"
+        );
+    }
+}

--- a/crates/llm-ollama/Cargo.toml
+++ b/crates/llm-ollama/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 async-trait.workspace = true
 desktop-assistant-core.workspace = true
+desktop-assistant-llm-http.workspace = true
 reqwest = { version = "0.13", features = ["stream", "json"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -114,16 +114,11 @@ impl OllamaClient {
             .await
             .map_err(|e| CoreError::Llm(format!("failed to check Ollama models: {e}")))?;
 
-        if !tags_response.status().is_success() {
-            let status = tags_response.status();
-            let body = tags_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "Ollama model list API error (HTTP {status}): {body}"
-            )));
-        }
+        let tags_response = desktop_assistant_llm_http::bail_for_status(
+            tags_response,
+            "Ollama model list API error",
+        )
+        .await?;
 
         let tags: OllamaTagsResponse = tags_response
             .json()
@@ -155,17 +150,11 @@ impl OllamaClient {
                 CoreError::Llm(format!("failed to pull Ollama model '{}': {e}", self.model))
             })?;
 
-        if !pull_response.status().is_success() {
-            let status = pull_response.status();
-            let body = pull_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "Ollama model pull API error for '{}' (HTTP {status}): {body}",
-                self.model
-            )));
-        }
+        let _ = desktop_assistant_llm_http::bail_for_status(
+            pull_response,
+            &format!("Ollama model pull API error for '{}'", self.model),
+        )
+        .await?;
 
         Ok(())
     }
@@ -184,16 +173,8 @@ impl OllamaClient {
             .await
             .map_err(|e| CoreError::Llm(format!("model tags HTTP request failed: {e}")))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "Ollama tags API error (HTTP {status}): {text}"
-            )));
-        }
+        let response =
+            desktop_assistant_llm_http::bail_for_status(response, "Ollama tags API error").await?;
 
         let tags: OllamaTagsResponse = response
             .json()
@@ -237,16 +218,9 @@ impl OllamaClient {
             .await
             .map_err(|e| CoreError::Llm(format!("embedding HTTP request failed: {e}")))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "Ollama embeddings API error (HTTP {status}): {body}"
-            )));
-        }
+        let response =
+            desktop_assistant_llm_http::bail_for_status(response, "Ollama embeddings API error")
+                .await?;
 
         let parsed: OllamaEmbedResponse = response
             .json()
@@ -465,16 +439,8 @@ impl OllamaClient {
             .await
             .map_err(|e| CoreError::Llm(format!("Ollama /api/tags request failed: {e}")))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "Ollama /api/tags error (HTTP {status}): {body}"
-            )));
-        }
+        let response =
+            desktop_assistant_llm_http::bail_for_status(response, "Ollama /api/tags error").await?;
 
         let tags: OllamaTagsResponse = response
             .json()

--- a/crates/llm-openai/Cargo.toml
+++ b/crates/llm-openai/Cargo.toml
@@ -8,6 +8,7 @@ license = "AGPL-3.0-or-later"
 async-trait.workspace = true
 bytes = "1"
 desktop-assistant-core.workspace = true
+desktop-assistant-llm-http.workspace = true
 reqwest = { version = "0.13", features = ["stream", "json"] }
 serde.workspace = true
 serde_json = "1"

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -129,16 +129,9 @@ impl OpenAiClient {
             .await
             .map_err(|e| CoreError::Llm(format!("embedding HTTP request failed: {e}")))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unable to read body".into());
-            return Err(CoreError::Llm(format!(
-                "OpenAI embeddings API error (HTTP {status}): {body}"
-            )));
-        }
+        let response =
+            desktop_assistant_llm_http::bail_for_status(response, "OpenAI embeddings API error")
+                .await?;
 
         let parsed: EmbeddingResponse = response
             .json()


### PR DESCRIPTION
## Summary
Adds a new \`desktop-assistant-llm-http\` crate with a single \`bail_for_status(response, context)\` helper that consolidates the "if non-success, read body, return \`CoreError::Llm\` with formatted detail" pattern that was duplicated across the reqwest-based connectors.

Updated 6 simple sites:
- **llm-openai:** embeddings endpoint
- **llm-ollama:** model list, model pull, tags lookup, embeddings, list_models

Left untouched: the 3 streaming dispatch sites (anthropic / openai / ollama) where each connector does provider-specific routing on the error — context-overflow detection, rate-limit / quota classification, model-loading and tools-unsupported signals. Those produce structured \`CoreError\` variants and aren't a fit for one helper.

The bonus problem from the original ticket (\`is_retryable_error\` string-sniffing for "429"/"503") was already resolved by an earlier change — the connector boundary now maps 429s into a structured \`CoreError::RateLimited\` variant and the retry classifier matches on that.

Net ~25 lines saved at the call sites; helper plus tests are 95 lines in the new crate.

## Test plan
- [x] \`cargo build --workspace --all-targets\`
- [x] \`cargo test -p desktop-assistant-llm-http\` (2 new tests cover the 2xx pass-through and the non-2xx formatted error)
- [x] \`cargo test --workspace\` (no regressions)
- [x] \`cargo fmt --all\`

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)