### PR TITLE
security: constant-time compare for static-password login (#37)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "time",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -32,6 +32,7 @@ keyring = "3"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "webpki-roots"] }
 libc = "0.2"
+subtle = "2"
 zeroize = "1"
 rcgen.workspace = true
 rustls.workspace = true

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -116,7 +116,15 @@ impl<S: SettingsService + 'static> ws::WsLoginService for WsBasicLogin<S> {
         }
 
         match &self.mode {
-            WsLoginMode::StaticPassword(expected) => password == expected,
+            // Constant-time compare so a byte-by-byte timing attacker
+            // can't peel the password one prefix at a time. Mostly
+            // theoretical for local-loopback HTTPS, but trivial to
+            // get right (#37). `ct_eq` returns false on length
+            // mismatch without short-circuiting per byte.
+            WsLoginMode::StaticPassword(expected) => {
+                use subtle::ConstantTimeEq;
+                password.as_bytes().ct_eq(expected.as_bytes()).into()
+            }
             WsLoginMode::SystemPassword => {
                 match config::authenticate_os_user_password(username, password) {
                     Ok(valid) => valid,


### PR DESCRIPTION
## Summary
\`WsBasicLogin::authenticate_basic\` now uses \`subtle::ConstantTimeEq\` on the static-password branch instead of \`==\`. A byte-by-byte timing attacker can no longer peel the password one prefix at a time.

Mostly theoretical for local-loopback HTTPS (the only transport this matches today), but trivial to get right and removes a class of sidechannel from the surface. \`subtle\` was already in the lockfile transitively; promoted to a direct daemon dep.

## Test plan
- [x] \`cargo build -p desktop-assistant-daemon\`
- [x] \`cargo test -p desktop-assistant-daemon\` (no regressions)
- [x] \`cargo fmt --all\`

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)