### PR TITLE
deps: migrate rustls-pemfile to rustls-pki-types PEM parsing (#20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
  "futures",
  "reqwest",
  "rustls 0.23.37",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -1038,7 +1038,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls 0.23.37",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "subtle",
@@ -3064,15 +3064,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,6 @@ serde_json = "1"
 toml = "1"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
-rustls-pemfile = "2"
+rustls-pki-types = { version = "1", features = ["std"] }
 tokio-rustls = "0.26"
 chrono = { version = "0.4", features = ["clock"] }

--- a/crates/client-common/Cargo.toml
+++ b/crates/client-common/Cargo.toml
@@ -18,7 +18,7 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
+rustls-pki-types = { workspace = true }
 tracing.workspace = true
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -417,9 +417,12 @@ fn build_tls_connector(ca_cert_path: Option<&Path>) -> Result<tokio_tungstenite:
     if let Some(ca_path) = ca_cert_path {
         let pem_bytes = std::fs::read(ca_path)
             .map_err(|e| anyhow!("reading CA cert {}: {e}", ca_path.display()))?;
+        use rustls::pki_types::pem::PemObject;
         let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-            rustls_pemfile::certs(&mut std::io::BufReader::new(pem_bytes.as_slice()))
-                .collect::<std::result::Result<Vec<_>, _>>()?;
+            rustls::pki_types::CertificateDer::pem_reader_iter(&mut std::io::BufReader::new(
+                pem_bytes.as_slice(),
+            ))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         for cert in certs {
             root_store.add(cert)?;
         }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -36,7 +36,7 @@ subtle = "2"
 zeroize = "1"
 rcgen.workspace = true
 rustls.workspace = true
-rustls-pemfile.workspace = true
+rustls-pki-types.workspace = true
 tokio-rustls.workspace = true
 time = "0.3"
 

--- a/crates/daemon/src/tls.rs
+++ b/crates/daemon/src/tls.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, anyhow};
 use rcgen::{
     BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
 const CA_CERT_FILENAME: &str = "ca.pem";
@@ -167,7 +168,7 @@ fn ensure_server_cert(
 /// expiry and a malformed-cert churn loop.
 fn is_pem_cert_expired(pem_bytes: &[u8]) -> bool {
     let mut reader = std::io::BufReader::new(pem_bytes);
-    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_reader_iter(&mut reader)
         .filter_map(|r| r.ok())
         .collect();
 
@@ -328,14 +329,13 @@ fn build_server_config(
     key_pem: &[u8],
 ) -> anyhow::Result<Arc<rustls::ServerConfig>> {
     let certs: Vec<CertificateDer<'static>> =
-        rustls_pemfile::certs(&mut std::io::BufReader::new(cert_chain_pem))
+        CertificateDer::pem_reader_iter(&mut std::io::BufReader::new(cert_chain_pem))
             .collect::<Result<Vec<_>, _>>()
             .context("parsing certificate PEM")?;
 
     let key: PrivateKeyDer<'static> =
-        rustls_pemfile::private_key(&mut std::io::BufReader::new(key_pem))
-            .context("parsing private key PEM")?
-            .ok_or_else(|| anyhow!("no private key found in PEM"))?;
+        PrivateKeyDer::from_pem_reader(&mut std::io::BufReader::new(key_pem))
+            .context("parsing private key PEM")?;
 
     let config = rustls::ServerConfig::builder()
         .with_no_client_auth()


### PR DESCRIPTION
## Summary
\`rustls-pemfile\` is unmaintained as of RUSTSEC-2025-0134. The PEM parsing API moved into \`rustls-pki-types\` itself, exposed via the \`PemObject\` trait — \`CertificateDer::pem_reader_iter(...)\` and \`PrivateKeyDer::from_pem_reader(...)\` cover everything we used.

Updates:
- workspace dep: drop \`rustls-pemfile = "2"\`, add \`rustls-pki-types = { version = "1", features = ["std"] }\`.
- \`crates/daemon/src/tls.rs\` — cert chain parsing for the expiry check and the server-config builder; private-key load.
- \`crates/client-common/src/ws_client.rs\` — CA cert load for the WSS TLS connector.

\`rustls-pemfile\` is now absent from \`Cargo.lock\`. The \`rsa@0.9.10\` Marvin Attack item from the same scan stays as upstream-blocked (transitive only, no direct dep).

## Test plan
- [x] \`cargo build --workspace --all-targets\`
- [x] \`cargo test --workspace\` (no regressions)
- [x] \`cargo fmt --all\`
- [x] \`grep "rustls-pemfile" Cargo.lock\` — absent

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)