### PR TITLE
storage: multi-tenant schema — add user_id to personal-data tables (#102)

### DIFF
--- a/crates/storage/migrations/016_multi_tenant_user_id.sql
+++ b/crates/storage/migrations/016_multi_tenant_user_id.sql
@@ -1,0 +1,151 @@
+-- Issue #102: multi-tenant schema — add `user_id` to personal-data tables.
+--
+-- Every personal-data table gains a `user_id TEXT NOT NULL` column so the
+-- daemon can scope queries by user (issue #105 wires the extraction from
+-- JWT `sub`). Single-tenant desktop installs collapse to the sentinel
+-- `'default'` user_id, which is also the backfill value for pre-existing
+-- rows. The auth-jwt-shared-crate branch carries `sub: String` in its
+-- `Claims` struct, so `TEXT` matches the eventual extraction shape.
+--
+-- Backfill strategy
+--   We use the standard `ADD COLUMN … DEFAULT 'default' NOT NULL` form,
+--   which Postgres materializes for existing rows. The DEFAULT is left
+--   in place so single-tenant deploys continue to work without #105 —
+--   inserts that omit `user_id` resolve to `'default'`. #105 will drop
+--   the defaults once every call site supplies a real `user_id`. The
+--   regression test `inserting_conversation_without_user_id_fails`
+--   explicitly drops the default before its INSERT to prove the NOT
+--   NULL constraint is in place.
+--
+-- Reversibility
+--   The existing migration tooling (`pool::run_migrations`) is forward-
+--   only — it has no `down` concept. Reversing this change requires a
+--   manual `ALTER TABLE … DROP COLUMN user_id` plus dropping the new
+--   indexes and restoring `tag_registry`'s old single-column PRIMARY KEY.
+--   The PR description records this as a known limitation; future
+--   migration tooling (sqlx-cli or refinery) would gain a paired
+--   down-migration without changing the forward shape.
+--
+-- Idempotency
+--   Every ALTER uses `IF NOT EXISTS` / DO-block guards so a partial
+--   apply (or a fresh-install re-apply) is safe. The tag_registry PK
+--   swap checks the current PK shape before mutating.
+
+-- ---------------------------------------------------------------------------
+-- conversations
+-- ---------------------------------------------------------------------------
+ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+-- Per-user listing ordered by recency — the conversation list hot path.
+CREATE INDEX IF NOT EXISTS conversations_user_id_updated_at_idx
+    ON conversations (user_id, updated_at DESC);
+
+-- Per-user active (non-archived) filter — the dreaming archival scan and
+-- the UI's "active conversations" view both need this.
+CREATE INDEX IF NOT EXISTS conversations_user_id_archived_at_idx
+    ON conversations (user_id, archived_at);
+
+-- ---------------------------------------------------------------------------
+-- messages
+-- ---------------------------------------------------------------------------
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+-- Per-user, per-conversation, ordered scan — every message-load path.
+-- This duplicates information already in `conversations.user_id` (each
+-- message inherits its conversation's user) but lets us scope queries
+-- without a JOIN, and the index keeps the user check cheap.
+CREATE INDEX IF NOT EXISTS messages_user_id_conv_ordinal_idx
+    ON messages (user_id, conversation_id, ordinal);
+
+-- ---------------------------------------------------------------------------
+-- knowledge_base — covers both KB entries and what was historically
+-- `factual_memory` (consolidated into the same table; see
+-- `migrate_json::LegacyMemory`).
+-- ---------------------------------------------------------------------------
+ALTER TABLE knowledge_base
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+-- Per-user listing / pagination by recency.
+CREATE INDEX IF NOT EXISTS knowledge_base_user_id_created_at_idx
+    ON knowledge_base (user_id, created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- message_summaries — collapsible summary anchors, child of conversations.
+-- ---------------------------------------------------------------------------
+ALTER TABLE message_summaries
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+CREATE INDEX IF NOT EXISTS message_summaries_user_id_conv_idx
+    ON message_summaries (user_id, conversation_id);
+
+-- ---------------------------------------------------------------------------
+-- dreaming_watermarks — per-conversation extraction watermarks.
+-- ---------------------------------------------------------------------------
+ALTER TABLE dreaming_watermarks
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+CREATE INDEX IF NOT EXISTS dreaming_watermarks_user_id_idx
+    ON dreaming_watermarks (user_id);
+
+-- ---------------------------------------------------------------------------
+-- tag_registry — formal tag vocabulary learned during dreaming
+-- consolidation (#108). Tag names must now be unique per user, not
+-- globally, so the PRIMARY KEY moves from `(name)` to `(user_id, name)`.
+-- ---------------------------------------------------------------------------
+ALTER TABLE tag_registry
+    ADD COLUMN IF NOT EXISTS user_id TEXT NOT NULL DEFAULT 'default';
+
+-- Swap the PK from `(name)` to `(user_id, name)`. Guarded by inspecting
+-- the current PK so a re-run is a no-op. The `tag_registry` table's
+-- self-referential `deprecated_for_tag TEXT REFERENCES tag_registry(name)`
+-- FK had to be dropped before we could mutate the PK; we recreate a
+-- broader (user_id, name) reference afterward so cross-user deprecation
+-- links can't form. Existing rows backfilled to 'default' keep their
+-- self-references intact because the rewritten FK lands inside the
+-- 'default' user_id partition.
+DO $$
+DECLARE
+    current_pk_cols TEXT;
+    dep_fk_name     TEXT;
+BEGIN
+    SELECT string_agg(a.attname, ',' ORDER BY array_position(i.indkey, a.attnum))
+      INTO current_pk_cols
+      FROM pg_index i
+      JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+     WHERE i.indrelid = 'tag_registry'::regclass
+       AND i.indisprimary;
+
+    IF current_pk_cols = 'name' THEN
+        -- Drop the old self-referential FK before reshaping the PK.
+        SELECT conname
+          INTO dep_fk_name
+          FROM pg_constraint
+         WHERE conrelid = 'tag_registry'::regclass
+           AND contype  = 'f';
+        IF dep_fk_name IS NOT NULL THEN
+            EXECUTE format('ALTER TABLE tag_registry DROP CONSTRAINT %I', dep_fk_name);
+        END IF;
+
+        ALTER TABLE tag_registry DROP CONSTRAINT tag_registry_pkey;
+        ALTER TABLE tag_registry ADD PRIMARY KEY (user_id, name);
+
+        -- Recreate the deprecation link inside the user's own namespace.
+        -- A tag can only deprecate another tag belonging to the same
+        -- user — multi-tenant isolation forbids cross-user pointers.
+        ALTER TABLE tag_registry
+            ADD CONSTRAINT tag_registry_deprecated_for_tag_fkey
+            FOREIGN KEY (user_id, deprecated_for_tag)
+            REFERENCES tag_registry (user_id, name)
+            ON DELETE SET NULL;
+    END IF;
+END $$;
+
+-- The pre-existing partial index `tag_registry_active_idx` on `(name)`
+-- still works for lookups within a single user when combined with a
+-- `user_id =` filter, but a leading-user_id variant is cheaper for the
+-- common "list this user's active tags" scan.
+CREATE INDEX IF NOT EXISTS tag_registry_user_id_active_idx
+    ON tag_registry (user_id, name)
+    WHERE deprecated_for_tag IS NULL;

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -124,5 +124,14 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Multi-tenant schema (issue #102) — every personal-data table gains
+    // `user_id NOT NULL` plus a `(user_id, …)` composite index for the
+    // hot query paths #105's scoping will use. Pre-existing rows are
+    // backfilled to the sentinel `'default'` user so single-tenant
+    // installs keep working without auth changes.
+    sqlx::raw_sql(include_str!("../migrations/016_multi_tenant_user_id.sql"))
+        .execute(pool)
+        .await?;
+
     Ok(())
 }

--- a/crates/storage/tests/multi_tenant_schema.rs
+++ b/crates/storage/tests/multi_tenant_schema.rs
@@ -427,6 +427,25 @@ async fn composite_user_id_index_exists_on_message_summaries() {
 // This proves the schema is in place even before #105 updates queries.
 // ---------------------------------------------------------------------------
 
+/// Running `run_migrations` a second time against an already-migrated
+/// schema must be a no-op — both the daemon and the dreaming worker
+/// invoke it at startup, and existing installs already see migrations
+/// 001-015 re-run cleanly on every boot. The multi-tenant migration
+/// has to preserve that contract.
+#[tokio::test]
+async fn migrations_are_idempotent() {
+    with_fixture("migrations_are_idempotent", |fx| async move {
+        fx.migrate().await;
+        // Second pass: must not raise (no duplicate-column errors, no
+        // duplicate-index errors, no PK-already-exists errors).
+        fx.migrate().await;
+        // Sanity-check the second pass left the column in place.
+        assert!(column_exists(&fx.pool, &fx.schema, "conversations", "user_id").await);
+        fx
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn inserting_conversation_without_user_id_fails() {
     with_fixture("inserting_conversation_without_user_id_fails", |fx| async move {

--- a/crates/storage/tests/multi_tenant_schema.rs
+++ b/crates/storage/tests/multi_tenant_schema.rs
@@ -1,0 +1,494 @@
+//! Integration tests for the multi-tenant schema migration (issue #102).
+//!
+//! These tests exercise the live migration tooling against a real Postgres
+//! instance with the `pgvector` extension available. Each test creates a
+//! private schema, points the connection pool's `search_path` at it, runs
+//! the embedded migrations, asserts schema/data invariants, then drops the
+//! schema on teardown.
+//!
+//! ## Running locally
+//!
+//! Set `TEST_DATABASE_URL` to a Postgres URL where the connecting role can
+//! `CREATE SCHEMA` and `CREATE EXTENSION vector`. Example using the
+//! pgvector docker image:
+//!
+//! ```sh
+//! podman run -d --name pg-test -e POSTGRES_PASSWORD=test -p 15432:5432 \
+//!     docker.io/pgvector/pgvector:pg17
+//! TEST_DATABASE_URL="postgres://postgres:test@localhost:15432/postgres" \
+//!     cargo test -p desktop-assistant-storage --test multi_tenant_schema
+//! ```
+//!
+//! When `TEST_DATABASE_URL` is unset (the default for `cargo test`), every
+//! test pass-skips with a log line so the suite stays green without a DB.
+
+use std::sync::Arc;
+
+use desktop_assistant_storage::run_migrations;
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+/// Sentinel user_id used for backfilling pre-multi-tenant rows. Must
+/// match the value the migration writes — single-tenant desktop deploys
+/// collapse to this id until JWT-based extraction (issue #105) lands.
+const DEFAULT_USER_ID: &str = "default";
+
+/// RAII guard that owns a freshly-created Postgres schema and a pool
+/// whose connections have `search_path` pinned to it. Dropping the
+/// guard drops the schema on a best-effort basis.
+struct SchemaFixture {
+    pool: PgPool,
+    schema: String,
+    admin_url: String,
+}
+
+impl SchemaFixture {
+    /// Build a fixture against `TEST_DATABASE_URL`, or `None` if the env
+    /// var is unset. Tests should pass-skip in the `None` case so the
+    /// suite stays green without a DB.
+    async fn try_new() -> Option<Self> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let schema = format!("mt_test_{}", Uuid::now_v7().simple());
+
+        // Admin connection just for schema lifecycle, kept short-lived
+        // so the per-test pool owns the only long-running connections.
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+            .execute(&admin)
+            .await
+            .expect("create test schema");
+        admin.close().await;
+
+        // Per-test pool with `search_path` pinned via `after_connect` so
+        // every connection (including those opened mid-test) lands in
+        // the right schema. `public` stays on the path so the
+        // `vector` type from pgvector remains resolvable.
+        let schema_for_hook = Arc::new(schema.clone());
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .after_connect(move |conn, _meta| {
+                let schema = Arc::clone(&schema_for_hook);
+                Box::pin(async move {
+                    let sql = format!("SET search_path TO \"{schema}\", public");
+                    sqlx::query(&sql).execute(conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect per-test pool");
+
+        Some(Self {
+            pool,
+            schema,
+            admin_url: url,
+        })
+    }
+
+    async fn migrate(&self) {
+        run_migrations(&self.pool)
+            .await
+            .expect("run_migrations succeeds against test schema");
+    }
+
+    /// Drop the schema on a best-effort basis — failures here don't fail
+    /// the test, but they do log so a developer can clean up manually.
+    async fn cleanup(self) {
+        self.pool.close().await;
+        let admin = match PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&self.admin_url)
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("cleanup: failed to reconnect to drop schema {}: {e}", self.schema);
+                return;
+            }
+        };
+        if let Err(e) = sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", self.schema))
+            .execute(&admin)
+            .await
+        {
+            eprintln!("cleanup: failed to drop schema {}: {e}", self.schema);
+        }
+        admin.close().await;
+    }
+}
+
+/// Run `body` with a fresh schema fixture, skipping the test (with a log
+/// line) when `TEST_DATABASE_URL` is unset. Cleanup runs even if `body`
+/// panics — without this every failed test leaks a schema.
+async fn with_fixture<F, Fut>(test_name: &str, body: F)
+where
+    F: FnOnce(SchemaFixture) -> Fut,
+    Fut: std::future::Future<Output = SchemaFixture>,
+{
+    let Some(fixture) = SchemaFixture::try_new().await else {
+        eprintln!(
+            "skip: TEST_DATABASE_URL not set; {test_name} pass-skipped. \
+             Set it to a Postgres URL with pgvector available to run."
+        );
+        return;
+    };
+    let fixture = body(fixture).await;
+    fixture.cleanup().await;
+}
+
+/// Returns true iff the named column exists on the named table inside
+/// the connection's current `search_path` first schema. Restricting to
+/// the test schema (rather than `current_schema()`) keeps the assertion
+/// honest if a stray `public` table with the same name ever appears.
+async fn column_exists(pool: &PgPool, schema: &str, table: &str, column: &str) -> bool {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::BIGINT FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2 AND column_name = $3",
+    )
+    .bind(schema)
+    .bind(table)
+    .bind(column)
+    .fetch_one(pool)
+    .await
+    .expect("query information_schema.columns");
+    row.0 > 0
+}
+
+/// Whether `column` on `table` is declared NOT NULL.
+async fn column_is_not_null(pool: &PgPool, schema: &str, table: &str, column: &str) -> bool {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT is_nullable FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2 AND column_name = $3",
+    )
+    .bind(schema)
+    .bind(table)
+    .bind(column)
+    .fetch_optional(pool)
+    .await
+    .expect("query is_nullable");
+    matches!(row, Some((s,)) if s == "NO")
+}
+
+/// True iff *any* index on `table` covers `(user_id, …)` as its leading
+/// column. We don't pin the exact index name — only the property that
+/// matters for the hot query path.
+async fn has_user_id_leading_index(pool: &PgPool, schema: &str, table: &str) -> bool {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::BIGINT
+         FROM pg_indexes i
+         JOIN pg_class c     ON c.relname = i.indexname
+         JOIN pg_index pi    ON pi.indexrelid = c.oid
+         JOIN pg_class t     ON t.oid = pi.indrelid
+         JOIN pg_namespace n ON n.oid = t.relnamespace
+         JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = pi.indkey[0]
+         WHERE n.nspname = $1 AND t.relname = $2 AND a.attname = 'user_id'",
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_one(pool)
+    .await
+    .expect("query for user_id-leading index");
+    row.0 > 0
+}
+
+// ---------------------------------------------------------------------------
+// Schema shape — every personal-data SQL table gains `user_id NOT NULL`.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_conversations() {
+    with_fixture(
+        "migration_adds_user_id_column_to_conversations",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(
+                column_exists(&fx.pool, &fx.schema, "conversations", "user_id").await,
+                "conversations.user_id should exist after migration"
+            );
+            assert!(
+                column_is_not_null(&fx.pool, &fx.schema, "conversations", "user_id").await,
+                "conversations.user_id should be NOT NULL"
+            );
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_messages() {
+    with_fixture("migration_adds_user_id_column_to_messages", |fx| async move {
+        fx.migrate().await;
+        assert!(column_exists(&fx.pool, &fx.schema, "messages", "user_id").await);
+        assert!(column_is_not_null(&fx.pool, &fx.schema, "messages", "user_id").await);
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_knowledge_base() {
+    with_fixture(
+        "migration_adds_user_id_column_to_knowledge_base",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(column_exists(&fx.pool, &fx.schema, "knowledge_base", "user_id").await);
+            assert!(column_is_not_null(&fx.pool, &fx.schema, "knowledge_base", "user_id").await);
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_message_summaries() {
+    with_fixture(
+        "migration_adds_user_id_column_to_message_summaries",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(column_exists(&fx.pool, &fx.schema, "message_summaries", "user_id").await);
+            assert!(
+                column_is_not_null(&fx.pool, &fx.schema, "message_summaries", "user_id").await
+            );
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_dreaming_watermarks() {
+    with_fixture(
+        "migration_adds_user_id_column_to_dreaming_watermarks",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(column_exists(&fx.pool, &fx.schema, "dreaming_watermarks", "user_id").await);
+            assert!(
+                column_is_not_null(&fx.pool, &fx.schema, "dreaming_watermarks", "user_id").await
+            );
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn migration_adds_user_id_column_to_tag_registry() {
+    with_fixture(
+        "migration_adds_user_id_column_to_tag_registry",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(column_exists(&fx.pool, &fx.schema, "tag_registry", "user_id").await);
+            assert!(column_is_not_null(&fx.pool, &fx.schema, "tag_registry", "user_id").await);
+            fx
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Backfill — existing rows inserted before the migration get the sentinel id.
+// ---------------------------------------------------------------------------
+
+/// Simulate a "pre-migration" database state by running the legacy schema
+/// migrations only, inserting fixture rows, then running the full
+/// `run_migrations()` (which now includes the multi-tenant migration).
+/// The fixture rows must come out with `user_id = DEFAULT_USER_ID`.
+#[tokio::test]
+async fn migration_backfills_existing_conversation_rows_to_default_user() {
+    with_fixture(
+        "migration_backfills_existing_conversation_rows_to_default_user",
+        |fx| async move {
+            // 1. Stage the database to look like an install from before #102:
+            //    only the pre-multi-tenant migrations exist, so
+            //    `conversations` has no `user_id` column.
+            run_pre_multitenant_migrations(&fx.pool).await;
+
+            sqlx::query(
+                "INSERT INTO conversations (id, title) VALUES ('pre-1', 'Legacy Chat')",
+            )
+            .execute(&fx.pool)
+            .await
+            .expect("seed legacy conversation row");
+
+            // 2. Now run the full migration set — the multi-tenant migration
+            //    must backfill the legacy row.
+            fx.migrate().await;
+
+            let row: (String,) =
+                sqlx::query_as("SELECT user_id FROM conversations WHERE id = 'pre-1'")
+                    .fetch_one(&fx.pool)
+                    .await
+                    .expect("read back legacy conversation");
+            assert_eq!(
+                row.0, DEFAULT_USER_ID,
+                "pre-existing conversation row should be backfilled to '{DEFAULT_USER_ID}'"
+            );
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn migration_backfills_existing_knowledge_base_rows_to_default_user() {
+    with_fixture(
+        "migration_backfills_existing_knowledge_base_rows_to_default_user",
+        |fx| async move {
+            run_pre_multitenant_migrations(&fx.pool).await;
+
+            sqlx::query(
+                "INSERT INTO knowledge_base (id, content) VALUES ('kb-pre-1', 'legacy fact')",
+            )
+            .execute(&fx.pool)
+            .await
+            .expect("seed legacy KB row");
+
+            fx.migrate().await;
+
+            let row: (String,) =
+                sqlx::query_as("SELECT user_id FROM knowledge_base WHERE id = 'kb-pre-1'")
+                    .fetch_one(&fx.pool)
+                    .await
+                    .expect("read back legacy KB row");
+            assert_eq!(row.0, DEFAULT_USER_ID);
+            fx
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Composite indexes — every personal-data table has a `(user_id, …)` index
+// for the hot query paths #105's scoping will use.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn composite_user_id_index_exists_on_conversations() {
+    with_fixture(
+        "composite_user_id_index_exists_on_conversations",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(
+                has_user_id_leading_index(&fx.pool, &fx.schema, "conversations").await,
+                "conversations needs a `(user_id, …)` index for per-user listing"
+            );
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn composite_user_id_index_exists_on_messages() {
+    with_fixture(
+        "composite_user_id_index_exists_on_messages",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(has_user_id_leading_index(&fx.pool, &fx.schema, "messages").await);
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn composite_user_id_index_exists_on_knowledge_base() {
+    with_fixture(
+        "composite_user_id_index_exists_on_knowledge_base",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(has_user_id_leading_index(&fx.pool, &fx.schema, "knowledge_base").await);
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn composite_user_id_index_exists_on_message_summaries() {
+    with_fixture(
+        "composite_user_id_index_exists_on_message_summaries",
+        |fx| async move {
+            fx.migrate().await;
+            assert!(has_user_id_leading_index(&fx.pool, &fx.schema, "message_summaries").await);
+            fx
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard — NOT NULL means inserts without user_id fail loudly.
+// This proves the schema is in place even before #105 updates queries.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inserting_conversation_without_user_id_fails() {
+    with_fixture("inserting_conversation_without_user_id_fails", |fx| async move {
+        fx.migrate().await;
+
+        // Drop the default if the migration left one in place — without
+        // this the test would silently pass on the sentinel. Idempotent
+        // and a no-op if no default exists.
+        sqlx::query("ALTER TABLE conversations ALTER COLUMN user_id DROP DEFAULT")
+            .execute(&fx.pool)
+            .await
+            .ok();
+
+        let err = sqlx::query(
+            "INSERT INTO conversations (id, title) VALUES ('needs-user', 'should fail')",
+        )
+        .execute(&fx.pool)
+        .await
+        .expect_err("insert without user_id should fail under multi-tenant schema");
+
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("user_id") || msg.contains("not-null") || msg.contains("null value"),
+            "expected a not-null violation on user_id, got: {err}"
+        );
+        fx
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: hand-roll the pre-multi-tenant migration set so backfill tests
+// can stage a "legacy" DB before running the full migration chain.
+// Mirrors `run_migrations` up to migration 015 — the ordering and the
+// per-statement boundaries match.
+// ---------------------------------------------------------------------------
+
+async fn run_pre_multitenant_migrations(pool: &PgPool) {
+    let migrations: &[&str] = &[
+        include_str!("../migrations/001_initial_schema.sql"),
+        // pgvector must be created before any vector column references it.
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        include_str!("../migrations/002_vector_tables.sql"),
+        include_str!("../migrations/002b_tool_definitions.sql"),
+        include_str!("../migrations/003_vector_indexes.sql"),
+        include_str!("../migrations/004_embedding_model_tracking.sql"),
+        include_str!("../migrations/005_uuidv7_ids.sql"),
+        include_str!("../migrations/006_dreaming_watermarks.sql"),
+        include_str!("../migrations/007_chunked_embeddings.sql"),
+        include_str!("../migrations/008_message_summaries.sql"),
+        include_str!("../migrations/009_conversation_archived_at.sql"),
+        include_str!("../migrations/010_fix_damaged_embeddings.sql"),
+        include_str!("../migrations/011_conversation_last_model.sql"),
+        include_str!("../migrations/012_conversation_active_task.sql"),
+        include_str!("../migrations/013_conversation_message_fts.sql"),
+        include_str!("../migrations/014_tag_registry.sql"),
+        include_str!("../migrations/015_knowledge_base_review_columns.sql"),
+    ];
+    for sql in migrations {
+        sqlx::raw_sql(sql)
+            .execute(pool)
+            .await
+            .expect("pre-multi-tenant migration step succeeds");
+    }
+}


### PR DESCRIPTION
Closes #102.

## Summary

Adds migration **016_multi_tenant_user_id.sql** which extends every
SQL-backed personal-data table with `user_id TEXT NOT NULL`, plus a
leading `(user_id, …)` composite index for each hot query path. Existing
rows are backfilled to the sentinel `'default'` user_id so single-tenant
desktop installs keep working without auth changes, until #105 wires
`user_id` extraction from JWT `sub` and updates the queries.

The column `DEFAULT 'default'` is left in place after backfill so that
inserts written for the single-tenant world keep succeeding; #105 will
drop the default once every call site supplies a real `user_id`. The
regression test `inserting_conversation_without_user_id_fails` drops
the default before its INSERT to prove the `NOT NULL` constraint is
real.

Tables updated:
- `conversations` — indexes on `(user_id, updated_at DESC)` and `(user_id, archived_at)`
- `messages` — index on `(user_id, conversation_id, ordinal)`
- `knowledge_base` — index on `(user_id, created_at DESC)` (covers historical `factual_memory` data, which was consolidated into this table)
- `message_summaries` — index on `(user_id, conversation_id)` (the issue's "conversation summaries" bullet)
- `dreaming_watermarks` — index on `(user_id)`
- `tag_registry` — `PRIMARY KEY` moves from `(name)` to `(user_id, name)`; the self-referential `deprecated_for_tag` FK is rebound to `(user_id, deprecated_for_tag) → (user_id, name)` so cross-user deprecation pointers cannot form

The "conversation_search index" bullet in the issue is covered by adding `user_id` to both `messages` and `conversations`: the FTS lives on `tsv` generated columns on those tables, so per-user scoping inherits from the base tables.

## Out of scope — follow-up issue needed

Per the contributor guidance and the issue body, three of the listed
items live in `daemon.toml` / `mcp.toml` today and have no SQL table to
extend yet:

- **Model preferences** — partial state lives in `conversations.last_model_selection` JSONB (already gets `user_id` here), but the user-default model preferences referenced by the issue live in `daemon.toml`.
- **Connection definitions** — `daemon.toml`.
- **MCP server config** — `mcp.toml`.

Moving these into SQL with `user_id` is a meaningful refactor that
touches the daemon config layer, not the storage crate. Recommend a
follow-up issue: **"move model/connection/MCP config from TOML to SQL
with user_id"** that builds on this schema. `tool_definitions` is
similarly deferred: `is_core = TRUE` rows are system-shared, MCP-
registered rows are per-server, and the right ownership shape resolves
once the MCP-config move lands.

## Reversibility

The existing migration tooling (`pool::run_migrations`) is forward-only
— it has no `down` concept. The migration header documents that
manual reversal requires `ALTER TABLE … DROP COLUMN user_id`, dropping
the new indexes, and restoring `tag_registry`'s old single-column
`PRIMARY KEY`. A future move to `sqlx-cli` or `refinery` would gain a
paired down-migration without changing the forward shape.

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace` succeeds (all 35 test binaries green)
- [x] Multi-tenant schema tests pass against live Postgres + pgvector
- [x] Multi-tenant schema tests pass-skip when `TEST_DATABASE_URL` is unset (so CI without a DB stays green)
- [x] `cargo clippy -p desktop-assistant-storage --tests` is clean for new code
- [x] Migration is idempotent (`migrations_are_idempotent` exercises double-apply)
- [x] Pre-existing rows backfill to `'default'` (`migration_backfills_existing_*` tests stage legacy rows before running the full migration chain)

To run the live tests locally:

```sh
podman run -d --name pg-test -e POSTGRES_PASSWORD=test -p 15432:5432 \
    docker.io/pgvector/pgvector:pg17
TEST_DATABASE_URL="postgres://postgres:test@localhost:15432/postgres" \
    cargo test -p desktop-assistant-storage --test multi_tenant_schema
```

## Constraints honored

- Did not update existing queries to filter by `user_id` — that is #105's job.
- Did not touch `core` (#109), `api-model` (#110), or `auth-jwt` (#100, already merged) crates.
- Did not move TOML configs into SQL — scoped out with a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)