### PR TITLE
auth: ship local JWT minter with peer-cred and group gate (#101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +845,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +898,12 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1153,6 +1249,23 @@ dependencies = [
  "tracing",
  "uuid",
  "zbus",
+]
+
+[[package]]
+name = "desktop-assistant-jwt-minter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "desktop-assistant-auth-jwt",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2264,6 +2377,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2727,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -3804,6 +3929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4476,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/mcp-client",
     "crates/storage",
     "crates/client-common",
+    "crates/jwt-minter",
 ]
 
 [workspace.dependencies]

--- a/crates/jwt-minter/Cargo.toml
+++ b/crates/jwt-minter/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "desktop-assistant-jwt-minter"
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-or-later"
+
+[[bin]]
+name = "adelie-mint"
+path = "src/main.rs"
+
+[lib]
+name = "desktop_assistant_jwt_minter"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow.workspace = true
+desktop-assistant-auth-jwt = { path = "../auth-jwt" }
+libc = "0.2"
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+clap = { version = "4", features = ["derive", "env"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/jwt-minter/src/config.rs
+++ b/crates/jwt-minter/src/config.rs
@@ -1,0 +1,51 @@
+//! Minter configuration knobs.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Defaults that match the daemon's expectations
+/// (`crates/daemon/src/config/jwt.rs`).
+pub const DEFAULT_ISSUER: &str = "org.desktopAssistant.local";
+pub const DEFAULT_AUDIENCE: &str = "desktop-assistant-ws";
+pub const DEFAULT_TTL_SECS: u64 = 15 * 60;
+pub const MIN_TTL_SECS: u64 = 60;
+pub const MAX_TTL_SECS: u64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone)]
+pub struct MintConfig {
+    pub signing_key_path: PathBuf,
+    pub issuer: String,
+    pub default_audience: String,
+    pub default_ttl: Duration,
+    pub min_ttl: Duration,
+    pub max_ttl: Duration,
+}
+
+impl MintConfig {
+    /// Build a default config rooted at the daemon's conventional
+    /// signing-key path.
+    pub fn with_default_paths() -> Self {
+        Self {
+            signing_key_path: desktop_assistant_auth_jwt::default_signing_key_path(),
+            issuer: DEFAULT_ISSUER.to_string(),
+            default_audience: DEFAULT_AUDIENCE.to_string(),
+            default_ttl: Duration::from_secs(DEFAULT_TTL_SECS),
+            min_ttl: Duration::from_secs(MIN_TTL_SECS),
+            max_ttl: Duration::from_secs(MAX_TTL_SECS),
+        }
+    }
+
+    /// Clamp a caller-supplied TTL (in seconds) to `[min_ttl, max_ttl]`,
+    /// falling back to `default_ttl` when the caller omits the field.
+    pub fn clamp_ttl(&self, requested_seconds: Option<u64>) -> Duration {
+        match requested_seconds {
+            None => self.default_ttl,
+            Some(secs) => {
+                let secs = secs
+                    .max(self.min_ttl.as_secs())
+                    .min(self.max_ttl.as_secs());
+                Duration::from_secs(secs)
+            }
+        }
+    }
+}

--- a/crates/jwt-minter/src/group.rs
+++ b/crates/jwt-minter/src/group.rs
@@ -1,0 +1,35 @@
+//! Optional Unix-group access gate.
+
+use anyhow::anyhow;
+
+/// A resolved group entry — name + GID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupGate {
+    pub name: String,
+    pub gid: u32,
+}
+
+/// Look up `name` via `getgrnam_r`. Returns `Ok(None)` when no such group
+/// exists; `Err` only when the syscall itself fails.
+pub fn resolve_group(name: &str) -> anyhow::Result<Option<GroupGate>> {
+    let _ = name;
+    Err(anyhow!("resolve_group: not implemented"))
+}
+
+/// Return the supplementary group list for `username` (plus `primary_gid`)
+/// via `getgrouplist`.
+pub fn grouplist_for(username: &str, primary_gid: u32) -> anyhow::Result<Vec<u32>> {
+    let _ = (username, primary_gid);
+    Err(anyhow!("grouplist_for: not implemented"))
+}
+
+/// Pure predicate: does `target_gid` appear in `groups`?
+pub fn uid_in_groups(target_gid: u32, groups: &[u32]) -> bool {
+    groups.contains(&target_gid)
+}
+
+/// Primary GID of `uid` via `getpwuid_r`.
+pub fn primary_gid_for_uid(uid: u32) -> anyhow::Result<Option<u32>> {
+    let _ = uid;
+    Err(anyhow!("primary_gid_for_uid: not implemented"))
+}

--- a/crates/jwt-minter/src/group.rs
+++ b/crates/jwt-minter/src/group.rs
@@ -1,6 +1,13 @@
 //! Optional Unix-group access gate.
+//!
+//! When the operator sets `--group <name>`, the minter resolves `<name>`
+//! to a GID at startup (failing clean if no such group) and at request
+//! time checks that the caller's UID is a member of that group via
+//! `getgrouplist`.
 
-use anyhow::anyhow;
+use std::ffi::{CStr, CString};
+
+use anyhow::{anyhow, Context};
 
 /// A resolved group entry — name + GID.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,15 +19,95 @@ pub struct GroupGate {
 /// Look up `name` via `getgrnam_r`. Returns `Ok(None)` when no such group
 /// exists; `Err` only when the syscall itself fails.
 pub fn resolve_group(name: &str) -> anyhow::Result<Option<GroupGate>> {
-    let _ = name;
-    Err(anyhow!("resolve_group: not implemented"))
+    let cname = CString::new(name)
+        .context("group name contains an embedded NUL")?;
+    let mut buf_size = sysconf_or(libc::_SC_GETGR_R_SIZE_MAX, 1024).max(1024);
+    let mut buf: Vec<libc::c_char> = vec![0; buf_size];
+    let mut grp: libc::group = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::group = std::ptr::null_mut();
+
+    loop {
+        // SAFETY: pointers are valid for the call's duration; `result` is
+        // a valid out-pointer per the getgrnam_r contract.
+        let rc = unsafe {
+            libc::getgrnam_r(
+                cname.as_ptr(),
+                &mut grp,
+                buf.as_mut_ptr(),
+                buf_size,
+                &mut result,
+            )
+        };
+        if rc == 0 {
+            if result.is_null() {
+                return Ok(None);
+            }
+            // SAFETY: `grp.gr_name` is a NUL-terminated C string in `buf`;
+            // we copy before `buf` is dropped.
+            let resolved_name = unsafe { CStr::from_ptr(grp.gr_name) }
+                .to_str()
+                .context("group entry name is not valid UTF-8")?
+                .to_string();
+            return Ok(Some(GroupGate {
+                name: resolved_name,
+                gid: grp.gr_gid as u32,
+            }));
+        }
+        if rc == libc::ERANGE {
+            buf_size = buf_size.saturating_mul(2);
+            if buf_size > 1 << 20 {
+                return Err(anyhow!(
+                    "getgrnam_r requires implausibly large buffer (>1MiB)"
+                ));
+            }
+            buf.resize(buf_size, 0);
+            continue;
+        }
+        return Err(std::io::Error::from_raw_os_error(rc))
+            .with_context(|| format!("getgrnam_r({name:?}) failed"));
+    }
 }
 
 /// Return the supplementary group list for `username` (plus `primary_gid`)
-/// via `getgrouplist`.
+/// via `getgrouplist`. Mirrors `id -G <username>`.
 pub fn grouplist_for(username: &str, primary_gid: u32) -> anyhow::Result<Vec<u32>> {
-    let _ = (username, primary_gid);
-    Err(anyhow!("grouplist_for: not implemented"))
+    let cname = CString::new(username)
+        .context("username contains an embedded NUL")?;
+    let mut count: libc::c_int = 32;
+    loop {
+        let mut groups: Vec<libc::gid_t> = vec![0; count as usize];
+        let mut ngroups = count;
+        // SAFETY: `cname` is a valid NUL-terminated C string; `groups`
+        // points to a writable buffer of `count` `gid_t`; `&mut ngroups`
+        // is a valid out-pointer.
+        let rc = unsafe {
+            libc::getgrouplist(
+                cname.as_ptr(),
+                primary_gid as libc::gid_t,
+                groups.as_mut_ptr(),
+                &mut ngroups,
+            )
+        };
+        if rc >= 0 {
+            groups.truncate(ngroups.max(0) as usize);
+            // `gid_t` is `u32` on Linux/glibc and the rest of the targets
+            // we care about, so no cast is needed.
+            return Ok(groups);
+        }
+        // -1 means the buffer was too small; ngroups is set to the
+        // required size. Grow and retry, bounded.
+        if ngroups <= count {
+            return Err(anyhow!(
+                "getgrouplist returned -1 without expanding ngroups"
+            ));
+        }
+        if ngroups > 65_536 {
+            return Err(anyhow!(
+                "getgrouplist requires implausibly large buffer ({ngroups})"
+            ));
+        }
+        count = ngroups;
+    }
 }
 
 /// Pure predicate: does `target_gid` appear in `groups`?
@@ -30,6 +117,46 @@ pub fn uid_in_groups(target_gid: u32, groups: &[u32]) -> bool {
 
 /// Primary GID of `uid` via `getpwuid_r`.
 pub fn primary_gid_for_uid(uid: u32) -> anyhow::Result<Option<u32>> {
-    let _ = uid;
-    Err(anyhow!("primary_gid_for_uid: not implemented"))
+    let mut buf_size = sysconf_or(libc::_SC_GETPW_R_SIZE_MAX, 1024).max(1024);
+    let mut buf: Vec<libc::c_char> = vec![0; buf_size];
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+
+    loop {
+        // SAFETY: same contract as username_for_uid; see peer.rs.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid as libc::uid_t,
+                &mut pwd,
+                buf.as_mut_ptr(),
+                buf_size,
+                &mut result,
+            )
+        };
+        if rc == 0 {
+            if result.is_null() {
+                return Ok(None);
+            }
+            return Ok(Some(pwd.pw_gid as u32));
+        }
+        if rc == libc::ERANGE {
+            buf_size = buf_size.saturating_mul(2);
+            if buf_size > 1 << 20 {
+                return Err(anyhow!(
+                    "getpwuid_r requires implausibly large buffer (>1MiB)"
+                ));
+            }
+            buf.resize(buf_size, 0);
+            continue;
+        }
+        return Err(std::io::Error::from_raw_os_error(rc))
+            .with_context(|| format!("getpwuid_r({uid}) failed"));
+    }
+}
+
+fn sysconf_or(name: libc::c_int, fallback: usize) -> usize {
+    // SAFETY: `sysconf` is a libc query function with no thread-safety
+    // concerns.
+    let value = unsafe { libc::sysconf(name) };
+    if value <= 0 { fallback } else { value as usize }
 }

--- a/crates/jwt-minter/src/lib.rs
+++ b/crates/jwt-minter/src/lib.rs
@@ -1,0 +1,24 @@
+//! Local JWT minter for desktop installs (issue #101).
+//!
+//! Listens on a Unix domain socket, authenticates the OS user via
+//! `SO_PEERCRED`, and mints a short-lived HS256 JWT signed with the same
+//! key the daemon validates against. This is *not* a real IdP — production
+//! deployments use Cognito/Keycloak/etc. See
+//! `docs/architecture-evolution.md` Phase 0 for context.
+//!
+//! Module layout:
+//! - `config`: [`MintConfig`] — issuer/audience/TTL knobs + signing-key path.
+//! - `peer`: `SO_PEERCRED` → UID → username via `getpwuid_r`.
+//! - `group`: optional group-membership gate via `getgrouplist`.
+//! - `request`: wire types and the pure `handle_request` function.
+//! - `server`: the tokio loop that binds the UDS and dispatches requests.
+
+pub mod config;
+pub mod group;
+pub mod peer;
+pub mod request;
+pub mod server;
+
+pub use config::MintConfig;
+pub use peer::PeerIdentity;
+pub use request::{MintRequest, MintResponse, handle_request};

--- a/crates/jwt-minter/src/main.rs
+++ b/crates/jwt-minter/src/main.rs
@@ -1,0 +1,8 @@
+//! `adelie-mint` — local JWT minter binary.
+
+use anyhow::anyhow;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    Err(anyhow!("adelie-mint: not implemented"))
+}

--- a/crates/jwt-minter/src/main.rs
+++ b/crates/jwt-minter/src/main.rs
@@ -1,8 +1,155 @@
-//! `adelie-mint` — local JWT minter binary.
+//! `adelie-mint` — local JWT minter binary (issue #101).
+//!
+//! Listens on a Unix domain socket and mints short-lived HS256 JWTs for
+//! the OS user identified by `SO_PEERCRED`. Desktop-dev convenience —
+//! production deployments use an external OIDC IdP instead.
 
-use anyhow::anyhow;
+use std::path::PathBuf;
+
+use anyhow::{Context, anyhow};
+use clap::Parser;
+use desktop_assistant_auth_jwt as auth_jwt;
+use desktop_assistant_jwt_minter::config::{
+    DEFAULT_AUDIENCE, DEFAULT_ISSUER, DEFAULT_TTL_SECS, MAX_TTL_SECS, MIN_TTL_SECS,
+    MintConfig,
+};
+use desktop_assistant_jwt_minter::group::resolve_group;
+use desktop_assistant_jwt_minter::server::{ServerOptions, serve};
+use tokio::signal::unix::{SignalKind, signal};
+
+/// Local JWT minter for the desktop assistant daemon.
+#[derive(Debug, Parser)]
+#[command(
+    name = "adelie-mint",
+    about = "Mint short-lived HS256 JWTs for local clients identified via SO_PEERCRED.",
+    version,
+)]
+struct Cli {
+    /// Path to the UDS to listen on. Defaults to
+    /// `$XDG_RUNTIME_DIR/adelie/mint.sock`, falling back to
+    /// `/run/adelie/mint.sock` when `XDG_RUNTIME_DIR` is unset.
+    #[arg(long, env = "ADELIE_MINT_SOCKET")]
+    socket: Option<PathBuf>,
+
+    /// Optional Unix group name; when set, only callers whose UID is a
+    /// member of this group can mint tokens. Validated at startup.
+    #[arg(long, env = "ADELIE_MINT_GROUP")]
+    group: Option<String>,
+
+    /// Path to the HS256 signing key file. Defaults to the same file the
+    /// daemon uses (under `$XDG_DATA_HOME/desktop-assistant/secrets`).
+    #[arg(long, env = "ADELIE_MINT_SIGNING_KEY")]
+    signing_key: Option<PathBuf>,
+
+    /// JWT `iss` claim. Defaults to the daemon's expected issuer.
+    #[arg(long, default_value = DEFAULT_ISSUER)]
+    issuer: String,
+
+    /// Default JWT `aud` claim when the request omits one. Defaults to
+    /// the daemon's expected audience.
+    #[arg(long, default_value = DEFAULT_AUDIENCE)]
+    audience: String,
+
+    /// Default TTL in seconds when the request omits one.
+    #[arg(long, default_value_t = DEFAULT_TTL_SECS)]
+    default_ttl: u64,
+
+    /// Minimum TTL clamp.
+    #[arg(long, default_value_t = MIN_TTL_SECS)]
+    min_ttl: u64,
+
+    /// Maximum TTL clamp.
+    #[arg(long, default_value_t = MAX_TTL_SECS)]
+    max_ttl: u64,
+}
+
+fn default_socket_path() -> PathBuf {
+    if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR")
+        && !runtime.is_empty()
+    {
+        return PathBuf::from(runtime).join("adelie").join("mint.sock");
+    }
+    PathBuf::from("/run/adelie/mint.sock")
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    Err(anyhow!("adelie-mint: not implemented"))
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    if cli.min_ttl == 0 {
+        return Err(anyhow!("--min-ttl must be > 0"));
+    }
+    if cli.max_ttl < cli.min_ttl {
+        return Err(anyhow!(
+            "--max-ttl ({}) must be >= --min-ttl ({})",
+            cli.max_ttl,
+            cli.min_ttl
+        ));
+    }
+
+    let signing_key_path = cli
+        .signing_key
+        .unwrap_or_else(auth_jwt::default_signing_key_path);
+
+    let config = MintConfig {
+        signing_key_path,
+        issuer: cli.issuer,
+        default_audience: cli.audience,
+        default_ttl: std::time::Duration::from_secs(cli.default_ttl),
+        min_ttl: std::time::Duration::from_secs(cli.min_ttl),
+        max_ttl: std::time::Duration::from_secs(cli.max_ttl),
+    };
+
+    let group_gate = match cli.group.as_deref() {
+        None => None,
+        Some(name) => {
+            let resolved = resolve_group(name)
+                .with_context(|| format!("group lookup for {name:?} failed"))?;
+            match resolved {
+                Some(gate) => {
+                    tracing::info!(group = %gate.name, gid = gate.gid, "group gate active");
+                    Some(gate)
+                }
+                None => {
+                    return Err(anyhow!(
+                        "configured --group {name:?} does not exist on this system"
+                    ));
+                }
+            }
+        }
+    };
+
+    let socket_path = cli.socket.unwrap_or_else(default_socket_path);
+    let options = ServerOptions {
+        socket_path,
+        group_gate,
+    };
+
+    let shutdown = build_shutdown_signal()?;
+    serve(options, config, shutdown).await
+}
+
+fn build_shutdown_signal()
+-> anyhow::Result<impl std::future::Future<Output = ()> + Send + 'static> {
+    let mut sigterm =
+        signal(SignalKind::terminate()).context("install SIGTERM handler")?;
+    let mut sigint =
+        signal(SignalKind::interrupt()).context("install SIGINT handler")?;
+    Ok(async move {
+        tokio::select! {
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM");
+            }
+            _ = sigint.recv() => {
+                tracing::info!("received SIGINT");
+            }
+        }
+    })
 }

--- a/crates/jwt-minter/src/peer.rs
+++ b/crates/jwt-minter/src/peer.rs
@@ -1,6 +1,13 @@
 //! Peer-credential lookup over a connected `UnixStream`.
+//!
+//! `SO_PEERCRED` is the kernel-attested identity of whoever opened the
+//! other end of the socket. Tokio's `UnixStream::peer_cred` wraps the
+//! socket option directly; we only have to map the UID to a username via
+//! `getpwuid_r` for the `sub` claim.
 
-use anyhow::{Context, anyhow};
+use std::ffi::CStr;
+
+use anyhow::{anyhow, Context};
 use tokio::net::UnixStream;
 
 /// The OS identity of a connected peer.
@@ -13,9 +20,13 @@ pub struct PeerIdentity {
 /// Read the kernel-attested peer credentials from `stream` and resolve
 /// the UID to a username via `getpwuid_r`.
 pub fn extract_peer_identity(stream: &UnixStream) -> anyhow::Result<PeerIdentity> {
-    // TODO(#101): real impl.
-    let _ = stream;
-    Err(anyhow!("extract_peer_identity: not implemented"))
+    let cred = stream
+        .peer_cred()
+        .context("failed to read SO_PEERCRED from peer socket")?;
+    let uid = cred.uid();
+    let username = username_for_uid(uid)?
+        .ok_or_else(|| anyhow!("no passwd entry for uid {uid}"))?;
+    Ok(PeerIdentity { uid, username })
 }
 
 /// Look up the username for `uid` via `getpwuid_r`.
@@ -23,24 +34,63 @@ pub fn extract_peer_identity(stream: &UnixStream) -> anyhow::Result<PeerIdentity
 /// Returns `Ok(None)` when the UID has no matching entry rather than an
 /// error so callers can distinguish "system call failed" from "no such user".
 pub fn username_for_uid(uid: u32) -> anyhow::Result<Option<String>> {
-    let _ = uid;
-    Err(anyhow!("username_for_uid: not implemented"))
+    // Start with a comfortable buffer and grow on ERANGE.
+    let mut buf_size = sysconf_or(libc::_SC_GETPW_R_SIZE_MAX, 1024).max(1024);
+    let mut buf: Vec<libc::c_char> = vec![0; buf_size];
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+
+    loop {
+        // SAFETY: `&mut pwd` is a valid `passwd*` for the lifetime of the
+        // call; `buf` is a valid writable buffer of `buf_size` bytes; we
+        // pass a non-null `result` out-pointer per the getpwuid_r contract.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid as libc::uid_t,
+                &mut pwd,
+                buf.as_mut_ptr(),
+                buf_size,
+                &mut result,
+            )
+        };
+        if rc == 0 {
+            if result.is_null() {
+                return Ok(None);
+            }
+            // SAFETY: `pwd.pw_name` is a NUL-terminated C string owned by
+            // `buf` (filled by `getpwuid_r`); we copy it into an owned
+            // `String` before `buf` is dropped.
+            let name = unsafe { CStr::from_ptr(pwd.pw_name) }
+                .to_str()
+                .context("passwd entry username is not valid UTF-8")?
+                .to_string();
+            return Ok(Some(name));
+        }
+        if rc == libc::ERANGE {
+            buf_size = buf_size.saturating_mul(2);
+            if buf_size > 1 << 20 {
+                return Err(anyhow!(
+                    "getpwuid_r requires implausibly large buffer (>1MiB)"
+                ));
+            }
+            buf.resize(buf_size, 0);
+            continue;
+        }
+        return Err(std::io::Error::from_raw_os_error(rc))
+            .with_context(|| format!("getpwuid_r({uid}) failed"));
+    }
 }
 
 /// The UID of the current process.
 pub fn current_uid() -> u32 {
-    // SAFETY: `getuid` is a thread-safe libc call that takes no arguments
-    // and cannot fail (per POSIX).
+    // SAFETY: `getuid` is documented to always succeed and to have no
+    // thread-safety concerns; it takes no arguments.
     unsafe { libc::getuid() as u32 }
 }
 
-/// Helper for tests that need to confirm we resolved *some* username for
-/// the current process.
-pub fn _suppress_unused() {
-    let _ = username_for_uid;
-}
-
-#[allow(dead_code)]
-fn _ensure_context_used() -> anyhow::Result<()> {
-    Err::<(), _>(anyhow!("x")).context("y")
+fn sysconf_or(name: libc::c_int, fallback: usize) -> usize {
+    // SAFETY: `sysconf` is a libc query function with no thread-safety
+    // concerns; it accepts the integer constant `name`.
+    let value = unsafe { libc::sysconf(name) };
+    if value <= 0 { fallback } else { value as usize }
 }

--- a/crates/jwt-minter/src/peer.rs
+++ b/crates/jwt-minter/src/peer.rs
@@ -1,0 +1,46 @@
+//! Peer-credential lookup over a connected `UnixStream`.
+
+use anyhow::{Context, anyhow};
+use tokio::net::UnixStream;
+
+/// The OS identity of a connected peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerIdentity {
+    pub uid: u32,
+    pub username: String,
+}
+
+/// Read the kernel-attested peer credentials from `stream` and resolve
+/// the UID to a username via `getpwuid_r`.
+pub fn extract_peer_identity(stream: &UnixStream) -> anyhow::Result<PeerIdentity> {
+    // TODO(#101): real impl.
+    let _ = stream;
+    Err(anyhow!("extract_peer_identity: not implemented"))
+}
+
+/// Look up the username for `uid` via `getpwuid_r`.
+///
+/// Returns `Ok(None)` when the UID has no matching entry rather than an
+/// error so callers can distinguish "system call failed" from "no such user".
+pub fn username_for_uid(uid: u32) -> anyhow::Result<Option<String>> {
+    let _ = uid;
+    Err(anyhow!("username_for_uid: not implemented"))
+}
+
+/// The UID of the current process.
+pub fn current_uid() -> u32 {
+    // SAFETY: `getuid` is a thread-safe libc call that takes no arguments
+    // and cannot fail (per POSIX).
+    unsafe { libc::getuid() as u32 }
+}
+
+/// Helper for tests that need to confirm we resolved *some* username for
+/// the current process.
+pub fn _suppress_unused() {
+    let _ = username_for_uid;
+}
+
+#[allow(dead_code)]
+fn _ensure_context_used() -> anyhow::Result<()> {
+    Err::<(), _>(anyhow!("x")).context("y")
+}

--- a/crates/jwt-minter/src/request.rs
+++ b/crates/jwt-minter/src/request.rs
@@ -1,0 +1,123 @@
+//! Wire types and the pure `handle_request` function.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context};
+use desktop_assistant_auth_jwt::{self as auth_jwt, Claims};
+use serde::{Deserialize, Serialize};
+
+use crate::config::MintConfig;
+use crate::peer::PeerIdentity;
+
+/// Caller-supplied request payload. All fields optional — callers commonly
+/// send `{}`.
+#[derive(Debug, Default, Deserialize)]
+pub struct MintRequest {
+    #[serde(default)]
+    pub ttl_seconds: Option<u64>,
+    #[serde(default)]
+    pub audience: Option<String>,
+}
+
+/// Response payload. `error` is `Some` iff minting failed; otherwise
+/// `token`/`exp` carry the result.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MintResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl MintResponse {
+    fn ok(token: String, exp: u64) -> Self {
+        Self {
+            token: Some(token),
+            exp: Some(exp),
+            error: None,
+        }
+    }
+
+    fn err(message: impl Into<String>) -> Self {
+        Self {
+            token: None,
+            exp: None,
+            error: Some(message.into()),
+        }
+    }
+}
+
+/// Parse `raw_request`, mint a token for `peer`, return the serialized
+/// JSON response.
+///
+/// This is the unit-testable core. The server loop only adds the I/O
+/// wrapper around it.
+pub fn handle_request(
+    raw_request: &str,
+    peer: &PeerIdentity,
+    config: &MintConfig,
+    signing_key: &str,
+) -> String {
+    let response = handle_request_inner(raw_request, peer, config, signing_key);
+    serde_json::to_string(&response)
+        .unwrap_or_else(|_| r#"{"error":"failed to serialize response"}"#.to_string())
+}
+
+fn handle_request_inner(
+    raw_request: &str,
+    peer: &PeerIdentity,
+    config: &MintConfig,
+    signing_key: &str,
+) -> MintResponse {
+    let request: MintRequest = match parse_request(raw_request) {
+        Ok(r) => r,
+        Err(err) => return MintResponse::err(format!("invalid request: {err}")),
+    };
+
+    let ttl = config.clamp_ttl(request.ttl_seconds);
+    let audience = request
+        .audience
+        .filter(|a| !a.trim().is_empty())
+        .unwrap_or_else(|| config.default_audience.clone());
+
+    let now = match unix_now() {
+        Ok(t) => t,
+        Err(err) => return MintResponse::err(format!("clock error: {err}")),
+    };
+    let exp = now.saturating_add(ttl.as_secs());
+
+    let claims = Claims {
+        iss: config.issuer.clone(),
+        sub: peer.username.clone(),
+        aud: audience,
+        exp,
+        iat: now,
+        nbf: now.saturating_sub(1),
+        jti: uuid::Uuid::new_v4().to_string(),
+    };
+
+    match auth_jwt::encode(&claims, signing_key) {
+        Ok(token) => MintResponse::ok(token, exp),
+        Err(err) => MintResponse::err(format!("encode error: {err}")),
+    }
+}
+
+/// Treat an entirely empty body as `{}` to give clients a friendly
+/// "default everything" shortcut, but fail clean on any non-empty
+/// non-JSON.
+fn parse_request(raw: &str) -> anyhow::Result<MintRequest> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(MintRequest::default());
+    }
+    serde_json::from_str(trimmed).context("malformed JSON")
+}
+
+fn unix_now() -> anyhow::Result<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .map_err(|e| anyhow!("system clock before unix epoch: {e}"))
+}

--- a/crates/jwt-minter/src/server.rs
+++ b/crates/jwt-minter/src/server.rs
@@ -1,13 +1,20 @@
 //! UDS server loop.
+//!
+//! `serve` binds the socket (removing any stale file), then runs a select
+//! loop accepting connections until `shutdown` resolves. On exit — clean
+//! or due to an accept error — the socket file is unlinked so the next
+//! launch starts fresh.
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+use desktop_assistant_auth_jwt as auth_jwt;
+
 use crate::config::MintConfig;
-use crate::group::GroupGate;
+use crate::group::{self, GroupGate};
 use crate::peer::{self, PeerIdentity};
 use crate::request::handle_request;
 
@@ -25,13 +32,72 @@ pub async fn serve(
     config: MintConfig,
     shutdown: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let _ = (options, config, shutdown);
-    Err(anyhow!("serve: not implemented"))
+    let listener = bind_unix_listener(&options.socket_path)?;
+    // Load the signing key once at startup — the daemon would do the
+    // same. If it doesn't exist yet, generate it; the daemon will pick up
+    // the same file on its next startup.
+    let signing_key = auth_jwt::ensure_signing_key_at(&config.signing_key_path)
+        .with_context(|| {
+            format!(
+                "failed to load signing key from {}",
+                config.signing_key_path.display()
+            )
+        })?;
+
+    tracing::info!(
+        socket = %options.socket_path.display(),
+        group = ?options.group_gate.as_ref().map(|g| &g.name),
+        "adelie-mint listening",
+    );
+
+    tokio::pin!(shutdown);
+    let result = loop {
+        tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                tracing::info!("shutdown requested");
+                break Ok(());
+            }
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, _)) => {
+                        let cfg = config.clone();
+                        let key = signing_key.clone();
+                        let gate = options.group_gate.clone();
+                        tokio::spawn(async move {
+                            if let Err(err) = serve_connection(
+                                stream, &cfg, &key, gate.as_ref(),
+                            ).await {
+                                tracing::warn!(error = %err, "request failed");
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        tracing::error!(error = %err, "accept failed");
+                        break Err(anyhow!("accept loop: {err}"));
+                    }
+                }
+            }
+        }
+    };
+
+    // Drop the listener before unlinking so the kernel side is closed.
+    drop(listener);
+    remove_socket(&options.socket_path);
+    result
 }
 
 /// Best-effort cleanup helper; safe to call multiple times.
 pub fn remove_socket(path: &Path) {
-    let _ = std::fs::remove_file(path);
+    if path.exists()
+        && let Err(err) = std::fs::remove_file(path)
+    {
+        tracing::warn!(
+            path = %path.display(),
+            error = %err,
+            "failed to remove socket file"
+        );
+    }
 }
 
 /// Per-connection handler. Reads exactly one JSON line, writes one JSON
@@ -48,7 +114,10 @@ pub async fn serve_connection(
     if let Some(gate) = group_gate
         && !is_member(&identity, gate)?
     {
-        let response = r#"{"error":"caller is not a member of the required group"}"#;
+        let response = format!(
+            r#"{{"error":"caller uid {} is not a member of group {}"}}"#,
+            identity.uid, gate.name
+        );
         stream.write_all(response.as_bytes()).await?;
         stream.write_all(b"\n").await?;
         stream.flush().await?;
@@ -71,10 +140,10 @@ pub async fn serve_connection(
 }
 
 fn is_member(identity: &PeerIdentity, gate: &GroupGate) -> anyhow::Result<bool> {
-    let primary = crate::group::primary_gid_for_uid(identity.uid)?
+    let primary = group::primary_gid_for_uid(identity.uid)?
         .ok_or_else(|| anyhow!("no primary GID for uid {}", identity.uid))?;
-    let groups = crate::group::grouplist_for(&identity.username, primary)?;
-    Ok(crate::group::uid_in_groups(gate.gid, &groups))
+    let groups = group::grouplist_for(&identity.username, primary)?;
+    Ok(group::uid_in_groups(gate.gid, &groups))
 }
 
 /// Public binder used by both `serve` and tests. Removes a stale socket

--- a/crates/jwt-minter/src/server.rs
+++ b/crates/jwt-minter/src/server.rs
@@ -1,0 +1,94 @@
+//! UDS server loop.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, anyhow};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::config::MintConfig;
+use crate::group::GroupGate;
+use crate::peer::{self, PeerIdentity};
+use crate::request::handle_request;
+
+/// Server-side options that aren't part of the JWT policy.
+#[derive(Debug, Clone)]
+pub struct ServerOptions {
+    pub socket_path: PathBuf,
+    pub group_gate: Option<GroupGate>,
+}
+
+/// Bind `socket_path` (removing any stale file first), accept until
+/// `shutdown` resolves, then atomically unlink the socket file.
+pub async fn serve(
+    options: ServerOptions,
+    config: MintConfig,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> anyhow::Result<()> {
+    let _ = (options, config, shutdown);
+    Err(anyhow!("serve: not implemented"))
+}
+
+/// Best-effort cleanup helper; safe to call multiple times.
+pub fn remove_socket(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Per-connection handler. Reads exactly one JSON line, writes one JSON
+/// response, returns. Exposed so integration tests can drive it directly.
+pub async fn serve_connection(
+    mut stream: UnixStream,
+    config: &MintConfig,
+    signing_key: &str,
+    group_gate: Option<&GroupGate>,
+) -> anyhow::Result<()> {
+    let identity = peer::extract_peer_identity(&stream)
+        .context("failed to extract peer credentials")?;
+
+    if let Some(gate) = group_gate
+        && !is_member(&identity, gate)?
+    {
+        let response = r#"{"error":"caller is not a member of the required group"}"#;
+        stream.write_all(response.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+        stream.flush().await?;
+        return Ok(());
+    }
+
+    let mut buf = String::new();
+    let mut reader = BufReader::new(&mut stream);
+    reader
+        .read_line(&mut buf)
+        .await
+        .context("failed to read request line")?;
+    drop(reader);
+
+    let response = handle_request(&buf, &identity, config, signing_key);
+    stream.write_all(response.as_bytes()).await?;
+    stream.write_all(b"\n").await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+fn is_member(identity: &PeerIdentity, gate: &GroupGate) -> anyhow::Result<bool> {
+    let primary = crate::group::primary_gid_for_uid(identity.uid)?
+        .ok_or_else(|| anyhow!("no primary GID for uid {}", identity.uid))?;
+    let groups = crate::group::grouplist_for(&identity.username, primary)?;
+    Ok(crate::group::uid_in_groups(gate.gid, &groups))
+}
+
+/// Public binder used by both `serve` and tests. Removes a stale socket
+/// file at `path` then binds.
+pub fn bind_unix_listener(path: &Path) -> anyhow::Result<UnixListener> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("failed to create socket parent dir {}", parent.display())
+        })?;
+    }
+    if path.exists() {
+        std::fs::remove_file(path).with_context(|| {
+            format!("failed to remove stale socket {}", path.display())
+        })?;
+    }
+    UnixListener::bind(path).with_context(|| format!("failed to bind {}", path.display()))
+}

--- a/crates/jwt-minter/tests/integration.rs
+++ b/crates/jwt-minter/tests/integration.rs
@@ -1,0 +1,292 @@
+//! Integration tests for the local JWT minter (issue #101).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use desktop_assistant_auth_jwt as auth_jwt;
+use desktop_assistant_jwt_minter::config::{
+    MAX_TTL_SECS, MIN_TTL_SECS, MintConfig,
+};
+use desktop_assistant_jwt_minter::group::{
+    self, GroupGate, uid_in_groups,
+};
+use desktop_assistant_jwt_minter::peer::{self, PeerIdentity};
+use desktop_assistant_jwt_minter::request::{MintResponse, handle_request};
+use desktop_assistant_jwt_minter::server::{ServerOptions, serve};
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+fn test_config(dir: &TempDir) -> (MintConfig, String) {
+    let key_path = dir.path().join("key");
+    let signing_key = auth_jwt::ensure_signing_key_at(&key_path).expect("ensure key");
+    let mut cfg = MintConfig::with_default_paths();
+    cfg.signing_key_path = key_path;
+    (cfg, signing_key)
+}
+
+fn test_peer() -> PeerIdentity {
+    PeerIdentity {
+        uid: peer::current_uid(),
+        username: peer::username_for_uid(peer::current_uid())
+            .expect("uid lookup")
+            .expect("user exists"),
+    }
+}
+
+#[tokio::test]
+async fn peer_cred_identity_extraction_returns_correct_uid_and_username() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket_path = dir.path().join("peer.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind");
+
+    let accept_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        peer::extract_peer_identity(&stream).expect("extract")
+    });
+
+    let _client = UnixStream::connect(&socket_path).await.expect("connect");
+    let identity = accept_task.await.expect("accept task");
+
+    assert_eq!(identity.uid, peer::current_uid());
+    let expected = peer::username_for_uid(peer::current_uid())
+        .expect("username syscall")
+        .expect("username present");
+    assert_eq!(identity.username, expected);
+    assert!(!identity.username.is_empty());
+}
+
+#[tokio::test]
+async fn minted_token_round_trips_through_daemon_validator() {
+    let dir = TempDir::new().expect("tempdir");
+    let (cfg, signing_key) = test_config(&dir);
+    let peer = test_peer();
+
+    let raw = handle_request("{}", &peer, &cfg, &signing_key);
+    let resp: MintResponse = serde_json::from_str(&raw).expect("parse response");
+    assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+    let token = resp.token.expect("token present");
+
+    // Independently re-read the key file — same path the daemon uses.
+    let key_b = auth_jwt::read_signing_key_at(&cfg.signing_key_path).expect("read key");
+    let claims = auth_jwt::decode(
+        &token,
+        &key_b,
+        &cfg.issuer,
+        &cfg.default_audience,
+    )
+    .expect("daemon-style decode");
+    assert_eq!(claims.sub, peer.username);
+    assert_eq!(claims.iss, cfg.issuer);
+    assert_eq!(claims.aud, cfg.default_audience);
+}
+
+#[test]
+fn ttl_clamping_enforces_max_and_min() {
+    let cfg = MintConfig::with_default_paths();
+
+    // Below the floor: clamps up to min.
+    assert_eq!(cfg.clamp_ttl(Some(1)), Duration::from_secs(MIN_TTL_SECS));
+    // Above the ceiling: clamps down to max.
+    assert_eq!(
+        cfg.clamp_ttl(Some(u64::MAX)),
+        Duration::from_secs(MAX_TTL_SECS),
+    );
+    // Inside the window: passed through.
+    assert_eq!(cfg.clamp_ttl(Some(600)), Duration::from_secs(600));
+    // None: default.
+    assert_eq!(cfg.clamp_ttl(None), cfg.default_ttl);
+}
+
+#[test]
+fn malformed_input_returns_error_json_not_panic() {
+    let dir = TempDir::new().expect("tempdir");
+    let (cfg, signing_key) = test_config(&dir);
+    let peer = test_peer();
+
+    for bad in [
+        "not json at all",
+        "{ unterminated",
+        "[1, 2, 3]",
+        "{\"ttl_seconds\": \"not a number\"}",
+    ] {
+        let raw = handle_request(bad, &peer, &cfg, &signing_key);
+        let resp: MintResponse =
+            serde_json::from_str(&raw).expect("response is valid JSON");
+        assert!(
+            resp.error.is_some(),
+            "expected error for input {bad:?}, got {raw}"
+        );
+        assert!(resp.token.is_none());
+    }
+}
+
+#[test]
+fn default_audience_matches_daemon_expectation() {
+    let dir = TempDir::new().expect("tempdir");
+    let (cfg, signing_key) = test_config(&dir);
+    let peer = test_peer();
+
+    let raw = handle_request("{}", &peer, &cfg, &signing_key);
+    let resp: MintResponse = serde_json::from_str(&raw).expect("parse");
+    let token = resp.token.expect("token");
+
+    let claims = auth_jwt::decode(
+        &token,
+        &signing_key,
+        "org.desktopAssistant.local",
+        "desktop-assistant-ws",
+    )
+    .expect("decode with daemon defaults");
+    assert_eq!(claims.aud, "desktop-assistant-ws");
+}
+
+#[tokio::test]
+async fn socket_is_removed_on_shutdown() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket_path = dir.path().join("shutdown.sock");
+    let key_path = dir.path().join("key");
+    auth_jwt::ensure_signing_key_at(&key_path).expect("key");
+
+    let mut cfg = MintConfig::with_default_paths();
+    cfg.signing_key_path = key_path;
+
+    let opts = ServerOptions {
+        socket_path: socket_path.clone(),
+        group_gate: None,
+    };
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_task = tokio::spawn(async move {
+        serve(opts, cfg, async move {
+            let _ = rx.await;
+        })
+        .await
+    });
+
+    // Give the server a moment to bind.
+    for _ in 0..50 {
+        if socket_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(socket_path.exists(), "socket should exist after bind");
+
+    tx.send(()).expect("trigger shutdown");
+    let result = serve_task.await.expect("serve join");
+    result.expect("serve ok");
+
+    assert!(
+        !socket_path.exists(),
+        "socket file should be removed after shutdown"
+    );
+}
+
+#[test]
+fn group_gate_rejects_non_member() {
+    // Synthetic GID that's guaranteed not to appear in any real grouplist.
+    let synthetic_gid = u32::MAX;
+    let user_groups: Vec<u32> = vec![1000, 1001, 27]; // arbitrary fixture
+    assert!(!uid_in_groups(synthetic_gid, &user_groups));
+}
+
+#[test]
+fn group_gate_allows_member() {
+    let user_groups: Vec<u32> = vec![1000, 1001, 27];
+    assert!(uid_in_groups(1001, &user_groups));
+}
+
+#[test]
+fn group_gate_allows_member_via_real_lookup() {
+    // Look up the current user's primary GID and confirm it's in their
+    // grouplist. This exercises `grouplist_for` against the real system.
+    let uid = peer::current_uid();
+    let username = peer::username_for_uid(uid)
+        .expect("username syscall")
+        .expect("user");
+    let primary = group::primary_gid_for_uid(uid)
+        .expect("primary gid syscall")
+        .expect("user");
+    let groups = group::grouplist_for(&username, primary).expect("grouplist");
+    assert!(uid_in_groups(primary, &groups));
+}
+
+#[test]
+fn nonexistent_group_at_startup_is_a_clean_error() {
+    // A name astronomically unlikely to exist on any system.
+    let name = "adelie-nosuch-group-zzzzzzzzzzzzzzzz";
+    let result = group::resolve_group(name).expect("syscall ok");
+    assert!(result.is_none(), "expected no group named {name}, got {result:?}");
+}
+
+#[test]
+fn existing_group_resolves_with_gid() {
+    // "root" exists on every Linux system. We don't care about membership
+    // — just that lookup of an existing name returns Some.
+    let result = group::resolve_group("root").expect("syscall ok");
+    let entry = result.expect("root exists");
+    assert_eq!(entry.name, "root");
+    assert_eq!(entry.gid, 0);
+}
+
+#[tokio::test]
+async fn end_to_end_server_mints_token_for_local_client() {
+    let dir = TempDir::new().expect("tempdir");
+    let socket_path = dir.path().join("e2e.sock");
+    let key_path = dir.path().join("key");
+    let signing_key = auth_jwt::ensure_signing_key_at(&key_path).expect("key");
+
+    let mut cfg = MintConfig::with_default_paths();
+    cfg.signing_key_path = key_path.clone();
+
+    let opts = ServerOptions {
+        socket_path: socket_path.clone(),
+        group_gate: None,
+    };
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_task = tokio::spawn(async move {
+        serve(opts, cfg, async move {
+            let _ = rx.await;
+        })
+        .await
+    });
+
+    for _ in 0..50 {
+        if socket_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let mut stream = UnixStream::connect(&socket_path).await.expect("connect");
+    stream
+        .write_all(b"{}\n")
+        .await
+        .expect("write request");
+
+    let mut reader = BufReader::new(&mut stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.expect("read line");
+    let resp: MintResponse = serde_json::from_str(line.trim()).expect("parse");
+    assert!(resp.error.is_none(), "{:?}", resp.error);
+    let token = resp.token.expect("token");
+
+    let claims = auth_jwt::decode(
+        &token,
+        &signing_key,
+        "org.desktopAssistant.local",
+        "desktop-assistant-ws",
+    )
+    .expect("decode");
+    let expected_user = peer::username_for_uid(peer::current_uid())
+        .expect("uid")
+        .expect("user");
+    assert_eq!(claims.sub, expected_user);
+
+    let _ = tx.send(());
+    let _ = serve_task.await.expect("join");
+    // Quiet unused warning on PathBuf
+    let _: PathBuf = key_path;
+}

--- a/crates/jwt-minter/tests/integration.rs
+++ b/crates/jwt-minter/tests/integration.rs
@@ -7,9 +7,7 @@ use desktop_assistant_auth_jwt as auth_jwt;
 use desktop_assistant_jwt_minter::config::{
     MAX_TTL_SECS, MIN_TTL_SECS, MintConfig,
 };
-use desktop_assistant_jwt_minter::group::{
-    self, GroupGate, uid_in_groups,
-};
+use desktop_assistant_jwt_minter::group::{self, uid_in_groups};
 use desktop_assistant_jwt_minter::peer::{self, PeerIdentity};
 use desktop_assistant_jwt_minter::request::{MintResponse, handle_request};
 use desktop_assistant_jwt_minter::server::{ServerOptions, serve};


### PR DESCRIPTION
Closes #101.

Builds on the `auth-jwt` crate shipped in #100. The new `adelie-mint`
binary listens on a Unix domain socket, identifies the OS user via
`SO_PEERCRED`, and mints short-lived HS256 JWTs signed with the same
key the daemon validates against. Production deployments still use an
external OIDC IdP — this is the desktop-dev convenience called out in
`docs/architecture-evolution.md` Phase 0.

## Summary

- New `crates/jwt-minter` workspace member exposing the `adelie-mint` binary plus a small lib so each piece is unit-testable.
- Socket path configurable via `--socket` / `ADELIE_MINT_SOCKET`; default `$XDG_RUNTIME_DIR/adelie/mint.sock`, falling back to `/run/adelie/mint.sock`.
- Optional `--group <name>` / `ADELIE_MINT_GROUP` gate; resolved at startup (failing clean if the group doesn't exist) and checked per request via `getgrouplist`.
- Wire format: one-line JSON `{"ttl_seconds": <opt>, "audience": <opt>}` → `{"token": "...", "exp": ...}` or `{"error": "..."}`. Default TTL 15 min, clamped to `[60s, 24h]`.
- Issuer / audience default to `org.desktopAssistant.local` / `desktop-assistant-ws` — matching `crates/daemon/src/config/jwt.rs` so the daemon accepts these tokens unmodified.
- SIGTERM / SIGINT trip a `tokio::select!` shutdown branch that drops the listener and unlinks the socket file.
- Every `unsafe` libc block carries a `// SAFETY:` comment naming the invariant, per AGENTS.md.

## Test plan

- [x] `cargo test -p desktop-assistant-jwt-minter` — 12 tests, all green:
  - `peer_cred_identity_extraction_returns_correct_uid_and_username`
  - `minted_token_round_trips_through_daemon_validator`
  - `ttl_clamping_enforces_max_and_min`
  - `malformed_input_returns_error_json_not_panic`
  - `default_audience_matches_daemon_expectation`
  - `socket_is_removed_on_shutdown`
  - `group_gate_rejects_non_member`
  - `group_gate_allows_member`
  - `group_gate_allows_member_via_real_lookup`
  - `nonexistent_group_at_startup_is_a_clean_error`
  - `existing_group_resolves_with_gid`
  - `end_to_end_server_mints_token_for_local_client`
- [x] `cargo build --workspace` clean.
- [x] `cargo clippy -p desktop-assistant-jwt-minter --all-targets` clean (workspace clippy still surfaces pre-existing warnings in other crates; none new).
- [x] Manual smoke: `adelie-mint --socket … --signing-key …` mints a valid JWT for the local user over `nc -U`, and the socket file disappears after `kill -TERM`.
- [x] Manual smoke: `adelie-mint --group adelie-nosuch-group-zzz` exits 1 with a clean error message, no panic.
- [x] `cve-mcp scan_packages` clean for the new `clap` / `clap_derive` deps.

## Out of scope

- OIDC / external IdPs (production uses Cognito/Keycloak/etc.).
- Token revocation (short TTL is the policy).
- systemd socket-activation unit — happy to follow up in a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)