### PR TITLE
chore: refresh AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,75 +1,54 @@
-# Agent Instructions
+# Agent Instructions — desktop-assistant
 
-## Dependency Security Policy
+Repo-specific conventions for the Adelie daemon and its workspace crates. Cross-project workflow rules (issue/PR/board sync, parallel worktrees, warnings-are-failures, security review posture, TDD posture) live in the user's memory and are not duplicated here — this file covers what is specific to *this* codebase.
 
-After adding any new packages, **scan for CVEs before building**.
+## Workspace shape
 
-Build scripts (e.g. `build.rs` in Rust, install scripts in npm) execute at build time and are a potential attack vector. Scanning the updated lockfile *before* running a build catches malicious or vulnerable transitive dependencies before any build-time code can execute.
+Hexagonal layout. Trait boundaries live in `core::ports`; infrastructure adapters live in `daemon`, `storage`, and `llm-*`; wire types live in `api-model`. Cross-cutting context flows via task-locals defined in `core` (e.g. `REASONING_CONFIG`, `MODEL_OVERRIDE`, `CONTEXT_BUDGET` in `crates/core/src/ports/llm.rs`; `ACTIVE_CLIENT` in `crates/daemon/src/routing_llm.rs`).
 
-### Workflow
+- LLM provider crates (`crates/llm-*`) MUST NOT depend on the `daemon` crate. If you find yourself reaching for daemon state from a provider, it belongs on a task-local or a port trait.
+- Wire types (`api-model`) are separate from domain types (`core::domain`). The daemon's mapper layer translates between them. Don't leak wire shapes into domain code or vice versa.
+- Prefer extending an existing crate over adding a new one. New crates need an obvious seam — a stable trait boundary, a different dependency profile, or a different consumer.
 
-1. Add the dependency (e.g. `cargo add <crate>`) — this updates the lockfile but does not build.
-2. Scan immediately using `cve-mcp scan_packages` — parse the updated lockfile and pass all (name, version, ecosystem) tuples to the tool.
-3. Review findings. Investigate any Critical or High severity issues before proceeding.
-4. Only build once the scan is clean (or findings are understood and accepted).
-
-This applies regardless of ecosystem (Cargo, npm, PyPI, etc.).
-
-## Rust Conventions
-
-Apply these consistently across the workspace. The pre-commit checklist at the bottom is the floor; project-specific patterns are anchored to existing examples in the codebase rather than abstract rules.
+## Rust conventions
 
 ### Coding
-- `?` for error propagation. Reserve `unwrap` / `expect` for tests and proven invariants. When `expect`ing in production, the message must explain the invariant — not just describe what would be unwrapped.
-- Prefer `&str` / `&[T]` in argument position; take ownership only when storing.
-- Newtype wrappers for invariant-bearing values. Examples here: `ConnectionId`, `ModelRef`, `ConnectionRef`.
-- `From` / `Into` for type conversions; don't write `to_*` methods when traits suffice.
-- Combinators (`map`, `and_then`, `unwrap_or_else`, `?`) over `match` for short `Option` / `Result` chains. Use `match` when there's branching control flow with side effects.
-- Avoid `.clone()` on hot paths. `Arc<T>` for shared immutable, `Arc<Mutex<T>>` / `Arc<RwLock<T>>` for shared mutable.
+- `?` for error propagation. `unwrap` / `expect` are for tests and proven invariants. Production `expect` must explain the invariant, not just describe what is being unwrapped.
+- `&str` / `&[T]` in argument position; take ownership only when storing.
+- Newtype wrappers for invariant-bearing values (existing examples: `ConnectionId`, `ModelRef`, `ConnectionRef`).
+- `From` / `Into` over `to_*` methods when traits suffice.
+- Combinators (`map`, `and_then`, `unwrap_or_else`, `?`) for short `Option` / `Result` chains; `match` when there's branching with side effects.
+- Avoid `.clone()` on hot paths. `Arc<T>` for shared immutable; `Arc<Mutex<T>>` / `Arc<RwLock<T>>` for shared mutable.
 
 ### `unsafe`
-- Don't use `unsafe` unless it's necessary AND you've reasoned about soundness. The bar is high.
-- Required cases here: `std::env::set_var` / `remove_var` (Rust 2024 edition makes these `unsafe` because libc env-mutation is not threadsafe). Anything else needs a strong justification.
-- Every `unsafe` block must have a `// SAFETY:` comment naming the invariant the caller is relying on. No "obvious" unsafe — write the soundness argument down. Example from `crates/daemon/src/registry.rs`:
+The bar is high and the soundness argument must be written down in a `// SAFETY:` comment naming the invariant the caller relies on. Don't ship "obvious" unsafe. The only currently-acceptable case is the Rust 2024 edition's `unsafe { std::env::set_var(...) }` / `remove_var` because libc env-mutation is not thread-safe; anything else needs explicit justification.
 
-  ```rust
-  // SAFETY: single-threaded test; unique env-var name; no other code touches it.
-  unsafe { std::env::remove_var(&unused); }
-  ```
-
-### Testing
-- Unit tests colocated as `#[cfg(test)] mod tests {}` in lib files.
-- Integration tests in `tests/` next to `Cargo.toml`.
-- `#[tokio::test]` for async; `#[tokio::test(flavor = "multi_thread")]` only when explicitly testing concurrent behavior.
-- Mock at trait boundaries. For HTTP: `httpmock` (already a daemon dev-dep). For time: an injected `Clock` trait — see `BedrockClient::ModelClock` in `crates/llm-bedrock`.
-- Determinism: sort outputs before assertion; never depend on hash iteration order.
-- `expect("descriptive reason")` over `unwrap()` in tests so failure messages are self-explanatory.
-- Test public behavior, not private implementation. If a private fn needs testing, surface as `pub(crate)` with a documented contract.
-- Don't hold `std::sync::MutexGuard` across `.await`. Drop the guard explicitly before awaiting — `clippy::await_holding_lock` flags this.
+### Async
+- Don't hold non-async locks (`std::sync::Mutex`, `parking_lot::Mutex`) across `.await`. Drop the guard explicitly, or use `tokio::sync::Mutex` if the lock genuinely needs to span the await. `clippy::await_holding_lock` flags this and is not a suggestion.
+- `tokio::join!` for independent parallel work; `tokio::try_join!` when both must succeed and the first error should cancel the rest.
+- Long-running spawned tasks need cancellation — channel or `CancellationToken`. Don't leak.
+- Cross-cutting context propagates via `tokio::task_local!`. Don't add new ones casually; document the contract in the module-level doc when you do.
 
 ### Generics
 - `impl Trait` in argument position for single-bound, single-use parameters.
 - Named generics with `where` clauses for multiple bounds, recursion, or readability.
-- Avoid generic explosion: 3+ generic parameters usually indicates a missing struct or associated type.
+- 3+ generic parameters usually signals a missing struct or associated type.
 - Prefer `Arc<dyn Trait>` over hand-rolled enum-dispatch when there are many implementors and no perf-critical specialization (see open issue #44 for the `AnyLlmClient` cleanup).
-- Trait bounds: keep `Send + Sync + 'static` co-located on the trait def when the trait is only useful in async contexts.
+- `Send + Sync + 'static` co-located on the trait def when the trait is only useful in async contexts.
 
 ### Error handling
 - Library crates: `thiserror` with structured variants (e.g. `core::CoreError`).
 - Binary crates: `anyhow` with `Context::context()` for narrative.
-- **Never pattern-match on error message strings.** Pattern-match on variants. If you find yourself doing `error.to_string().contains("429")`, the upstream type is throwing away structured info that should be preserved (see open issue #46).
-- Surface enough context in `Display` for debugging without leaking secrets — see `redacted_secret_audit` for the API-key fingerprint pattern.
+- **Never pattern-match on error message strings.** Pattern-match on variants. `error.to_string().contains("429")` means the upstream type is throwing away structured info that should be preserved (open issue #46).
+- `Display` should carry enough context for debugging without leaking secrets — see the `redacted_secret_audit` API-key fingerprint pattern.
 
-### Async
-- Don't hold non-async locks (`std::sync::Mutex`, `parking_lot::Mutex`) across `.await`. Drop the guard explicitly, or use `tokio::sync::Mutex` if the lock genuinely needs to span the await.
-- `tokio::join!` for independent parallel work; `tokio::try_join!` when both must succeed and the first error should cancel the rest.
-- Long-running spawned tasks need cancellation — channel-based or `CancellationToken`. Don't leak.
-- Cross-cutting context: `tokio::task_local!`. Existing examples: `REASONING_CONFIG`, `MODEL_OVERRIDE`, `CONTEXT_BUDGET` in `crates/core/src/ports/llm.rs`, plus `ACTIVE_CLIENT` in `crates/daemon/src/routing_llm.rs`.
-
-### Workspace organization
-- Hexagonal layout: trait boundaries in `core::ports`, infrastructure adapters in `daemon` / `storage` / `llm-*`, wire types in `api-model`.
-- LLM provider crates (`crates/llm-*`) MUST NOT depend on the `daemon` crate. Cross-cutting context flows via task-locals defined in `core`.
-- Wire types (`api-model`) separate from domain types (`core::domain`). The daemon's mapper layer translates between them.
+### Testing
+- Unit tests colocated as `#[cfg(test)] mod tests {}` in lib files; integration tests in `tests/` next to `Cargo.toml`.
+- `#[tokio::test]` for async; `#[tokio::test(flavor = "multi_thread")]` only when explicitly testing concurrent behavior.
+- Mock at trait boundaries. For HTTP: `httpmock` (already a daemon dev-dep). For time: an injected `Clock` trait — see `BedrockClient::ModelClock` in `crates/llm-bedrock`.
+- Determinism: sort outputs before assertion; never depend on hash iteration order.
+- `expect("descriptive reason")` over `unwrap()` in tests so failure messages are self-explanatory.
+- Test public behavior, not private implementation. If a private fn needs testing, surface it as `pub(crate)` with a documented contract.
 
 ### Documentation
 - Doc comments (`///`) on every public item.
@@ -77,7 +56,25 @@ Apply these consistently across the workspace. The pre-commit checklist at the b
 - For shared trait-locks / task-locals, document the contract in the module-level doc.
 - Don't narrate PR / issue history in code comments. Reference issues only when the comment captures a non-obvious WHY tied to that issue.
 
-### Pre-commit checklist
-1. `cargo clippy --workspace --all-targets`
-2. `cargo test --workspace`
-3. (Future: `cargo fmt --check` and `cargo clippy ... -- -D warnings` once the pre-existing warnings are remediated — tracked in follow-up issues.)
+## Storage & migrations
+
+- Migrations are append-only and ordinally numbered. Two concurrent PRs cannot share an ordinal — coordinate before opening, or rebase to take the next number. This is the one place parallel worktrees genuinely conflict; the conflict is invisible until both PRs merge, so check before pushing.
+- Schema changes that touch personal-data tables must respect the multi-tenant boundary (`user_id` scoping). See the multi-tenant schema work (#102) as the reference shape.
+
+## Daemon entry points & operations
+
+The daemon is built and run as `cargo run -p desktop-assistant-daemon`. Operational recipes — installing as a systemd user service, running a parallel dev instance, packaging — live in the `justfile` and `README.md`. When adding new operational behavior, prefer extending an existing `just` recipe over inventing a new entry point.
+
+## Build hygiene
+
+The workspace is held to:
+
+- `cargo fmt`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace`
+
+New code keeps it there. The user-memory "warnings are failures" rule covers the posture; this note exists so contributors know the baseline this repo enforces.
+
+## Dependency safety
+
+This workspace uses `cargo` exclusively for dependency management (no `cargo-edit`). The `cve-mcp` MCP server's `scan_packages` tool is wired up; the user-memory security-review rule covers when and how to use it. Repo-specific note: build scripts (`build.rs`) execute on first build, so the scan happens between lockfile change and first `cargo build`, not after.


### PR DESCRIPTION
## Summary

- Trims workflow-procedural content (GitHub issue/PR/board sync, dependency-scan workflow, pre-commit checklist) that now lives in cross-project user memory.
- Keeps repo-specific code conventions: workspace shape (hexagonal layout, port crates vs. provider crates, wire vs. domain types), Rust style anchored to concrete examples in the codebase, storage/migration coordination, and the operational seams the daemon exposes.
- Adds an explicit note that the workspace is held to `cargo clippy --workspace --all-targets -- -D warnings` and new code keeps it there.

## Why

Workflow rules (self-assignment, board sync, warnings-are-failures, security review, TDD posture) apply to every adelie-ai repo and now live in user-level memory. Per-repo AGENTS.md files should be narrow to repo-specific code conventions so they don't drift apart and don't compete with the canonical workflow rules.

## Test plan

- [ ] Read through AGENTS.md and confirm it accurately reflects current workspace shape and the Rust conventions you want contributors held to.
- [ ] Confirm the workflow rules removed from this file are sufficiently covered by user-memory (`feedback_github_workflow.md`, `feedback_warnings_are_failures.md`, `feedback_security_review.md`, `feedback_testing_tdd.md`, `feedback_parallel_worktrees.md`).
- [ ] Sanity-check that no in-flight worktree relies on text that was removed.