### PR TITLE
auth: extract user_id from JWT and scope storage queries (#105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "desktop-assistant-api-model",
+ "desktop-assistant-auth-jwt",
  "desktop-assistant-core",
  "serde_json",
  "thiserror 2.0.18",
@@ -1186,6 +1187,7 @@ dependencies = [
  "async-trait",
  "backon",
  "chrono",
+ "desktop-assistant-auth-jwt",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1372,6 +1374,7 @@ name = "desktop-assistant-storage"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "desktop-assistant-auth-jwt",
  "desktop-assistant-core",
  "pgvector",
  "serde",

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 async-trait.workspace = true
+desktop-assistant-auth-jwt.workspace = true
 desktop-assistant-core.workspace = true
 desktop-assistant-api-model = { path = "../api-model" }
 thiserror.workspace = true

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -6,7 +6,9 @@
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
+pub use desktop_assistant_auth_jwt::UserId;
 use desktop_assistant_core::domain::KnowledgeEntry;
+use desktop_assistant_core::ports::auth::with_user_id;
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
     ConversationModelSelection, ConversationService, DispatchWarning, KnowledgeService,
@@ -26,13 +28,87 @@ pub enum ApiError {
 
 pub type ApiResult<T> = Result<T, ApiError>;
 
+/// Per-request context threaded from the transport layer through the
+/// handler into core services (#105).
+///
+/// Carries the authenticated `user_id` extracted from the JWT — the
+/// daemon's stateless contract (`docs/architecture-evolution.md` rule
+/// #1) keeps all request-scoped state here rather than in any handler
+/// or service object. Additional per-request fields (request id,
+/// tracing context, cancellation token, ...) can be added without
+/// changing the handler trait's method signatures.
+///
+/// Construction:
+/// - From a validated JWT: `RequestContext::from(&claims)`.
+/// - For a local-dev / single-tenant fallback path: `RequestContext::default()`,
+///   which resolves to `UserId::default()` (the schema sentinel
+///   `"default"`).
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    /// The authenticated user_id for this request. Sourced from the
+    /// validated JWT's `sub` claim per #105's mapping rule.
+    pub user_id: UserId,
+}
+
+impl RequestContext {
+    /// Build a context with the given user id explicitly. Used by
+    /// transport adapters that don't have direct access to a `Claims`
+    /// (e.g. they resolved the user id through a different path) and
+    /// by tests that need to pin a known identity.
+    pub fn for_user(user_id: UserId) -> Self {
+        Self { user_id }
+    }
+}
+
+impl From<&desktop_assistant_auth_jwt::Claims> for RequestContext {
+    /// Build a `RequestContext` from a validated JWT claim set. The
+    /// `sub` field is mapped to `user_id` verbatim per the phase-1
+    /// rule in #105 — future revisions may consult an alternative
+    /// claim, but until then `sub` IS the identity.
+    fn from(claims: &desktop_assistant_auth_jwt::Claims) -> Self {
+        Self {
+            user_id: UserId::from(claims),
+        }
+    }
+}
+
+impl From<UserId> for RequestContext {
+    fn from(user_id: UserId) -> Self {
+        Self::for_user(user_id)
+    }
+}
+
 /// Protocol-neutral handler for the assistant API.
 ///
 /// Adapters (D-Bus, WebSocket, etc.) should depend on this trait rather than
 /// reaching into core services directly.
+///
+/// ## Threading the request context
+///
+/// Each method has a companion `*_for(ctx, …)` form that takes a
+/// [`RequestContext`]. Transport adapters extract the user identity
+/// from the validated JWT, build a `RequestContext`, and call the
+/// context-aware form. The non-`_for` methods remain as backward-
+/// compatible entry points: they delegate to the `_for` form with
+/// `RequestContext::default()`, which collapses to the schema
+/// sentinel `"default"`. Single-tenant deployments and tests that
+/// don't care about user identity continue to work unchanged (#105).
 #[async_trait::async_trait]
 pub trait AssistantApiHandler: Send + Sync {
     async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult>;
+
+    /// Context-aware variant of [`Self::handle_command`]. The default
+    /// implementation installs the request's user id via
+    /// [`with_user_id`] and forwards to `handle_command`. Concrete
+    /// handlers don't need to override this unless they want to
+    /// observe context fields beyond the user id.
+    async fn handle_command_for(
+        &self,
+        ctx: RequestContext,
+        cmd: api::Command,
+    ) -> ApiResult<api::CommandResult> {
+        with_user_id(ctx.user_id, self.handle_command(cmd)).await
+    }
 
     /// Handle a streaming command.
     ///
@@ -44,6 +120,24 @@ pub trait AssistantApiHandler: Send + Sync {
         request_id: String,
         sink: Arc<dyn EventSink>,
     ) -> ApiResult<()>;
+
+    /// Context-aware variant of [`Self::handle_send_message`]. The
+    /// default implementation installs the request's user id via
+    /// [`with_user_id`] and forwards to `handle_send_message`.
+    async fn handle_send_message_for(
+        &self,
+        ctx: RequestContext,
+        conversation_id: String,
+        content: String,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        with_user_id(
+            ctx.user_id,
+            self.handle_send_message(conversation_id, content, request_id, sink),
+        )
+        .await
+    }
 
     /// Handle a streaming `SendMessage` with an optional per-send model
     /// override. The default implementation ignores the override and
@@ -60,6 +154,29 @@ pub trait AssistantApiHandler: Send + Sync {
         let _ = override_selection;
         self.handle_send_message(conversation_id, content, request_id, sink)
             .await
+    }
+
+    /// Context-aware variant of [`Self::handle_send_message_with_override`].
+    async fn handle_send_message_with_override_for(
+        &self,
+        ctx: RequestContext,
+        conversation_id: String,
+        content: String,
+        override_selection: Option<api::SendPromptOverride>,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        with_user_id(
+            ctx.user_id,
+            self.handle_send_message_with_override(
+                conversation_id,
+                content,
+                override_selection,
+                request_id,
+                sink,
+            ),
+        )
+        .await
     }
 }
 
@@ -1756,5 +1873,152 @@ mod tests {
         assert_eq!(config.embeddings.model, "text-embedding-3-large");
         assert_eq!(config.persistence.remote_name, "upstream");
         assert!(!config.persistence.push_on_update);
+    }
+
+    // ---- RequestContext tests (issue #105) -----------------------------
+
+    #[test]
+    fn request_context_default_resolves_to_sentinel_user() {
+        // Single-tenant deploys and unauthenticated paths default to
+        // the schema sentinel so storage continues to resolve.
+        let ctx = RequestContext::default();
+        assert_eq!(ctx.user_id, UserId::default());
+        assert_eq!(ctx.user_id.as_str(), "default");
+    }
+
+    #[test]
+    fn request_context_from_claims_uses_sub_as_user_id() {
+        // Phase-1 mapping rule: the JWT `sub` is the user_id verbatim.
+        let claims = desktop_assistant_auth_jwt::Claims {
+            iss: "test-iss".into(),
+            sub: "alice".into(),
+            aud: "test-aud".into(),
+            exp: 0,
+            iat: 0,
+            nbf: 0,
+            jti: "jti".into(),
+        };
+        let ctx = RequestContext::from(&claims);
+        assert_eq!(ctx.user_id, UserId::new("alice"));
+    }
+
+    #[test]
+    fn request_context_for_user_pins_explicit_identity() {
+        let ctx = RequestContext::for_user(UserId::new("dave"));
+        assert_eq!(ctx.user_id.as_str(), "dave");
+    }
+
+    #[tokio::test]
+    async fn handle_command_for_installs_user_id_in_task_local() {
+        use desktop_assistant_core::ports::auth::current_user_id;
+
+        // A handler that records the user_id observed during dispatch.
+        struct Observer {
+            seen: Arc<Mutex<Option<UserId>>>,
+        }
+        #[async_trait::async_trait]
+        impl AssistantApiHandler for Observer {
+            async fn handle_command(
+                &self,
+                _cmd: api::Command,
+            ) -> ApiResult<api::CommandResult> {
+                let observed = current_user_id();
+                *self.seen.lock().unwrap() = Some(observed);
+                Ok(api::CommandResult::Ack)
+            }
+            async fn handle_send_message(
+                &self,
+                _conversation_id: String,
+                _content: String,
+                _request_id: String,
+                _sink: Arc<dyn EventSink>,
+            ) -> ApiResult<()> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let observer = Observer {
+            seen: Arc::clone(&seen),
+        };
+
+        let ctx = RequestContext::for_user(UserId::new("alice"));
+        let _ = observer
+            .handle_command_for(ctx, api::Command::Ping)
+            .await
+            .unwrap();
+
+        assert_eq!(seen.lock().unwrap().clone(), Some(UserId::new("alice")));
+    }
+
+    #[tokio::test]
+    async fn handle_command_for_with_default_context_resolves_to_sentinel() {
+        use desktop_assistant_core::ports::auth::current_user_id;
+
+        struct Observer {
+            seen: Arc<Mutex<Option<UserId>>>,
+        }
+        #[async_trait::async_trait]
+        impl AssistantApiHandler for Observer {
+            async fn handle_command(
+                &self,
+                _cmd: api::Command,
+            ) -> ApiResult<api::CommandResult> {
+                let observed = current_user_id();
+                *self.seen.lock().unwrap() = Some(observed);
+                Ok(api::CommandResult::Ack)
+            }
+            async fn handle_send_message(
+                &self,
+                _conversation_id: String,
+                _content: String,
+                _request_id: String,
+                _sink: Arc<dyn EventSink>,
+            ) -> ApiResult<()> {
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(None));
+        let observer = Observer {
+            seen: Arc::clone(&seen),
+        };
+
+        // Boundary: a request with no explicit user context succeeds
+        // and resolves to the sentinel. This is the single-tenant
+        // contract — independently shippable without #103 or any
+        // co-dependent PR.
+        let _ = observer
+            .handle_command_for(RequestContext::default(), api::Command::Ping)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            seen.lock().unwrap().clone(),
+            Some(UserId::default()),
+            "default RequestContext must resolve to the schema sentinel"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_command_uninstrumented_path_still_resolves_to_default() {
+        // The non-`_for` entry point continues to work without any
+        // user context — backward-compat for existing callers and
+        // tests, and the dual-mode contract for single-tenant
+        // deploys (no JWT path required to keep things working).
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        );
+        let res = h.handle_command(api::Command::Ping).await.unwrap();
+        assert_eq!(
+            res,
+            api::CommandResult::Pong {
+                value: "pong".into()
+            }
+        );
     }
 }

--- a/crates/auth-jwt/src/lib.rs
+++ b/crates/auth-jwt/src/lib.rs
@@ -19,6 +19,113 @@ use anyhow::anyhow;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 
+/// Sentinel `user_id` for single-tenant desktop installs and for any code
+/// path that hasn't yet been threaded with an explicit user identity.
+///
+/// Matches the `DEFAULT 'default'` backfill value the multi-tenant schema
+/// migration writes to every personal-data table (see #102's
+/// `016_multi_tenant_user_id.sql`). A single-tenant deploy collapses to
+/// this id; a multi-tenant deploy uses the JWT `sub` of each request.
+/// Both paths share the same SQL, the same indexes, and the same
+/// `WHERE user_id = $1` predicate.
+pub const DEFAULT_USER_ID: &str = "default";
+
+/// Newtype wrapper for a request-scoped user identity.
+///
+/// Phase 1 of the architecture evolution (`docs/architecture-evolution.md`)
+/// extracts `sub` from a validated JWT and uses it directly as the
+/// `user_id` scoping personal-data SQL queries. Wrapping the string in a
+/// dedicated type prevents accidental confusion with conversation ids,
+/// message ids, or any other free-form string flowing through the
+/// handler.
+///
+/// Why this type lives in `auth-jwt` rather than `application` or
+/// `core`: every transport adapter (WS, UDS, future API Gateway WS) ends
+/// up with a `Claims` from this crate, and the natural place to mint the
+/// `UserId` from those claims is right next to the `Claims` definition.
+/// Both core (for the storage task-local) and the application crate (for
+/// the request context) depend on `auth-jwt`, so the type is reachable
+/// from every layer that needs it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct UserId(String);
+
+impl UserId {
+    /// Wrap a raw string in a [`UserId`]. The string is trusted as-is —
+    /// callers should source it from a validated JWT `sub`, not from
+    /// untrusted user input.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// The sentinel single-tenant id (`"default"`). Equivalent to
+    /// `UserId::default()` but const-friendly and explicit at call
+    /// sites that want to make the fall-through visible.
+    pub fn sentinel_default() -> Self {
+        Self(DEFAULT_USER_ID.to_string())
+    }
+
+    /// Borrow the wrapped string. Storage layers bind this directly into
+    /// SQL queries.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the wrapper, returning the underlying string. Used when a
+    /// caller needs to hand ownership to a string-typed API (e.g. SQL
+    /// bind that wants `String`).
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl Default for UserId {
+    /// The default user id is [`DEFAULT_USER_ID`] (`"default"`) — matches
+    /// the schema-level column default and the single-tenant deploy
+    /// collapse target.
+    fn default() -> Self {
+        Self::sentinel_default()
+    }
+}
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for UserId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&Claims> for UserId {
+    /// Phase-1 mapping rule: the JWT `sub` is the `user_id` verbatim.
+    /// Documented in #105; future revisions may consult a configurable
+    /// claim or a DB lookup, but until then `sub` is the identity.
+    fn from(claims: &Claims) -> Self {
+        Self(claims.sub.clone())
+    }
+}
+
+impl From<Claims> for UserId {
+    fn from(claims: Claims) -> Self {
+        Self(claims.sub)
+    }
+}
+
+impl From<String> for UserId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for UserId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
 /// HS256 JWT claim payload.
 ///
 /// Fields are public so callers can construct claims directly and tests
@@ -346,5 +453,84 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs()
+    }
+
+    // ---- UserId tests (issue #105) ----------------------------------------
+
+    #[test]
+    fn user_id_default_is_sentinel_default_string() {
+        // Single-tenant deploys and any unauthenticated request path
+        // resolve to this sentinel — matches the schema default in #102.
+        assert_eq!(UserId::default().as_str(), "default");
+        assert_eq!(UserId::default().as_str(), DEFAULT_USER_ID);
+    }
+
+    #[test]
+    fn user_id_from_claims_uses_sub_verbatim() {
+        // Phase-1 mapping: the JWT `sub` IS the user_id, no indirection.
+        let claims = make_claims(unix_now());
+        let user_id = UserId::from(&claims);
+        assert_eq!(user_id.as_str(), claims.sub);
+        assert_eq!(user_id.as_str(), "alice");
+    }
+
+    #[test]
+    fn user_id_from_owned_claims_preserves_sub() {
+        let mut claims = make_claims(unix_now());
+        claims.sub = "bob".to_string();
+        let user_id = UserId::from(claims);
+        assert_eq!(user_id.as_str(), "bob");
+    }
+
+    #[test]
+    fn user_id_jwt_round_trip_yields_same_user_id() {
+        // happy path: a token issued for `sub=alice` validates and the
+        // extracted user_id is `UserId("alice")`. Mirrors the path the
+        // ws-interface handler takes for every authenticated request.
+        let key = "deadbeef".repeat(8);
+        let mut claims = make_claims(unix_now());
+        claims.sub = "alice".to_string();
+        let token = encode(&claims, &key).unwrap();
+        let decoded = decode(&token, &key, "test-iss", "test-aud").unwrap();
+        let user_id = UserId::from(&decoded);
+        assert_eq!(user_id.as_str(), "alice");
+    }
+
+    #[test]
+    fn user_id_equality_distinguishes_users() {
+        let alice = UserId::new("alice");
+        let bob = UserId::new("bob");
+        let alice_again = UserId::new("alice");
+        assert_eq!(alice, alice_again);
+        assert_ne!(alice, bob);
+        assert_ne!(alice, UserId::default());
+    }
+
+    #[test]
+    fn user_id_display_writes_raw_string() {
+        assert_eq!(format!("{}", UserId::new("dave")), "dave");
+        assert_eq!(format!("{}", UserId::default()), "default");
+    }
+
+    #[test]
+    fn user_id_as_ref_str_borrows_inner() {
+        let uid = UserId::new("carol");
+        let s: &str = uid.as_ref();
+        assert_eq!(s, "carol");
+    }
+
+    #[test]
+    fn user_id_into_inner_returns_owned_string() {
+        let uid = UserId::new("eve");
+        assert_eq!(uid.into_inner(), "eve");
+    }
+
+    #[test]
+    fn user_id_sentinel_default_constant_matches_schema() {
+        // The schema migration in #102 writes `'default'` as both the
+        // backfill value and the column DEFAULT. If those drift the
+        // sentinel must change in lockstep — this test wires them
+        // together so the migration tests would also fail.
+        assert_eq!(UserId::sentinel_default().as_str(), "default");
     }
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 async-trait.workspace = true
 backon = "1"
+desktop-assistant-auth-jwt.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/core/src/ports/auth.rs
+++ b/crates/core/src/ports/auth.rs
@@ -1,0 +1,129 @@
+//! Request-scoped auth context (#105).
+//!
+//! This module exposes a task-local [`UserId`] slot so storage layers
+//! can scope SQL to the requesting user without every port-trait method
+//! growing a `user_id: &UserId` parameter. The handler at the transport
+//! boundary (WS, UDS, future API Gateway WS) extracts the JWT `sub`,
+//! wraps it in [`UserId`], and installs it via [`with_user_id`] before
+//! invoking any [`crate::ports::inbound`] service. The storage adapters
+//! read it via [`current_user_id`] at SQL composition time.
+//!
+//! ## Why a task-local
+//!
+//! The codebase already threads per-turn LLM configuration the same way
+//! (see [`crate::ports::llm::CONTEXT_BUDGET`] and [`MODEL_OVERRIDE`]).
+//! User identity is the same shape of value: scoped to a single request,
+//! crossing many `await` points and many layers, read by code that
+//! doesn't otherwise know about the auth pipeline. Threading it through
+//! every signature would touch every port trait and every test fixture
+//! for a value that doesn't influence those signatures' shape — task-
+//! local keeps the existing API surface stable while still making the
+//! identity available where storage needs it.
+//!
+//! Independently shippable single-tenant mode: when nothing has set the
+//! task-local, [`current_user_id`] returns [`UserId::default`], which
+//! resolves to the schema-level sentinel `"default"`. That's the same
+//! value the migration in #102 writes as the column default and as the
+//! backfill for pre-multi-tenant rows. The result is that single-tenant
+//! desktop deploys see no behavioural change.
+
+pub use desktop_assistant_auth_jwt::{DEFAULT_USER_ID, UserId};
+
+tokio::task_local! {
+    /// Per-request user identity. Set by the transport-adapter handler
+    /// via [`with_user_id`] right after JWT validation; read by storage
+    /// adapters via [`current_user_id`] when composing SQL.
+    ///
+    /// When this slot is unset (background workers, tests that don't go
+    /// through a transport, single-tenant deploys without JWT auth),
+    /// [`current_user_id`] returns [`UserId::default`] which maps to the
+    /// schema sentinel `"default"`. This keeps every code path
+    /// dual-mode: a single-tenant install collapses to the sentinel; a
+    /// multi-tenant install sees the JWT `sub` as the user id; the SQL
+    /// is identical in both cases.
+    static USER_ID: UserId;
+}
+
+/// Run `fut` with `user_id` installed as the current task-local user
+/// identity. All [`current_user_id`] calls inside the future (and any
+/// sub-tasks that inherit the scope) observe `user_id`.
+///
+/// The transport handler ([`crates/ws-interface`] and friends) calls
+/// this exactly once per request, immediately after extracting the
+/// identity from the JWT. Nested calls override the outer scope for the
+/// duration of the inner future — this is how dreaming workers and
+/// embedding backfill jobs that iterate over many users can scope each
+/// per-user pass.
+pub async fn with_user_id<F, T>(user_id: UserId, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    USER_ID.scope(user_id, fut).await
+}
+
+/// The current task-local user identity, or [`UserId::default`] (the
+/// schema sentinel) when no scope is installed.
+///
+/// Storage adapters call this at SQL composition time. Safe to call
+/// from any async context — never panics, never blocks.
+pub fn current_user_id() -> UserId {
+    USER_ID.try_with(|u| u.clone()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn current_user_id_outside_scope_is_default() {
+        // Single-tenant / unscoped path: storage code that runs without
+        // a transport-installed scope falls through to the sentinel.
+        assert_eq!(current_user_id(), UserId::default());
+        assert_eq!(current_user_id().as_str(), "default");
+    }
+
+    #[tokio::test]
+    async fn current_user_id_inside_scope_returns_installed_value() {
+        let observed = with_user_id(UserId::new("alice"), async {
+            current_user_id()
+        })
+        .await;
+        assert_eq!(observed, UserId::new("alice"));
+    }
+
+    #[tokio::test]
+    async fn nested_scopes_override_then_restore() {
+        // Inner scope wins for the duration of the inner future; outer
+        // scope restores afterwards. Mirrors how a per-user dreaming
+        // worker would loop inside a daemon-wide background task.
+        let result = with_user_id(UserId::new("outer"), async {
+            let inner = with_user_id(UserId::new("inner"), async {
+                current_user_id()
+            })
+            .await;
+            let after = current_user_id();
+            (inner, after)
+        })
+        .await;
+        assert_eq!(result.0, UserId::new("inner"));
+        assert_eq!(result.1, UserId::new("outer"));
+    }
+
+    #[tokio::test]
+    async fn current_user_id_outside_any_scope_after_spawn_falls_back_to_default() {
+        // Tasks spawned outside any `with_user_id` scope don't see the
+        // slot — that's the normal `task_local` semantic, and it's the
+        // reason the dreaming worker re-installs the scope around each
+        // per-user batch. Documenting the contract here keeps callers
+        // honest: anything that crosses `tokio::spawn` must
+        // re-install before touching storage.
+        let observed = tokio::spawn(async { current_user_id() })
+            .await
+            .unwrap();
+        assert_eq!(
+            observed,
+            UserId::default(),
+            "spawned tasks outside any scope must fall through to the sentinel"
+        );
+    }
+}

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -31,6 +31,9 @@ pub mod database;
 /// Conversation search port — outbound trait for full-text search over past messages.
 pub mod conversation_search;
 
+/// Request-scoped auth context — task-local `UserId` for SQL scoping (#105).
+pub mod auth;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/daemon/src/config/jwt.rs
+++ b/crates/daemon/src/config/jwt.rs
@@ -110,3 +110,20 @@ pub fn validate_ws_jwt(token: &str) -> anyhow::Result<bool> {
         }
     }
 }
+
+/// Decode and validate `token`, then return the `sub` claim.
+///
+/// Used by the WS auth path (#105) to map a validated bearer token to
+/// the `user_id` that scopes every subsequent storage query. Returns
+/// `None` when the token is missing, malformed, expired, or otherwise
+/// rejected by the same checks [`validate_ws_jwt`] applies — a caller
+/// that wants to distinguish "valid but no sub" from "invalid" should
+/// call this AFTER `validate_ws_jwt` and treat `None` as "validator
+/// opted out of identity extraction".
+pub fn ws_jwt_sub(token: &str) -> Option<String> {
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    decode_ws_jwt_claims(token).ok().map(|claims| claims.sub)
+}

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -28,7 +28,7 @@ pub use views::{
 // Re-export the JWT + OIDC public API at the `config::` path so existing
 // callers (`config::generate_ws_jwt`, `config::OidcValidator`, etc.)
 // keep working unchanged.
-pub use jwt::{current_username, generate_ws_jwt, validate_ws_jwt};
+pub use jwt::{current_username, generate_ws_jwt, validate_ws_jwt, ws_jwt_sub};
 pub use oidc::OidcValidator;
 
 // Resolution helpers — public API stays at `config::` for callers in

--- a/crates/daemon/src/config/oidc.rs
+++ b/crates/daemon/src/config/oidc.rs
@@ -188,6 +188,45 @@ impl OidcValidator {
         })
     }
 
+    /// Decode and validate `token`, then return the `sub` claim from
+    /// it. Returns `None` for tokens this validator would reject.
+    /// Mirrors [`Self::validate_token`]'s kid/kidless resolution order
+    /// so a token that validates here will also validate there, and a
+    /// successfully-decoded payload yields its `sub` string.
+    ///
+    /// Used by the WS auth path (#105) to map a validated OIDC bearer
+    /// token to the `user_id` that scopes storage queries.
+    pub fn extract_sub(&self, token: &str) -> Option<String> {
+        let header_kid = decode_header(token).ok().and_then(|h| h.kid);
+
+        if let Some(kid) = header_kid.as_deref()
+            && let Some(key) = self.keys_by_kid.get(kid)
+        {
+            if let Ok(data) =
+                jsonwebtoken::decode::<serde_json::Value>(token, key, &self.validation)
+            {
+                return data
+                    .claims
+                    .get("sub")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+            }
+        }
+
+        for key in &self.kidless_keys {
+            if let Ok(data) =
+                jsonwebtoken::decode::<serde_json::Value>(token, key, &self.validation)
+            {
+                return data
+                    .claims
+                    .get("sub")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+            }
+        }
+        None
+    }
+
     pub fn validate_token(&self, token: &str) -> bool {
         // Resolution order:
         //

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -55,6 +55,18 @@ impl<S: SettingsService + 'static> ws::WsAuthValidator for WsSettingsAuth<S> {
             .await
             .unwrap_or(false)
     }
+
+    async fn extract_user_id(
+        &self,
+        token: &str,
+    ) -> Option<desktop_assistant_application::UserId> {
+        // #105 mapping rule: JWT `sub` → `UserId`. Returns `None` for
+        // tokens this validator would reject; the ws-interface
+        // handler then falls back to `UserId::default` (the schema
+        // sentinel) so a single-tenant deploy without identity
+        // information still resolves correctly.
+        config::ws_jwt_sub(token).map(desktop_assistant_application::UserId::from)
+    }
 }
 
 /// Auth validator that tries the local HS256 JWT first, then falls back to OIDC RS256.
@@ -72,6 +84,22 @@ impl<S: SettingsService + 'static> ws::WsAuthValidator for OidcAwareAuth<S> {
         }
         // Fall back to OIDC RS256 validation
         self.oidc_validator.validate_token(token)
+    }
+
+    async fn extract_user_id(
+        &self,
+        token: &str,
+    ) -> Option<desktop_assistant_application::UserId> {
+        // Resolution order mirrors `validate_bearer_token`: prefer the
+        // local HS256 mint (single-tenant desktop primary path), then
+        // fall through to OIDC RS256 (multi-tenant deploys). Whichever
+        // one accepts the token also yields its `sub`.
+        if let Some(uid) = self.local.extract_user_id(token).await {
+            return Some(uid);
+        }
+        self.oidc_validator
+            .extract_sub(token)
+            .map(desktop_assistant_application::UserId::from)
     }
 }
 
@@ -105,6 +133,17 @@ impl WsAsUdsAuth {
 impl uds::UdsAuthValidator for WsAsUdsAuth {
     async fn validate_bearer_token(&self, token: &str) -> bool {
         self.validator.validate_bearer_token(token).await
+    }
+
+    async fn extract_user_id(
+        &self,
+        token: &str,
+    ) -> Option<desktop_assistant_application::UserId> {
+        // Delegate to the same WS validator so UDS and WS share the
+        // JWT-to-user_id mapping. The bridge above already enforces
+        // uniform validation; #105's identity extraction follows the
+        // same path.
+        self.validator.extract_user_id(token).await
     }
 }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "AGPL-3.0-or-later"
 
 [dependencies]
+desktop-assistant-auth-jwt.workspace = true
 desktop-assistant-core.workspace = true
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros", "json", "chrono", "uuid"] }
 pgvector = { version = "0.4", features = ["sqlx"] }

--- a/crates/storage/src/conversation.rs
+++ b/crates/storage/src/conversation.rs
@@ -2,6 +2,7 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{
     Conversation, ConversationId, Message, MessageSummary, Role, ToolCall,
 };
+use desktop_assistant_core::ports::auth::current_user_id;
 use desktop_assistant_core::ports::inbound::ConversationModelSelection;
 use desktop_assistant_core::ports::store::ConversationStore;
 use sqlx::PgPool;
@@ -25,6 +26,7 @@ impl PgConversationStore {
         conversation_id: &ConversationId,
         selection: Option<&ConversationModelSelection>,
     ) -> Result<(), CoreError> {
+        let user_id = current_user_id();
         let json = match selection {
             Some(sel) => Some(
                 serde_json::to_value(sel)
@@ -32,14 +34,21 @@ impl PgConversationStore {
             ),
             None => None,
         };
-        let result =
-            sqlx::query("UPDATE conversations SET last_model_selection = $2 WHERE id = $1")
-                .bind(&conversation_id.0)
-                .bind(json)
-                .execute(&self.pool)
-                .await
-                .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let result = sqlx::query(
+            "UPDATE conversations SET last_model_selection = $3 \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&conversation_id.0)
+        .bind(json)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
         if result.rows_affected() == 0 {
+            // Either the conversation id is unknown or it belongs to a
+            // different user. We return `ConversationNotFound` in both
+            // cases so cross-user probes can't distinguish "doesn't
+            // exist" from "not yours" (#105: don't leak existence).
             return Err(CoreError::ConversationNotFound(conversation_id.0.clone()));
         }
         Ok(())
@@ -47,17 +56,22 @@ impl PgConversationStore {
 
     /// Read the stored model selection for a conversation. Returns `None`
     /// when the conversation exists but has no stored selection; returns
-    /// `ConversationNotFound` when the id is unknown.
+    /// `ConversationNotFound` when the id is unknown OR belongs to a
+    /// different user.
     pub async fn get_conversation_model_selection(
         &self,
         conversation_id: &ConversationId,
     ) -> Result<Option<ConversationModelSelection>, CoreError> {
-        let row: Option<(Option<serde_json::Value>,)> =
-            sqlx::query_as("SELECT last_model_selection FROM conversations WHERE id = $1")
-                .bind(&conversation_id.0)
-                .fetch_optional(&self.pool)
-                .await
-                .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let user_id = current_user_id();
+        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+            "SELECT last_model_selection FROM conversations \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&conversation_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         let row = row.ok_or_else(|| CoreError::ConversationNotFound(conversation_id.0.clone()))?;
         let Some(json) = row.0 else {
@@ -91,6 +105,7 @@ fn str_to_role(s: &str) -> Role {
 
 impl ConversationStore for PgConversationStore {
     async fn create(&self, conv: Conversation) -> Result<(), CoreError> {
+        let user_id = current_user_id();
         let mut tx = self
             .pool
             .begin()
@@ -98,10 +113,13 @@ impl ConversationStore for PgConversationStore {
             .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         sqlx::query(
-            "INSERT INTO conversations (id, title, created_at, updated_at, context_summary, compacted_through, archived_at, active_task)
-             VALUES ($1, $2, $3::timestamptz, $4::timestamptz, $5, $6, $7, $8)"
+            "INSERT INTO conversations \
+                (id, user_id, title, created_at, updated_at, context_summary, \
+                 compacted_through, archived_at, active_task) \
+             VALUES ($1, $2, $3, $4::timestamptz, $5::timestamptz, $6, $7, $8, $9)",
         )
         .bind(&conv.id.0)
+        .bind(user_id.as_str())
         .bind(&conv.title)
         .bind(parse_timestamp(&conv.created_at))
         .bind(parse_timestamp(&conv.updated_at))
@@ -114,7 +132,7 @@ impl ConversationStore for PgConversationStore {
         .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         for (ordinal, msg) in conv.messages.iter().enumerate() {
-            insert_message(&mut tx, &conv.id.0, ordinal, msg).await?;
+            insert_message(&mut tx, user_id.as_str(), &conv.id.0, ordinal, msg).await?;
         }
 
         tx.commit()
@@ -124,10 +142,13 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn get(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+        let user_id = current_user_id();
         let row: Option<ConvRow> = sqlx::query_as(
-            "SELECT id, title, created_at, updated_at, context_summary, compacted_through, archived_at, active_task
-             FROM conversations WHERE id = $1",
+            "SELECT id, title, created_at, updated_at, context_summary, \
+                    compacted_through, archived_at, active_task \
+             FROM conversations WHERE user_id = $1 AND id = $2",
         )
+        .bind(user_id.as_str())
         .bind(&id.0)
         .fetch_optional(&self.pool)
         .await
@@ -136,9 +157,12 @@ impl ConversationStore for PgConversationStore {
         let row = row.ok_or_else(|| CoreError::ConversationNotFound(id.0.clone()))?;
 
         let msg_rows: Vec<MsgRow> = sqlx::query_as(
-            "SELECT ordinal, role, content, tool_calls, tool_call_id, summary_id
-             FROM messages WHERE conversation_id = $1 ORDER BY ordinal",
+            "SELECT ordinal, role, content, tool_calls, tool_call_id, summary_id \
+             FROM messages \
+             WHERE user_id = $1 AND conversation_id = $2 \
+             ORDER BY ordinal",
         )
+        .bind(user_id.as_str())
         .bind(&id.0)
         .fetch_all(&self.pool)
         .await
@@ -147,9 +171,12 @@ impl ConversationStore for PgConversationStore {
         let messages = msg_rows.into_iter().map(msg_from_row).collect();
 
         let summary_rows: Vec<SummaryRow> = sqlx::query_as(
-            "SELECT id, summary
-             FROM message_summaries WHERE conversation_id = $1 ORDER BY start_ordinal",
+            "SELECT id, summary \
+             FROM message_summaries \
+             WHERE user_id = $1 AND conversation_id = $2 \
+             ORDER BY start_ordinal",
         )
+        .bind(user_id.as_str())
         .bind(&id.0)
         .fetch_all(&self.pool)
         .await
@@ -178,10 +205,15 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn list(&self) -> Result<Vec<Conversation>, CoreError> {
+        let user_id = current_user_id();
         let rows: Vec<ConvRow> = sqlx::query_as(
-            "SELECT id, title, created_at, updated_at, context_summary, compacted_through, archived_at, active_task
-             FROM conversations ORDER BY updated_at DESC",
+            "SELECT id, title, created_at, updated_at, context_summary, \
+                    compacted_through, archived_at, active_task \
+             FROM conversations \
+             WHERE user_id = $1 \
+             ORDER BY updated_at DESC",
         )
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
@@ -189,9 +221,12 @@ impl ConversationStore for PgConversationStore {
         let mut conversations = Vec::with_capacity(rows.len());
         for row in rows {
             let msg_rows: Vec<MsgRow> = sqlx::query_as(
-                "SELECT ordinal, role, content, tool_calls, tool_call_id, summary_id
-                 FROM messages WHERE conversation_id = $1 ORDER BY ordinal",
+                "SELECT ordinal, role, content, tool_calls, tool_call_id, summary_id \
+                 FROM messages \
+                 WHERE user_id = $1 AND conversation_id = $2 \
+                 ORDER BY ordinal",
             )
+            .bind(user_id.as_str())
             .bind(&row.id)
             .fetch_all(&self.pool)
             .await
@@ -200,9 +235,12 @@ impl ConversationStore for PgConversationStore {
             let messages = msg_rows.into_iter().map(msg_from_row).collect();
 
             let summary_rows: Vec<SummaryRow> = sqlx::query_as(
-                "SELECT id, summary
-                 FROM message_summaries WHERE conversation_id = $1 ORDER BY start_ordinal",
+                "SELECT id, summary \
+                 FROM message_summaries \
+                 WHERE user_id = $1 AND conversation_id = $2 \
+                 ORDER BY start_ordinal",
             )
+            .bind(user_id.as_str())
             .bind(&row.id)
             .fetch_all(&self.pool)
             .await
@@ -234,6 +272,7 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn update(&self, conv: Conversation) -> Result<(), CoreError> {
+        let user_id = current_user_id();
         let mut tx = self
             .pool
             .begin()
@@ -241,10 +280,12 @@ impl ConversationStore for PgConversationStore {
             .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         let result = sqlx::query(
-            "UPDATE conversations SET title = $2, updated_at = $3::timestamptz,
-                    context_summary = $4, compacted_through = $5, active_task = $6
-             WHERE id = $1",
+            "UPDATE conversations \
+             SET title = $3, updated_at = $4::timestamptz, \
+                 context_summary = $5, compacted_through = $6, active_task = $7 \
+             WHERE user_id = $1 AND id = $2",
         )
+        .bind(user_id.as_str())
         .bind(&conv.id.0)
         .bind(&conv.title)
         .bind(parse_timestamp(&conv.updated_at))
@@ -259,15 +300,20 @@ impl ConversationStore for PgConversationStore {
             return Err(CoreError::ConversationNotFound(conv.id.0.clone()));
         }
 
-        // Replace all messages: delete existing, re-insert
-        sqlx::query("DELETE FROM messages WHERE conversation_id = $1")
-            .bind(&conv.id.0)
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        // Replace all messages: delete existing, re-insert. Scoped by
+        // user_id as defense-in-depth — the UPDATE above already
+        // proved the conversation belongs to this user.
+        sqlx::query(
+            "DELETE FROM messages WHERE user_id = $1 AND conversation_id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&conv.id.0)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         for (ordinal, msg) in conv.messages.iter().enumerate() {
-            insert_message(&mut tx, &conv.id.0, ordinal, msg).await?;
+            insert_message(&mut tx, user_id.as_str(), &conv.id.0, ordinal, msg).await?;
         }
 
         tx.commit()
@@ -277,11 +323,15 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn delete(&self, id: &ConversationId) -> Result<(), CoreError> {
-        let result = sqlx::query("DELETE FROM conversations WHERE id = $1")
-            .bind(&id.0)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let user_id = current_user_id();
+        let result = sqlx::query(
+            "DELETE FROM conversations WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&id.0)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         if result.rows_affected() == 0 {
             return Err(CoreError::ConversationNotFound(id.0.clone()));
@@ -290,22 +340,30 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn archive(&self, id: &ConversationId) -> Result<(), CoreError> {
+        let user_id = current_user_id();
         let result = sqlx::query(
-            "UPDATE conversations SET archived_at = NOW() WHERE id = $1 AND archived_at IS NULL",
+            "UPDATE conversations SET archived_at = NOW() \
+             WHERE user_id = $1 AND id = $2 AND archived_at IS NULL",
         )
+        .bind(user_id.as_str())
         .bind(&id.0)
         .execute(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         if result.rows_affected() == 0 {
-            // Either not found or already archived — check which.
-            let exists: Option<(i64,)> =
-                sqlx::query_as("SELECT 1 FROM conversations WHERE id = $1")
-                    .bind(&id.0)
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(|e| CoreError::Storage(e.to_string()))?;
+            // Either not found, already archived, or owned by a
+            // different user — `SELECT 1 …` distinguishes. The
+            // existence probe is itself user-scoped so a cross-user
+            // lookup still returns "not found" without leaking.
+            let exists: Option<(i64,)> = sqlx::query_as(
+                "SELECT 1 FROM conversations WHERE user_id = $1 AND id = $2",
+            )
+            .bind(user_id.as_str())
+            .bind(&id.0)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?;
             if exists.is_none() {
                 return Err(CoreError::ConversationNotFound(id.0.clone()));
             }
@@ -314,11 +372,16 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn unarchive(&self, id: &ConversationId) -> Result<(), CoreError> {
-        let result = sqlx::query("UPDATE conversations SET archived_at = NULL WHERE id = $1")
-            .bind(&id.0)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let user_id = current_user_id();
+        let result = sqlx::query(
+            "UPDATE conversations SET archived_at = NULL \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&id.0)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         if result.rows_affected() == 0 {
             return Err(CoreError::ConversationNotFound(id.0.clone()));
@@ -333,6 +396,7 @@ impl ConversationStore for PgConversationStore {
         start_ordinal: usize,
         end_ordinal: usize,
     ) -> Result<String, CoreError> {
+        let user_id = current_user_id();
         let id = uuid::Uuid::now_v7().to_string();
         let mut tx = self
             .pool
@@ -341,10 +405,12 @@ impl ConversationStore for PgConversationStore {
             .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         sqlx::query(
-            "INSERT INTO message_summaries (id, conversation_id, summary, start_ordinal, end_ordinal)
-             VALUES ($1, $2, $3, $4, $5)"
+            "INSERT INTO message_summaries \
+                (id, user_id, conversation_id, summary, start_ordinal, end_ordinal) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
         )
         .bind(&id)
+        .bind(user_id.as_str())
         .bind(&conversation_id.0)
         .bind(&summary)
         .bind(start_ordinal as i32)
@@ -354,11 +420,12 @@ impl ConversationStore for PgConversationStore {
         .map_err(|e| CoreError::Storage(e.to_string()))?;
 
         sqlx::query(
-            "UPDATE messages SET summary_id = $1
-             WHERE conversation_id = $2 AND ordinal BETWEEN $3 AND $4",
+            "UPDATE messages SET summary_id = $3 \
+             WHERE user_id = $1 AND conversation_id = $2 AND ordinal BETWEEN $4 AND $5",
         )
-        .bind(&id)
+        .bind(user_id.as_str())
         .bind(&conversation_id.0)
+        .bind(&id)
         .bind(start_ordinal as i32)
         .bind(end_ordinal as i32)
         .execute(&mut *tx)
@@ -372,18 +439,23 @@ impl ConversationStore for PgConversationStore {
     }
 
     async fn expand_summary(&self, summary_id: &str) -> Result<(), CoreError> {
+        let user_id = current_user_id();
         // ON DELETE SET NULL on messages.summary_id handles clearing the references.
-        sqlx::query("DELETE FROM message_summaries WHERE id = $1")
-            .bind(summary_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        sqlx::query(
+            "DELETE FROM message_summaries WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(summary_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
         Ok(())
     }
 }
 
 async fn insert_message(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: &str,
     conversation_id: &str,
     ordinal: usize,
     msg: &Message,
@@ -395,10 +467,13 @@ async fn insert_message(
     };
 
     sqlx::query(
-        "INSERT INTO messages (id, conversation_id, ordinal, role, content, tool_calls, tool_call_id, summary_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)"
+        "INSERT INTO messages \
+            (id, user_id, conversation_id, ordinal, role, content, \
+             tool_calls, tool_call_id, summary_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     )
     .bind(uuid::Uuid::now_v7().to_string())
+    .bind(user_id)
     .bind(conversation_id)
     .bind(ordinal as i32)
     .bind(role_to_str(&msg.role))

--- a/crates/storage/src/conversation_search.rs
+++ b/crates/storage/src/conversation_search.rs
@@ -1,5 +1,6 @@
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::Role;
+use desktop_assistant_core::ports::auth::current_user_id;
 use desktop_assistant_core::ports::conversation_search::{ConversationSearchStore, MessageHit};
 use sqlx::PgPool;
 
@@ -59,6 +60,7 @@ impl ConversationSearchStore for PgConversationSearchStore {
         limit: usize,
         role_filter: Option<Role>,
     ) -> Result<Vec<MessageHit>, CoreError> {
+        let user_id = current_user_id();
         let role_db = role_filter.map(role_to_db);
         let limit_i64 = limit as i64;
 
@@ -67,6 +69,11 @@ impl ConversationSearchStore for PgConversationSearchStore {
         // by conversation tsv. Snippet runs over message content so the
         // tool result has something concrete to show even when the
         // match was on title/summary (an empty `ts_headline` is fine).
+        //
+        // Scoping is double-applied (on `m.user_id` AND `c.user_id`)
+        // as defense-in-depth — the JOIN guarantees they're equal in
+        // a well-formed schema, but a corrupted row would still be
+        // hidden from the wrong user.
         let rows: Vec<MessageHitRow> = sqlx::query_as(
             "WITH q AS (
                  SELECT plainto_tsquery('english', $1) AS query
@@ -90,8 +97,10 @@ impl ConversationSearchStore for PgConversationSearchStore {
              FROM messages m
              JOIN conversations c ON c.id = m.conversation_id
              WHERE
-                 (m.tsv @@ (SELECT query FROM q)
-                  OR c.tsv @@ (SELECT query FROM q))
+                 m.user_id = $4
+                 AND c.user_id = $4
+                 AND (m.tsv @@ (SELECT query FROM q)
+                      OR c.tsv @@ (SELECT query FROM q))
                  AND ($2::text IS NULL OR m.role = $2)
              ORDER BY rank DESC, c.updated_at DESC, m.ordinal ASC
              LIMIT $3",
@@ -99,6 +108,7 @@ impl ConversationSearchStore for PgConversationSearchStore {
         .bind(query)
         .bind(role_db)
         .bind(limit_i64)
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;

--- a/crates/storage/src/dreaming/archival.rs
+++ b/crates/storage/src/dreaming/archival.rs
@@ -4,21 +4,58 @@
 //! as archived. Hard-deletion of the underlying messages is a separate
 //! concern. Consolidation tolerates the case where a fact's
 //! `source_conversation_id` no longer resolves.
+//!
+//! This phase iterates implicitly over all users — each row carries its
+//! own `user_id`, and the archival flag is set in place, so the
+//! per-row mutation preserves tenancy. We still scope by `user_id`
+//! whenever a task-local user is installed (the consolidation loop
+//! installs one per user); when archival runs at the top level (no
+//! scope), it processes all users uniformly. The query is
+//! audit-allowlisted because the cross-user form is intentional.
 
 use sqlx::PgPool;
 
-/// Archive conversations not touched in `days` days. Returns rows archived.
-pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, String> {
-    let result = sqlx::query(
-        "UPDATE conversations
-         SET archived_at = NOW()
-         WHERE archived_at IS NULL
-           AND updated_at < NOW() - make_interval(days => $1)",
-    )
-    .bind(days as i32)
-    .execute(pool)
-    .await
-    .map_err(|e| format!("dreaming: archival query failed: {e}"))?;
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_auth_jwt::DEFAULT_USER_ID;
 
-    Ok(result.rows_affected() as usize)
+/// Archive conversations not touched in `days` days. Returns rows archived.
+///
+/// When the task-local user-id is the schema sentinel (`"default"`) the
+/// archival sweep operates over the sentinel partition — which, in
+/// single-tenant deploys, IS the whole table. In multi-tenant deploys
+/// archival is normally driven from inside a per-user consolidation
+/// cycle, so the scope picks the right partition automatically.
+pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, String> {
+    let user_id = current_user_id();
+    if user_id.as_str() == DEFAULT_USER_ID {
+        // Audit-allowlisted: when no per-user scope is installed (e.g.
+        // a daemon-wide archival sweep), the worker archives across
+        // all users. Single-tenant installs degenerate to the
+        // sentinel partition.
+        let result = sqlx::query(
+            "UPDATE conversations \
+             SET archived_at = NOW() \
+             WHERE archived_at IS NULL \
+               AND updated_at < NOW() - make_interval(days => $1)",
+        )
+        .bind(days as i32)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("dreaming: archival query failed: {e}"))?;
+        Ok(result.rows_affected() as usize)
+    } else {
+        let result = sqlx::query(
+            "UPDATE conversations \
+             SET archived_at = NOW() \
+             WHERE user_id = $2 \
+               AND archived_at IS NULL \
+               AND updated_at < NOW() - make_interval(days => $1)",
+        )
+        .bind(days as i32)
+        .bind(user_id.as_str())
+        .execute(pool)
+        .await
+        .map_err(|e| format!("dreaming: archival query failed: {e}"))?;
+        Ok(result.rows_affected() as usize)
+    }
 }

--- a/crates/storage/src/dreaming/common.rs
+++ b/crates/storage/src/dreaming/common.rs
@@ -1,26 +1,57 @@
 //! Transcript loading, watermark management, and other shared helpers.
+//!
+//! The dreaming worker is a daemon-wide background task (rule #6 in
+//! `docs/architecture-evolution.md`): it iterates over every user's
+//! conversations and processes each one. The cross-user iteration is
+//! deliberate — there's only one worker per daemon, not per-user — but
+//! the per-conversation sub-queries must still scope to the owning
+//! user (#105). The pattern used by [`super::run_dreaming_scan`] is:
+//!
+//! 1. Call [`find_conversations_with_new_messages`] (cross-user) to get
+//!    `(conversation_id, user_id, watermark, context_summary)` rows.
+//! 2. For each row, install the user's `UserId` via
+//!    [`desktop_assistant_core::ports::auth::with_user_id`] and run the
+//!    rest of the per-conversation work inside that scope. Every helper
+//!    in this module then reads `current_user_id()` and scopes its SQL
+//!    by it.
+//!
+//! The cross-user scan in step 1 is the only query that intentionally
+//! crosses tenancy; it's documented in the audit allowlist.
 
 use sqlx::PgPool;
 
 use super::types::{MAX_CONVERSATIONS_PER_SCAN, MAX_MESSAGE_CHARS};
+use desktop_assistant_core::ports::auth::current_user_id;
 
-/// Conversations that have messages beyond their watermark.
-/// Returns `(conversation_id, last_processed_ordinal, context_summary)`.
+/// Conversations that have messages beyond their watermark, with their
+/// owning user. Returns `(conversation_id, user_id, watermark,
+/// context_summary)`. The caller wraps the per-row work in
+/// [`with_user_id`] so downstream helpers scope correctly.
+///
+/// This query is intentionally cross-user — the dreaming worker is one
+/// process per daemon, not one per tenant — and is listed in the audit
+/// allowlist.
 pub async fn find_conversations_with_new_messages(
     pool: &PgPool,
-) -> Result<Vec<(String, i32, String)>, String> {
-    let rows: Vec<(String, i32, String)> = sqlx::query_as(
-        "SELECT c.id,
-                COALESCE(w.last_processed_ordinal, 0) AS watermark,
-                c.context_summary
-         FROM conversations c
-         LEFT JOIN dreaming_watermarks w ON w.conversation_id = c.id
-         WHERE EXISTS (
-             SELECT 1 FROM messages m
-             WHERE m.conversation_id = c.id
-               AND m.ordinal > COALESCE(w.last_processed_ordinal, 0)
-         )
-         ORDER BY c.updated_at DESC
+) -> Result<Vec<(String, String, i32, String)>, String> {
+    // Audit-allowlisted: cross-user scan in the dreaming background
+    // worker. The returned `user_id` column is consumed by the worker
+    // to install a per-user scope before any subsequent query runs.
+    let rows: Vec<(String, String, i32, String)> = sqlx::query_as(
+        "SELECT c.id, \
+                c.user_id, \
+                COALESCE(w.last_processed_ordinal, 0) AS watermark, \
+                c.context_summary \
+         FROM conversations c \
+         LEFT JOIN dreaming_watermarks w \
+                ON w.conversation_id = c.id AND w.user_id = c.user_id \
+         WHERE EXISTS ( \
+             SELECT 1 FROM messages m \
+             WHERE m.conversation_id = c.id \
+               AND m.user_id = c.user_id \
+               AND m.ordinal > COALESCE(w.last_processed_ordinal, 0) \
+         ) \
+         ORDER BY c.updated_at DESC \
          LIMIT $1",
     )
     .bind(MAX_CONVERSATIONS_PER_SCAN)
@@ -31,18 +62,22 @@ pub async fn find_conversations_with_new_messages(
     Ok(rows)
 }
 
-/// Load user and assistant messages after `from_ordinal` as a formatted transcript.
+/// Load user and assistant messages after `from_ordinal` as a formatted
+/// transcript. Scoped to the task-local user id (the dreaming worker
+/// installs it before calling this).
 pub async fn load_new_transcript(
     pool: &PgPool,
     conversation_id: &str,
     from_ordinal: i32,
 ) -> Result<String, String> {
+    let user_id = current_user_id();
     let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT role, content FROM messages
-         WHERE conversation_id = $1 AND ordinal > $2
-           AND role IN ('user', 'assistant')
+        "SELECT role, content FROM messages \
+         WHERE user_id = $1 AND conversation_id = $2 AND ordinal > $3 \
+           AND role IN ('user', 'assistant') \
          ORDER BY ordinal ASC",
     )
+    .bind(user_id.as_str())
     .bind(conversation_id)
     .bind(from_ordinal)
     .fetch_all(pool)
@@ -68,16 +103,19 @@ pub async fn load_new_transcript(
 ///
 /// Returns an empty string if the conversation has been hard-deleted —
 /// callers must handle that case (consolidation falls through to KB-only
-/// judgment).
+/// judgment). Scoped to the task-local user id.
 pub async fn load_full_transcript(
     pool: &PgPool,
     conversation_id: &str,
 ) -> Result<String, String> {
+    let user_id = current_user_id();
     let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT role, content FROM messages
-         WHERE conversation_id = $1 AND role IN ('user', 'assistant')
+        "SELECT role, content FROM messages \
+         WHERE user_id = $1 AND conversation_id = $2 \
+           AND role IN ('user', 'assistant') \
          ORDER BY ordinal ASC",
     )
+    .bind(user_id.as_str())
     .bind(conversation_id)
     .fetch_all(pool)
     .await
@@ -96,31 +134,42 @@ pub async fn load_full_transcript(
     Ok(transcript)
 }
 
-/// Get the maximum message ordinal for a conversation.
+/// Get the maximum message ordinal for a conversation. Scoped to the
+/// task-local user id.
 pub async fn get_max_ordinal(pool: &PgPool, conversation_id: &str) -> Result<i32, String> {
-    let row: (Option<i32>,) =
-        sqlx::query_as("SELECT MAX(ordinal) FROM messages WHERE conversation_id = $1")
-            .bind(conversation_id)
-            .fetch_one(pool)
-            .await
-            .map_err(|e| format!("dreaming: failed to get max ordinal: {e}"))?;
+    let user_id = current_user_id();
+    let row: (Option<i32>,) = sqlx::query_as(
+        "SELECT MAX(ordinal) FROM messages \
+         WHERE user_id = $1 AND conversation_id = $2",
+    )
+    .bind(user_id.as_str())
+    .bind(conversation_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("dreaming: failed to get max ordinal: {e}"))?;
 
     Ok(row.0.unwrap_or(0))
 }
 
-/// UPSERT the watermark for a conversation.
+/// UPSERT the watermark for a conversation. Scoped to the task-local
+/// user id. The `(user_id, conversation_id)` pair is the natural key on
+/// `dreaming_watermarks` after #102's migration.
 pub async fn update_watermark(
     pool: &PgPool,
     conversation_id: &str,
     ordinal: i32,
 ) -> Result<(), String> {
+    let user_id = current_user_id();
     sqlx::query(
-        "INSERT INTO dreaming_watermarks (conversation_id, last_processed_ordinal, last_scanned_at)
-         VALUES ($1, $2, NOW())
-         ON CONFLICT (conversation_id) DO UPDATE
-            SET last_processed_ordinal = EXCLUDED.last_processed_ordinal,
-                last_scanned_at = NOW()",
+        "INSERT INTO dreaming_watermarks \
+            (user_id, conversation_id, last_processed_ordinal, last_scanned_at) \
+         VALUES ($1, $2, $3, NOW()) \
+         ON CONFLICT (conversation_id) DO UPDATE \
+            SET last_processed_ordinal = EXCLUDED.last_processed_ordinal, \
+                last_scanned_at = NOW() \
+            WHERE dreaming_watermarks.user_id = $1",
     )
+    .bind(user_id.as_str())
     .bind(conversation_id)
     .bind(ordinal)
     .execute(pool)

--- a/crates/storage/src/dreaming/consolidation.rs
+++ b/crates/storage/src/dreaming/consolidation.rs
@@ -20,6 +20,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use desktop_assistant_core::ports::auth::{UserId, current_user_id, with_user_id};
 use pgvector::Vector;
 use sqlx::PgPool;
 
@@ -48,17 +49,50 @@ pub async fn run_consolidation_phase(
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
 ) -> Result<ConsolidationStats, String> {
-    let focals = load_entries_needing_review(pool).await?;
-    if focals.is_empty() {
+    // Load focals across all users, grouped by user. The cross-user
+    // scan is audit-allowlisted (background-worker entry point); from
+    // here on every per-user batch installs a `with_user_id` scope so
+    // all sub-queries land in the right partition.
+    let focals_by_user = load_entries_needing_review_by_user(pool).await?;
+    if focals_by_user.is_empty() {
         tracing::debug!("dreaming: no entries needing review");
         return Ok(ConsolidationStats::default());
     }
-    tracing::info!(
-        "dreaming: consolidation reviewing {} focal entr{}",
-        focals.len(),
-        if focals.len() == 1 { "y" } else { "ies" }
-    );
 
+    let mut total = ConsolidationStats::default();
+
+    for (user_id_str, focals) in focals_by_user {
+        if focals.is_empty() {
+            continue;
+        }
+        tracing::info!(
+            "dreaming: consolidation reviewing {} focal entr{} for user {user_id_str}",
+            focals.len(),
+            if focals.len() == 1 { "y" } else { "ies" }
+        );
+
+        let stats = with_user_id(UserId::new(user_id_str.clone()), async {
+            consolidate_user_focals(pool, llm_fn, embed_fn, embedding_model, focals).await
+        })
+        .await?;
+
+        total.reviewed += stats.reviewed;
+        total.merged_clusters += stats.merged_clusters;
+        total.updated += stats.updated;
+        total.scope_added += stats.scope_added;
+        total.soft_deleted += stats.soft_deleted;
+    }
+
+    Ok(total)
+}
+
+async fn consolidate_user_focals(
+    pool: &PgPool,
+    llm_fn: &DreamingLlmFn,
+    embed_fn: &BackfillEmbedFn,
+    embedding_model: &str,
+    focals: Vec<KbRow>,
+) -> Result<ConsolidationStats, String> {
     let mut buffer = OpBuffer::new();
 
     for focal in &focals {
@@ -136,16 +170,60 @@ pub async fn run_consolidation_phase(
     Ok(stats)
 }
 
-async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String> {
-    let rows: Vec<(String, String, Vec<String>, serde_json::Value)> = sqlx::query_as(
-        "SELECT id, content, tags, metadata
-         FROM knowledge_base
-         WHERE reviewed_at IS NULL
-           AND deleted_at IS NULL
-           AND review_generation < $1
-         ORDER BY created_at ASC
+async fn load_entries_needing_review_by_user(
+    pool: &PgPool,
+) -> Result<Vec<(String, Vec<KbRow>)>, String> {
+    // Audit-allowlisted: cross-user scan in the dreaming background
+    // worker. The caller groups by user_id and installs a per-user
+    // task-local scope before doing anything else with each row.
+    let rows: Vec<(String, String, String, Vec<String>, serde_json::Value)> = sqlx::query_as(
+        "SELECT user_id, id, content, tags, metadata \
+         FROM knowledge_base \
+         WHERE reviewed_at IS NULL \
+           AND deleted_at IS NULL \
+           AND review_generation < $1 \
+         ORDER BY user_id, created_at ASC \
          LIMIT $2",
     )
+    .bind(MAX_REVIEW_GENERATION)
+    .bind(MAX_REVIEWS_PER_CYCLE)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("dreaming: load focals failed: {e}"))?;
+
+    let mut grouped: BTreeMap<String, Vec<KbRow>> = BTreeMap::new();
+    for (user_id, id, content, tags, metadata_json) in rows {
+        grouped
+            .entry(user_id)
+            .or_default()
+            .push(KbRow {
+                id,
+                content,
+                tags,
+                metadata: KbMetadata::from_json(&metadata_json),
+                distance: f64::NAN,
+            });
+    }
+    Ok(grouped.into_iter().collect())
+}
+
+/// Legacy helper kept for symmetry; tests still construct KbRows with
+/// the same factory shape.
+#[cfg(test)]
+#[allow(dead_code)]
+async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String> {
+    let user_id = current_user_id();
+    let rows: Vec<(String, String, Vec<String>, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, content, tags, metadata \
+         FROM knowledge_base \
+         WHERE user_id = $1 \
+           AND reviewed_at IS NULL \
+           AND deleted_at IS NULL \
+           AND review_generation < $2 \
+         ORDER BY created_at ASC \
+         LIMIT $3",
+    )
+    .bind(user_id.as_str())
     .bind(MAX_REVIEW_GENERATION)
     .bind(MAX_REVIEWS_PER_CYCLE)
     .fetch_all(pool)
@@ -165,13 +243,16 @@ async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String
 }
 
 async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>, String> {
+    let user_id = current_user_id();
     // Pull the focal's first embedding chunk to use as the similarity probe.
-    let focal_chunk: Option<(Vec<Vector>,)> =
-        sqlx::query_as("SELECT embedding FROM knowledge_base WHERE id = $1")
-            .bind(&focal.id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| format!("dreaming: load focal embedding failed: {e}"))?;
+    let focal_chunk: Option<(Vec<Vector>,)> = sqlx::query_as(
+        "SELECT embedding FROM knowledge_base WHERE user_id = $1 AND id = $2",
+    )
+    .bind(user_id.as_str())
+    .bind(&focal.id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("dreaming: load focal embedding failed: {e}"))?;
 
     let probe = match focal_chunk.and_then(|(v,)| v.into_iter().next()) {
         Some(v) => v,
@@ -183,25 +264,28 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
 
     let mut by_id: BTreeMap<String, KbRow> = BTreeMap::new();
 
-    // Tag-overlap search.
+    // Tag-overlap search. Scoped to the same user — candidates from
+    // other users' KBs must never reach the LLM's review window.
     if !focal.tags.is_empty() {
         let tag_rows: Vec<(String, String, Vec<String>, serde_json::Value, f64)> =
             sqlx::query_as(
-                "SELECT kb.id, kb.content, kb.tags, kb.metadata,
-                        COALESCE(MIN(u.chunk <=> $1), 2.0) AS distance
-                 FROM knowledge_base kb
-                 LEFT JOIN LATERAL unnest(kb.embedding) AS u(chunk) ON true
-                 WHERE kb.id != $2
-                   AND kb.deleted_at IS NULL
-                   AND kb.tags && $3
-                 GROUP BY kb.id, kb.content, kb.tags, kb.metadata
-                 ORDER BY distance ASC
+                "SELECT kb.id, kb.content, kb.tags, kb.metadata, \
+                        COALESCE(MIN(u.chunk <=> $1), 2.0) AS distance \
+                 FROM knowledge_base kb \
+                 LEFT JOIN LATERAL unnest(kb.embedding) AS u(chunk) ON true \
+                 WHERE kb.user_id = $5 \
+                   AND kb.id != $2 \
+                   AND kb.deleted_at IS NULL \
+                   AND kb.tags && $3 \
+                 GROUP BY kb.id, kb.content, kb.tags, kb.metadata \
+                 ORDER BY distance ASC \
                  LIMIT $4",
             )
             .bind(&probe)
             .bind(&focal.id)
             .bind(&focal.tags)
             .bind(MAX_REVIEW_CANDIDATES)
+            .bind(user_id.as_str())
             .fetch_all(pool)
             .await
             .map_err(|e| format!("dreaming: tag-overlap retrieve failed: {e}"))?;
@@ -220,24 +304,26 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
         }
     }
 
-    // Embedding-similarity search (catches related-by-content entries that
-    // don't share tags).
+    // Embedding-similarity search (catches related-by-content entries
+    // that don't share tags). Scoped to the same user.
     let emb_rows: Vec<(String, String, Vec<String>, serde_json::Value, f64)> =
         sqlx::query_as(
-            "SELECT kb.id, kb.content, kb.tags, kb.metadata,
-                    MIN(u.chunk <=> $1) AS distance
-             FROM knowledge_base kb,
-                  LATERAL unnest(kb.embedding) AS u(chunk)
-             WHERE kb.id != $2
-               AND kb.deleted_at IS NULL
-               AND kb.embedding IS NOT NULL
-             GROUP BY kb.id, kb.content, kb.tags, kb.metadata
-             ORDER BY distance ASC
+            "SELECT kb.id, kb.content, kb.tags, kb.metadata, \
+                    MIN(u.chunk <=> $1) AS distance \
+             FROM knowledge_base kb, \
+                  LATERAL unnest(kb.embedding) AS u(chunk) \
+             WHERE kb.user_id = $4 \
+               AND kb.id != $2 \
+               AND kb.deleted_at IS NULL \
+               AND kb.embedding IS NOT NULL \
+             GROUP BY kb.id, kb.content, kb.tags, kb.metadata \
+             ORDER BY distance ASC \
              LIMIT $3",
         )
         .bind(&probe)
         .bind(&focal.id)
         .bind(MAX_REVIEW_CANDIDATES)
+        .bind(user_id.as_str())
         .fetch_all(pool)
         .await
         .map_err(|e| format!("dreaming: embedding retrieve failed: {e}"))?;
@@ -274,16 +360,19 @@ async fn retrieve_by_tags_only(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow
     if focal.tags.is_empty() {
         return Ok(Vec::new());
     }
+    let user_id = current_user_id();
     let rows: Vec<(String, String, Vec<String>, serde_json::Value)> = sqlx::query_as(
-        "SELECT id, content, tags, metadata
-         FROM knowledge_base
-         WHERE id != $1 AND deleted_at IS NULL AND tags && $2
-         ORDER BY updated_at DESC
+        "SELECT id, content, tags, metadata \
+         FROM knowledge_base \
+         WHERE user_id = $4 \
+           AND id != $1 AND deleted_at IS NULL AND tags && $2 \
+         ORDER BY updated_at DESC \
          LIMIT $3",
     )
     .bind(&focal.id)
     .bind(&focal.tags)
     .bind(MAX_REVIEW_CANDIDATES)
+    .bind(user_id.as_str())
     .fetch_all(pool)
     .await
     .map_err(|e| format!("dreaming: tag-only retrieve failed: {e}"))?;
@@ -652,11 +741,13 @@ async fn load_cluster_members(
         }
     }
     if !missing.is_empty() {
+        let user_id = current_user_id();
         type KbRowTuple = (String, String, Vec<String>, serde_json::Value);
         let rows: Result<Vec<KbRowTuple>, _> = sqlx::query_as(
-            "SELECT id, content, tags, metadata FROM knowledge_base
-             WHERE id = ANY($1) AND deleted_at IS NULL",
+            "SELECT id, content, tags, metadata FROM knowledge_base \
+             WHERE user_id = $1 AND id = ANY($2) AND deleted_at IS NULL",
         )
+        .bind(user_id.as_str())
         .bind(&missing)
         .fetch_all(pool)
         .await;

--- a/crates/storage/src/dreaming/extraction.rs
+++ b/crates/storage/src/dreaming/extraction.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeSet;
 
 use desktop_assistant_core::chunking::{CHUNK_MAX_CHARS, CHUNK_OVERLAP, chunk_text};
+use desktop_assistant_core::ports::auth::{UserId, current_user_id, with_user_id};
 use pgvector::Vector;
 use sqlx::PgPool;
 
@@ -48,64 +49,106 @@ pub async fn run_extraction_phase(
         conversations.len()
     );
 
+    let mut total_written = 0usize;
+
+    for (conv_id, user_id_str, watermark, context_summary) in conversations {
+        // Install the conversation's owning user as the request-scoped
+        // identity for the duration of this conversation's processing.
+        // Every sub-query (`tag_registry::list_active_tags`,
+        // `get_max_ordinal`, `load_new_transcript`, `update_watermark`,
+        // `write_extracted_fact`) reads `current_user_id()` at SQL
+        // composition time and lands inside this user's partition.
+        let written_this_conv = with_user_id(UserId::new(user_id_str.clone()), async {
+            process_one_conversation_for_extraction(
+                pool,
+                llm_fn,
+                embed_fn,
+                embedding_model,
+                &conv_id,
+                watermark,
+                &context_summary,
+            )
+            .await
+        })
+        .await;
+
+        match written_this_conv {
+            Ok(n) => {
+                total_written += n;
+                tracing::info!(
+                    "dreaming: conversation {conv_id} (user {user_id_str}) wrote {n} fact(s)"
+                );
+            }
+            Err(e) => tracing::warn!(
+                "dreaming: extraction for conversation {conv_id} (user {user_id_str}) failed: {e}"
+            ),
+        }
+    }
+
+    Ok(total_written)
+}
+
+/// Per-conversation extraction body. Runs inside a `with_user_id` scope
+/// installed by [`run_extraction_phase`]; all helpers read the scope.
+async fn process_one_conversation_for_extraction(
+    pool: &PgPool,
+    llm_fn: &DreamingLlmFn,
+    embed_fn: &BackfillEmbedFn,
+    embedding_model: &str,
+    conv_id: &str,
+    watermark: i32,
+    context_summary: &str,
+) -> Result<usize, String> {
+    // Tag registry is per-user (#102 PK is `(user_id, name)`); the
+    // task-local scope already picks the right partition.
     let registry = tag_registry::list_active_tags(pool).await?;
     let registry_names: BTreeSet<String> =
         registry.iter().map(|t| t.name.clone()).collect();
 
-    let mut total_written = 0usize;
-
-    for (conv_id, watermark, context_summary) in conversations {
-        let max_ordinal = get_max_ordinal(pool, &conv_id).await?;
-        if max_ordinal <= watermark {
-            continue;
-        }
-
-        let transcript = load_new_transcript(pool, &conv_id, watermark).await?;
-        if transcript.is_empty() {
-            update_watermark(pool, &conv_id, max_ordinal).await?;
-            continue;
-        }
-
-        let system_prompt = build_extraction_system_prompt(&registry);
-        let user_prompt = build_extraction_user_prompt(&context_summary, &transcript);
-
-        let response = match llm_fn(system_prompt, user_prompt).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!("dreaming: extraction LLM call failed for {conv_id}: {e}");
-                continue;
-            }
-        };
-
-        let proposals = parse_extraction_response(&response);
-
-        let mut written_this_conv = 0usize;
-        for proposal in proposals {
-            match write_extracted_fact(
-                pool,
-                embed_fn,
-                embedding_model,
-                &conv_id,
-                proposal,
-                &registry_names,
-            )
-            .await
-            {
-                Ok(true) => written_this_conv += 1,
-                Ok(false) => {}
-                Err(e) => tracing::warn!("dreaming: write_extracted_fact failed: {e}"),
-            }
-        }
-
-        update_watermark(pool, &conv_id, max_ordinal).await?;
-        total_written += written_this_conv;
-
-        tracing::info!(
-            "dreaming: conversation {conv_id} wrote {written_this_conv} fact(s)"
-        );
+    let max_ordinal = get_max_ordinal(pool, conv_id).await?;
+    if max_ordinal <= watermark {
+        return Ok(0);
     }
 
-    Ok(total_written)
+    let transcript = load_new_transcript(pool, conv_id, watermark).await?;
+    if transcript.is_empty() {
+        update_watermark(pool, conv_id, max_ordinal).await?;
+        return Ok(0);
+    }
+
+    let system_prompt = build_extraction_system_prompt(&registry);
+    let user_prompt = build_extraction_user_prompt(context_summary, &transcript);
+
+    let response = match llm_fn(system_prompt, user_prompt).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("dreaming: extraction LLM call failed for {conv_id}: {e}");
+            return Ok(0);
+        }
+    };
+
+    let proposals = parse_extraction_response(&response);
+
+    let mut written = 0usize;
+    for proposal in proposals {
+        match write_extracted_fact(
+            pool,
+            embed_fn,
+            embedding_model,
+            conv_id,
+            proposal,
+            &registry_names,
+        )
+        .await
+        {
+            Ok(true) => written += 1,
+            Ok(false) => {}
+            Err(e) => tracing::warn!("dreaming: write_extracted_fact failed: {e}"),
+        }
+    }
+
+    update_watermark(pool, conv_id, max_ordinal).await?;
+    Ok(written)
 }
 
 /// One fact as proposed by the LLM, before tag resolution.
@@ -294,13 +337,15 @@ async fn write_extracted_fact(
 
     let id = uuid::Uuid::now_v7().to_string();
     let tags_vec: Vec<String> = final_tags.into_iter().collect();
+    let user_id = current_user_id();
 
     sqlx::query(
-        "INSERT INTO knowledge_base
-            (id, content, tags, metadata, embedding, embedding_model)
-         VALUES ($1, $2, $3, $4, $5::vector[], $6)",
+        "INSERT INTO knowledge_base \
+            (id, user_id, content, tags, metadata, embedding, embedding_model) \
+         VALUES ($1, $2, $3, $4, $5, $6::vector[], $7)",
     )
     .bind(&id)
+    .bind(user_id.as_str())
     .bind(&proposal.content)
     .bind(&tags_vec)
     .bind(metadata.to_json())

--- a/crates/storage/src/dreaming/reconcile.rs
+++ b/crates/storage/src/dreaming/reconcile.rs
@@ -9,6 +9,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use desktop_assistant_core::chunking::{CHUNK_MAX_CHARS, CHUNK_OVERLAP, chunk_text};
+use desktop_assistant_core::ports::auth::current_user_id;
 use pgvector::Vector;
 use sqlx::PgPool;
 
@@ -199,6 +200,7 @@ pub async fn apply_ops(
     synthesized: &[SynthesizedMerge],
     soft_delete_ttl_days: i32,
 ) -> Result<ConsolidationStats, String> {
+    let user_id = current_user_id();
     let mut stats = ConsolidationStats::default();
 
     let mut tx = pool
@@ -207,13 +209,17 @@ pub async fn apply_ops(
         .map_err(|e| format!("dreaming: begin tx failed: {e}"))?;
 
     // First, reap any soft-deleted entries past their TTL. Cheap, and
-    // happens in the same tx so a single cycle stays atomic.
+    // happens in the same tx so a single cycle stays atomic. Scoped to
+    // the current user — TTL reaping for other users happens when
+    // their own consolidation cycles run.
     sqlx::query(
-        "DELETE FROM knowledge_base
-         WHERE deleted_at IS NOT NULL
+        "DELETE FROM knowledge_base \
+         WHERE user_id = $2 \
+           AND deleted_at IS NOT NULL \
            AND deleted_at < NOW() - make_interval(days => $1)",
     )
     .bind(soft_delete_ttl_days)
+    .bind(user_id.as_str())
     .execute(&mut *tx)
     .await
     .map_err(|e| format!("dreaming: TTL reap failed: {e}"))?;
@@ -235,8 +241,9 @@ pub async fn apply_ops(
         // Preserve source_conversation_id of the canonical row but apply
         // the new scope.
         let existing_metadata: Option<(serde_json::Value,)> = sqlx::query_as(
-            "SELECT metadata FROM knowledge_base WHERE id = $1",
+            "SELECT metadata FROM knowledge_base WHERE user_id = $1 AND id = $2",
         )
+        .bind(user_id.as_str())
         .bind(&merge.canonical_id)
         .fetch_optional(&mut *tx)
         .await
@@ -248,12 +255,12 @@ pub async fn apply_ops(
         metadata.scope = merge.new_scope.clone();
 
         sqlx::query(
-            "UPDATE knowledge_base
-             SET content = $1, metadata = $2, embedding = $3::vector[],
-                 embedding_model = $4, updated_at = NOW(),
-                 reviewed_at = NOW(),
-                 review_generation = LEAST(review_generation + 1, $5)
-             WHERE id = $6",
+            "UPDATE knowledge_base \
+             SET content = $1, metadata = $2, embedding = $3::vector[], \
+                 embedding_model = $4, updated_at = NOW(), \
+                 reviewed_at = NOW(), \
+                 review_generation = LEAST(review_generation + 1, $5) \
+             WHERE user_id = $7 AND id = $6",
         )
         .bind(&merge.new_content)
         .bind(metadata.to_json())
@@ -261,6 +268,7 @@ pub async fn apply_ops(
         .bind(embedding_model)
         .bind(MAX_REVIEW_GENERATION)
         .bind(&merge.canonical_id)
+        .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
         .map_err(|e| format!("dreaming: merge canonical update failed: {e}"))?;
@@ -274,11 +282,12 @@ pub async fn apply_ops(
             .collect();
         if !to_delete.is_empty() {
             sqlx::query(
-                "UPDATE knowledge_base
-                 SET deleted_at = NOW(), reviewed_at = NOW()
-                 WHERE id = ANY($1) AND deleted_at IS NULL",
+                "UPDATE knowledge_base \
+                 SET deleted_at = NOW(), reviewed_at = NOW() \
+                 WHERE user_id = $2 AND id = ANY($1) AND deleted_at IS NULL",
             )
             .bind(&to_delete)
+            .bind(user_id.as_str())
             .execute(&mut *tx)
             .await
             .map_err(|e| format!("dreaming: cluster soft-delete failed: {e}"))?;
@@ -299,18 +308,19 @@ pub async fn apply_ops(
             embeddings.into_iter().map(Vector::from).collect();
 
         sqlx::query(
-            "UPDATE knowledge_base
-             SET content = $1, embedding = $2::vector[], embedding_model = $3,
-                 updated_at = NOW(),
-                 reviewed_at = NOW(),
-                 review_generation = LEAST(review_generation + 1, $4)
-             WHERE id = $5",
+            "UPDATE knowledge_base \
+             SET content = $1, embedding = $2::vector[], embedding_model = $3, \
+                 updated_at = NOW(), \
+                 reviewed_at = NOW(), \
+                 review_generation = LEAST(review_generation + 1, $4) \
+             WHERE user_id = $6 AND id = $5",
         )
         .bind(&new_content)
         .bind(&embedding_vecs)
         .bind(embedding_model)
         .bind(MAX_REVIEW_GENERATION)
         .bind(&id)
+        .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
         .map_err(|e| format!("dreaming: update failed: {e}"))?;
@@ -320,8 +330,9 @@ pub async fn apply_ops(
     // Standalone scope additions.
     for (id, scope) in buffer.standalone_scope_adds() {
         let existing: Option<(serde_json::Value,)> = sqlx::query_as(
-            "SELECT metadata FROM knowledge_base WHERE id = $1",
+            "SELECT metadata FROM knowledge_base WHERE user_id = $1 AND id = $2",
         )
+        .bind(user_id.as_str())
         .bind(&id)
         .fetch_optional(&mut *tx)
         .await
@@ -331,12 +342,13 @@ pub async fn apply_ops(
             let mut metadata = KbMetadata::from_json(&value);
             metadata.scope = Some(scope);
             sqlx::query(
-                "UPDATE knowledge_base
-                 SET metadata = $1, updated_at = NOW(), reviewed_at = NOW()
-                 WHERE id = $2",
+                "UPDATE knowledge_base \
+                 SET metadata = $1, updated_at = NOW(), reviewed_at = NOW() \
+                 WHERE user_id = $3 AND id = $2",
             )
             .bind(metadata.to_json())
             .bind(&id)
+            .bind(user_id.as_str())
             .execute(&mut *tx)
             .await
             .map_err(|e| format!("dreaming: scope-add update failed: {e}"))?;
@@ -347,11 +359,12 @@ pub async fn apply_ops(
     // Standalone soft-deletes.
     for (id, _reason) in buffer.standalone_deletes() {
         sqlx::query(
-            "UPDATE knowledge_base
-             SET deleted_at = NOW(), reviewed_at = NOW()
-             WHERE id = $1 AND deleted_at IS NULL",
+            "UPDATE knowledge_base \
+             SET deleted_at = NOW(), reviewed_at = NOW() \
+             WHERE user_id = $2 AND id = $1 AND deleted_at IS NULL",
         )
         .bind(&id)
+        .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
         .map_err(|e| format!("dreaming: soft-delete failed: {e}"))?;
@@ -363,11 +376,12 @@ pub async fn apply_ops(
     let touched: Vec<String> = buffer.all_reviewed_ids().iter().cloned().collect();
     if !touched.is_empty() {
         sqlx::query(
-            "UPDATE knowledge_base
-             SET reviewed_at = COALESCE(reviewed_at, NOW())
-             WHERE id = ANY($1)",
+            "UPDATE knowledge_base \
+             SET reviewed_at = COALESCE(reviewed_at, NOW()) \
+             WHERE user_id = $2 AND id = ANY($1)",
         )
         .bind(&touched)
+        .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
         .map_err(|e| format!("dreaming: reviewed_at update failed: {e}"))?;

--- a/crates/storage/src/knowledge.rs
+++ b/crates/storage/src/knowledge.rs
@@ -1,5 +1,6 @@
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::KnowledgeEntry;
+use desktop_assistant_core::ports::auth::current_user_id;
 use desktop_assistant_core::ports::knowledge::KnowledgeBaseStore;
 use pgvector::Vector;
 use sqlx::PgPool;
@@ -21,22 +22,33 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         embedding: Option<Vec<Vec<f32>>>,
         embedding_model: Option<String>,
     ) -> Result<KnowledgeEntry, CoreError> {
+        let user_id = current_user_id();
         let embedding_vecs: Option<Vec<Vector>> =
             embedding.map(|chunks| chunks.into_iter().map(Vector::from).collect());
 
+        // ON CONFLICT (id) inherently respects the schema's unique
+        // constraint on `id`; since the KB id is a UUID we don't expect
+        // collisions across users in practice. The upsert path still
+        // refuses to leak rows: a writer can only land in the user's
+        // own partition because the WHERE filter on the conflict update
+        // matches only their row, and the insert path stamps user_id
+        // from the current request.
         let row: KbRow = sqlx::query_as(
-            "INSERT INTO knowledge_base (id, content, tags, metadata, embedding, embedding_model)
-             VALUES ($1, $2, $3, $4, $5::vector[], $6)
-             ON CONFLICT (id) DO UPDATE
-                SET content = EXCLUDED.content,
-                    tags = EXCLUDED.tags,
-                    metadata = EXCLUDED.metadata,
-                    embedding = EXCLUDED.embedding,
-                    embedding_model = EXCLUDED.embedding_model,
-                    updated_at = NOW()
+            "INSERT INTO knowledge_base \
+                (id, user_id, content, tags, metadata, embedding, embedding_model) \
+             VALUES ($1, $2, $3, $4, $5, $6::vector[], $7) \
+             ON CONFLICT (id) DO UPDATE \
+                SET content = EXCLUDED.content, \
+                    tags = EXCLUDED.tags, \
+                    metadata = EXCLUDED.metadata, \
+                    embedding = EXCLUDED.embedding, \
+                    embedding_model = EXCLUDED.embedding_model, \
+                    updated_at = NOW() \
+                WHERE knowledge_base.user_id = $2 \
              RETURNING id, content, tags, metadata, created_at, updated_at",
         )
         .bind(&entry.id)
+        .bind(user_id.as_str())
         .bind(&entry.content)
         .bind(&entry.tags)
         .bind(&entry.metadata)
@@ -56,6 +68,7 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         tags: Option<Vec<String>>,
         limit: usize,
     ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        let user_id = current_user_id();
         let embedding_vec = Vector::from(query_embedding);
         let fetch_limit = (limit * 2) as i64;
         let result_limit = limit as i64;
@@ -65,7 +78,8 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
                 SELECT id, content, tags, metadata, created_at, updated_at,
                        MIN(chunk <=> $1) AS min_distance
                 FROM knowledge_base, unnest(embedding) AS chunk
-                WHERE ($2::text[] IS NULL OR tags && $2)
+                WHERE user_id = $6
+                  AND ($2::text[] IS NULL OR tags && $2)
                   AND embedding IS NOT NULL
                 GROUP BY id, content, tags, metadata, created_at, updated_at
             ),
@@ -79,7 +93,8 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
                 SELECT id, content, tags, metadata, created_at, updated_at,
                        ROW_NUMBER() OVER (ORDER BY ts_rank_cd(tsv, query) DESC) AS rank_t
                 FROM knowledge_base, plainto_tsquery('english', $4) query
-                WHERE ($2::text[] IS NULL OR tags && $2)
+                WHERE user_id = $6
+                  AND ($2::text[] IS NULL OR tags && $2)
                   AND tsv @@ query
                 ORDER BY ts_rank_cd(tsv, query) DESC
                 LIMIT $3
@@ -104,6 +119,7 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         .bind(fetch_limit)
         .bind(query)
         .bind(result_limit)
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
@@ -117,12 +133,14 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         tags: Option<Vec<String>>,
         limit: usize,
     ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        let user_id = current_user_id();
         let result_limit = limit as i64;
         let rows: Vec<KbRow> = sqlx::query_as(
             "WITH q AS (SELECT plainto_tsquery('english', $1) AS query)
              SELECT id, content, tags, metadata, created_at, updated_at
              FROM knowledge_base
-             WHERE tsv @@ (SELECT query FROM q)
+             WHERE user_id = $4
+               AND tsv @@ (SELECT query FROM q)
                AND ($2::text[] IS NULL OR tags && $2)
              ORDER BY ts_rank_cd(tsv, (SELECT query FROM q)) DESC,
                       updated_at DESC
@@ -131,6 +149,7 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         .bind(query)
         .bind(&tags)
         .bind(result_limit)
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
@@ -144,18 +163,21 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         offset: usize,
         tag_filter: Option<Vec<String>>,
     ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        let user_id = current_user_id();
         let limit_i64 = limit as i64;
         let offset_i64 = offset as i64;
         let rows: Vec<KbRow> = sqlx::query_as(
             "SELECT id, content, tags, metadata, created_at, updated_at
              FROM knowledge_base
-             WHERE ($1::text[] IS NULL OR tags && $1)
+             WHERE user_id = $4
+               AND ($1::text[] IS NULL OR tags && $1)
              ORDER BY updated_at DESC, id
              LIMIT $2 OFFSET $3",
         )
         .bind(&tag_filter)
         .bind(limit_i64)
         .bind(offset_i64)
+        .bind(user_id.as_str())
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
@@ -164,19 +186,25 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
     }
 
     async fn delete(&self, id: &str) -> Result<(), CoreError> {
-        sqlx::query("DELETE FROM knowledge_base WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let user_id = current_user_id();
+        sqlx::query(
+            "DELETE FROM knowledge_base WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
         Ok(())
     }
 
     async fn get(&self, id: &str) -> Result<Option<KnowledgeEntry>, CoreError> {
+        let user_id = current_user_id();
         let row: Option<KbRow> = sqlx::query_as(
             "SELECT id, content, tags, metadata, created_at, updated_at
-             FROM knowledge_base WHERE id = $1",
+             FROM knowledge_base WHERE user_id = $1 AND id = $2",
         )
+        .bind(user_id.as_str())
         .bind(id)
         .fetch_optional(&self.pool)
         .await

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -10,6 +10,13 @@ pub mod pool;
 pub mod tag_registry;
 pub mod tool_registry;
 
+/// Re-export the request-scoped user-id task-local API so storage call
+/// sites can resolve `current_user_id()` without depending directly on
+/// `desktop_assistant_core::ports::auth`. The actual storage adapters
+/// in this crate use this helper at SQL composition time (issue #105).
+pub use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
+pub use desktop_assistant_auth_jwt::{DEFAULT_USER_ID, UserId};
+
 pub use conversation::PgConversationStore;
 pub use conversation_search::PgConversationSearchStore;
 pub use database::execute_database_query;

--- a/crates/storage/src/tag_registry.rs
+++ b/crates/storage/src/tag_registry.rs
@@ -12,6 +12,7 @@
 //! `name + description` for similarity dedup, and a `deprecated_for_tag`
 //! chain so a retired tag can point at its replacement.
 
+use desktop_assistant_core::ports::auth::current_user_id;
 use pgvector::Vector;
 use sqlx::PgPool;
 
@@ -53,13 +54,21 @@ pub enum CreateTagOutcome {
 }
 
 /// Load all active (non-deprecated) tags ordered by name.
+///
+/// The tag registry is per-user (#102 moved the PK to `(user_id, name)`)
+/// so the scope reads the task-local user identity. Dreaming, which is
+/// the primary consumer, runs per conversation and inherits each
+/// conversation's `user_id` via [`with_user_id`] — see #105 for the
+/// threading contract.
 pub async fn list_active_tags(pool: &PgPool) -> Result<Vec<TagRecord>, String> {
+    let user_id = current_user_id();
     let rows: Vec<(String, String, serde_json::Value, Vec<String>)> = sqlx::query_as(
-        "SELECT name, description, examples, distinguish_from
-         FROM tag_registry
-         WHERE deprecated_for_tag IS NULL
+        "SELECT name, description, examples, distinguish_from \
+         FROM tag_registry \
+         WHERE user_id = $1 AND deprecated_for_tag IS NULL \
          ORDER BY name ASC",
     )
+    .bind(user_id.as_str())
     .fetch_all(pool)
     .await
     .map_err(|e| format!("tag_registry: list failed: {e}"))?;
@@ -67,12 +76,15 @@ pub async fn list_active_tags(pool: &PgPool) -> Result<Vec<TagRecord>, String> {
     Ok(rows.into_iter().map(row_to_record).collect())
 }
 
-/// Look up a single tag by name (active or deprecated).
+/// Look up a single tag by name (active or deprecated). Scoped to the
+/// current task-local user.
 pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, String> {
+    let user_id = current_user_id();
     let row: Option<(String, String, serde_json::Value, Vec<String>)> = sqlx::query_as(
-        "SELECT name, description, examples, distinguish_from
-         FROM tag_registry WHERE name = $1",
+        "SELECT name, description, examples, distinguish_from \
+         FROM tag_registry WHERE user_id = $1 AND name = $2",
     )
+    .bind(user_id.as_str())
     .bind(name)
     .fetch_optional(pool)
     .await
@@ -85,15 +97,21 @@ pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, Str
 ///
 /// Returns the input name if it isn't deprecated. Returns `None` if the chain
 /// terminates at a missing tag (shouldn't happen given the FK, but graceful).
+/// The chain is followed within a single user's tag partition; cross-user
+/// pointers are forbidden by the FK in #102's migration.
 pub async fn resolve_active_name(pool: &PgPool, name: &str) -> Result<Option<String>, String> {
+    let user_id = current_user_id();
     let mut current = name.to_string();
     for _ in 0..16 {
-        let row: Option<(Option<String>,)> =
-            sqlx::query_as("SELECT deprecated_for_tag FROM tag_registry WHERE name = $1")
-                .bind(&current)
-                .fetch_optional(pool)
-                .await
-                .map_err(|e| format!("tag_registry: resolve failed: {e}"))?;
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT deprecated_for_tag FROM tag_registry \
+             WHERE user_id = $1 AND name = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&current)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| format!("tag_registry: resolve failed: {e}"))?;
         match row {
             None => return Ok(None),
             Some((None,)) => return Ok(Some(current)),
@@ -118,6 +136,7 @@ pub async fn create_or_match_tag(
     embedding_model: &str,
     proposal: TagProposal,
 ) -> Result<CreateTagOutcome, String> {
+    let user_id = current_user_id();
     let normalized = normalize_tag_name(&proposal.name);
 
     if let Some(existing) = get_tag(pool, &normalized).await? {
@@ -137,13 +156,14 @@ pub async fn create_or_match_tag(
     let query_vec = Vector::from(vector);
 
     let nearest: Option<(String, String, serde_json::Value, Vec<String>, f64)> = sqlx::query_as(
-        "SELECT name, description, examples, distinguish_from, (embedding <=> $1) AS distance
-         FROM tag_registry
-         WHERE deprecated_for_tag IS NULL AND embedding IS NOT NULL
-         ORDER BY embedding <=> $1
+        "SELECT name, description, examples, distinguish_from, (embedding <=> $1) AS distance \
+         FROM tag_registry \
+         WHERE user_id = $2 AND deprecated_for_tag IS NULL AND embedding IS NOT NULL \
+         ORDER BY embedding <=> $1 \
          LIMIT 1",
     )
     .bind(&query_vec)
+    .bind(user_id.as_str())
     .fetch_optional(pool)
     .await
     .map_err(|e| format!("tag_registry: nearest search failed: {e}"))?;
@@ -167,10 +187,11 @@ pub async fn create_or_match_tag(
     );
 
     sqlx::query(
-        "INSERT INTO tag_registry
-            (name, description, examples, distinguish_from, embedding, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6)",
+        "INSERT INTO tag_registry \
+            (user_id, name, description, examples, distinguish_from, embedding, embedding_model) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
     )
+    .bind(user_id.as_str())
     .bind(&normalized)
     .bind(&proposal.description)
     .bind(&examples_json)

--- a/crates/storage/tests/audit_user_id_scoping.rs
+++ b/crates/storage/tests/audit_user_id_scoping.rs
@@ -113,6 +113,38 @@ const ALLOWED_CROSS_USER_QUERIES: &[AllowedCrossUserQuery] = &[
                     worker; it iterates all rows by design and \
                     preserves the existing user_id on each row.",
     },
+    // Dreaming archival, when invoked without a per-user task-local
+    // scope, archives across all users (single-tenant degenerate
+    // case). When called from within a per-user consolidation cycle
+    // it takes the scoped branch which DOES filter by user_id; the
+    // unscoped branch lives next to it in the same file.
+    AllowedCrossUserQuery {
+        file: "src/dreaming/archival.rs",
+        line_hint: 0,
+        rationale: "archival sweep with no per-user scope installed; \
+                    single-tenant fallback that archives across the \
+                    sentinel user_id partition. A scoped branch \
+                    immediately follows.",
+    },
+    // Dreaming background-worker cross-user scans. These are the only
+    // queries in the worker that intentionally cross tenancy — the
+    // worker groups results by user_id and installs a per-user
+    // task-local scope before any subsequent SQL.
+    AllowedCrossUserQuery {
+        file: "src/dreaming/common.rs",
+        line_hint: 0,
+        rationale: "find_conversations_with_new_messages: dreaming \
+                    worker entry point. Returns rows including user_id \
+                    so the worker can install a per-user scope.",
+    },
+    AllowedCrossUserQuery {
+        file: "src/dreaming/consolidation.rs",
+        line_hint: 0,
+        rationale: "load_entries_needing_review_by_user: dreaming \
+                    consolidation entry point. Returns rows grouped \
+                    by user_id; the worker installs a per-user \
+                    scope before processing each group.",
+    },
 ];
 
 /// Result of scanning a single SQL fragment.

--- a/crates/storage/tests/audit_user_id_scoping.rs
+++ b/crates/storage/tests/audit_user_id_scoping.rs
@@ -1,0 +1,453 @@
+//! Static audit (#105): every SQL query that touches a personal-data
+//! table must scope by `user_id`.
+//!
+//! The acceptance criterion for #105 reads:
+//!
+//! > Audit pass: no SQL query reaches the DB without `user_id` in its
+//! > `WHERE`.
+//!
+//! A live `EXPLAIN`-based check would be more rigorous, but it requires
+//! a Postgres instance and would only catch queries we actually
+//! exercised in CI. This static scan reads every `crates/storage/src/`
+//! file, finds every `sqlx::query*` call, extracts the SQL string,
+//! identifies which personal-data tables it touches, and asserts that
+//! the SQL mentions `user_id`. If a query targets a personal-data
+//! table without saying `user_id`, the test names the file/line and
+//! the offending SQL fragment.
+//!
+//! ## What counts as a personal-data table
+//!
+//! The list mirrors the columns added by migration
+//! `016_multi_tenant_user_id.sql`:
+//!
+//! - `conversations`
+//! - `messages`
+//! - `knowledge_base`
+//! - `message_summaries`
+//! - `dreaming_watermarks`
+//! - `tag_registry`
+//!
+//! Tables that are deliberately cross-user (system-wide) are exempt:
+//!
+//! - `tool_definitions` — registered tools live at the daemon scope,
+//!   not the user scope. The architecture-evolution doc (#7) notes
+//!   that stdio MCPs are single-tenant-only; multi-tenant tool
+//!   registration is a separate follow-up.
+//! - `dreaming_watermarks` *queries from the dreaming worker* are
+//!   per-conversation: the worker iterates over conversations and
+//!   inherits each conversation's `user_id` via the JOIN. The audit
+//!   still requires the WHERE to mention `user_id` because the worker
+//!   loops should include it as defense-in-depth.
+//!
+//! ## What the scan ignores
+//!
+//! - Migration files (`migrations/*.sql`) — those are the DDL that
+//!   creates the columns; they can't reference them in a WHERE.
+//! - `information_schema.*` and `pg_*` queries — Postgres catalogs are
+//!   shared.
+//! - DDL-style statements (`CREATE`, `ALTER`, `SET`) — they don't
+//!   address user data.
+//! - The scratch-schema execution path in `database.rs` — it runs
+//!   user-authored read-only SQL inside a transaction that's already
+//!   per-user-scoped (see `execute_database_query`'s contract).
+//!
+//! ## When the test fails
+//!
+//! The error message names the table, the file, the line number, and
+//! the SQL fragment that doesn't mention `user_id`. Either add
+//! `user_id = $N AND …` (or include `user_id` in the INSERT column
+//! list), or — if the query genuinely needs to be cross-user — add an
+//! entry to the documented allowlist below with a one-line rationale.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Personal-data tables — every SQL targeting these must scope by
+/// `user_id`. Mirrors migration `016_multi_tenant_user_id.sql`.
+const PERSONAL_DATA_TABLES: &[&str] = &[
+    "conversations",
+    "messages",
+    "knowledge_base",
+    "message_summaries",
+    "dreaming_watermarks",
+    "tag_registry",
+];
+
+/// Allowlist for queries that legitimately span multiple users.
+///
+/// Each entry is `(file, line, reason)` — the line is the line where
+/// the `sqlx::query…(` call begins, matching the diagnostic the audit
+/// emits. Keep this small; prefer fixing the query.
+struct AllowedCrossUserQuery {
+    file: &'static str,
+    line_hint: usize,
+    /// Reason this query is exempt — read by humans reviewing the
+    /// allowlist, not consumed by the test runtime. `#[allow(dead_code)]`
+    /// keeps the field as code-as-documentation without warnings.
+    #[allow(dead_code)]
+    rationale: &'static str,
+}
+
+const ALLOWED_CROSS_USER_QUERIES: &[AllowedCrossUserQuery] = &[
+    // Background worker startup probes — count rows across the whole
+    // table to decide whether to run the legacy JSON migration. Pre-
+    // multi-tenant data has already been backfilled to the sentinel
+    // user_id; this is a one-shot bootstrap helper, not a per-request
+    // path.
+    AllowedCrossUserQuery {
+        file: "src/migrate_json.rs",
+        line_hint: 0,
+        rationale: "is_*_table_empty: bootstrap-only COUNT(*) probe \
+                    used to decide whether to run JSON->Postgres \
+                    migration; runs once at daemon startup, not in any \
+                    request path.",
+    },
+    // Embedding backfill is a daemon-wide background worker (#74) that
+    // iterates over every row regardless of user_id; the model-stamp
+    // invariant it enforces is system-wide. Each per-row write inherits
+    // the row's existing user_id (the column is not modified).
+    AllowedCrossUserQuery {
+        file: "src/embedding_backfill.rs",
+        line_hint: 0,
+        rationale: "embedding backfill is a daemon-wide background \
+                    worker; it iterates all rows by design and \
+                    preserves the existing user_id on each row.",
+    },
+];
+
+/// Result of scanning a single SQL fragment.
+#[derive(Debug)]
+struct Finding {
+    file: PathBuf,
+    line: usize,
+    tables: Vec<String>,
+    sql_excerpt: String,
+}
+
+#[test]
+fn every_storage_query_targeting_a_personal_data_table_includes_user_id() {
+    let storage_src = storage_src_root();
+    let mut files: Vec<PathBuf> = Vec::new();
+    walk_rust_files(&storage_src, &mut files);
+    assert!(
+        !files.is_empty(),
+        "audit: expected to find Rust files under {}",
+        storage_src.display()
+    );
+
+    let mut findings: Vec<Finding> = Vec::new();
+    for path in &files {
+        let content = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for site in extract_query_sites(&content) {
+            // Skip queries whose SQL doesn't touch any personal-data
+            // table (system tables, catalogs, settings, etc.).
+            let tables = personal_tables_referenced(&site.sql);
+            if tables.is_empty() {
+                continue;
+            }
+            // Pass: query mentions user_id, however it's spelled. We're
+            // lenient on the exact form so a `WHERE user_id = $1` or an
+            // INSERT column list of `(id, user_id, …)` or a JOIN's
+            // `USING (user_id, …)` all count.
+            if sql_mentions_user_id(&site.sql) {
+                continue;
+            }
+            // Pass: the call site is in the documented allowlist.
+            let rel = path.strip_prefix(crate_root()).unwrap_or(path);
+            if is_allowed(rel, site.line) {
+                continue;
+            }
+            findings.push(Finding {
+                file: rel.to_path_buf(),
+                line: site.line,
+                tables,
+                sql_excerpt: shrink_excerpt(&site.sql),
+            });
+        }
+    }
+
+    if !findings.is_empty() {
+        let mut msg = String::from(
+            "audit: SQL queries against personal-data tables must scope by `user_id` (#105).\n\n",
+        );
+        for f in &findings {
+            msg.push_str(&format!(
+                "  {}:{}\n    tables: {}\n    sql: {}\n\n",
+                f.file.display(),
+                f.line,
+                f.tables.join(", "),
+                f.sql_excerpt,
+            ));
+        }
+        msg.push_str(
+            "If a query is legitimately cross-user (background worker, system table, \
+             startup probe), add it to ALLOWED_CROSS_USER_QUERIES in this test with a \
+             one-line rationale. Otherwise add `user_id` to the WHERE clause or \
+             INSERT column list and bind `current_user_id()`.",
+        );
+        panic!("{msg}");
+    }
+}
+
+// ---------- helpers ---------------------------------------------------------
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn storage_src_root() -> PathBuf {
+    crate_root().join("src")
+}
+
+fn walk_rust_files(dir: &Path, acc: &mut Vec<PathBuf>) {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_rust_files(&path, acc);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            acc.push(path);
+        }
+    }
+}
+
+/// A single `sqlx::query…(` call site discovered by the scan.
+#[derive(Debug)]
+struct QuerySite {
+    line: usize,
+    sql: String,
+}
+
+/// Walk `content` and pull out every SQL string passed to a
+/// `sqlx::query…(` call. The extractor is line-aware (so we can report
+/// the line of the call) and handles multi-line raw strings.
+///
+/// Implementation note: `content` may contain non-ASCII (em-dashes in
+/// doc comments, Unicode quote marks, ...). We use `match_indices`
+/// rather than byte-stepping with `i += 1` so we never land inside a
+/// multi-byte UTF-8 code-point.
+fn extract_query_sites(content: &str) -> Vec<QuerySite> {
+    let mut sites = Vec::new();
+    let bytes = content.as_bytes();
+    for (i, _) in content.match_indices("sqlx::query") {
+        // Advance past the method name and any `_as` / `_scalar` /
+        // generic args, up to the `(` that opens the call. ASCII-only
+        // characters in this range, so byte stepping is safe.
+        let mut j = i;
+        while j < bytes.len() && bytes[j] != b'(' {
+            // If we hit a non-paren that means this isn't a call
+            // expression (e.g. `use sqlx::query` import line) — bail
+            // on excessive lookahead.
+            if j - i > 64 {
+                break;
+            }
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'(' {
+            continue;
+        }
+        // After `(`, the first non-whitespace argument should be a
+        // string literal — `"..."`, `r#"..."#`, or some other expression
+        // we don't recognise (in which case we skip this call site).
+        let arg_start = skip_whitespace(content, j + 1);
+        if let Some(sql) = extract_string_literal(content, arg_start) {
+            sites.push(QuerySite {
+                line: line_of(content, i),
+                sql,
+            });
+        }
+    }
+    sites
+}
+
+fn skip_whitespace(s: &str, mut i: usize) -> usize {
+    let bytes = s.as_bytes();
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\n' || bytes[i] == b'\t')
+    {
+        i += 1;
+    }
+    i
+}
+
+fn extract_string_literal(content: &str, start: usize) -> Option<String> {
+    let bytes = content.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+    // Handle `r#"..."#` and `r##"..."##`. The opening sequence is
+    // pure-ASCII so byte indexing is safe up to the body.
+    if bytes[start] == b'r' {
+        let mut hash_count = 0;
+        let mut k = start + 1;
+        while k < bytes.len() && bytes[k] == b'#' {
+            hash_count += 1;
+            k += 1;
+        }
+        if k < bytes.len() && bytes[k] == b'"' {
+            // Body starts at k+1; ends at the first `"<hashes>` of the
+            // matching hash count. `content[..]` slice is UTF-8 safe.
+            let body_start = k + 1;
+            let mut needle = String::from("\"");
+            for _ in 0..hash_count {
+                needle.push('#');
+            }
+            if let Some(rel_end) = content[body_start..].find(&needle) {
+                return Some(content[body_start..body_start + rel_end].to_string());
+            }
+            return None;
+        }
+        return None;
+    }
+    if bytes[start] != b'"' {
+        return None;
+    }
+    // Plain `"..."` literal. The literal body may contain multi-byte
+    // characters, so we step by char-indices on the slice after the
+    // opening quote, watching for unescaped `"` to terminate.
+    let body_start = start + 1;
+    let tail = &content[body_start..];
+    let mut chars = tail.char_indices().peekable();
+    while let Some((idx, c)) = chars.next() {
+        if c == '\\' {
+            // Skip the next escaped char regardless of width.
+            chars.next();
+            continue;
+        }
+        if c == '"' {
+            return Some(tail[..idx].to_string());
+        }
+    }
+    None
+}
+
+fn line_of(content: &str, byte_offset: usize) -> usize {
+    1 + content[..byte_offset.min(content.len())].matches('\n').count()
+}
+
+/// Return the personal-data tables that the SQL fragment references.
+/// Matches are case-insensitive whole-word — `messages` matches but
+/// `message_summaries` does not when looking for `messages` alone.
+fn personal_tables_referenced(sql: &str) -> Vec<String> {
+    let mut found: BTreeSet<&'static str> = BTreeSet::new();
+    let lower = sql.to_ascii_lowercase();
+    for tbl in PERSONAL_DATA_TABLES {
+        if contains_whole_word(&lower, tbl) {
+            found.insert(*tbl);
+        }
+    }
+    found.into_iter().map(String::from).collect()
+}
+
+fn contains_whole_word(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.is_empty() {
+        return false;
+    }
+    let mut i = 0;
+    while i + n.len() <= bytes.len() {
+        if &bytes[i..i + n.len()] == n {
+            let before_ok = i == 0 || !is_ident_char(bytes[i - 1]);
+            let after_ok = i + n.len() == bytes.len() || !is_ident_char(bytes[i + n.len()]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_ident_char(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_'
+}
+
+fn sql_mentions_user_id(sql: &str) -> bool {
+    sql.to_ascii_lowercase().contains("user_id")
+}
+
+fn is_allowed(file: &Path, line: usize) -> bool {
+    let file_str = file.to_string_lossy();
+    ALLOWED_CROSS_USER_QUERIES.iter().any(|allowed| {
+        file_str.replace('\\', "/").ends_with(allowed.file)
+            && (allowed.line_hint == 0 || allowed.line_hint == line)
+    })
+}
+
+fn shrink_excerpt(sql: &str) -> String {
+    let one_line = sql
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    // Avoid slicing inside multi-byte chars when the excerpt contains
+    // non-ASCII (e.g. an em-dash in a code comment). `char_indices`
+    // gives us a safe truncation point.
+    if one_line.chars().count() > 160 {
+        let cutoff = one_line
+            .char_indices()
+            .nth(160)
+            .map(|(i, _)| i)
+            .unwrap_or(one_line.len());
+        format!("{}...", &one_line[..cutoff])
+    } else {
+        one_line
+    }
+}
+
+// ---------- self-tests of the scanner --------------------------------------
+
+#[test]
+fn scanner_finds_query_sites() {
+    let src = "\
+        let row = sqlx::query(\"SELECT 1 FROM conversations WHERE id = $1\")\n\
+            .bind(&id)\n\
+            .fetch_one(&pool);\n\
+        let row = sqlx::query_as::<_, MyRow>(\n\
+            r#\"SELECT id FROM messages WHERE conversation_id = $1\"#\n\
+        )\n\
+            .bind(&cid)\n\
+            .fetch_one(&pool);\n";
+    let sites = extract_query_sites(src);
+    // The Rust source above uses both the plain "..." and the raw
+    // form, so we expect both to be detected.
+    assert_eq!(sites.len(), 2, "{sites:?}");
+    assert!(sites[0].sql.contains("conversations"));
+    assert!(sites[1].sql.contains("messages"));
+}
+
+#[test]
+fn personal_tables_distinguishes_messages_from_message_summaries() {
+    let q = "SELECT id FROM message_summaries WHERE id = $1";
+    let found = personal_tables_referenced(q);
+    assert!(found.contains(&"message_summaries".to_string()));
+    assert!(!found.contains(&"messages".to_string()));
+}
+
+#[test]
+fn sql_with_user_id_in_where_passes_the_mention_check() {
+    assert!(sql_mentions_user_id(
+        "SELECT * FROM conversations WHERE user_id = $1 AND id = $2"
+    ));
+    assert!(sql_mentions_user_id(
+        "INSERT INTO messages (id, user_id, content) VALUES ($1, $2, $3)"
+    ));
+    assert!(!sql_mentions_user_id("SELECT * FROM conversations c"));
+}
+
+#[test]
+fn scanner_extracts_multiline_raw_string_correctly() {
+    let src = "\
+        sqlx::query(\n\
+            r#\"SELECT id, content FROM knowledge_base\n\
+               WHERE user_id = $1 AND tags && $2\"#,\n\
+        )\n";
+    let sites = extract_query_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert!(sites[0].sql.contains("knowledge_base"));
+    assert!(sites[0].sql.contains("user_id"));
+}

--- a/crates/storage/tests/user_id_scoping.rs
+++ b/crates/storage/tests/user_id_scoping.rs
@@ -1,0 +1,438 @@
+//! Cross-user isolation integration tests for #105.
+//!
+//! These tests exercise the storage adapters end-to-end against a real
+//! Postgres instance with the multi-tenant schema in place. They prove
+//! that:
+//!
+//! - Writes under user A land in A's partition only.
+//! - Reads under user A see only A's rows.
+//! - Cross-user lookups return `ConversationNotFound` rather than
+//!   leaking the existence of another user's data.
+//! - The single-tenant default path (no `UserId` scope installed)
+//!   resolves to the schema sentinel `"default"`, so an unscoped
+//!   request can still write and read.
+//!
+//! ## Running locally
+//!
+//! Set `TEST_DATABASE_URL` to a Postgres URL where the connecting role
+//! can `CREATE SCHEMA` and `CREATE EXTENSION vector`:
+//!
+//! ```sh
+//! podman run -d --name pg-test -e POSTGRES_PASSWORD=test -p 15432:5432 \
+//!     docker.io/pgvector/pgvector:pg17
+//! TEST_DATABASE_URL="postgres://postgres:test@localhost:15432/postgres" \
+//!     cargo test -p desktop-assistant-storage --test user_id_scoping
+//! ```
+//!
+//! When `TEST_DATABASE_URL` is unset every test pass-skips with a log
+//! line so the suite stays green without a DB.
+
+use std::sync::Arc;
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Conversation, ConversationId, KnowledgeEntry, Message, Role};
+use desktop_assistant_core::ports::knowledge::KnowledgeBaseStore;
+use desktop_assistant_core::ports::store::ConversationStore;
+use desktop_assistant_storage::{
+    PgConversationStore, PgKnowledgeBaseStore, UserId, run_migrations, with_user_id,
+};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+/// RAII fixture: private schema, pool pinned to it, migrations applied.
+struct Fixture {
+    pool: PgPool,
+    schema: String,
+    admin_url: String,
+}
+
+impl Fixture {
+    async fn try_new() -> Option<Self> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let schema = format!("issue105_{}", Uuid::now_v7().simple());
+
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        sqlx::query(&format!("CREATE SCHEMA \"{schema}\""))
+            .execute(&admin)
+            .await
+            .expect("create test schema");
+        admin.close().await;
+
+        let schema_for_hook = Arc::new(schema.clone());
+        let pool = PgPoolOptions::new()
+            .max_connections(8)
+            .after_connect(move |conn, _| {
+                let schema = Arc::clone(&schema_for_hook);
+                Box::pin(async move {
+                    let sql = format!("SET search_path TO \"{schema}\", public");
+                    sqlx::query(&sql).execute(conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect per-test pool");
+
+        run_migrations(&pool)
+            .await
+            .expect("run_migrations succeeds");
+
+        Some(Self {
+            pool,
+            schema,
+            admin_url: url,
+        })
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        if let Ok(admin) = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&self.admin_url)
+            .await
+        {
+            let _ = sqlx::query(&format!("DROP SCHEMA \"{}\" CASCADE", self.schema))
+                .execute(&admin)
+                .await;
+            admin.close().await;
+        }
+    }
+}
+
+async fn with_fixture<F, Fut>(name: &str, body: F)
+where
+    F: FnOnce(Fixture) -> Fut,
+    Fut: std::future::Future<Output = Fixture>,
+{
+    let Some(fx) = Fixture::try_new().await else {
+        eprintln!("skip: TEST_DATABASE_URL not set; {name} pass-skipped");
+        return;
+    };
+    let fx = body(fx).await;
+    fx.cleanup().await;
+}
+
+fn make_conversation(id: &str, title: &str) -> Conversation {
+    let mut conv = Conversation::new(id, title);
+    conv.created_at = "2026-01-01 00:00:00".to_string();
+    conv.updated_at = "2026-01-01 00:00:00".to_string();
+    conv.messages.push(Message::new(Role::User, "hello"));
+    conv
+}
+
+// -- conversations -----------------------------------------------------------
+
+#[tokio::test]
+async fn user_a_writes_then_user_b_cannot_list_it() {
+    // Two users concurrent: A writes a conversation under their scope;
+    // B's list under their own scope returns nothing. Mirrors the
+    // top-level `two_users_concurrent_conversations_isolated` test in
+    // the issue brief.
+    with_fixture("user_a_writes_then_user_b_cannot_list_it", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+
+        // User A: insert a conversation.
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create(make_conversation("conv-a-1", "alice chat"))
+                .await
+                .expect("alice create");
+        })
+        .await;
+
+        // User B: list — should see nothing.
+        let bobs_list = with_user_id(UserId::new("bob"), async { store.list().await })
+            .await
+            .expect("bob list");
+        assert!(
+            bobs_list.is_empty(),
+            "bob's list must NOT include alice's conversations, got {} row(s)",
+            bobs_list.len()
+        );
+
+        // User A: list — should see exactly their one row.
+        let alices_list = with_user_id(UserId::new("alice"), async { store.list().await })
+            .await
+            .expect("alice list");
+        assert_eq!(alices_list.len(), 1);
+        assert_eq!(alices_list[0].id.0, "conv-a-1");
+
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn user_b_cannot_read_user_a_conversation_by_id() {
+    // Cross-user direct lookup must return NotFound — don't leak the
+    // existence of A's conversation to B.
+    with_fixture("user_b_cannot_read_user_a_conversation_by_id", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create(make_conversation("conv-x", "alice"))
+                .await
+                .expect("alice create");
+        })
+        .await;
+
+        let bob_get =
+            with_user_id(UserId::new("bob"), async { store.get(&ConversationId::from("conv-x")).await }).await;
+        match bob_get {
+            Err(CoreError::ConversationNotFound(id)) => {
+                assert_eq!(id, "conv-x", "bob's NotFound must echo the id he asked for");
+            }
+            other => panic!("expected ConversationNotFound, got {other:?}"),
+        }
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn user_b_cannot_delete_user_a_conversation_by_id() {
+    // Mutating cross-user attempt also returns NotFound — same don't-
+    // leak-existence rule as the read path.
+    with_fixture("user_b_cannot_delete_user_a_conversation_by_id", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create(make_conversation("conv-y", "alice"))
+                .await
+                .expect("alice create");
+        })
+        .await;
+
+        let bob_delete = with_user_id(UserId::new("bob"), async {
+            store.delete(&ConversationId::from("conv-y")).await
+        })
+        .await;
+        match bob_delete {
+            Err(CoreError::ConversationNotFound(id)) => {
+                assert_eq!(id, "conv-y");
+            }
+            other => panic!("expected ConversationNotFound, got {other:?}"),
+        }
+
+        // Alice's row is still intact.
+        let alices_get = with_user_id(UserId::new("alice"), async {
+            store.get(&ConversationId::from("conv-y")).await
+        })
+        .await;
+        assert!(alices_get.is_ok(), "alice's row should still be readable");
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn two_users_concurrent_conversations_isolated() {
+    // tokio::join concurrent writes — neither user sees the other's
+    // data afterwards. Direct exercise of the issue's primary
+    // acceptance test.
+    with_fixture("two_users_concurrent_conversations_isolated", |fx| async move {
+        let store = Arc::new(PgConversationStore::new(fx.pool.clone()));
+
+        let store_a = Arc::clone(&store);
+        let store_b = Arc::clone(&store);
+
+        let alice = with_user_id(UserId::new("alice"), async move {
+            store_a.create(make_conversation("conv-a", "alice")).await
+        });
+        let bob = with_user_id(UserId::new("bob"), async move {
+            store_b.create(make_conversation("conv-b", "bob")).await
+        });
+        let (a, b) = tokio::join!(alice, bob);
+        a.expect("alice create");
+        b.expect("bob create");
+
+        let alices_list =
+            with_user_id(UserId::new("alice"), async { store.list().await }).await.unwrap();
+        let bobs_list =
+            with_user_id(UserId::new("bob"), async { store.list().await }).await.unwrap();
+
+        assert_eq!(alices_list.len(), 1);
+        assert_eq!(alices_list[0].id.0, "conv-a");
+        assert_eq!(bobs_list.len(), 1);
+        assert_eq!(bobs_list[0].id.0, "conv-b");
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn existing_messages_table_inserts_set_user_id() {
+    // Regression: prove the message-insert path stamps the
+    // task-local user id into messages.user_id (not just
+    // conversations.user_id).
+    with_fixture("existing_messages_table_inserts_set_user_id", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create(make_conversation("conv-msg", "alice"))
+                .await
+                .expect("alice create");
+        })
+        .await;
+
+        let row: (String,) = sqlx::query_as(
+            "SELECT user_id FROM messages WHERE conversation_id = $1 LIMIT 1",
+        )
+        .bind("conv-msg")
+        .fetch_one(&fx.pool)
+        .await
+        .expect("read back message row");
+        assert_eq!(row.0, "alice");
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn request_with_default_user_id_succeeds_in_single_tenant_path() {
+    // Single-tenant deploy boundary: no scope installed, no JWT in
+    // play, write/read still works against the sentinel partition.
+    with_fixture(
+        "request_with_default_user_id_succeeds_in_single_tenant_path",
+        |fx| async move {
+            let store = PgConversationStore::new(fx.pool.clone());
+
+            // No `with_user_id` wrapper — the storage layer falls
+            // through to the sentinel.
+            store
+                .create(make_conversation("conv-default", "single tenant"))
+                .await
+                .expect("create with no scope installed");
+
+            let list = store.list().await.expect("list with no scope");
+            assert_eq!(list.len(), 1);
+            assert_eq!(list[0].id.0, "conv-default");
+
+            // The persisted row must carry the sentinel `user_id`.
+            let row: (String,) = sqlx::query_as(
+                "SELECT user_id FROM conversations WHERE id = $1",
+            )
+            .bind("conv-default")
+            .fetch_one(&fx.pool)
+            .await
+            .expect("read back");
+            assert_eq!(row.0, "default");
+            fx
+        },
+    )
+    .await;
+}
+
+// -- knowledge base ----------------------------------------------------------
+
+#[tokio::test]
+async fn knowledge_writes_are_isolated_per_user() {
+    with_fixture("knowledge_writes_are_isolated_per_user", |fx| async move {
+        let store = PgKnowledgeBaseStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            let entry = KnowledgeEntry::new("kb-alice", "alice loves rust", vec!["pref".into()]);
+            store.write(entry, None, None).await.expect("alice write");
+        })
+        .await;
+
+        with_user_id(UserId::new("bob"), async {
+            let entry = KnowledgeEntry::new("kb-bob", "bob loves zig", vec!["pref".into()]);
+            store.write(entry, None, None).await.expect("bob write");
+        })
+        .await;
+
+        // Each user lists only their own entry.
+        let alices = with_user_id(UserId::new("alice"), async {
+            store.list(100, 0, None).await
+        })
+        .await
+        .unwrap();
+        assert_eq!(alices.len(), 1);
+        assert_eq!(alices[0].id, "kb-alice");
+
+        let bobs = with_user_id(UserId::new("bob"), async {
+            store.list(100, 0, None).await
+        })
+        .await
+        .unwrap();
+        assert_eq!(bobs.len(), 1);
+        assert_eq!(bobs[0].id, "kb-bob");
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn knowledge_search_does_not_leak_across_users() {
+    // pgvector / FTS path: user A indexes a doc; user B searches the
+    // same query and doesn't see it. Mirrors the issue brief's
+    // `knowledge_search_does_not_leak_across_users` test.
+    with_fixture("knowledge_search_does_not_leak_across_users", |fx| async move {
+        let store = PgKnowledgeBaseStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            let entry = KnowledgeEntry::new(
+                "kb-alice-doc",
+                "Alice's private project notes about widget refactoring",
+                vec!["project".into()],
+            );
+            store.write(entry, None, None).await.expect("alice index");
+        })
+        .await;
+
+        // FTS-only path (no embedding required).
+        let bob_hits = with_user_id(UserId::new("bob"), async {
+            store.search_text("widget refactoring", None, 10).await
+        })
+        .await
+        .unwrap();
+        assert!(
+            bob_hits.is_empty(),
+            "bob's text search must not see alice's doc, got {} hit(s)",
+            bob_hits.len()
+        );
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn knowledge_get_by_id_does_not_leak_across_users() {
+    with_fixture("knowledge_get_by_id_does_not_leak_across_users", |fx| async move {
+        let store = PgKnowledgeBaseStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            let entry =
+                KnowledgeEntry::new("kb-shared-id", "alice content", vec!["pref".into()]);
+            store.write(entry, None, None).await.expect("alice write");
+        })
+        .await;
+
+        // Bob tries to fetch by the exact same id — must miss.
+        let bob_fetch = with_user_id(UserId::new("bob"), async { store.get("kb-shared-id").await })
+            .await
+            .unwrap();
+        assert!(
+            bob_fetch.is_none(),
+            "bob's get by id must miss when the id belongs to alice"
+        );
+
+        // Alice still sees it.
+        let alice_fetch =
+            with_user_id(UserId::new("alice"), async { store.get("kb-shared-id").await })
+                .await
+                .unwrap();
+        assert!(alice_fetch.is_some());
+        fx
+    })
+    .await;
+}

--- a/crates/transport-dispatch/Cargo.toml
+++ b/crates/transport-dispatch/Cargo.toml
@@ -16,7 +16,7 @@ uuid = { version = "1", features = ["v4"] }
 
 desktop-assistant-api-model = { path = "../api-model" }
 desktop-assistant-application = { path = "../application" }
+desktop-assistant-core.workspace = true
 
 [dev-dependencies]
-desktop-assistant-core = { path = "../core" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_application::{ApiError, AssistantApiHandler, EventSink};
+use desktop_assistant_core::ports::auth::{UserId, with_user_id};
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc;
@@ -122,11 +123,13 @@ pub async fn dispatch_loop<R, W>(
         }
     });
 
-    // `auth` is stable for the connection; clone into spawned tasks so
-    // #105 (per-user state) can dispatch via the same identity. Today
-    // only the user_id is read; keeping the full context flowing means
-    // we won't have to plumb it later.
-    let _ = auth;
+    // `auth` is stable for the connection; we clone the user id into
+    // every handler invocation so the per-task `with_user_id` scope
+    // (#105) is established before any storage call. Spawned
+    // `SendMessage` tasks get their own clone so the scope still
+    // applies after the spawn boundary (`task_local` doesn't inherit
+    // across `tokio::spawn`).
+    let user_id = UserId::new(auth.user_id.clone());
 
     while let Some(item) = inbound.next().await {
         let req = match item {
@@ -162,23 +165,33 @@ pub async fn dispatch_loop<R, W>(
                 }
 
                 let handler = Arc::clone(&handler);
+                let user_id_for_task = user_id.clone();
                 tokio::spawn(async move {
-                    let _ = handler
-                        .handle_send_message_with_override(
+                    // Re-install the per-connection user id inside the
+                    // spawned task — `task_local` scopes do not inherit
+                    // across `tokio::spawn`. Without this, the streaming
+                    // path would resolve to `UserId::default` and write
+                    // messages under the sentinel partition.
+                    let _ = with_user_id(
+                        user_id_for_task,
+                        handler.handle_send_message_with_override(
                             conversation_id,
                             content,
                             override_selection,
                             request_id,
                             sink,
-                        )
-                        .await;
+                        ),
+                    )
+                    .await;
                 });
             }
 
             api::Command::SetConfig { changes } => {
-                let res = handler
-                    .handle_command(api::Command::SetConfig { changes })
-                    .await;
+                let res = with_user_id(
+                    user_id.clone(),
+                    handler.handle_command(api::Command::SetConfig { changes }),
+                )
+                .await;
                 match res {
                     Ok(api::CommandResult::Config(config)) => {
                         if out_tx
@@ -238,7 +251,8 @@ pub async fn dispatch_loop<R, W>(
             }
 
             other => {
-                let res = handler.handle_command(other).await;
+                let res =
+                    with_user_id(user_id.clone(), handler.handle_command(other)).await;
                 match res {
                     Ok(result) => {
                         if out_tx

--- a/crates/uds-interface/src/lib.rs
+++ b/crates/uds-interface/src/lib.rs
@@ -65,11 +65,23 @@ pub trait UdsAuthValidator: Send + Sync {
     /// Validate a bearer token. Returning `true` enters the dispatcher
     /// loop; returning `false` causes the listener to write an error
     /// frame and close.
-    ///
-    /// Returning the subject would let the dispatcher attach a real
-    /// `user_id` to the connection (#105); for now a bool keeps this
-    /// crate's surface aligned with `ws-interface::WsAuthValidator`.
     async fn validate_bearer_token(&self, token: &str) -> bool;
+
+    /// Extract the user id ([JWT `sub`]) from a bearer token that
+    /// [`Self::validate_bearer_token`] already accepted (#105).
+    ///
+    /// Default returns `None`, which collapses the connection to the
+    /// schema sentinel `UserId::default()`. Single-tenant desktop
+    /// installs that don't care about identity can keep the default;
+    /// multi-tenant or multi-user-host deploys override this method
+    /// to return the JWT subject so storage queries scope per-user.
+    async fn extract_user_id(
+        &self,
+        token: &str,
+    ) -> Option<desktop_assistant_application::UserId> {
+        let _ = token;
+        None
+    }
 }
 
 /// Convenience JWT validator: holds the signing key + expected
@@ -327,6 +339,12 @@ async fn handle_connection(
         return Ok(());
     }
 
+    // Identity (#105): the validator either returns the `sub` (multi-
+    // tenant deploys) or `None` (single-tenant fallback, mapped to
+    // the schema sentinel). The dispatcher installs this into the
+    // per-task task-local before each command runs.
+    let user_id = auth.extract_user_id(&token).await.unwrap_or_default();
+
     // Auth passed; enter the shared dispatcher.
     let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<anyhow::Result<WsRequest>>(16);
     let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<WsFrame>(64);
@@ -383,10 +401,10 @@ async fn handle_connection(
 
     let sink = PollSender::new(outbound_tx.clone());
 
-    // We have a validated bearer token; we don't yet have the decoded
-    // claims at the trait boundary (#105 will fix this — the trait
-    // returns the subject). Use the token-derived placeholder for now.
-    let auth_ctx = AuthContext::new("uds-user");
+    // Per-connection identity resolved above (#105). The dispatcher
+    // installs this into the `with_user_id` task-local around each
+    // command so storage queries scope to the right partition.
+    let auth_ctx = AuthContext::new(user_id.into_inner());
 
     dispatch_loop(handler, auth_ctx, inbound, sink).await;
 

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use base64::Engine;
 use desktop_assistant_api_model as api;
-use desktop_assistant_application::AssistantApiHandler;
+use desktop_assistant_application::{AssistantApiHandler, UserId};
 use desktop_assistant_transport_dispatch::{AuthContext, dispatch_loop};
 use futures::{SinkExt, StreamExt};
 use tracing::{debug, warn};
@@ -30,6 +30,24 @@ pub struct WsServerState {
 #[async_trait::async_trait]
 pub trait WsAuthValidator: Send + Sync {
     async fn validate_bearer_token(&self, token: &str) -> bool;
+
+    /// Extract the user id ([JWT `sub`]) from a bearer token that
+    /// [`Self::validate_bearer_token`] already accepted (#105).
+    ///
+    /// The default returns `None` — meaning "validator opted out of
+    /// identity extraction"; the WS handler then falls back to
+    /// [`UserId::default`] (the schema sentinel `"default"`). That
+    /// covers single-tenant deploys that don't need multi-tenancy
+    /// without forcing every existing validator implementation to
+    /// change.
+    ///
+    /// Multi-tenant correctness REQUIRES returning `Some(user_id)`.
+    /// The current mapping rule is `sub` → `user_id` verbatim;
+    /// future revisions may consult a different claim.
+    async fn extract_user_id(&self, token: &str) -> Option<UserId> {
+        let _ = token;
+        None
+    }
 }
 
 #[async_trait::async_trait]
@@ -161,7 +179,19 @@ async fn ws_handler(
         return (StatusCode::UNAUTHORIZED, "invalid bearer token").into_response();
     }
 
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+    // Resolve the per-connection user identity once at upgrade time
+    // (#105). The validator returns `Some(sub)` for multi-tenant
+    // tokens; in the single-tenant fallback path it returns `None`
+    // and we collapse to the schema sentinel `"default"`. Identity
+    // is per-connection: one WS upgrade carries one bearer token,
+    // so every command on this socket runs as the same user.
+    let user_id = state
+        .auth_validator
+        .extract_user_id(&token)
+        .await
+        .unwrap_or_default();
+
+    ws.on_upgrade(move |socket| handle_socket(socket, state, user_id))
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -226,7 +256,7 @@ async fn auth_config_handler(State(state): State<WsServerState>) -> impl IntoRes
 /// `WsFrame` values into `Message::Text`. A `tokio_util::PollSender`
 /// gives us a `Sink<WsFrame>` over the mpsc so the dispatcher's
 /// generic bound is satisfied without a hand-rolled adapter.
-async fn handle_socket(socket: WebSocket, state: WsServerState) {
+async fn handle_socket(socket: WebSocket, state: WsServerState, user_id: UserId) {
     use tokio::sync::mpsc;
     use tokio_util::sync::PollSender;
 
@@ -266,11 +296,12 @@ async fn handle_socket(socket: WebSocket, state: WsServerState) {
 
     let sink = PollSender::new(outbound_tx.clone());
 
-    // The current bearer-token validator only returns `bool`. #105 will
-    // plumb the JWT claim subject through to here; today we use a
-    // stable placeholder so the dispatcher signature already requires
-    // an `AuthContext`.
-    let auth = AuthContext::new("ws-user");
+    // Per-connection identity resolved in `ws_handler` (#105): the
+    // bearer token's `sub` if the validator extracted one, otherwise
+    // the schema sentinel for single-tenant fallback. The dispatcher
+    // installs this into the per-task task-local on every dispatched
+    // command so storage queries scope correctly.
+    let auth = AuthContext::new(user_id.into_inner());
 
     dispatch_loop(Arc::clone(&state.handler), auth, inbound, sink).await;
 


### PR DESCRIPTION
Closes #105

## Why this is independently shippable

The schema sentinel `user_id = 'default'` is already the column default and the backfill value for pre-multi-tenant rows (#102). Code paths that don't install an explicit `UserId` scope collapse to that sentinel, so single-tenant desktop deploys see no behavioural change. The PR is self-contained — no co-dependent merge with #103 or any in-flight work, and the audit test in this PR enforces the rule going forward.

## Summary

- New `UserId` newtype in `auth-jwt` next to `Claims`; phase-1 mapping is `sub` → `user_id` verbatim.
- New `core::ports::auth` exposes a `tokio::task_local` `USER_ID` with `with_user_id(uid, fut)` and `current_user_id()`. Storage reads it at SQL composition time. Same pattern as the existing `REASONING_CONFIG` / `CONTEXT_BUDGET` task-locals — keeps every port-trait signature unchanged.
- `application::AssistantApiHandler` gains companion `*_for(ctx, …)` methods that install the scope before delegating. Non-`_for` paths stay backward-compatible and resolve to the sentinel.
- `ws::WsAuthValidator` and `uds::UdsAuthValidator` get an additive `extract_user_id(&token) -> Option<UserId>` method (default `None` → sentinel fallback). Daemon implementations decode the validated JWT via new `config::ws_jwt_sub` (local HS256) and `OidcValidator::extract_sub` (OIDC RS256), preferring the local mint then falling back to OIDC.
- `transport-dispatch::dispatch_loop` wraps each handler call in `with_user_id(auth.user_id, …)`. The spawned `SendMessage` task re-installs the scope inside its body — `task_local` doesn't inherit across `tokio::spawn`.
- Every personal-data SQL query (conversations, messages, knowledge_base, message_summaries, dreaming_watermarks, tag_registry) binds `current_user_id()`.

## Audit mechanism

Static-grep test in `crates/storage/tests/audit_user_id_scoping.rs`. Reads every `sqlx::query*` call site, extracts the SQL string, identifies the personal-data tables touched, and asserts each query mentions `user_id` or is in the documented allowlist. Verified the failure mode by temporarily stripping `user_id =` from `delete_conversation`'s WHERE clause — the test failed and named the file/line/SQL excerpt; reverting restored green.

Four queries are allowlisted with documented rationale:
- `is_*_table_empty` — startup probes for the legacy JSON migration.
- `embedding_backfill` — daemon-wide worker; preserves each row's existing user_id.
- `dreaming/archival` (no-scope fallback branch) — single-tenant sweep; the scoped branch immediately follows.
- `find_conversations_with_new_messages` and `load_entries_needing_review_by_user` — dreaming entry points that return `user_id` so the worker can install a per-user scope before any subsequent SQL.

## Test plan

- [x] `cargo test -p desktop-assistant-auth-jwt --lib` — 8 new `UserId` tests pass.
- [x] `cargo test -p desktop-assistant-core --lib` — 4 task-local tests pass; 200 existing tests still pass.
- [x] `cargo test -p desktop-assistant-application` — 5 new `RequestContext` + handler tests pass; existing 6 still pass.
- [x] `cargo test -p desktop-assistant-storage --test audit_user_id_scoping` — audit passes (1 main + 4 scanner self-tests).
- [x] `cargo test -p desktop-assistant-storage --test user_id_scoping` against pgvector:pg17 — 9 cross-user isolation tests pass:
  - `two_users_concurrent_conversations_isolated`
  - `user_a_writes_then_user_b_cannot_list_it`
  - `user_b_cannot_read_user_a_conversation_by_id` (returns NotFound, not Forbidden — no existence leak)
  - `user_b_cannot_delete_user_a_conversation_by_id`
  - `existing_messages_table_inserts_set_user_id`
  - `request_with_default_user_id_succeeds_in_single_tenant_path`
  - `knowledge_writes_are_isolated_per_user`
  - `knowledge_search_does_not_leak_across_users`
  - `knowledge_get_by_id_does_not_leak_across_users`
- [x] `cargo test --workspace` — all 24 crates green.
- [x] `cargo build --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no new warnings (pre-existing warnings on main untouched).
- [x] `cargo audit` — same 4 pre-existing rustls/webpki advisories as main; nothing introduced by this PR.
- [x] Verified the audit test would fail on a planted unscoped query (temporarily removed `user_id` from `delete_conversation`; test failed; reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)