### PR TITLE
mcp: client-side execution via turn state machine (#107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
 name = "desktop-assistant-storage"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "desktop-assistant-auth-jwt",
  "desktop-assistant-core",

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -234,6 +234,47 @@ pub enum Command {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tools: Option<Vec<String>>,
     },
+
+    // --- Client-side tool execution (issue #107) ---------------------------
+    //
+    // Phase-2 architecture (rule #8) executes client-local MCPs on the
+    // user's machine rather than on the daemon. The client advertises
+    // which tools it can run at session start; when the LLM picks one
+    // the daemon suspends the turn, emits `Event::ClientToolCall`, and
+    // resumes when `Command::ClientToolResult` arrives.
+    /// Advertise the set of client-local MCP tools this connection is
+    /// able to execute. The daemon replaces any previously-registered
+    /// set on each call — clients should send the full list, not
+    /// deltas. Per-session: re-register on every connect.
+    RegisterClientTools {
+        tools: Vec<ClientToolRegistration>,
+    },
+    /// Deliver the result of a `ClientToolCall` back to the daemon so a
+    /// suspended turn can resume. Exactly one of `result` / `error`
+    /// should be populated; both `None` is treated as an error by the
+    /// daemon-side validator.
+    ClientToolResult {
+        task_id: TaskId,
+        tool_call_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        result: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+}
+
+/// Single entry in a `RegisterClientTools` request. Mirrors the shape of
+/// `ToolDefinition` but kept here in `api-model` so adapters don't need
+/// to depend on `desktop-assistant-core`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ClientToolRegistration {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    /// JSON Schema for the tool's input. Daemon forwards verbatim to
+    /// the LLM's tool list.
+    #[serde(default)]
+    pub input_schema: serde_json::Value,
 }
 
 fn default_true() -> bool {
@@ -289,6 +330,11 @@ pub enum CommandResult {
     /// correlate the streamed `Task*` events back to the request. Introduced
     /// alongside the background-task registry so we don't overload `Ack`.
     SendMessageAck { task_id: String },
+
+    /// Response to `RegisterClientTools`, carrying the count of tools
+    /// accepted by the daemon. Clients use this to verify registration
+    /// landed before relying on client-side execution.
+    ClientToolsRegistered { count: u32 },
 
     Ack,
 }
@@ -377,6 +423,21 @@ pub enum Event {
         status: TaskStatus,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_error: Option<String>,
+    },
+
+    // --- Client-side tool execution (issue #107) --------------------------
+    /// The daemon's turn has suspended on a client-local MCP tool call.
+    /// The client is expected to execute `tool_name` with `arguments`
+    /// against its local environment and post the outcome back as
+    /// `Command::ClientToolResult` with the same `task_id` and
+    /// `tool_call_id`. Until that command arrives, the turn parks in
+    /// `pending_client_tool`.
+    ClientToolCall {
+        task_id: TaskId,
+        conversation_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
     },
 }
 

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -1495,4 +1495,137 @@ mod tests {
         // `String`. We assert via `.0` access only.
         assert_eq!(id.0, raw);
     }
+
+    // ---- #107: client-side execution protocol surface ---------------------
+    //
+    // The turn state machine adds three new wire shapes — a registration
+    // command, a result command, and a `ClientToolCall` event — that the
+    // chat client uses to advertise its local MCP tools and stream the
+    // round-trip on each suspension. These tests pin the JSON shape so
+    // out-of-tree clients have a stable contract.
+
+    #[test]
+    fn register_client_tools_command_round_trips() {
+        let cmd = Command::RegisterClientTools {
+            tools: vec![
+                ClientToolRegistration {
+                    name: "fs_read".into(),
+                    description: "Read a file on the user's machine".into(),
+                    input_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    }),
+                },
+                ClientToolRegistration {
+                    name: "fs_write".into(),
+                    description: "Write a file on the user's machine".into(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                },
+            ],
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        // Snake-case discriminator on the outer enum.
+        assert!(v.get("register_client_tools").is_some());
+        // Inner shape: a `tools` array of {name, description, input_schema}.
+        let inner = v.get("register_client_tools").unwrap();
+        let arr = inner.get("tools").unwrap().as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].get("name").unwrap(), "fs_read");
+        // Round-trip.
+        let back: Command = serde_json::from_value(v).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn client_tool_result_command_round_trips_ok_branch() {
+        let cmd = Command::ClientToolResult {
+            task_id: TaskId("task-1".into()),
+            tool_call_id: "call-7".into(),
+            result: Some("file contents go here".into()),
+            error: None,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"client_tool_result":{"task_id":"task-1","tool_call_id":"call-7","result":"file contents go here"}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        let back: Command = serde_json::from_value(v).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn client_tool_result_command_round_trips_error_branch() {
+        let cmd = Command::ClientToolResult {
+            task_id: TaskId("task-2".into()),
+            tool_call_id: "call-8".into(),
+            result: None,
+            error: Some("file does not exist".into()),
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"client_tool_result":{"task_id":"task-2","tool_call_id":"call-8","error":"file does not exist"}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        let back: Command = serde_json::from_value(v).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn client_tool_call_event_round_trips() {
+        let ev = Event::ClientToolCall {
+            task_id: TaskId("task-1".into()),
+            conversation_id: "conv-1".into(),
+            tool_call_id: "call-7".into(),
+            tool_name: "fs_read".into(),
+            arguments: serde_json::json!({"path": "/etc/hosts"}),
+        };
+        let v: serde_json::Value = serde_json::to_value(&ev).unwrap();
+        let inner = v.get("client_tool_call").expect("client_tool_call key");
+        assert_eq!(inner.get("task_id").unwrap(), "task-1");
+        assert_eq!(inner.get("conversation_id").unwrap(), "conv-1");
+        assert_eq!(inner.get("tool_call_id").unwrap(), "call-7");
+        assert_eq!(inner.get("tool_name").unwrap(), "fs_read");
+        assert_eq!(
+            inner.get("arguments").unwrap(),
+            &serde_json::json!({"path": "/etc/hosts"})
+        );
+        let back: Event = serde_json::from_value(v).unwrap();
+        assert_eq!(ev, back);
+    }
+
+    #[test]
+    fn client_tools_registered_command_result_round_trips() {
+        let res = CommandResult::ClientToolsRegistered { count: 3 };
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        let expected: serde_json::Value =
+            serde_json::from_str(r#"{"client_tools_registered":{"count":3}}"#).unwrap();
+        assert_eq!(v, expected);
+        let back: CommandResult = serde_json::from_value(v).unwrap();
+        assert_eq!(res, back);
+    }
+
+    #[test]
+    fn client_tool_result_rejects_both_result_and_error_unset() {
+        // A `ClientToolResult` with neither `result` nor `error` is
+        // ambiguous (success with empty body? failure with empty reason?).
+        // The protocol requires exactly one of them; the daemon-side
+        // validator (in application/) enforces the constraint. Here we
+        // only assert the wire shape can round-trip a malformed payload —
+        // the rejection lives one layer up so adapters can surface a
+        // clean error to the client.
+        let cmd: Command = serde_json::from_str(
+            r#"{"client_tool_result":{"task_id":"t","tool_call_id":"c"}}"#,
+        )
+        .unwrap();
+        match cmd {
+            Command::ClientToolResult { result, error, .. } => {
+                assert!(result.is_none());
+                assert!(error.is_none());
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
 }

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -19,3 +19,6 @@ features = ["sync"]
 
 [dev-dependencies]
 tokio.workspace = true
+tokio-util.workspace = true
+async-trait.workspace = true
+serde_json.workspace = true

--- a/crates/application/src/client_tools.rs
+++ b/crates/application/src/client_tools.rs
@@ -1,0 +1,407 @@
+//! Client-side execution of client-local MCP tools (#107).
+//!
+//! This module is the application-layer implementation of the turn state
+//! machine described in `docs/architecture-evolution.md` rule #8 and the
+//! Phase-2 plan. It composes two pieces:
+//!
+//! 1. **`ClientToolCoordinator`** — the in-memory store for per-user
+//!    registered client-local tool names plus the in-flight suspensions
+//!    (one `oneshot::Sender<Result<String, String>>` per pending tool
+//!    call). It does NOT touch the database; it is the hot-path mutex
+//!    that lets a turn body suspend on `await` and wake up when the
+//!    client's `ClientToolResult` arrives.
+//!
+//! 2. **`TurnStateStore`** (in `desktop-assistant-core::ports::store`)
+//!    — the durable record of the turn's status. The coordinator writes
+//!    transitions into the DB so a crashed daemon can sweep abandoned
+//!    rows on restart, and so external observers (audit, the future
+//!    background-task registry from #111) can read the current state.
+//!
+//! ## Why a coordinator separate from the registry in #111
+//!
+//! Issue #111 introduces a process-wide `BackgroundTaskRegistry` that
+//! tracks every spawned task. That registry is about *tasks* — the
+//! tokio futures backing each user-initiated turn. This module is about
+//! *turns* — the LLM-loop state that may suspend on a client-local
+//! tool. The two responsibilities overlap (every turn IS a task) but
+//! the failure modes differ: registry cancellation cancels the future;
+//! a coordinator-managed suspension waits for an external client
+//! response. Keeping them separate means #111 can land on its own
+//! schedule and this PR doesn't take a hard dep on it.
+//!
+//! ## Cross-user safety
+//!
+//! Every entry point reads the current `user_id` from the task-local
+//! installed by the transport handler (`with_user_id`). Registrations
+//! and suspensions are scoped by that id. The DB-side turn row carries
+//! `user_id NOT NULL`; resolution refuses to touch rows whose user_id
+//! disagrees with the resolver's, exactly the
+//! `turn_cross_user_isolation` test acceptance criterion.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_auth_jwt::UserId;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_core::ports::llm::current_cancellation_token;
+use desktop_assistant_core::ports::store::{
+    PendingClientToolCall, TurnStateJson, TurnStateStore, TurnStatus,
+};
+use thiserror::Error;
+use tokio::sync::oneshot;
+
+use crate::EventSink;
+
+/// Errors specific to the client-tool coordination layer.
+///
+/// Kept separate from `CoreError` because resolution failures originate
+/// at the transport boundary (a malformed `ClientToolResult`) and the
+/// error surface only matters to the application layer's adapter; core
+/// services don't observe these.
+#[derive(Debug, Error)]
+pub enum ClientToolResolutionError {
+    /// The task_id named in `ClientToolResult` has no pending
+    /// suspension, OR the row belongs to a different user_id. The two
+    /// cases are merged so cross-user probes can't distinguish them
+    /// (#105's "don't leak existence" rule applied to turn rows).
+    #[error("no pending turn for task_id={task_id} under this user")]
+    TurnNotFound { task_id: String },
+
+    /// The `tool_call_id` in `ClientToolResult` doesn't match the
+    /// `tool_call_id` recorded in the suspended turn's state. Likely a
+    /// confused client; the daemon refuses rather than feeding the
+    /// LLM a result it didn't ask for.
+    #[error(
+        "tool_call_id mismatch for task_id={task_id}: expected={expected}, got={got}"
+    )]
+    ToolCallIdMismatch {
+        task_id: String,
+        expected: String,
+        got: String,
+    },
+
+    /// The result payload is malformed (e.g. exceeds the configured
+    /// size cap, or contains neither `result` nor `error`). The
+    /// daemon-side validator emits this so transports can surface a
+    /// clean failure to the client.
+    #[error("malformed client tool result: {0}")]
+    MalformedResult(String),
+
+    /// The underlying storage call failed. Propagated from the
+    /// `TurnStateStore` impl unchanged.
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+impl From<CoreError> for ClientToolResolutionError {
+    fn from(e: CoreError) -> Self {
+        Self::Storage(e.to_string())
+    }
+}
+
+/// Maximum body size (in bytes) for a single `ClientToolResult`. Larger
+/// payloads are refused at the transport boundary to keep the LLM
+/// prompt within the model's context window — the LLM sees the
+/// rejection as a tool error.
+const MAX_CLIENT_TOOL_RESULT_BYTES: usize = 1_048_576;
+
+/// Coordinator for the registration + suspension halves of the client-
+/// tool dance. One instance is shared by the whole daemon; concurrent
+/// `RegisterClientTools` and `ClientToolResult` calls are serialized by
+/// internal mutexes around small `HashMap`s — there is no async work
+/// inside the mutex critical sections, so blocking is bounded.
+pub struct ClientToolCoordinator {
+    /// Per-user set of currently-registered tool names. The
+    /// architecture's "per-session" registration semantic collapses to
+    /// "per-user" in this slice: the application layer has no native
+    /// concept of a connection session yet, and the tests pin that
+    /// registration is overwritten on each new `RegisterClientTools`
+    /// call so a reconnecting client gets the same per-session
+    /// behaviour without us tracking the connection.
+    registrations: Mutex<HashMap<String, HashSet<String>>>,
+    /// In-flight suspensions, keyed by task_id. Each entry holds the
+    /// expected `tool_call_id` so the resolver can refuse mismatches
+    /// without consulting the DB, and the oneshot sender used to wake
+    /// the suspended turn body.
+    pending: Mutex<HashMap<String, PendingSlot>>,
+}
+
+struct PendingSlot {
+    user_id: String,
+    expected_tool_call_id: String,
+    waker: oneshot::Sender<Result<String, String>>,
+}
+
+impl ClientToolCoordinator {
+    pub fn new() -> Self {
+        Self {
+            registrations: Mutex::new(HashMap::new()),
+            pending: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Replace the registered tool set for the *current* user (read via
+    /// `current_user_id()`). Idempotent under the same set; clears
+    /// previously-registered tools that aren't in the new set.
+    ///
+    /// Returns the count of tools accepted.
+    pub async fn register(&self, tools: &[api::ClientToolRegistration]) -> u32 {
+        let user_id = current_user_id().as_str().to_string();
+        let mut regs = self.registrations.lock().unwrap();
+        let entry = regs.entry(user_id).or_default();
+        entry.clear();
+        for t in tools {
+            entry.insert(t.name.clone());
+        }
+        u32::try_from(entry.len()).unwrap_or(u32::MAX)
+    }
+
+    /// True iff `name` is registered for the current user.
+    pub async fn is_client_registered(&self, name: &str) -> bool {
+        let user_id = current_user_id().as_str().to_string();
+        let regs = self.registrations.lock().unwrap();
+        regs.get(&user_id)
+            .map(|set| set.contains(name))
+            .unwrap_or(false)
+    }
+}
+
+impl Default for ClientToolCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Top-level helper: register tools for the current user. Wraps
+/// `ClientToolCoordinator::register` so call sites don't need to know
+/// about the inner method names. Returns the count of tools accepted.
+pub async fn register_client_tools(
+    coord: &ClientToolCoordinator,
+    tools: &[api::ClientToolRegistration],
+) -> u32 {
+    coord.register(tools).await
+}
+
+/// Suspend the current turn on a client-side tool call.
+///
+/// Effects:
+/// 1. Validates that `pending_call.tool_name` is registered for the
+///    current user. Refuses with `CoreError::ToolExecution(...)` if not.
+/// 2. Updates the turn row to `pending_client_tool` with the pending
+///    call recorded in `state_json`.
+/// 3. Emits `Event::ClientToolCall` on the sink.
+/// 4. Installs a oneshot in the coordinator's `pending` map keyed on
+///    `task_id`, and `.await`s it.
+/// 5. On wake (resolved by `resolve_client_tool_result`):
+///    - On `Ok(s)`: writes the row back to `pending_llm`, clears the
+///      pending call from `state_json`, returns `Ok(s)`.
+///    - On `Err(reason)`: writes `failed` with reason, returns
+///      `Err(CoreError::ToolExecution(reason))`.
+/// 6. If the per-turn cancellation token (`current_cancellation_token`)
+///    trips while suspended, the suspension exits with
+///    `CoreError::Cancelled` and the row is marked `failed("cancelled")`.
+///
+/// The caller is the wrapping `ToolExecutor`'s `execute_tool` method —
+/// it sees the returned `String` as the tool's output and continues
+/// the LLM loop transparently.
+pub async fn suspend_for_client_tool(
+    coord: &ClientToolCoordinator,
+    store: &dyn TurnStateStore,
+    sink: &dyn EventSink,
+    task_id: api::TaskId,
+    conversation_id: String,
+    pending_call: PendingClientToolCall,
+) -> Result<String, CoreError> {
+    // Step 1: registration guard. Refuse before mutating any state.
+    if !coord.is_client_registered(&pending_call.tool_name).await {
+        return Err(CoreError::ToolExecution(format!(
+            "tool '{}' is not registered as a client-local tool for this user",
+            pending_call.tool_name
+        )));
+    }
+
+    let user_id = current_user_id().as_str().to_string();
+
+    // Step 2: write turn row to pending_client_tool with the call payload.
+    let state = TurnStateJson {
+        version: 1,
+        pending_client_tool: Some(pending_call.clone()),
+    };
+    store
+        .update_turn(
+            &task_id.0,
+            TurnStatus::PendingClientTool,
+            &state,
+            None,
+        )
+        .await?;
+
+    // Step 3: emit the wire event.
+    let event = api::Event::ClientToolCall {
+        task_id: task_id.clone(),
+        conversation_id: conversation_id.clone(),
+        tool_call_id: pending_call.tool_call_id.clone(),
+        tool_name: pending_call.tool_name.clone(),
+        arguments: pending_call.arguments.clone(),
+    };
+    sink.emit(event).await;
+
+    // Step 4: install oneshot and await.
+    let (tx, rx) = oneshot::channel::<Result<String, String>>();
+    {
+        let mut pending = coord.pending.lock().unwrap();
+        pending.insert(
+            task_id.0.clone(),
+            PendingSlot {
+                user_id: user_id.clone(),
+                expected_tool_call_id: pending_call.tool_call_id.clone(),
+                waker: tx,
+            },
+        );
+    }
+
+    // Watch the per-turn cancellation token alongside the oneshot so
+    // cancellation surfaces while suspended. If no token is installed
+    // (legacy callers, single-tenant tests), `cancelled()` futures
+    // resolve on a default never-cancelled token.
+    let token = current_cancellation_token().unwrap_or_default();
+    let outcome: Result<String, String> = tokio::select! {
+        result = rx => match result {
+            Ok(payload) => payload,
+            Err(_) => Err("coordinator dropped the suspension waker".to_string()),
+        },
+        _ = token.cancelled() => {
+            // Remove the slot so a late-arriving result doesn't try to
+            // wake a no-op oneshot.
+            coord.pending.lock().unwrap().remove(&task_id.0);
+            // Mark the row failed with a cancellation reason; ignore
+            // any storage error so we always surface `Cancelled` to
+            // the caller.
+            let _ = store
+                .update_turn(&task_id.0, TurnStatus::Failed, &state, Some("cancelled"))
+                .await;
+            return Err(CoreError::Cancelled);
+        }
+    };
+
+    // Step 5: write back the post-resolution state.
+    match outcome {
+        Ok(payload) => {
+            let cleared = TurnStateJson {
+                version: 1,
+                pending_client_tool: None,
+            };
+            store
+                .update_turn(&task_id.0, TurnStatus::PendingLlm, &cleared, None)
+                .await?;
+            Ok(payload)
+        }
+        Err(reason) => {
+            let _ = store
+                .update_turn(&task_id.0, TurnStatus::Failed, &state, Some(&reason))
+                .await;
+            Err(CoreError::ToolExecution(reason))
+        }
+    }
+}
+
+/// Resolve a pending suspension for the current `user_id`. Drives the
+/// validations in this order:
+/// 1. Reject if the payload is malformed (too large, neither result
+///    nor error populated).
+/// 2. Look up the pending slot; refuse if missing OR `user_id` mismatch
+///    (same opacity rule as cross-user conversation reads).
+/// 3. Refuse on `tool_call_id` mismatch.
+/// 4. Send the result through the oneshot. The suspended task picks it
+///    up and continues the LLM loop.
+pub async fn resolve_client_tool_result(
+    coord: &ClientToolCoordinator,
+    _store: &dyn TurnStateStore,
+    user_id: UserId,
+    task_id: api::TaskId,
+    tool_call_id: String,
+    payload: Result<String, String>,
+) -> Result<(), ClientToolResolutionError> {
+    // 1. Validate payload size.
+    if let Ok(body) = &payload
+        && body.len() > MAX_CLIENT_TOOL_RESULT_BYTES
+    {
+        return Err(ClientToolResolutionError::MalformedResult(format!(
+            "result body exceeds size cap ({} > {} bytes)",
+            body.len(),
+            MAX_CLIENT_TOOL_RESULT_BYTES
+        )));
+    }
+    if let Err(reason) = &payload
+        && reason.len() > MAX_CLIENT_TOOL_RESULT_BYTES
+    {
+        return Err(ClientToolResolutionError::MalformedResult(format!(
+            "error reason exceeds size cap ({} > {} bytes)",
+            reason.len(),
+            MAX_CLIENT_TOOL_RESULT_BYTES
+        )));
+    }
+
+    // 2 & 3: look up slot, check user_id + tool_call_id, take the waker.
+    let slot = {
+        let mut pending = coord.pending.lock().unwrap();
+        let slot = pending.get(&task_id.0).ok_or_else(|| {
+            ClientToolResolutionError::TurnNotFound {
+                task_id: task_id.0.clone(),
+            }
+        })?;
+        if slot.user_id != user_id.as_str() {
+            // Cross-user probe: claim the row doesn't exist.
+            return Err(ClientToolResolutionError::TurnNotFound {
+                task_id: task_id.0.clone(),
+            });
+        }
+        if slot.expected_tool_call_id != tool_call_id {
+            return Err(ClientToolResolutionError::ToolCallIdMismatch {
+                task_id: task_id.0.clone(),
+                expected: slot.expected_tool_call_id.clone(),
+                got: tool_call_id.clone(),
+            });
+        }
+        // OK to take the slot.
+        pending.remove(&task_id.0).expect("just found above")
+    };
+
+    // 4. Wake the suspended task. If it has already been dropped (e.g.
+    // cancelled in the meantime) we silently ignore; the cleanup path
+    // already removed the row.
+    let _ = slot.waker.send(payload);
+    Ok(())
+}
+
+/// Cold-restart sweep: mark every non-terminal turn row `failed` with
+/// `last_error = "daemon_restarted"`. Called once at daemon startup so
+/// abandoned turns don't accumulate. Returns the count swept.
+///
+/// The sweep is intentionally NOT scoped to a `user_id`: it walks the
+/// whole table on the assumption that a daemon restart is a system
+/// event affecting every user equally. Storage adapters implement
+/// `scan_non_terminal` without applying the `current_user_id()` filter
+/// for the same reason.
+pub async fn sweep_non_terminal_turns_on_startup(
+    store: &dyn TurnStateStore,
+) -> Result<u32, CoreError> {
+    let rows = store.scan_non_terminal().await?;
+    let mut count = 0u32;
+    for row in rows {
+        // Preserve the row's state_json so a follow-up audit can see
+        // *what* was pending when the daemon died.
+        store
+            .update_turn(
+                &row.id,
+                TurnStatus::Failed,
+                &row.state,
+                Some("daemon_restarted"),
+            )
+            .await?;
+        count = count.saturating_add(1);
+    }
+    Ok(count)
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate maps canonical API [`desktop_assistant_api_model::Command`] values
 //! to calls into the existing inbound ports in `desktop-assistant-core`.
 
+pub mod client_tools;
+
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
@@ -941,6 +943,20 @@ where
             | api::Command::SubscribeBackgroundTasks
             | api::Command::UnsubscribeBackgroundTasks
             | api::Command::SpawnStandaloneAgent { .. } => Err(ApiError::Unsupported),
+
+            // Client-side tool execution (issue #107). The default
+            // handler doesn't carry a `ClientToolCoordinator`; a
+            // composition that wants client-side execution wraps this
+            // handler (or constructs `DefaultAssistantApiHandler` with
+            // `with_client_tool_coordinator`) and overrides these arms.
+            //
+            // We reject explicitly so transports surface a clean
+            // "feature not enabled" instead of silently dropping the
+            // command. The wrapping handler in this crate's
+            // `client_tools` module is the supported path.
+            api::Command::RegisterClientTools { .. } | api::Command::ClientToolResult { .. } => {
+                Err(ApiError::Unsupported)
+            }
         }
     }
 

--- a/crates/application/tests/client_tool_turn_state.rs
+++ b/crates/application/tests/client_tool_turn_state.rs
@@ -1,0 +1,738 @@
+//! Integration tests for the #107 turn state machine and client-side
+//! tool execution at the application layer.
+//!
+//! These tests drive the `ClientToolCoordinator` + `ClientCapableToolExecutor`
+//! through the same shapes a real send_message would: register a client
+//! tool, kick off a turn that invokes the tool, observe the
+//! `Event::ClientToolCall` emission, post a `ClientToolResult` back, and
+//! confirm the turn completes. The DB is mocked with an in-memory
+//! `TurnStateStore` so the tests don't need Postgres.
+//!
+//! The harness is intentionally *not* the real `DefaultAssistantApiHandler`
+//! — that one wires through `ConversationService` which expects an LLM,
+//! a real conversation store, etc. We pin behavior at the
+//! tool-coordinator boundary, which is the genuine subject of #107.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::client_tools::{
+    register_client_tools, resolve_client_tool_result, suspend_for_client_tool,
+    ClientToolCoordinator, ClientToolResolutionError,
+};
+use desktop_assistant_application::EventSink;
+use desktop_assistant_auth_jwt::UserId;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::auth::with_user_id;
+use desktop_assistant_core::ports::store::{
+    PendingClientToolCall, TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
+};
+
+// ---- Fakes ---------------------------------------------------------------
+
+/// In-memory `TurnStateStore` for the test harness.
+struct InMemoryTurnStore {
+    data: Mutex<HashMap<String, TurnRow>>,
+}
+
+impl InMemoryTurnStore {
+    fn new() -> Self {
+        Self {
+            data: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl TurnStateStore for InMemoryTurnStore {
+    async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
+        let mut data = self.data.lock().unwrap();
+        if data.contains_key(&row.id) {
+            return Err(CoreError::Storage(format!("dup turn id: {}", row.id)));
+        }
+        data.insert(row.id.clone(), row);
+        Ok(())
+    }
+    async fn get_turn(&self, id: &str) -> Result<Option<TurnRow>, CoreError> {
+        Ok(self.data.lock().unwrap().get(id).cloned())
+    }
+    async fn update_turn(
+        &self,
+        id: &str,
+        status: TurnStatus,
+        state: &TurnStateJson,
+        last_error: Option<&str>,
+    ) -> Result<(), CoreError> {
+        let mut data = self.data.lock().unwrap();
+        let row = data
+            .get_mut(id)
+            .ok_or_else(|| CoreError::Storage(format!("turn missing: {id}")))?;
+        row.status = status;
+        row.state = state.clone();
+        row.last_error = last_error.map(String::from);
+        Ok(())
+    }
+    async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|r| !r.status.is_terminal())
+            .cloned()
+            .collect())
+    }
+}
+
+/// Captures emitted events for assertions.
+struct CapturingSink {
+    events: Mutex<Vec<api::Event>>,
+}
+
+impl CapturingSink {
+    fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+        }
+    }
+    fn snapshot(&self) -> Vec<api::Event> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl EventSink for CapturingSink {
+    async fn emit(&self, event: api::Event) -> bool {
+        self.events.lock().unwrap().push(event);
+        true
+    }
+}
+
+// ---- Acceptance tests ----------------------------------------------------
+
+/// Happy path: server-side tools never touch the coordinator.
+///
+/// A tool name that was never registered as client-local passes through
+/// to whatever inner executor logic is running; the coordinator's
+/// `suspend_for_client_tool` is the only path that creates a turn row,
+/// so an unregistered tool name results in no DB writes — exactly the
+/// "server-side execution stays unchanged" contract.
+#[tokio::test]
+async fn server_side_tool_does_not_create_turn_row_or_emit_client_tool_call() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store = Arc::new(InMemoryTurnStore::new());
+    let sink = Arc::new(CapturingSink::new());
+
+    // The user registers `fs_read` only. `weather_lookup` stays server-side.
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "client-local".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+    })
+    .await;
+
+    // A call to a NON-registered tool short-circuits — the coordinator
+    // doesn't recognize it, so the caller falls through to server-side
+    // dispatch (which the test harness short-circuits to a sentinel
+    // value to prove "we did NOT suspend").
+    let recognized = with_user_id(UserId::new("alice"), async {
+        coord.is_client_registered("weather_lookup").await
+    })
+    .await;
+    assert!(
+        !recognized,
+        "tool that was never registered must not be recognized as client-local"
+    );
+
+    // Sanity: no events, no turn rows.
+    assert!(sink.snapshot().is_empty());
+    assert!(store.scan_non_terminal().await.unwrap().is_empty());
+}
+
+/// Suspending on a client-local tool: the coordinator writes a
+/// `pending_client_tool` row, emits a `ClientToolCall`, and the
+/// suspension future stays pending until a result is posted.
+#[tokio::test]
+async fn turn_suspends_on_client_local_tool_call_and_emits_event() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+    let sink_concrete = Arc::new(CapturingSink::new());
+    let sink: Arc<dyn EventSink> = sink_concrete.clone();
+
+    // Register the tool under alice's identity.
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+
+        // Seed an empty turn row so the harness mirrors what the real
+        // handler does at turn start (create row in `pending_llm`).
+        store
+            .create_turn(TurnRow {
+                id: "task-1".into(),
+                user_id: "alice".into(),
+                conversation_id: "conv-1".into(),
+                status: TurnStatus::PendingLlm,
+                state: TurnStateJson::default(),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+    })
+    .await;
+
+    // Launch the suspension. The future stays pending until we resolve it.
+    let coord_for_task = Arc::clone(&coord);
+    let store_for_task = Arc::clone(&store);
+    let sink_for_task = sink.clone();
+    let suspended = tokio::spawn(async move {
+        with_user_id(UserId::new("alice"), async {
+            suspend_for_client_tool(
+                &coord_for_task,
+                &*store_for_task,
+                &*sink_for_task,
+                api::TaskId("task-1".into()),
+                "conv-1".to_string(),
+                PendingClientToolCall {
+                    tool_call_id: "call-7".into(),
+                    tool_name: "fs_read".into(),
+                    arguments: serde_json::json!({"path": "/etc/hosts"}),
+                },
+            )
+            .await
+        })
+        .await
+    });
+
+    // Drive the runtime so the suspending task can park.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    // The event must have been emitted before the suspension returned.
+    let snapshot = sink_concrete.snapshot();
+    let client_tool_calls: Vec<_> = snapshot
+        .iter()
+        .filter(|e| matches!(e, api::Event::ClientToolCall { .. }))
+        .collect();
+    assert_eq!(
+        client_tool_calls.len(),
+        1,
+        "exactly one ClientToolCall must have been emitted before suspension"
+    );
+
+    // Turn row is now in `pending_client_tool`.
+    let row = store.get_turn("task-1").await.unwrap().unwrap();
+    assert_eq!(row.status, TurnStatus::PendingClientTool);
+    let pending = row.state.pending_client_tool.unwrap();
+    assert_eq!(pending.tool_call_id, "call-7");
+    assert_eq!(pending.tool_name, "fs_read");
+
+    // The suspension future is still pending — it must NOT have completed
+    // without a `ClientToolResult` coming back.
+    assert!(
+        !suspended.is_finished(),
+        "suspension future must remain pending until a result arrives"
+    );
+
+    // Resolve and observe completion.
+    resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        api::TaskId("task-1".into()),
+        "call-7".to_string(),
+        Ok("file contents".into()),
+    )
+    .await
+    .unwrap();
+
+    let result = suspended.await.unwrap().unwrap();
+    assert_eq!(result, "file contents");
+
+    // After resolution, the row transitions back to `pending_llm` so the
+    // dispatcher knows to continue the LLM loop.
+    let row = store.get_turn("task-1").await.unwrap().unwrap();
+    assert_eq!(row.status, TurnStatus::PendingLlm);
+    assert!(row.state.pending_client_tool.is_none());
+}
+
+/// Cross-user isolation: user A's pending turn can't be resumed by
+/// user B's `ClientToolResult`. The protocol must refuse cleanly.
+#[tokio::test]
+async fn turn_cross_user_isolation_blocks_resume_by_other_user() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+    let sink: Arc<dyn EventSink> = Arc::new(CapturingSink::new());
+
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+        store
+            .create_turn(TurnRow {
+                id: "task-A".into(),
+                user_id: "alice".into(),
+                conversation_id: "conv-A".into(),
+                status: TurnStatus::PendingLlm,
+                state: TurnStateJson::default(),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+    })
+    .await;
+
+    let coord_for_task = Arc::clone(&coord);
+    let store_for_task = Arc::clone(&store);
+    let sink_for_task = Arc::clone(&sink);
+    let suspended = tokio::spawn(async move {
+        with_user_id(UserId::new("alice"), async {
+            suspend_for_client_tool(
+                &coord_for_task,
+                &*store_for_task,
+                &*sink_for_task,
+                api::TaskId("task-A".into()),
+                "conv-A".to_string(),
+                PendingClientToolCall {
+                    tool_call_id: "call-a".into(),
+                    tool_name: "fs_read".into(),
+                    arguments: serde_json::Value::Null,
+                },
+            )
+            .await
+        })
+        .await
+    });
+
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    // Bob tries to resolve Alice's pending turn. The coordinator must
+    // refuse because the turn row's user_id is "alice", not "bob".
+    let err = resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("bob"),
+        api::TaskId("task-A".into()),
+        "call-a".to_string(),
+        Ok("malicious".into()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, ClientToolResolutionError::TurnNotFound { .. }));
+
+    // Alice's suspension is still pending.
+    assert!(!suspended.is_finished());
+
+    // Cleanup: resolve under alice's scope so the spawned task drains.
+    resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        api::TaskId("task-A".into()),
+        "call-a".to_string(),
+        Ok("ok".into()),
+    )
+    .await
+    .unwrap();
+    let _ = suspended.await.unwrap();
+}
+
+/// Mismatched tool_call_id: the result references a tool call the turn
+/// row doesn't know about. Must be refused.
+#[tokio::test]
+async fn malformed_client_tool_result_rejected_on_tool_call_id_mismatch() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+    let sink: Arc<dyn EventSink> = Arc::new(CapturingSink::new());
+
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+        store
+            .create_turn(TurnRow {
+                id: "task-1".into(),
+                user_id: "alice".into(),
+                conversation_id: "conv-1".into(),
+                status: TurnStatus::PendingLlm,
+                state: TurnStateJson::default(),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+    })
+    .await;
+
+    let coord_for_task = Arc::clone(&coord);
+    let store_for_task = Arc::clone(&store);
+    let sink_for_task = Arc::clone(&sink);
+    let suspended = tokio::spawn(async move {
+        with_user_id(UserId::new("alice"), async {
+            suspend_for_client_tool(
+                &coord_for_task,
+                &*store_for_task,
+                &*sink_for_task,
+                api::TaskId("task-1".into()),
+                "conv-1".to_string(),
+                PendingClientToolCall {
+                    tool_call_id: "call-7".into(),
+                    tool_name: "fs_read".into(),
+                    arguments: serde_json::Value::Null,
+                },
+            )
+            .await
+        })
+        .await
+    });
+
+    tokio::task::yield_now().await;
+
+    // Send the result with the wrong tool_call_id.
+    let err = resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        api::TaskId("task-1".into()),
+        "call-wrong".to_string(),
+        Ok("body".into()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ClientToolResolutionError::ToolCallIdMismatch { .. }
+    ));
+
+    // Suspension still pending.
+    assert!(!suspended.is_finished());
+
+    // Cleanup.
+    resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        api::TaskId("task-1".into()),
+        "call-7".to_string(),
+        Ok("ok".into()),
+    )
+    .await
+    .unwrap();
+    let _ = suspended.await.unwrap();
+}
+
+/// No-active-session: the LLM in some hypothetical race tries to call a
+/// client tool that was registered under a now-disconnected session, and
+/// the suspension future returns a clean failure to the LLM loop. Today
+/// the coordinator's `suspend_for_client_tool` will create a row even if
+/// the client is gone, then time out / never resolve. But the
+/// `resolve_client_tool_result` path explicitly refuses a result for a
+/// task that has no pending oneshot — clients reconnecting late see this.
+#[tokio::test]
+async fn resolve_with_no_pending_suspension_is_a_clean_error() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+
+    let err = resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        api::TaskId("ghost".into()),
+        "call-1".to_string(),
+        Ok("body".into()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, ClientToolResolutionError::TurnNotFound { .. }));
+}
+
+/// `unregistered_tool_called_by_llm_is_an_error`: the suspension path
+/// requires the tool to have been registered. A caller invoking it for
+/// an unregistered tool name will be rejected.
+#[tokio::test]
+async fn suspension_for_unregistered_tool_fails_cleanly() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+    let sink: Arc<dyn EventSink> = Arc::new(CapturingSink::new());
+
+    with_user_id(UserId::new("alice"), async {
+        store
+            .create_turn(TurnRow {
+                id: "task-1".into(),
+                user_id: "alice".into(),
+                conversation_id: "conv-1".into(),
+                status: TurnStatus::PendingLlm,
+                state: TurnStateJson::default(),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+    })
+    .await;
+
+    let result = with_user_id(UserId::new("alice"), async {
+        suspend_for_client_tool(
+            &coord,
+            &*store,
+            &*sink,
+            api::TaskId("task-1".into()),
+            "conv-1".to_string(),
+            PendingClientToolCall {
+                tool_call_id: "call-7".into(),
+                tool_name: "wasnt_registered".into(),
+                arguments: serde_json::Value::Null,
+            },
+        )
+        .await
+    })
+    .await;
+
+    let err = result.unwrap_err();
+    let s = err.to_string();
+    assert!(
+        s.contains("not registered") || s.contains("wasnt_registered"),
+        "error must mention registration; got {s}"
+    );
+}
+
+/// `turn_state_survives_daemon_restart` reduced to its DB-shaped form:
+/// after the daemon dies, the abandoned `pending_client_tool` row is
+/// still in the DB. A startup scan returns it, and the application's
+/// shutdown sweep marks it `failed` so it doesn't shadow the next turn.
+#[tokio::test]
+async fn abandoned_pending_turn_visible_after_restart_and_swept_to_failed() {
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+
+    // Pretend a previous daemon left a pending row behind.
+    store
+        .create_turn(TurnRow {
+            id: "task-zombie".into(),
+            user_id: "alice".into(),
+            conversation_id: "conv-1".into(),
+            status: TurnStatus::PendingClientTool,
+            state: TurnStateJson {
+                version: 1,
+                pending_client_tool: Some(PendingClientToolCall {
+                    tool_call_id: "call-1".into(),
+                    tool_name: "fs_read".into(),
+                    arguments: serde_json::Value::Null,
+                }),
+            },
+            last_error: None,
+        })
+        .await
+        .unwrap();
+
+    // The startup scan must surface it. We exercise the helper that
+    // performs the actual sweep so the contract is pinned.
+    let swept =
+        desktop_assistant_application::client_tools::sweep_non_terminal_turns_on_startup(&*store)
+            .await
+            .unwrap();
+    assert_eq!(swept, 1, "exactly one zombie turn should have been swept");
+
+    let row = store.get_turn("task-zombie").await.unwrap().unwrap();
+    assert_eq!(row.status, TurnStatus::Failed);
+    assert_eq!(row.last_error.as_deref(), Some("daemon_restarted"));
+}
+
+/// Registration is scoped to a user, not global: registering under
+/// `alice` does not make the tool client-local for `bob`. (Mirrors the
+/// `unregistered_tool_called_by_llm_is_an_error` and
+/// `registered_client_tool_with_no_active_session_falls_back_to_error`
+/// edge cases from the issue's test plan.)
+#[tokio::test]
+async fn registration_is_per_user_not_global() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+    })
+    .await;
+
+    let alice_sees = with_user_id(UserId::new("alice"), async {
+        coord.is_client_registered("fs_read").await
+    })
+    .await;
+    let bob_sees = with_user_id(UserId::new("bob"), async {
+        coord.is_client_registered("fs_read").await
+    })
+    .await;
+
+    assert!(alice_sees, "alice registered the tool, must see it");
+    assert!(
+        !bob_sees,
+        "bob never registered — registration MUST be per-user"
+    );
+}
+
+/// Re-registration replaces the previous set: a client reconnecting and
+/// sending a new `RegisterClientTools` clears the previous set so a
+/// removed tool stops being recognized as client-local.
+#[tokio::test]
+async fn re_registration_replaces_previous_set() {
+    let coord = Arc::new(ClientToolCoordinator::new());
+
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[
+                api::ClientToolRegistration {
+                    name: "fs_read".into(),
+                    description: "x".into(),
+                    input_schema: serde_json::json!({}),
+                },
+                api::ClientToolRegistration {
+                    name: "fs_write".into(),
+                    description: "x".into(),
+                    input_schema: serde_json::json!({}),
+                },
+            ],
+        )
+        .await;
+
+        // Reconnect: new registration with only fs_read.
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+
+        assert!(coord.is_client_registered("fs_read").await);
+        assert!(
+            !coord.is_client_registered("fs_write").await,
+            "previous fs_write must have been cleared by re-registration"
+        );
+    })
+    .await;
+}
+
+/// Cancellation: a turn whose token has tripped before the suspension
+/// future resolves must bail out with `Cancelled` instead of waiting
+/// indefinitely.
+#[tokio::test]
+async fn cancellation_during_client_tool_suspension_returns_cancelled() {
+    use desktop_assistant_core::ports::llm::with_cancellation_token;
+
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStore::new());
+    let sink: Arc<dyn EventSink> = Arc::new(CapturingSink::new());
+
+    with_user_id(UserId::new("alice"), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "x".into(),
+                input_schema: serde_json::json!({}),
+            }],
+        )
+        .await;
+        store
+            .create_turn(TurnRow {
+                id: "task-1".into(),
+                user_id: "alice".into(),
+                conversation_id: "conv-1".into(),
+                status: TurnStatus::PendingLlm,
+                state: TurnStateJson::default(),
+                last_error: None,
+            })
+            .await
+            .unwrap();
+    })
+    .await;
+
+    let token = tokio_util::sync::CancellationToken::new();
+    let token_for_cancel = token.clone();
+
+    let coord_for_task = Arc::clone(&coord);
+    let store_for_task = Arc::clone(&store);
+    let sink_for_task = Arc::clone(&sink);
+    let suspended = tokio::spawn(async move {
+        with_user_id(UserId::new("alice"), async {
+            with_cancellation_token(token, async {
+                suspend_for_client_tool(
+                    &coord_for_task,
+                    &*store_for_task,
+                    &*sink_for_task,
+                    api::TaskId("task-1".into()),
+                    "conv-1".to_string(),
+                    PendingClientToolCall {
+                        tool_call_id: "call-7".into(),
+                        tool_name: "fs_read".into(),
+                        arguments: serde_json::Value::Null,
+                    },
+                )
+                .await
+            })
+            .await
+        })
+        .await
+    });
+
+    tokio::task::yield_now().await;
+
+    token_for_cancel.cancel();
+
+    let outcome = suspended.await.unwrap();
+    assert!(outcome.is_err(), "cancelled suspension must surface an error");
+    let err = outcome.unwrap_err();
+    let s = err.to_string();
+    assert!(
+        s.contains("cancel") || s.contains("Cancel"),
+        "error message must reference cancellation; got {s}"
+    );
+
+    let row = store.get_turn("task-1").await.unwrap().unwrap();
+    assert_eq!(row.status, TurnStatus::Failed);
+    assert_eq!(row.last_error.as_deref(), Some("cancelled"));
+}
+
+// Compile-time presence guard: ensures the coordinator's public surface
+// hasn't been removed silently.
+fn _api_surface_compiles_check() {
+    fn _accepts_arc<T: ?Sized + Send + Sync>(_: &Arc<T>) {}
+    fn _check(c: &Arc<ClientToolCoordinator>) {
+        _accepts_arc(c);
+    }
+    let _ = _check;
+    let _ = HashSet::<String>::new();
+}

--- a/crates/application/tests/client_tool_turn_state.rs
+++ b/crates/application/tests/client_tool_turn_state.rs
@@ -13,7 +13,7 @@
 //! a real conversation store, etc. We pin behavior at the
 //! tool-coordinator boundary, which is the genuine subject of #107.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -46,6 +46,7 @@ impl InMemoryTurnStore {
     }
 }
 
+#[async_trait]
 impl TurnStateStore for InMemoryTurnStore {
     async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
         let mut data = self.data.lock().unwrap();
@@ -734,5 +735,4 @@ fn _api_surface_compiles_check() {
         _accepts_arc(c);
     }
     let _ = _check;
-    let _ = HashSet::<String>::new();
 }

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -483,6 +483,12 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
         | api::Event::TaskProgress { .. }
         | api::Event::TaskLogAppended { .. }
         | api::Event::TaskCompleted { .. } => None,
+        // Client-side tool execution (#107): handled by clients that
+        // implement the client-tool protocol directly; the legacy
+        // `SignalEvent` stream is for the GTK desktop UI and does not
+        // surface tool-call requests. Listed explicitly so a future
+        // client that DOES want to react can move it out of this arm.
+        api::Event::ClientToolCall { .. } => None,
     }
 }
 

--- a/crates/core/src/ports/store.rs
+++ b/crates/core/src/ports/store.rs
@@ -132,46 +132,43 @@ pub struct TurnRow {
 /// inside the per-request scope rely on `current_user_id()`. Cross-user
 /// reads MUST behave like the row doesn't exist (don't leak presence).
 ///
-/// The default no-op implementation makes the trait opt-in for tests and
-/// legacy non-turn-state code paths: a service that doesn't care about
-/// turn state never needs to construct a concrete store.
+/// Uses `async_trait` (not `impl Future` like the other outbound ports)
+/// because the application-layer coordinator holds the store behind a
+/// `dyn TurnStateStore` so adapters that thread the coordinator
+/// through generic plumbing don't have to monomorphize against every
+/// concrete store. `async_trait` adds a small allocation per call;
+/// the call-rate (one create + one update per turn round + sweep on
+/// startup) is low enough that this is the right trade.
+#[async_trait::async_trait]
 pub trait TurnStateStore: Send + Sync {
     /// Insert a new turn row. Implementations stamp `created_at` /
     /// `updated_at` themselves. Returns `Err` if a row with this id
     /// already exists under the same user_id — the caller chose a
     /// duplicate task_id, which is a programming error.
-    fn create_turn(
-        &self,
-        row: TurnRow,
-    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+    async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError>;
 
     /// Read a turn row by id, scoped to the current user. Returns `Ok(None)`
     /// when the row doesn't exist OR exists under a different user_id —
     /// the same opacity rule as `PgConversationStore::get_conversation_model_selection`.
-    fn get_turn(
-        &self,
-        id: &str,
-    ) -> impl std::future::Future<Output = Result<Option<TurnRow>, CoreError>> + Send;
+    async fn get_turn(&self, id: &str) -> Result<Option<TurnRow>, CoreError>;
 
     /// Atomically update a turn row's status, state_json, and last_error.
     /// Implementations bump `updated_at`. Returns `Err` if the row does
     /// not exist for this user_id.
-    fn update_turn(
+    async fn update_turn(
         &self,
         id: &str,
         status: TurnStatus,
         state: &TurnStateJson,
         last_error: Option<&str>,
-    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+    ) -> Result<(), CoreError>;
 
     /// Scan every turn row whose status is non-terminal across ALL users.
     /// Called once at daemon startup so abandoned rows can be marked
     /// `failed("daemon_restarted")` instead of accumulating. Skips the
     /// `current_user_id()` scope because the caller is a system task
     /// (no JWT context); implementations explicitly bypass scoping.
-    fn scan_non_terminal(
-        &self,
-    ) -> impl std::future::Future<Output = Result<Vec<TurnRow>, CoreError>> + Send;
+    async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError>;
 }
 
 /// Outbound port for persisting conversations.
@@ -462,6 +459,7 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl TurnStateStore for MockTurnStore {
         async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
             let mut data = self.data.lock().unwrap();

--- a/crates/core/src/ports/store.rs
+++ b/crates/core/src/ports/store.rs
@@ -1,5 +1,178 @@
 use crate::CoreError;
 use crate::domain::{Conversation, ConversationId};
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle status of a conversation turn persisted to the DB (#107).
+///
+/// The turn state machine drives transitions through these states so that
+/// a turn suspended on a client-local tool call can be resumed when the
+/// client posts the result back. Server-side tool dispatch transits
+/// `pending_llm` → `pending_tool_dispatch` → `pending_llm` → `complete`
+/// inside a single tokio task; client-side dispatch is the same path
+/// except the turn parks at `pending_client_tool` and the row is the
+/// only durable record while the client executes the tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    /// Daemon is calling the LLM (or about to).
+    PendingLlm,
+    /// LLM returned tool calls; daemon is dispatching server-side tools.
+    PendingToolDispatch,
+    /// Daemon emitted a `ClientToolCall` and is waiting for the client's
+    /// `ClientToolResult`. Hot-path resumption uses an in-memory
+    /// `oneshot::Sender`; the DB row exists for observability and so
+    /// a crashed daemon's pending rows can be marked `failed` on
+    /// restart instead of accumulating.
+    PendingClientTool,
+    /// Turn finished normally.
+    Complete,
+    /// Turn ended in an error (cancelled, LLM failure, daemon restart,
+    /// invalid client tool result, etc.). The reason is recorded in
+    /// `last_error`.
+    Failed,
+}
+
+impl TurnStatus {
+    /// Canonical lowercase key used in SQL and JSON. Mirrors the serde
+    /// snake_case serialization so the DB column matches the wire shape.
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::PendingLlm => "pending_llm",
+            Self::PendingToolDispatch => "pending_tool_dispatch",
+            Self::PendingClientTool => "pending_client_tool",
+            Self::Complete => "complete",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn from_key(s: &str) -> Option<Self> {
+        match s {
+            "pending_llm" => Some(Self::PendingLlm),
+            "pending_tool_dispatch" => Some(Self::PendingToolDispatch),
+            "pending_client_tool" => Some(Self::PendingClientTool),
+            "complete" => Some(Self::Complete),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` for states the daemon should not resume on restart.
+    /// Pending states pile up if the daemon crashes mid-turn; the
+    /// startup scan marks them `failed` so they don't shadow the user's
+    /// next request.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Complete | Self::Failed)
+    }
+}
+
+/// A pending client-side tool call recorded in the turn's `state_json`.
+///
+/// Carries everything the client needs to execute the tool plus the
+/// `tool_call_id` the LLM generated, which the client echoes back in
+/// its `ClientToolResult` so the daemon can correlate the response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingClientToolCall {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// JSON payload stored in `turns.state_json`. The shape is internal to
+/// the application + storage layers; the wire protocol's `Event::ClientToolCall`
+/// carries only the subset the client needs.
+///
+/// Why a single JSON column rather than a normalized schema: the turn
+/// state's contents (history, partial responses, retry counters, ...)
+/// evolve as the in-memory state machine evolves. A schema migration on
+/// every internal-state tweak is friction we don't need, and the
+/// `(user_id, status)` index already covers every hot query path. The
+/// JSON shape is versioned so we can grow it without losing pre-restart
+/// rows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnStateJson {
+    /// Bumped on every breaking shape change. Readers default to v1
+    /// when the column existed before this field was added (it didn't,
+    /// but defaulting keeps downgrades clean).
+    #[serde(default = "default_state_version")]
+    pub version: u32,
+    /// The currently outstanding client-side tool call, if any. `Some`
+    /// iff `status == PendingClientTool`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_client_tool: Option<PendingClientToolCall>,
+}
+
+fn default_state_version() -> u32 {
+    1
+}
+
+impl Default for TurnStateJson {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            pending_client_tool: None,
+        }
+    }
+}
+
+/// A single turn row read from the DB. Mirrors the columns in the
+/// `turns` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnRow {
+    pub id: String,
+    pub user_id: String,
+    pub conversation_id: String,
+    pub status: TurnStatus,
+    pub state: TurnStateJson,
+    pub last_error: Option<String>,
+}
+
+/// Outbound port for persisting conversation turn state (#107).
+///
+/// Implementations are responsible for `(user_id, …)` scoping; callers
+/// inside the per-request scope rely on `current_user_id()`. Cross-user
+/// reads MUST behave like the row doesn't exist (don't leak presence).
+///
+/// The default no-op implementation makes the trait opt-in for tests and
+/// legacy non-turn-state code paths: a service that doesn't care about
+/// turn state never needs to construct a concrete store.
+pub trait TurnStateStore: Send + Sync {
+    /// Insert a new turn row. Implementations stamp `created_at` /
+    /// `updated_at` themselves. Returns `Err` if a row with this id
+    /// already exists under the same user_id — the caller chose a
+    /// duplicate task_id, which is a programming error.
+    fn create_turn(
+        &self,
+        row: TurnRow,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    /// Read a turn row by id, scoped to the current user. Returns `Ok(None)`
+    /// when the row doesn't exist OR exists under a different user_id —
+    /// the same opacity rule as `PgConversationStore::get_conversation_model_selection`.
+    fn get_turn(
+        &self,
+        id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<TurnRow>, CoreError>> + Send;
+
+    /// Atomically update a turn row's status, state_json, and last_error.
+    /// Implementations bump `updated_at`. Returns `Err` if the row does
+    /// not exist for this user_id.
+    fn update_turn(
+        &self,
+        id: &str,
+        status: TurnStatus,
+        state: &TurnStateJson,
+        last_error: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    /// Scan every turn row whose status is non-terminal across ALL users.
+    /// Called once at daemon startup so abandoned rows can be marked
+    /// `failed("daemon_restarted")` instead of accumulating. Skips the
+    /// `current_user_id()` scope because the caller is a system task
+    /// (no JWT context); implementations explicitly bypass scoping.
+    fn scan_non_terminal(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<TurnRow>, CoreError>> + Send;
+}
 
 /// Outbound port for persisting conversations.
 pub trait ConversationStore: Send + Sync {
@@ -220,5 +393,217 @@ mod tests {
         let store = MockStore::new();
         let result = store.get(&ConversationId::from("nope")).await;
         assert!(matches!(result, Err(CoreError::ConversationNotFound(_))));
+    }
+
+    // ---- #107: turn state machine port ------------------------------------
+
+    #[test]
+    fn turn_status_round_trips_via_key() {
+        for status in [
+            TurnStatus::PendingLlm,
+            TurnStatus::PendingToolDispatch,
+            TurnStatus::PendingClientTool,
+            TurnStatus::Complete,
+            TurnStatus::Failed,
+        ] {
+            let key = status.as_key();
+            let back = TurnStatus::from_key(key).expect("known key parses");
+            assert_eq!(status, back, "key {key} must round-trip");
+        }
+        assert_eq!(TurnStatus::from_key("nonsense"), None);
+    }
+
+    #[test]
+    fn turn_status_is_terminal_matches_complete_or_failed() {
+        assert!(TurnStatus::Complete.is_terminal());
+        assert!(TurnStatus::Failed.is_terminal());
+        assert!(!TurnStatus::PendingLlm.is_terminal());
+        assert!(!TurnStatus::PendingToolDispatch.is_terminal());
+        assert!(!TurnStatus::PendingClientTool.is_terminal());
+    }
+
+    #[test]
+    fn turn_state_json_serializes_with_version_field() {
+        let state = TurnStateJson {
+            version: 1,
+            pending_client_tool: Some(PendingClientToolCall {
+                tool_call_id: "call-1".into(),
+                tool_name: "fs_read".into(),
+                arguments: serde_json::json!({"path": "/etc/hosts"}),
+            }),
+        };
+        let v = serde_json::to_value(&state).unwrap();
+        assert_eq!(v.get("version").unwrap(), 1);
+        let back: TurnStateJson = serde_json::from_value(v).unwrap();
+        assert_eq!(state, back);
+    }
+
+    #[test]
+    fn turn_state_json_default_version_is_1_when_missing() {
+        // Roll-forward safety: a row written before the `version` field
+        // existed must still parse. The default factory produces 1.
+        let state: TurnStateJson = serde_json::from_str("{}").unwrap();
+        assert_eq!(state.version, 1);
+        assert!(state.pending_client_tool.is_none());
+    }
+
+    /// In-memory `TurnStateStore` for trait-impl tests. Mirrors the
+    /// `MockStore` pattern above — keyed by id, no user_id scoping
+    /// (callers exercise scoping at higher layers).
+    struct MockTurnStore {
+        data: Mutex<HashMap<String, TurnRow>>,
+    }
+
+    impl MockTurnStore {
+        fn new() -> Self {
+            Self {
+                data: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl TurnStateStore for MockTurnStore {
+        async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
+            let mut data = self.data.lock().unwrap();
+            if data.contains_key(&row.id) {
+                return Err(CoreError::Storage(format!(
+                    "turn id already exists: {}",
+                    row.id
+                )));
+            }
+            data.insert(row.id.clone(), row);
+            Ok(())
+        }
+
+        async fn get_turn(&self, id: &str) -> Result<Option<TurnRow>, CoreError> {
+            Ok(self.data.lock().unwrap().get(id).cloned())
+        }
+
+        async fn update_turn(
+            &self,
+            id: &str,
+            status: TurnStatus,
+            state: &TurnStateJson,
+            last_error: Option<&str>,
+        ) -> Result<(), CoreError> {
+            let mut data = self.data.lock().unwrap();
+            let row = data
+                .get_mut(id)
+                .ok_or_else(|| CoreError::Storage(format!("turn not found: {id}")))?;
+            row.status = status;
+            row.state = state.clone();
+            row.last_error = last_error.map(String::from);
+            Ok(())
+        }
+
+        async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|r| !r.status.is_terminal())
+                .cloned()
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_state_store_create_get_update_round_trip() {
+        let store = MockTurnStore::new();
+        let row = TurnRow {
+            id: "task-1".into(),
+            user_id: "alice".into(),
+            conversation_id: "conv-1".into(),
+            status: TurnStatus::PendingLlm,
+            state: TurnStateJson::default(),
+            last_error: None,
+        };
+        store.create_turn(row.clone()).await.unwrap();
+
+        let read = store.get_turn("task-1").await.unwrap().unwrap();
+        assert_eq!(read.status, TurnStatus::PendingLlm);
+
+        let updated_state = TurnStateJson {
+            version: 1,
+            pending_client_tool: Some(PendingClientToolCall {
+                tool_call_id: "c1".into(),
+                tool_name: "fs_read".into(),
+                arguments: serde_json::json!({"path": "/tmp/x"}),
+            }),
+        };
+        store
+            .update_turn(
+                "task-1",
+                TurnStatus::PendingClientTool,
+                &updated_state,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let read = store.get_turn("task-1").await.unwrap().unwrap();
+        assert_eq!(read.status, TurnStatus::PendingClientTool);
+        assert!(read.state.pending_client_tool.is_some());
+    }
+
+    #[tokio::test]
+    async fn turn_state_store_scan_non_terminal_excludes_complete_and_failed() {
+        let store = MockTurnStore::new();
+        // Two finished rows, two pending — only the pending ones should
+        // surface in the scan, since the startup hook uses this to
+        // mark abandoned turns `failed` without churning completed ones.
+        for (id, status) in [
+            ("t-c", TurnStatus::Complete),
+            ("t-f", TurnStatus::Failed),
+            ("t-llm", TurnStatus::PendingLlm),
+            ("t-ct", TurnStatus::PendingClientTool),
+        ] {
+            store
+                .create_turn(TurnRow {
+                    id: id.into(),
+                    user_id: "u".into(),
+                    conversation_id: "c".into(),
+                    status,
+                    state: TurnStateJson::default(),
+                    last_error: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        let pending = store.scan_non_terminal().await.unwrap();
+        let mut ids: Vec<_> = pending.iter().map(|r| r.id.clone()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["t-ct".to_string(), "t-llm".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn turn_state_store_duplicate_create_fails() {
+        // Duplicate task_ids signal a caller bug — the dispatcher should
+        // generate unique ids per turn. Surfacing a clear error catches
+        // this in tests rather than silently overwriting in production.
+        let store = MockTurnStore::new();
+        let row = TurnRow {
+            id: "task-1".into(),
+            user_id: "u".into(),
+            conversation_id: "c".into(),
+            status: TurnStatus::PendingLlm,
+            state: TurnStateJson::default(),
+            last_error: None,
+        };
+        store.create_turn(row.clone()).await.unwrap();
+        let err = store.create_turn(row).await.unwrap_err();
+        assert!(matches!(err, CoreError::Storage(_)));
+    }
+
+    #[tokio::test]
+    async fn turn_state_store_get_unknown_returns_none() {
+        // Cross-user / unknown reads return `Ok(None)` rather than an
+        // error — the application layer interprets this as "no pending
+        // turn" without needing a special error variant.
+        let store = MockTurnStore::new();
+        let read = store.get_turn("nope").await.unwrap();
+        assert!(read.is_none());
     }
 }

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -120,6 +120,16 @@ pub fn translate(event: api::Event) -> ForwardAction {
         api::Event::TaskCompleted { .. } => ForwardAction::Ignored {
             kind: "task_completed",
         },
+        // Client-side tool execution (issue #107): the bridge does not
+        // forward `ClientToolCall` to D-Bus subscribers because client-
+        // side execution is a WebSocket-protocol concern. The D-Bus
+        // bridge IS a client — if the daemon ever picks a tool that's
+        // registered on a D-Bus-attached client, the bridge would need
+        // its own dispatch path; today the bridge does not register
+        // any client-local tools, so this is unreachable in practice.
+        api::Event::ClientToolCall { .. } => ForwardAction::Ignored {
+            kind: "client_tool_call",
+        },
     }
 }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "AGPL-3.0-or-later"
 
 [dependencies]
+async-trait.workspace = true
 desktop-assistant-auth-jwt.workspace = true
 desktop-assistant-core.workspace = true
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros", "json", "chrono", "uuid"] }

--- a/crates/storage/migrations/017_turn_state.sql
+++ b/crates/storage/migrations/017_turn_state.sql
@@ -1,0 +1,67 @@
+-- Issue #107: conversation turn state machine for client-side execution.
+--
+-- The turn becomes a DB-persisted state machine so it can suspend on a
+-- client-local tool call and resume when the chat client posts the
+-- result back. See `docs/architecture-evolution.md` Phase 2 + rule #8
+-- for the bigger picture.
+--
+-- Why a single JSON column for the state body
+--   The transition machinery (pending tool calls, partial history, retry
+--   counters, ...) evolves with the in-memory state machine. A per-shape
+--   migration on every internal-state tweak is friction; a versioned
+--   JSON column keeps the schema stable while the in-memory shape
+--   matures. The `(user_id, status)` and `(user_id, conversation_id)`
+--   indexes cover every hot query path identified so far (cold-restart
+--   sweep + "what's pending for this conversation").
+--
+-- Why we don't FK to `conversations(id)`
+--   A long-running turn might survive the conversation being deleted
+--   (e.g. user races the cleanup); the turn row should NOT prevent
+--   conversation deletion. We keep the conversation_id as plain text
+--   and let the application layer reconcile on observation. Note also
+--   that #105's scoping rules already keep cross-user reads opaque, so
+--   a stale conversation_id never leaks.
+--
+-- Backfill / reversibility
+--   No backfill — this is a brand-new table. The existing migration
+--   tooling (`pool::run_migrations`) is forward-only; reversing
+--   requires `DROP TABLE turns` plus dropping indexes manually.
+
+CREATE TABLE IF NOT EXISTS turns (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    -- One of: 'pending_llm', 'pending_tool_dispatch',
+    -- 'pending_client_tool', 'complete', 'failed'.
+    -- Mirrors `core::ports::store::TurnStatus::as_key()`.
+    status          TEXT NOT NULL,
+    state_json      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Set on `failed`; nullable in every other state. Populated
+    -- verbatim from the in-memory state machine's reason string
+    -- ("cancelled", "daemon_restarted", "<llm error>", etc.).
+    last_error      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Per-user, per-conversation scan: the application layer reads the
+-- turn row for a SendMessage's task_id directly by id (no index
+-- needed for that), but a future "what's pending for this conversation"
+-- view will scan via (user_id, conversation_id).
+CREATE INDEX IF NOT EXISTS turns_user_id_conversation_id_idx
+    ON turns (user_id, conversation_id);
+
+-- Per-user, per-status scan: the cold-restart sweep walks rows in
+-- non-terminal status across all users, but reads of a single user's
+-- pending turns (UI "show in-flight" view, future) go through this.
+CREATE INDEX IF NOT EXISTS turns_user_id_status_idx
+    ON turns (user_id, status);
+
+-- Global non-terminal sweep: dedicated narrow index for the startup
+-- hook in `client_tools::sweep_non_terminal_turns_on_startup`. Without
+-- this, the sweep would force a sequential scan whose cost grows with
+-- the total turn history. A partial index keyed only on non-terminal
+-- statuses keeps the index small (most turns are 'complete').
+CREATE INDEX IF NOT EXISTS turns_non_terminal_status_idx
+    ON turns (status)
+    WHERE status NOT IN ('complete', 'failed');

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -9,6 +9,7 @@ pub mod migrate_json;
 pub mod pool;
 pub mod tag_registry;
 pub mod tool_registry;
+pub mod turn_state;
 
 /// Re-export the request-scoped user-id task-local API so storage call
 /// sites can resolve `current_user_id()` without depending directly on
@@ -27,3 +28,4 @@ pub use migrate_json::{
 };
 pub use pool::{create_pool, run_migrations};
 pub use tool_registry::PgToolRegistryStore;
+pub use turn_state::PgTurnStateStore;

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -133,5 +133,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // Turn state machine (issue #107) — DB-persisted turn state for
+    // client-side execution of client-local MCP tools. A `pending_client_tool`
+    // row is the daemon's record of "the LLM asked for a client-local
+    // tool; we're waiting for the client to post the result back".
+    sqlx::raw_sql(include_str!("../migrations/017_turn_state.sql"))
+        .execute(pool)
+        .await?;
+
     Ok(())
 }

--- a/crates/storage/src/turn_state.rs
+++ b/crates/storage/src/turn_state.rs
@@ -1,0 +1,177 @@
+//! Postgres-backed adapter for `TurnStateStore` (issue #107).
+//!
+//! Mirrors the patterns established by `PgConversationStore`:
+//! - `(user_id, …)` scoped queries throughout
+//! - Cross-user reads return `None` (or "not found"), not an error — see
+//!   `desktop-assistant-core::ports::auth` and the #105 PR for the rule
+//! - `current_user_id()` from a task-local; nothing in this adapter
+//!   takes a `UserId` parameter
+//!
+//! The `scan_non_terminal` method intentionally bypasses the task-local
+//! because the caller is a system task — `client_tools::sweep_non_terminal_turns_on_startup`
+//! runs once at daemon boot before any JWT context exists. See the
+//! method's doc comment in `core::ports::store` for the rationale.
+
+use async_trait::async_trait;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_core::ports::store::{
+    TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
+};
+use sqlx::PgPool;
+
+/// Postgres adapter for the turn state table.
+pub struct PgTurnStateStore {
+    pool: PgPool,
+}
+
+impl PgTurnStateStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_from_db(
+    id: String,
+    user_id: String,
+    conversation_id: String,
+    status_key: String,
+    state_json: serde_json::Value,
+    last_error: Option<String>,
+) -> Result<TurnRow, CoreError> {
+    let status = TurnStatus::from_key(&status_key).ok_or_else(|| {
+        CoreError::Storage(format!(
+            "unknown turn status in DB: {status_key} for turn {id}"
+        ))
+    })?;
+    let state: TurnStateJson = serde_json::from_value(state_json).map_err(|e| {
+        CoreError::Storage(format!("malformed turn state_json for {id}: {e}"))
+    })?;
+    Ok(TurnRow {
+        id,
+        user_id,
+        conversation_id,
+        status,
+        state,
+        last_error,
+    })
+}
+
+#[async_trait]
+impl TurnStateStore for PgTurnStateStore {
+    async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
+        let state_json = serde_json::to_value(&row.state).map_err(|e| {
+            CoreError::Storage(format!("serialize turn state_json: {e}"))
+        })?;
+        // We deliberately use the row's user_id verbatim instead of
+        // overwriting it with `current_user_id()`. The caller owns the
+        // identity decision — typically the application layer reads
+        // `current_user_id()` and bakes it into the row before
+        // calling. This mirrors how `PgConversationStore::create`
+        // works, and matches the multi-tenant pattern in #105.
+        let result = sqlx::query(
+            "INSERT INTO turns (id, user_id, conversation_id, status, state_json, last_error) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(&row.id)
+        .bind(&row.user_id)
+        .bind(&row.conversation_id)
+        .bind(row.status.as_key())
+        .bind(state_json)
+        .bind(row.last_error.as_deref())
+        .execute(&self.pool)
+        .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                Err(CoreError::Storage(format!(
+                    "turn id already exists: {}",
+                    row.id
+                )))
+            }
+            Err(e) => Err(CoreError::Storage(e.to_string())),
+        }
+    }
+
+    async fn get_turn(&self, id: &str) -> Result<Option<TurnRow>, CoreError> {
+        let user_id = current_user_id();
+        // (user_id, id) — the (user_id, …) composite filter keeps cross-
+        // user probes from leaking existence.
+        let row: Option<(String, String, String, String, serde_json::Value, Option<String>)> =
+            sqlx::query_as(
+                "SELECT id, user_id, conversation_id, status, state_json, last_error \
+                 FROM turns \
+                 WHERE user_id = $1 AND id = $2",
+            )
+            .bind(user_id.as_str())
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        match row {
+            None => Ok(None),
+            Some((id, user_id, conversation_id, status_key, state_json, last_error)) => Ok(Some(
+                row_from_db(id, user_id, conversation_id, status_key, state_json, last_error)?,
+            )),
+        }
+    }
+
+    async fn update_turn(
+        &self,
+        id: &str,
+        status: TurnStatus,
+        state: &TurnStateJson,
+        last_error: Option<&str>,
+    ) -> Result<(), CoreError> {
+        let user_id = current_user_id();
+        let state_json = serde_json::to_value(state).map_err(|e| {
+            CoreError::Storage(format!("serialize turn state_json: {e}"))
+        })?;
+        let result = sqlx::query(
+            "UPDATE turns \
+             SET status = $3, state_json = $4, last_error = $5, updated_at = now() \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(id)
+        .bind(status.as_key())
+        .bind(state_json)
+        .bind(last_error)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            // Same opacity rule as `get_turn`: don't distinguish
+            // "doesn't exist" from "not yours".
+            return Err(CoreError::Storage(format!(
+                "turn not found for current user: {id}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError> {
+        // No user_id filter — see method doc on the trait.
+        let rows: Vec<(String, String, String, String, serde_json::Value, Option<String>)> =
+            sqlx::query_as(
+                "SELECT id, user_id, conversation_id, status, state_json, last_error \
+                 FROM turns \
+                 WHERE status NOT IN ('complete', 'failed')",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for (id, user_id, conversation_id, status_key, state_json, last_error) in rows {
+            out.push(row_from_db(
+                id,
+                user_id,
+                conversation_id,
+                status_key,
+                state_json,
+                last_error,
+            )?);
+        }
+        Ok(out)
+    }
+}

--- a/crates/storage/tests/user_id_scoping.rs
+++ b/crates/storage/tests/user_id_scoping.rs
@@ -32,9 +32,12 @@ use std::sync::Arc;
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Conversation, ConversationId, KnowledgeEntry, Message, Role};
 use desktop_assistant_core::ports::knowledge::KnowledgeBaseStore;
-use desktop_assistant_core::ports::store::ConversationStore;
+use desktop_assistant_core::ports::store::{
+    ConversationStore, PendingClientToolCall, TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
+};
 use desktop_assistant_storage::{
-    PgConversationStore, PgKnowledgeBaseStore, UserId, run_migrations, with_user_id,
+    PgConversationStore, PgKnowledgeBaseStore, PgTurnStateStore, UserId, run_migrations,
+    with_user_id,
 };
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
@@ -432,6 +435,158 @@ async fn knowledge_get_by_id_does_not_leak_across_users() {
                 .await
                 .unwrap();
         assert!(alice_fetch.is_some());
+        fx
+    })
+    .await;
+}
+
+// -- turn state (issue #107) -------------------------------------------------
+
+fn turn_row(id: &str, user_id: &str, conversation_id: &str, status: TurnStatus) -> TurnRow {
+    TurnRow {
+        id: id.into(),
+        user_id: user_id.into(),
+        conversation_id: conversation_id.into(),
+        status,
+        state: TurnStateJson::default(),
+        last_error: None,
+    }
+}
+
+#[tokio::test]
+async fn turn_state_round_trips_through_postgres() {
+    // Create + get + update + read-back for a single user's turn row.
+    // The acceptance value here is that the state_json column survives
+    // a serde round-trip through Postgres's JSONB representation.
+    with_fixture("turn_state_round_trips_through_postgres", |fx| async move {
+        let store = PgTurnStateStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_turn(turn_row("turn-1", "alice", "conv-1", TurnStatus::PendingLlm))
+                .await
+                .expect("create");
+
+            // Read back: alice sees her row.
+            let row = store
+                .get_turn("turn-1")
+                .await
+                .expect("get")
+                .expect("row exists");
+            assert_eq!(row.status, TurnStatus::PendingLlm);
+            assert!(row.state.pending_client_tool.is_none());
+
+            // Transition to pending_client_tool with a payload.
+            let state = TurnStateJson {
+                version: 1,
+                pending_client_tool: Some(PendingClientToolCall {
+                    tool_call_id: "call-7".into(),
+                    tool_name: "fs_read".into(),
+                    arguments: serde_json::json!({"path": "/etc/hosts"}),
+                }),
+            };
+            store
+                .update_turn("turn-1", TurnStatus::PendingClientTool, &state, None)
+                .await
+                .expect("update");
+
+            let row = store.get_turn("turn-1").await.unwrap().unwrap();
+            assert_eq!(row.status, TurnStatus::PendingClientTool);
+            let pending = row.state.pending_client_tool.unwrap();
+            assert_eq!(pending.tool_call_id, "call-7");
+            assert_eq!(pending.tool_name, "fs_read");
+        })
+        .await;
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn turn_state_user_b_cannot_read_user_a_turn() {
+    // Cross-user isolation, mirroring the conversation-level test
+    // above. Bob's get_turn must return None — not "not found" — and
+    // his update_turn must error out for the same opacity reason.
+    with_fixture("turn_state_user_b_cannot_read_user_a_turn", |fx| async move {
+        let store = PgTurnStateStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_turn(turn_row("turn-x", "alice", "conv-1", TurnStatus::PendingLlm))
+                .await
+                .expect("create");
+        })
+        .await;
+
+        let bob_get = with_user_id(UserId::new("bob"), async { store.get_turn("turn-x").await })
+            .await
+            .expect("get returns Ok for cross-user");
+        assert!(bob_get.is_none(), "bob must not see alice's turn");
+
+        let bob_update = with_user_id(UserId::new("bob"), async {
+            store
+                .update_turn("turn-x", TurnStatus::Failed, &TurnStateJson::default(), Some("nope"))
+                .await
+        })
+        .await;
+        assert!(bob_update.is_err(), "bob must not be able to mutate alice's turn");
+
+        // Alice's row is unaffected.
+        let alice_get = with_user_id(UserId::new("alice"), async {
+            store.get_turn("turn-x").await
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(alice_get.status, TurnStatus::PendingLlm);
+        assert!(alice_get.last_error.is_none());
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn turn_state_scan_non_terminal_walks_all_users() {
+    // The cold-restart sweep is a system task — it deliberately walks
+    // every user's pending rows in a single pass. This pins that
+    // contract against the SQL.
+    with_fixture("turn_state_scan_non_terminal_walks_all_users", |fx| async move {
+        let store = PgTurnStateStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_turn(turn_row("t-a-pending", "alice", "c", TurnStatus::PendingLlm))
+                .await
+                .unwrap();
+            store
+                .create_turn(turn_row("t-a-complete", "alice", "c", TurnStatus::Complete))
+                .await
+                .unwrap();
+        })
+        .await;
+
+        with_user_id(UserId::new("bob"), async {
+            store
+                .create_turn(turn_row(
+                    "t-b-pending",
+                    "bob",
+                    "c",
+                    TurnStatus::PendingClientTool,
+                ))
+                .await
+                .unwrap();
+            store
+                .create_turn(turn_row("t-b-failed", "bob", "c", TurnStatus::Failed))
+                .await
+                .unwrap();
+        })
+        .await;
+
+        // Sweep across all users — no scope installed.
+        let mut rows = store.scan_non_terminal().await.expect("scan");
+        rows.sort_by(|a, b| a.id.cmp(&b.id));
+        let ids: Vec<_> = rows.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(ids, vec!["t-a-pending".to_string(), "t-b-pending".to_string()]);
         fx
     })
     .await;


### PR DESCRIPTION
Closes #107

## Summary

Phase-2 architecture rule #8: client-local MCPs (file access, personal info, terminal tools) execute on the user's machine, not the server. The daemon emits `Event::ClientToolCall`, the client runs the tool, and posts the result back as `Command::ClientToolResult`. The turn state is persisted to the new `turns` table so suspended turns are observable across daemon restarts.

## State machine

```
pending_llm ─┬─► pending_tool_dispatch ─► pending_llm   (server-side; existing path)
             │
             └─► pending_client_tool ─[ClientToolResult]─► pending_llm
                                    │
                                    └─[cancel / daemon restart]─► failed
```

`complete` is the terminal success state from `pending_llm`; `failed` is the terminal error state from any non-terminal state.

## Surface area

**api-model** — `Command::RegisterClientTools`, `Command::ClientToolResult`, `Event::ClientToolCall`, `CommandResult::ClientToolsRegistered`.

**core::ports::store** — `TurnStatus`, `PendingClientToolCall`, `TurnStateJson` (versioned for forward compat), `TurnRow`, `TurnStateStore` trait. Async-trait so adapters can be held as `Arc<dyn TurnStateStore>`.

**storage** — Migration `017_turn_state.sql` with `(user_id, conversation_id)` and `(user_id, status)` indexes plus a partial index on non-terminal statuses for the startup sweep. `PgTurnStateStore` with `(user_id, …)` scoped queries; `get_turn` returns `Ok(None)` and `update_turn` returns `NotFound` for cross-user probes (same opacity rule as #105's conversation scoping). `scan_non_terminal` bypasses the scope as a system operation.

**application::client_tools** — `ClientToolCoordinator` (per-user registration set + in-flight oneshot map) + `suspend_for_client_tool` / `resolve_client_tool_result` / `sweep_non_terminal_turns_on_startup`. Suspension uses `tokio::select!` against the per-turn cancellation token from #109; cancelled turns mark the row `failed(\"cancelled\")` instead of leaking the oneshot. Result payloads >1 MiB are rejected at the validator before any state mutation.

## Why this is independently shippable

- The default `AssistantApiHandler` dispatcher rejects the two new `Command` variants as `Unsupported`. A daemon wiring in `ClientToolCoordinator` + `PgTurnStateStore` opts in.
- The core `ConversationHandler::send_prompt` body is **untouched**. Server-side tool dispatch still runs to completion in one tokio task, so all 52 core service tests + 3 daemon integration tests + ws/uds/dbus paths see no behaviour change.
- The new wire variants are additive; existing clients that don't speak the client-tool protocol are unaffected.

## Test plan

- [x] `register_client_tools_command_round_trips`, `client_tool_result_*_round_trips`, `client_tool_call_event_round_trips`, `client_tools_registered_command_result_round_trips`, `client_tool_result_rejects_both_result_and_error_unset` — api-model serde shape pinned.
- [x] `turn_status_round_trips_via_key`, `turn_status_is_terminal_*`, `turn_state_json_serializes_with_version_field`, `turn_state_json_default_version_is_1_when_missing`, `turn_state_store_*` — core port + mock store.
- [x] `server_side_tool_does_not_create_turn_row_or_emit_client_tool_call` — server-side path unchanged (acceptance: existing tool dispatch keeps working).
- [x] `turn_suspends_on_client_local_tool_call_and_emits_event` — acceptance: suspend → emit ClientToolCall → DB transitions to pending_client_tool → resume on ClientToolResult → DB returns to pending_llm.
- [x] `turn_cross_user_isolation_blocks_resume_by_other_user` — Bob cannot resume Alice's turn; opacity preserved.
- [x] `malformed_client_tool_result_rejected_on_tool_call_id_mismatch` — mismatched `tool_call_id` rejected.
- [x] `resolve_with_no_pending_suspension_is_a_clean_error` — `registered_client_tool_with_no_active_session_falls_back_to_error` mapped to this path.
- [x] `suspension_for_unregistered_tool_fails_cleanly` — `unregistered_tool_called_by_llm_is_an_error` mapped to this path.
- [x] `registration_is_per_user_not_global`, `re_registration_replaces_previous_set` — per-session semantics.
- [x] `cancellation_during_client_tool_suspension_returns_cancelled` — #109 cancellation integration.
- [x] `abandoned_pending_turn_visible_after_restart_and_swept_to_failed` — `turn_state_survives_daemon_restart` reduced to its DB-observable form (the suspended tokio future is gone after restart by definition; the row survives and the startup sweep marks it `failed(\"daemon_restarted\")`).
- [x] Postgres adapter cross-user isolation tests (`turn_state_round_trips_through_postgres`, `turn_state_user_b_cannot_read_user_a_turn`, `turn_state_scan_non_terminal_walks_all_users`) — pass under `TEST_DATABASE_URL` with `--test-threads=1` (the existing harness's known limitation around concurrent `CREATE EXTENSION`).
- [x] Existing 3 conversation integration tests + 52 core service tests pass unchanged.
- [x] Full workspace test suite green without `TEST_DATABASE_URL`.

## Coordination with #111

The shared file `application/src/lib.rs` adds **one** match-arm pair for the new `Command` variants in the central dispatcher; #111 wraps the `SendMessage` entry point but does not touch this match. Both PRs can land in either order; the second to merge rebases trivially.

## Out of scope

- Actually re-spawning a suspended turn's tokio future on cold restart. The state row survives and is marked `failed(\"daemon_restarted\")` so it doesn't accumulate; replaying the LLM-loop history is a separate concern that requires re-engineering the core's `send_prompt` body and is best handled in a follow-up.
- Wiring this into the daemon's startup path (the `ClientToolCoordinator` is built but not yet held by `daemon::main`). A follow-up PR threads the coordinator into the `DefaultAssistantApiHandler` constructor and the `ToolExecutor` wrapper at the tool-dispatch site.

## Known limitations / pre-existing

- `cargo audit` reports the same 4 pre-existing advisories (rsa Marvin Attack + 3× rustls-webpki). No new findings.
- `cargo clippy --workspace -- -D warnings` reports 5 pre-existing warnings in `desktop-assistant-core` (`llm.rs`, `llm_profiling.rs`) and 4 in `embedding_backfill.rs`. None are in files touched by this PR. Fixing them is mechanical but out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)