### PR TITLE
application: durable background tasks across daemon restart (#115)

### DIFF
--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -47,9 +47,13 @@ use std::sync::{Arc, Mutex};
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_auth_jwt::UserId;
+use desktop_assistant_core::ports::store::{
+    BackgroundTaskRow, BackgroundTaskStatus, BackgroundTaskStore,
+};
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
+use tracing::{error, warn};
 
 /// Configuration knobs for the registry.
 ///
@@ -87,6 +91,14 @@ pub enum TaskError {
     /// would break the user-isolation contract (#105).
     #[error("task not found")]
     NotFound,
+
+    /// The task is already in a terminal state — typically a `Failed`
+    /// row that survived a daemon restart. `cancel` on such a row would
+    /// otherwise look like a silent no-op; surfacing this distinct
+    /// variant lets transport adapters return a clean 409-style error
+    /// to the client instead of pretending the cancel succeeded (#115).
+    #[error("task is already terminal")]
+    AlreadyTerminal,
 }
 
 /// Per-task event sink for log lines emitted by a running task body.
@@ -211,8 +223,34 @@ impl BackgroundTaskRegistry {
                 tasks: Mutex::new(HashMap::new()),
                 user_channels: Mutex::new(HashMap::new()),
                 completion_notify: Mutex::new(HashMap::new()),
+                store: None,
             }),
         }
+    }
+
+    /// Attach a [`BackgroundTaskStore`] so spawned rows are mirrored to
+    /// the database and survive a daemon restart (#115).
+    ///
+    /// When no store is attached the registry behaves as a pure in-memory
+    /// cache — every existing single-tenant test path takes this branch.
+    /// When a store is attached, `spawn` writes a row before the body
+    /// starts, finalize updates that row with the terminal status, and
+    /// the daemon-startup hook `sweep_non_terminal_on_startup` marks
+    /// every row left behind by a previous incarnation as `Failed`.
+    ///
+    /// The store is held behind a `dyn` trait object because the daemon's
+    /// `main.rs` may want to test with an in-memory mock without
+    /// monomorphizing the registry against the storage crate. The trait
+    /// is `Send + Sync` so cloning the registry across tokio tasks
+    /// works without extra boxing.
+    pub fn with_store(mut self, store: Arc<dyn BackgroundTaskStore>) -> Self {
+        // Mutate via Arc::get_mut: cheap, panics if any other clone
+        // exists (which would be a programming error — the store is
+        // attached at construction time, before any clone goes out).
+        let inner = Arc::get_mut(&mut self.inner)
+            .expect("with_store called after the registry was cloned");
+        inner.store = Some(store);
+        self
     }
 
     /// Spawn a new background task under `user_id`.
@@ -310,12 +348,23 @@ impl BackgroundTaskRegistry {
         let task_id_for_body = task_id.clone();
         let user_id_for_body = user_id.clone();
         let ctx_for_body = ctx.clone();
+        let view_for_persist = view.clone();
         tokio::spawn(async move {
+            // Mirror the in-memory row to the persistence store BEFORE
+            // running the user body. The await happens inside the spawned
+            // task (spawn() itself is non-async by design) so the registry's
+            // public API stays unchanged. If the write fails we log and
+            // keep going — losing durability is a strictly worse outcome
+            // than refusing to run the work, so we degrade rather than
+            // abort. The cold-restart sweep would only miss this row
+            // anyway; the user-visible task continues to work.
+            inner.persist_create(&task_id_for_body, &user_id_for_body, &view_for_persist).await;
+
             // Run the body. We always finalize, even on panic, via a
             // drop-guard so the registry never gets stuck with a row
             // in `Running` after the task disappears.
             let result = body(ctx_for_body).await;
-            inner.finalize(&task_id_for_body, &user_id_for_body, result);
+            inner.finalize(&task_id_for_body, &user_id_for_body, result).await;
         });
 
         task_id
@@ -323,6 +372,18 @@ impl BackgroundTaskRegistry {
 
     /// Request cancellation of `id` owned by `user_id`. Cooperative — the
     /// running future is responsible for noticing.
+    ///
+    /// Returns:
+    /// - `Err(TaskError::NotFound)` when the id is unknown or owned by
+    ///   another user (the #105 opacity rule conflates the two).
+    /// - `Err(TaskError::AlreadyTerminal)` when the row exists and
+    ///   belongs to the caller but is in a terminal state — typically a
+    ///   row that survived a daemon restart and was marked `Failed` by
+    ///   the cold-restart sweep. The distinct variant prevents silent
+    ///   no-ops and lets transport adapters return a clean error to the
+    ///   client (#115).
+    /// - `Ok(())` after tripping the cancellation token; the task body
+    ///   is responsible for noticing and yielding.
     pub fn cancel(&self, user_id: &UserId, id: &api::TaskId) -> Result<(), TaskError> {
         let tasks = self.inner.tasks.lock().expect("tasks poisoned");
         let Some(state) = tasks.get(id) else {
@@ -331,6 +392,12 @@ impl BackgroundTaskRegistry {
         if &state.owner != user_id {
             // Existence-hiding: pretend it doesn't exist (#105 contract).
             return Err(TaskError::NotFound);
+        }
+        if matches!(
+            state.view.status,
+            api::TaskStatus::Completed | api::TaskStatus::Failed | api::TaskStatus::Cancelled
+        ) {
+            return Err(TaskError::AlreadyTerminal);
         }
         state.token.cancel();
         Ok(())
@@ -424,6 +491,190 @@ impl BackgroundTaskRegistry {
         sender.subscribe()
     }
 
+    /// Cold-restart sweep (#115): mark every persisted, non-terminal
+    /// task row as `Failed` and surface it in the in-memory registry so
+    /// `list`/`get`/`logs` see the leftovers from the previous daemon
+    /// incarnation.
+    ///
+    /// Best-effort resume policy until #129 lands:
+    ///
+    /// - `TaskKind::Conversation` and `TaskKind::Subagent` — marked
+    ///   `Failed { last_error: "daemon restarted mid-turn" }`. The
+    ///   conversation history is intact in `conversations`/`messages`;
+    ///   the user re-prompts to continue.
+    /// - `TaskKind::Standalone` — marked `Failed { last_error:
+    ///   "daemon restarted; resume not yet implemented" }`. #129
+    ///   replaces this branch with a real resume from persisted turn
+    ///   state.
+    ///
+    /// Persisted log replay is OUT of scope. The in-memory log for a
+    /// resumed row starts fresh, prefixed with a single `Lifecycle`
+    /// entry summarising the outcome.
+    ///
+    /// Returns the number of rows surfaced. Errors short-circuit so a
+    /// transient DB failure doesn't leave the registry half-populated.
+    pub async fn sweep_non_terminal_on_startup(&self) -> Result<u32, anyhow::Error> {
+        let Some(store) = self.inner.store.as_ref() else {
+            return Ok(0);
+        };
+        let mut rows = store.scan_non_terminal().await?;
+        // Sort so rows without a parent come first: this guarantees a
+        // parent is in the in-memory map before we try to register a
+        // child under it, regardless of the order the DB returns them
+        // in (sqlx makes no ordering guarantees). A child whose parent
+        // is itself missing (e.g. parent finished but child still
+        // pending) keeps its `parent` field but the parent's
+        // `children` vector won't gain the entry — same policy as
+        // in-memory dropped parents.
+        rows.sort_by_key(|r| r.parent_task_id.is_some());
+        let mut count = 0u32;
+        for row in rows {
+            // Parse the kind so we can branch on the resume policy.
+            let kind: api::TaskKind = match serde_json::from_value(row.kind_json.clone()) {
+                Ok(k) => k,
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        task_id = %row.id,
+                        "parse kind_json during cold-restart sweep; skipping",
+                    );
+                    continue;
+                }
+            };
+            let last_error = match &kind {
+                api::TaskKind::Conversation { .. } | api::TaskKind::Subagent { .. } => {
+                    "daemon restarted mid-turn"
+                }
+                api::TaskKind::Standalone { .. } => {
+                    // Until #129 lands, standalone tasks can't resume —
+                    // we mark them Failed but emit a distinct error
+                    // message so the UI can surface the "we lost it"
+                    // case differently from a genuine error.
+                    "daemon restarted; resume not yet implemented"
+                }
+            };
+            let now = now_ms();
+            // Persist the terminal transition first so a second crash
+            // doesn't re-surface the row endlessly.
+            //
+            // The store's `update_task` reads `current_user_id()` from
+            // the task-local. The sweep runs at daemon boot before any
+            // request scope is installed, so we wrap the call in a
+            // `with_user_id` set to the row's owner. This mirrors the
+            // discipline used elsewhere in the application layer when a
+            // system task touches user-scoped storage.
+            let owner = UserId::new(row.user_id.clone());
+            let store_for_call = Arc::clone(store);
+            let row_id_for_call = row.id.clone();
+            let progress_for_call = row.progress_hint.clone();
+            if let Err(e) = desktop_assistant_core::ports::auth::with_user_id(owner, async move {
+                store_for_call
+                    .update_task(
+                        &row_id_for_call,
+                        BackgroundTaskStatus::Failed,
+                        Some(last_error),
+                        progress_for_call.as_deref(),
+                        Some(now),
+                    )
+                    .await
+            })
+            .await
+            {
+                warn!(error = %e, task_id = %row.id, "sweep update_task failed; skipping in-memory surface");
+                continue;
+            }
+
+            // Surface the row in the in-memory registry so `list`/`get`
+            // see it. Marked `completed = true` so `wait` returns
+            // immediately and `cancel` rejects with `AlreadyTerminal`.
+            let owner = UserId::new(row.user_id.clone());
+            let view = api::TaskView {
+                id: api::TaskId(row.id.clone()),
+                kind: kind.clone(),
+                status: api::TaskStatus::Failed,
+                started_at: row.started_at,
+                ended_at: Some(now),
+                last_error: Some(last_error.to_string()),
+                parent: row.parent_task_id.clone().map(api::TaskId),
+                children: Vec::new(),
+                title: row.title.clone(),
+                progress_hint: row.progress_hint.clone(),
+            };
+            {
+                let mut tasks = self.inner.tasks.lock().expect("tasks poisoned");
+                tasks.insert(
+                    view.id.clone(),
+                    TaskState {
+                        owner: owner.clone(),
+                        view: view.clone(),
+                        // The token is already inert; cancelling a
+                        // terminal task is a programmer error caught
+                        // upstream by `AlreadyTerminal`.
+                        token: CancellationToken::new(),
+                        logs: VecDeque::with_capacity(2),
+                        next_seq: 1,
+                        completed: true,
+                    },
+                );
+            }
+
+            // Emit a single lifecycle log so the UI sees a "we lost it"
+            // marker when it inspects the task. We append directly into
+            // the just-inserted state rather than going through the
+            // `TaskLogSink` because the latter has no context to know
+            // we want a specific message rather than the generic
+            // "task started" line.
+            {
+                let mut tasks = self.inner.tasks.lock().expect("tasks poisoned");
+                if let Some(state) = tasks.get_mut(&view.id) {
+                    let entry = api::TaskLogEntry {
+                        seq: state.next_seq,
+                        timestamp: now,
+                        level: api::LogLevel::Warn,
+                        category: api::LogCategory::Lifecycle,
+                        message: last_error.to_string(),
+                        data: None,
+                    };
+                    state.next_seq += 1;
+                    state.logs.push_back(entry);
+                }
+            }
+
+            // Re-link the child to its parent if the parent also
+            // surfaced via this sweep. We only walk in the inserted
+            // direction; orphaned children (parent terminal already)
+            // keep their `parent` field but the parent's `children`
+            // vector won't contain them — that matches the policy
+            // applied to in-memory dropped parents.
+            if let Some(parent_id) = &view.parent {
+                let mut tasks = self.inner.tasks.lock().expect("tasks poisoned");
+                if let Some(parent_state) = tasks.get_mut(parent_id) {
+                    parent_state.view.children.push(view.id.clone());
+                }
+            }
+
+            // Broadcast TaskStarted then TaskCompleted so a UI that
+            // subscribes immediately after restart still observes the
+            // lifecycle. This mirrors what a real spawn+finalize would
+            // have emitted.
+            self.inner.broadcast(
+                &owner,
+                api::Event::TaskStarted { task: view.clone() },
+            );
+            self.inner.broadcast(
+                &owner,
+                api::Event::TaskCompleted {
+                    id: view.id.0.clone(),
+                    status: api::TaskStatus::Failed,
+                    last_error: Some(last_error.to_string()),
+                },
+            );
+
+            count = count.saturating_add(1);
+        }
+        Ok(count)
+    }
+
     /// Resolve when `id`'s task reaches a terminal state. Used by the
     /// foreground send-message wrapper to keep the old "await until
     /// done" contract while still routing through the registry.
@@ -505,6 +756,10 @@ struct Inner {
     user_channels: Mutex<HashMap<UserId, broadcast::Sender<api::Event>>>,
     /// Per-task completion notifies, lazily created by `wait`.
     completion_notify: Mutex<HashMap<api::TaskId, Arc<tokio::sync::Notify>>>,
+    /// Optional persistence layer (#115). When attached, spawned tasks
+    /// are mirrored to the DB so a daemon restart can sweep abandoned
+    /// rows. `None` keeps the registry purely in-memory (the default).
+    store: Option<Arc<dyn BackgroundTaskStore>>,
 }
 
 impl Inner {
@@ -517,10 +772,99 @@ impl Inner {
         }
     }
 
+    /// Mirror a newly-spawned task to the persistence store. Logs and
+    /// continues on failure — see the call site comment in `spawn` for
+    /// the rationale.
+    async fn persist_create(
+        self: &Arc<Self>,
+        task_id: &api::TaskId,
+        user_id: &UserId,
+        view: &api::TaskView,
+    ) {
+        let Some(store) = self.store.as_ref() else {
+            return;
+        };
+        let kind_json = match serde_json::to_value(&view.kind) {
+            Ok(v) => v,
+            Err(e) => {
+                // Serialization failure is a code bug — log loudly so
+                // tests catch it but keep the task running.
+                error!(
+                    error = %e,
+                    task_id = %task_id.0,
+                    "serialize TaskKind for persistence",
+                );
+                return;
+            }
+        };
+        let row = BackgroundTaskRow {
+            id: task_id.0.clone(),
+            user_id: user_id.as_str().to_string(),
+            kind_json,
+            status: api_status_to_db(view.status),
+            parent_task_id: view.parent.as_ref().map(|p| p.0.clone()),
+            title: view.title.clone(),
+            last_error: view.last_error.clone(),
+            progress_hint: view.progress_hint.clone(),
+            started_at: view.started_at,
+            ended_at: view.ended_at,
+        };
+        if let Err(e) = store.create_task(row).await {
+            warn!(
+                error = %e,
+                task_id = %task_id.0,
+                "persist background task on spawn",
+            );
+        }
+    }
+
+    /// Persist the terminal state of `task_id` to the store. Called from
+    /// `finalize` once the in-memory transition is committed.
+    async fn persist_update(
+        self: &Arc<Self>,
+        task_id: &api::TaskId,
+        user_id: &UserId,
+        status: BackgroundTaskStatus,
+        last_error: Option<&str>,
+        progress_hint: Option<&str>,
+        ended_at: Option<i64>,
+    ) {
+        let Some(store) = self.store.as_ref() else {
+            return;
+        };
+        // The store's `update_task` is scoped to `current_user_id()`.
+        // The registry's task body runs without an installed user-id
+        // task-local, so we wrap the call to ensure the WHERE clause
+        // sees the right scope. This mirrors the discipline applied
+        // by other application-layer call sites that bridge between
+        // a registry's owned `UserId` and the storage layer's
+        // task-local.
+        let store = Arc::clone(store);
+        let owner = user_id.clone();
+        let task_id = task_id.0.clone();
+        let last_error = last_error.map(String::from);
+        let progress_hint = progress_hint.map(String::from);
+        let result = desktop_assistant_core::ports::auth::with_user_id(owner, async move {
+            store
+                .update_task(
+                    &task_id,
+                    status,
+                    last_error.as_deref(),
+                    progress_hint.as_deref(),
+                    ended_at,
+                )
+                .await
+        })
+        .await;
+        if let Err(e) = result {
+            warn!(error = %e, "persist background task on update");
+        }
+    }
+
     /// Transition `task_id` to a terminal state based on `result` and
     /// the cancellation-token state, broadcast `TaskCompleted`, and wake
     /// any waiters. Called from the `tokio::spawn` task wrapper.
-    fn finalize(
+    async fn finalize(
         self: &Arc<Self>,
         task_id: &api::TaskId,
         user_id: &UserId,
@@ -582,9 +926,33 @@ impl Inner {
             api::Event::TaskCompleted {
                 id: task_id.0.clone(),
                 status,
-                last_error,
+                last_error: last_error.clone(),
             },
         );
+
+        // Persist the terminal state. The in-memory broadcast happens
+        // first because subscribers don't care about durability — they
+        // care about the lifecycle event. Persistence happens after so
+        // a slow DB doesn't gate the wake. The progress_hint snapshot
+        // is read under a tiny critical section, decoupled from the
+        // broadcast above.
+        let (progress_hint, ended_at) = {
+            let tasks = self.tasks.lock().expect("tasks poisoned");
+            let view = tasks.get(task_id).map(|s| s.view.clone());
+            (
+                view.as_ref().and_then(|v| v.progress_hint.clone()),
+                view.and_then(|v| v.ended_at),
+            )
+        };
+        self.persist_update(
+            task_id,
+            user_id,
+            api_status_to_db(status),
+            last_error.as_deref(),
+            progress_hint.as_deref(),
+            ended_at,
+        )
+        .await;
 
         // Wake waiters.
         let waiter = {
@@ -597,6 +965,31 @@ impl Inner {
         if let Some(notify) = waiter {
             notify.notify_waiters();
         }
+    }
+}
+
+fn api_status_to_db(s: api::TaskStatus) -> BackgroundTaskStatus {
+    match s {
+        api::TaskStatus::Pending => BackgroundTaskStatus::Pending,
+        api::TaskStatus::Running => BackgroundTaskStatus::Running,
+        api::TaskStatus::Completed => BackgroundTaskStatus::Completed,
+        api::TaskStatus::Failed => BackgroundTaskStatus::Failed,
+        api::TaskStatus::Cancelled => BackgroundTaskStatus::Cancelled,
+    }
+}
+
+/// Inverse of [`api_status_to_db`]. Currently used by sweep tests and
+/// by callers that observe a `BackgroundTaskRow` (e.g. a future
+/// "list across all daemons" command). Kept alongside the forward
+/// mapping so the two stay symmetric.
+#[allow(dead_code)]
+fn db_status_to_api(s: BackgroundTaskStatus) -> api::TaskStatus {
+    match s {
+        BackgroundTaskStatus::Pending => api::TaskStatus::Pending,
+        BackgroundTaskStatus::Running => api::TaskStatus::Running,
+        BackgroundTaskStatus::Completed => api::TaskStatus::Completed,
+        BackgroundTaskStatus::Failed => api::TaskStatus::Failed,
+        BackgroundTaskStatus::Cancelled => api::TaskStatus::Cancelled,
     }
 }
 

--- a/crates/application/tests/durable_background_tasks.rs
+++ b/crates/application/tests/durable_background_tasks.rs
@@ -1,0 +1,767 @@
+//! Issue #115 acceptance tests: durable background tasks across daemon
+//! restart.
+//!
+//! These tests describe the desired *business outcomes* of the
+//! persistence layer that mirrors the in-memory
+//! `BackgroundTaskRegistry`:
+//!
+//! 1. Every spawn writes a row to the store.
+//! 2. Every terminal transition updates the row.
+//! 3. A "daemon restart" (a fresh registry pointed at the same store)
+//!    sweeps non-terminal rows into `Failed` and surfaces them in the
+//!    in-memory map.
+//! 4. The resume policy distinguishes `Conversation`/`Subagent` (mark
+//!    failed; user re-prompts) from `Standalone` (mark failed with a
+//!    distinct message until #129's real resume lands).
+//! 5. Cross-user isolation survives restart.
+//! 6. Cancel on a post-restart Failed row returns `AlreadyTerminal`,
+//!    not a silent no-op.
+//!
+//! The mock store in this file is a pure in-memory `Mutex<HashMap>`;
+//! the real Postgres adapter is covered by the storage crate's
+//! `user_id_scoping` tests (which gain a few cases below the registry
+//! tests). Keeping the registry tests off Postgres lets every
+//! contributor run the suite without spinning up a DB.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::background_tasks::{
+    BackgroundTaskRegistry, TaskError,
+};
+use desktop_assistant_application::UserId;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::store::{
+    BackgroundTaskRow, BackgroundTaskStatus, BackgroundTaskStore,
+};
+use tokio::sync::Notify;
+use tokio::time::{timeout, Duration};
+
+/// In-memory `BackgroundTaskStore` for tests. Records SQL-like
+/// invariants the registry depends on:
+///  - duplicate ids fail to create
+///  - update on a missing/cross-user id returns Err
+///  - scan_non_terminal walks across users
+struct MockStore {
+    rows: Mutex<HashMap<String, BackgroundTaskRow>>,
+}
+
+impl MockStore {
+    fn new() -> Self {
+        Self {
+            rows: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn snapshot(&self) -> Vec<BackgroundTaskRow> {
+        self.rows.lock().unwrap().values().cloned().collect()
+    }
+
+    fn get_raw(&self, id: &str) -> Option<BackgroundTaskRow> {
+        self.rows.lock().unwrap().get(id).cloned()
+    }
+}
+
+#[async_trait]
+impl BackgroundTaskStore for MockStore {
+    async fn create_task(&self, row: BackgroundTaskRow) -> Result<(), CoreError> {
+        let mut rows = self.rows.lock().unwrap();
+        if rows.contains_key(&row.id) {
+            return Err(CoreError::Storage(format!(
+                "background task id already exists: {}",
+                row.id
+            )));
+        }
+        rows.insert(row.id.clone(), row);
+        Ok(())
+    }
+
+    async fn get_task(&self, id: &str) -> Result<Option<BackgroundTaskRow>, CoreError> {
+        // No user-scope filtering in the mock — the registry exercises
+        // scoping via the real Postgres adapter; the mock just provides
+        // the surface the registry calls.
+        Ok(self.rows.lock().unwrap().get(id).cloned())
+    }
+
+    async fn update_task(
+        &self,
+        id: &str,
+        status: BackgroundTaskStatus,
+        last_error: Option<&str>,
+        progress_hint: Option<&str>,
+        ended_at: Option<i64>,
+    ) -> Result<(), CoreError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .get_mut(id)
+            .ok_or_else(|| CoreError::Storage(format!("background task not found: {id}")))?;
+        row.status = status;
+        row.last_error = last_error.map(String::from);
+        row.progress_hint = progress_hint.map(String::from);
+        row.ended_at = ended_at;
+        Ok(())
+    }
+
+    async fn list_tasks_for_user(
+        &self,
+        user_id: &str,
+        include_finished: bool,
+        limit: Option<u32>,
+    ) -> Result<Vec<BackgroundTaskRow>, CoreError> {
+        let rows = self.rows.lock().unwrap();
+        let mut out: Vec<_> = rows
+            .values()
+            .filter(|r| r.user_id == user_id)
+            .filter(|r| {
+                if include_finished {
+                    true
+                } else {
+                    matches!(
+                        r.status,
+                        BackgroundTaskStatus::Pending | BackgroundTaskStatus::Running
+                    )
+                }
+            })
+            .cloned()
+            .collect();
+        out.sort_by_key(|r| std::cmp::Reverse(r.started_at));
+        if let Some(limit) = limit {
+            out.truncate(limit as usize);
+        }
+        Ok(out)
+    }
+
+    async fn scan_non_terminal(&self) -> Result<Vec<BackgroundTaskRow>, CoreError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|r| !r.status.is_terminal())
+            .cloned()
+            .collect())
+    }
+}
+
+/// Wait until `pred()` returns true, polling at most ~2s. Fails with a
+/// helpful label instead of hanging if the predicate never trips.
+async fn wait_until<F: FnMut() -> bool>(mut pred: F, label: &str) {
+    for _ in 0..200 {
+        if pred() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("predicate '{label}' never became true within timeout");
+}
+
+fn standalone_kind() -> api::TaskKind {
+    api::TaskKind::Standalone {
+        name: "researcher".into(),
+        conversation_id: "conv-stan".into(),
+    }
+}
+
+fn conv_kind(id: &str) -> api::TaskKind {
+    api::TaskKind::Conversation {
+        conversation_id: id.into(),
+    }
+}
+
+// ----------------------------------------------------------------------
+// 1. Spawn writes a row to the store; the row mirrors the in-memory view.
+// ----------------------------------------------------------------------
+
+#[tokio::test]
+async fn standalone_task_status_persists_across_restart() {
+    // Spawn a Standalone task; let it run to a parking point; observe
+    // that the DB has a `Running` row. Drop the registry, build a new
+    // one against the same store, run the sweep, and observe that the
+    // row is now `Failed` with the standalone-specific error message.
+    let store = Arc::new(MockStore::new());
+
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        standalone_kind(),
+        "stan".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            // Block until cancel — we'll never observe natural completion.
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+
+    // Wait for the body to enter steady state so the persistence write
+    // has had a chance to land.
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+        },
+        "row persisted as Running",
+    )
+    .await;
+
+    let row = store.get_raw(&task_id.0).expect("row present after spawn");
+    assert_eq!(row.user_id, "alice");
+    assert_eq!(row.status, BackgroundTaskStatus::Running);
+    assert_eq!(row.title, "stan");
+    assert!(row.last_error.is_none());
+
+    // "Restart": drop the original registry without finalizing the task,
+    // then build a fresh one against the same store and run the sweep.
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    let count = post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+    assert_eq!(count, 1, "exactly one row should be swept");
+
+    // DB row reads Failed with the standalone resume-not-yet-implemented
+    // message — covers the "until #129 lands" branch from the issue.
+    let row = store
+        .get_raw(&task_id.0)
+        .expect("row still present post-sweep");
+    assert_eq!(row.status, BackgroundTaskStatus::Failed);
+    assert_eq!(
+        row.last_error.as_deref(),
+        Some("daemon restarted; resume not yet implemented"),
+    );
+    assert!(row.ended_at.is_some(), "ended_at must be stamped");
+
+    // In-memory: list() now surfaces the row as Failed.
+    let listed = post_restart.list(&user, /*include_finished*/ true, None);
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].status, api::TaskStatus::Failed);
+    assert_eq!(
+        listed[0].last_error.as_deref(),
+        Some("daemon restarted; resume not yet implemented"),
+    );
+}
+
+#[tokio::test]
+async fn conversation_task_marked_failed_on_restart() {
+    // The Conversation/Subagent branch of the resume policy uses the
+    // "daemon restarted mid-turn" message.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        conv_kind("conv-99"),
+        "conv".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+        },
+        "row persisted as Running",
+    )
+    .await;
+
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let row = store.get_raw(&task_id.0).unwrap();
+    assert_eq!(row.status, BackgroundTaskStatus::Failed);
+    assert_eq!(
+        row.last_error.as_deref(),
+        Some("daemon restarted mid-turn"),
+    );
+}
+
+#[tokio::test]
+async fn cancelled_tasks_persist_as_cancelled() {
+    // Cancel → finalize → DB row reads Cancelled, not Failed. After a
+    // restart the sweep MUST NOT touch this row (terminal is terminal).
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        standalone_kind(),
+        "stan".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    registry.cancel(&user, &task_id).expect("cancel");
+    registry.wait(&task_id).await;
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Cancelled)
+                .unwrap_or(false)
+        },
+        "row persisted as Cancelled",
+    )
+    .await;
+    let row_before_restart = store.get_raw(&task_id.0).unwrap();
+
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    let count = post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+    assert_eq!(count, 0, "terminal rows are never swept");
+    let row_after = store.get_raw(&task_id.0).unwrap();
+    assert_eq!(row_after.status, BackgroundTaskStatus::Cancelled);
+    assert_eq!(
+        row_after.last_error, row_before_restart.last_error,
+        "sweep must not rewrite last_error on a terminal row"
+    );
+}
+
+#[tokio::test]
+async fn completed_tasks_persist_as_completed() {
+    // Happy path: run to natural completion; row reads Completed; sweep
+    // is a no-op.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+
+    let task_id = registry.spawn(
+        user.clone(),
+        standalone_kind(),
+        "stan".into(),
+        move |_ctx| async move { Ok(()) },
+    );
+    registry.wait(&task_id).await;
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Completed)
+                .unwrap_or(false)
+        },
+        "row persisted as Completed",
+    )
+    .await;
+
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    let count = post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+    assert_eq!(count, 0, "completed rows are never swept");
+    assert_eq!(
+        store.get_raw(&task_id.0).unwrap().status,
+        BackgroundTaskStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn task_rows_are_user_id_scoped() {
+    // Alice and Bob both spawn standalone tasks; the restart sweep
+    // marks each as Failed but the in-memory listings stay scoped: a
+    // user only sees their own rows.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let alice = UserId::new("alice");
+    let bob = UserId::new("bob");
+
+    let parked = Arc::new(Notify::new());
+    let parked_a = Arc::clone(&parked);
+    let parked_b = Arc::clone(&parked);
+    let task_alice = registry.spawn(
+        alice.clone(),
+        standalone_kind(),
+        "alice-stan".into(),
+        move |ctx| async move {
+            parked_a.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    let task_bob = registry.spawn(
+        bob.clone(),
+        standalone_kind(),
+        "bob-stan".into(),
+        move |ctx| async move {
+            parked_b.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    // Two parks → two notifies; wait for both.
+    for _ in 0..2 {
+        timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    }
+    wait_until(
+        || {
+            store
+                .get_raw(&task_alice.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+                && store
+                    .get_raw(&task_bob.0)
+                    .map(|r| r.status == BackgroundTaskStatus::Running)
+                    .unwrap_or(false)
+        },
+        "both rows persisted",
+    )
+    .await;
+
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let alice_list = post_restart.list(&alice, true, None);
+    let bob_list = post_restart.list(&bob, true, None);
+    assert_eq!(alice_list.len(), 1, "alice sees only her row");
+    assert_eq!(alice_list[0].id, task_alice);
+    assert_eq!(bob_list.len(), 1, "bob sees only his row");
+    assert_eq!(bob_list[0].id, task_bob);
+
+    // Cross-user `get` returns None (existence-hiding).
+    assert!(post_restart.get(&alice, &task_bob).is_none());
+    assert!(post_restart.get(&bob, &task_alice).is_none());
+}
+
+#[tokio::test]
+async fn resumed_standalone_emits_lifecycle_log_until_129_lands() {
+    // The sweep emits exactly one Lifecycle log entry per resumed row
+    // so the UI's log viewer can show the "we lost it" reason. Until
+    // #129 lands, the message is the standalone-specific "resume not
+    // yet implemented" string.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        standalone_kind(),
+        "stan".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+        },
+        "row persisted as Running",
+    )
+    .await;
+    drop(registry);
+
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let (logs, _) = post_restart
+        .logs(&user, &task_id, 0, 100)
+        .expect("logs after sweep");
+    let lifecycle: Vec<_> = logs
+        .iter()
+        .filter(|e| matches!(e.category, api::LogCategory::Lifecycle))
+        .collect();
+    assert_eq!(
+        lifecycle.len(),
+        1,
+        "sweep emits exactly one lifecycle log entry, got {}: {:?}",
+        lifecycle.len(),
+        logs,
+    );
+    assert_eq!(
+        lifecycle[0].message,
+        "daemon restarted; resume not yet implemented"
+    );
+    assert_eq!(lifecycle[0].level, api::LogLevel::Warn);
+}
+
+#[tokio::test]
+async fn parent_child_links_preserved_across_restart() {
+    // Spawn a parent Standalone, then a child Subagent that references
+    // the parent. Restart. The child's `parent` field still points at
+    // the parent; the parent's `children` vector still contains the
+    // child id. This is the contract from the issue body.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+
+    let parked = Arc::new(Notify::new());
+    let parked_p = Arc::clone(&parked);
+    let parent_id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: "parent".into(),
+            conversation_id: "conv-p".into(),
+        },
+        "parent".into(),
+        move |ctx| async move {
+            parked_p.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+
+    let parked_c = Arc::clone(&parked);
+    let child_kind = api::TaskKind::Subagent {
+        parent_task_id: parent_id.clone(),
+        conversation_id: "conv-c".into(),
+        name: "child".into(),
+    };
+    let child_id = registry.spawn(
+        user.clone(),
+        child_kind,
+        "child".into(),
+        move |ctx| async move {
+            parked_c.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store.get_raw(&parent_id.0).is_some() && store.get_raw(&child_id.0).is_some()
+        },
+        "both rows persisted",
+    )
+    .await;
+
+    // The persisted child row carries the parent reference.
+    let child_row = store.get_raw(&child_id.0).unwrap();
+    assert_eq!(child_row.parent_task_id.as_deref(), Some(parent_id.0.as_str()));
+
+    drop(registry);
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let parent_view = post_restart
+        .get(&user, &parent_id)
+        .expect("parent surfaces");
+    let child_view = post_restart
+        .get(&user, &child_id)
+        .expect("child surfaces");
+    assert_eq!(child_view.parent.as_ref(), Some(&parent_id));
+    assert!(
+        parent_view.children.contains(&child_id),
+        "parent's children must include the child id, got {:?}",
+        parent_view.children,
+    );
+}
+
+#[tokio::test]
+async fn cancel_on_post_restart_failed_task_returns_already_terminal() {
+    // Sweep marks a row Failed. A subsequent cancel must NOT pretend to
+    // succeed — clients need to know the task is unrecoverable.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("alice");
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        standalone_kind(),
+        "stan".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+        },
+        "row persisted as Running",
+    )
+    .await;
+    drop(registry);
+
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let err = post_restart
+        .cancel(&user, &task_id)
+        .expect_err("cancel on post-restart Failed must error");
+    assert_eq!(err, TaskError::AlreadyTerminal);
+}
+
+#[tokio::test]
+async fn concurrent_spawn_and_restart_does_not_corrupt_state() {
+    // Race a spawn against a freshly-constructed registry pointed at the
+    // same store. The point isn't "this exact interleaving never
+    // happens" — it's that the persistence layer is the source of
+    // truth, so two registries can't produce duplicate rows for the
+    // same task_id and a partially-written row never trips the sweep
+    // into a bad state.
+    let store = Arc::new(MockStore::new());
+
+    // Pre-populate the store with a row that simulates "a task that
+    // was running before the restart".
+    let pre_id = "pre-existing-row".to_string();
+    store
+        .create_task(BackgroundTaskRow {
+            id: pre_id.clone(),
+            user_id: "alice".to_string(),
+            kind_json: serde_json::to_value(standalone_kind()).unwrap(),
+            status: BackgroundTaskStatus::Running,
+            parent_task_id: None,
+            title: "pre".into(),
+            last_error: None,
+            progress_hint: None,
+            started_at: 1_700_000_000,
+            ended_at: None,
+        })
+        .await
+        .unwrap();
+
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+
+    // Concurrently: spawn a new task AND run the sweep. The sweep should
+    // only touch the pre-existing row; the new spawn's row should
+    // remain Running (not be incorrectly captured by an in-flight sweep).
+    let registry_clone = registry.clone();
+    let spawner = tokio::spawn(async move {
+        registry_clone.spawn(
+            UserId::new("alice"),
+            standalone_kind(),
+            "new".into(),
+            move |ctx| async move {
+                ctx.token.cancelled().await;
+                Ok(())
+            },
+        )
+    });
+    let sweep_count = registry.sweep_non_terminal_on_startup().await.unwrap();
+    let new_id = spawner.await.unwrap();
+
+    // The pre-existing row is now Failed.
+    assert_eq!(
+        store.get_raw(&pre_id).unwrap().status,
+        BackgroundTaskStatus::Failed
+    );
+
+    // The newly-spawned row exists, distinct from the pre-existing one.
+    // Allow brief delay for the persistence write to land.
+    wait_until(|| store.get_raw(&new_id.0).is_some(), "new row persisted").await;
+    let snapshot = store.snapshot();
+    let ids: std::collections::HashSet<_> = snapshot.iter().map(|r| r.id.clone()).collect();
+    assert!(ids.contains(&pre_id));
+    assert!(ids.contains(&new_id.0));
+    // The sweep is intended to run at daemon boot, before any new
+    // spawn. If the race happened to catch the new row too, that's
+    // still correct behavior — what matters is the store ends in a
+    // consistent state.
+    assert!(sweep_count >= 1, "sweep must touch the pre-existing row");
+
+    // No duplicate IDs in the store.
+    assert_eq!(ids.len(), snapshot.len(), "no duplicate ids in store");
+}
+
+#[tokio::test]
+async fn business_outcome_user_sees_failed_status_in_list_after_restart() {
+    // Top-level integration: a user spawns a standalone, simulates a
+    // restart, and then a follow-up `list(user_id)` call surfaces the
+    // task with status Failed and a visible `last_error`.
+    let store = Arc::new(MockStore::new());
+    let registry = BackgroundTaskRegistry::new().with_store(store.clone());
+    let user = UserId::new("dave");
+
+    let parked = Arc::new(Notify::new());
+    let parked_for_body = Arc::clone(&parked);
+    let task_id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: "weekly-report".into(),
+            conversation_id: "conv-1".into(),
+        },
+        "weekly report".into(),
+        move |ctx| async move {
+            parked_for_body.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    timeout(Duration::from_secs(2), parked.notified()).await.unwrap();
+    wait_until(
+        || {
+            store
+                .get_raw(&task_id.0)
+                .map(|r| r.status == BackgroundTaskStatus::Running)
+                .unwrap_or(false)
+        },
+        "row persisted",
+    )
+    .await;
+    drop(registry);
+
+    let post_restart = BackgroundTaskRegistry::new().with_store(store.clone());
+    post_restart
+        .sweep_non_terminal_on_startup()
+        .await
+        .expect("sweep");
+
+    let tasks = post_restart.list(&user, /*include_finished=*/ true, None);
+    assert_eq!(tasks.len(), 1);
+    let task = &tasks[0];
+    assert_eq!(task.id, task_id);
+    assert_eq!(task.status, api::TaskStatus::Failed);
+    assert!(
+        task.last_error.is_some(),
+        "user-visible last_error must be set so the UI can show why",
+    );
+}

--- a/crates/core/src/ports/store.rs
+++ b/crates/core/src/ports/store.rs
@@ -2,6 +2,11 @@ use crate::CoreError;
 use crate::domain::{Conversation, ConversationId};
 use serde::{Deserialize, Serialize};
 
+// `BackgroundTaskRow` (#115) is defined in this module rather than in
+// `application` so that storage adapters can depend on `core` only —
+// the application layer's in-memory `BackgroundTaskRegistry` plugs in
+// through this port.
+
 /// Lifecycle status of a conversation turn persisted to the DB (#107).
 ///
 /// The turn state machine drives transitions through these states so that
@@ -169,6 +174,138 @@ pub trait TurnStateStore: Send + Sync {
     /// `current_user_id()` scope because the caller is a system task
     /// (no JWT context); implementations explicitly bypass scoping.
     async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError>;
+}
+
+// ---- #115: background task persistence ------------------------------------
+
+/// Lifecycle status of a background task. Mirrors
+/// `desktop_assistant_api_model::TaskStatus` but lives in core so storage
+/// adapters can depend on this crate alone. The textual keys returned by
+/// [`BackgroundTaskStatus::as_key`] are what the DB column stores; they
+/// match the serde rename_all = "snake_case" the api-model uses on the
+/// wire so consumers that round-trip between layers see the same string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundTaskStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl BackgroundTaskStatus {
+    /// Canonical lowercase key persisted to the DB and broadcast on the
+    /// wire. Mirrors the snake-case serde representation so a column
+    /// value can be parsed by `from_key` and serialized by serde
+    /// interchangeably.
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn from_key(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "running" => Some(Self::Running),
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// `true` for `Completed | Failed | Cancelled`. Used by the
+    /// cold-restart sweep so terminal rows are skipped on the way to
+    /// marking pending/running ones `Failed`.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+/// A single background-task row read from or written to the DB.
+///
+/// `kind_json` is the verbatim JSON-encoded `api_model::TaskKind` —
+/// kept opaque here so the store interface doesn't depend on
+/// `api-model` (which would invert the dependency graph). The
+/// application layer is responsible for serializing and parsing this
+/// payload; the store treats it as a JSON blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundTaskRow {
+    pub id: String,
+    pub user_id: String,
+    pub kind_json: serde_json::Value,
+    pub status: BackgroundTaskStatus,
+    pub parent_task_id: Option<String>,
+    pub title: String,
+    pub last_error: Option<String>,
+    pub progress_hint: Option<String>,
+    /// Unix epoch milliseconds when the row was first inserted in
+    /// `Running` state. Mirrors `TaskView.started_at` so the value
+    /// survives a daemon restart.
+    pub started_at: i64,
+    /// Unix epoch milliseconds when the row reached a terminal state.
+    /// `None` while non-terminal.
+    pub ended_at: Option<i64>,
+}
+
+/// Outbound port for persisting background-task rows (#115).
+///
+/// Mirrors the in-memory `BackgroundTaskRegistry` so a daemon restart
+/// can sweep abandoned tasks. Implementations enforce `(user_id, …)`
+/// scoping on every read/update except `scan_non_terminal`, which is a
+/// system-task hook that intentionally walks across users.
+#[async_trait::async_trait]
+pub trait BackgroundTaskStore: Send + Sync {
+    /// Insert a new task row. Implementations stamp `created_at` /
+    /// `updated_at` themselves. Returns `Err` when the id is already
+    /// present — the caller chose a duplicate id, which is a
+    /// programming error.
+    async fn create_task(&self, row: BackgroundTaskRow) -> Result<(), CoreError>;
+
+    /// Read a single row by id, scoped to the current user. Returns
+    /// `Ok(None)` when the row doesn't exist OR belongs to another
+    /// user — the opacity rule (#105) prevents cross-user existence
+    /// leaks.
+    async fn get_task(&self, id: &str) -> Result<Option<BackgroundTaskRow>, CoreError>;
+
+    /// Update a task row's status, last_error, progress_hint, and
+    /// ended_at, scoped to the current user. Implementations bump
+    /// `updated_at`. Returns `Err` if the row does not exist for this
+    /// user.
+    async fn update_task(
+        &self,
+        id: &str,
+        status: BackgroundTaskStatus,
+        last_error: Option<&str>,
+        progress_hint: Option<&str>,
+        ended_at: Option<i64>,
+    ) -> Result<(), CoreError>;
+
+    /// List rows owned by the given user, ordered by `started_at`
+    /// descending. When `include_finished` is `false`, only
+    /// `Pending`/`Running` rows are returned. The caller passes the
+    /// user_id explicitly because list is sometimes invoked under a
+    /// different request scope than the row's owner (e.g. test
+    /// harness) — the implementation still applies a `WHERE user_id =
+    /// $1` for the scoping audit.
+    async fn list_tasks_for_user(
+        &self,
+        user_id: &str,
+        include_finished: bool,
+        limit: Option<u32>,
+    ) -> Result<Vec<BackgroundTaskRow>, CoreError>;
+
+    /// Scan every row whose status is non-terminal across ALL users.
+    /// Called once at daemon startup. Like `TurnStateStore::scan_non_terminal`,
+    /// implementations explicitly bypass `current_user_id()` because
+    /// the caller is a system task.
+    async fn scan_non_terminal(&self) -> Result<Vec<BackgroundTaskRow>, CoreError>;
 }
 
 /// Outbound port for persisting conversations.
@@ -603,5 +740,32 @@ mod tests {
         let store = MockTurnStore::new();
         let read = store.get_turn("nope").await.unwrap();
         assert!(read.is_none());
+    }
+
+    // ---- #115: background task store ----------------------------------
+
+    #[test]
+    fn background_task_status_round_trips_via_key() {
+        for status in [
+            BackgroundTaskStatus::Pending,
+            BackgroundTaskStatus::Running,
+            BackgroundTaskStatus::Completed,
+            BackgroundTaskStatus::Failed,
+            BackgroundTaskStatus::Cancelled,
+        ] {
+            let key = status.as_key();
+            let back = BackgroundTaskStatus::from_key(key).expect("known key parses");
+            assert_eq!(status, back, "key {key} must round-trip");
+        }
+        assert_eq!(BackgroundTaskStatus::from_key("nonsense"), None);
+    }
+
+    #[test]
+    fn background_task_status_terminal_classification() {
+        assert!(BackgroundTaskStatus::Completed.is_terminal());
+        assert!(BackgroundTaskStatus::Failed.is_terminal());
+        assert!(BackgroundTaskStatus::Cancelled.is_terminal());
+        assert!(!BackgroundTaskStatus::Pending.is_terminal());
+        assert!(!BackgroundTaskStatus::Running.is_terminal());
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1381,8 +1381,36 @@ async fn main() -> Result<()> {
     // (#111). #114 will surface the same registry through the
     // ListBackgroundTasks / CancelBackgroundTask command arms; until
     // then it powers the existing send path's cancellation hook.
-    let background_task_registry =
-        Arc::new(desktop_assistant_application::background_tasks::BackgroundTaskRegistry::new());
+    //
+    // Issue #115: when a Postgres pool is available, attach a
+    // `PgBackgroundTaskStore` so spawned tasks survive a daemon
+    // restart. The cold-restart sweep marks every non-terminal row
+    // `Failed` immediately after construction so the user observes
+    // them via the existing `list` path instead of silently losing
+    // them. The sweep is best-effort — see the issue body for the
+    // resume policy; #129 will replace the standalone branch with a
+    // real resume.
+    let background_task_registry = {
+        let registry =
+            desktop_assistant_application::background_tasks::BackgroundTaskRegistry::new();
+        if let Some(pool) = &pg_pool {
+            let store: std::sync::Arc<
+                dyn desktop_assistant_core::ports::store::BackgroundTaskStore,
+            > = std::sync::Arc::new(
+                desktop_assistant_storage::PgBackgroundTaskStore::new(pool.clone()),
+            );
+            let registry = registry.with_store(store);
+            if let Err(e) = registry.sweep_non_terminal_on_startup().await {
+                tracing::warn!(
+                    error = %e,
+                    "cold-restart sweep of background tasks failed; continuing",
+                );
+            }
+            Arc::new(registry)
+        } else {
+            Arc::new(registry)
+        }
+    };
     let api_handler: Arc<dyn desktop_assistant_application::AssistantApiHandler> =
         Arc::new(
             DefaultAssistantApiHandler::new(

--- a/crates/storage/migrations/018_background_tasks.sql
+++ b/crates/storage/migrations/018_background_tasks.sql
@@ -1,0 +1,80 @@
+-- Issue #115: durable background tasks (resume across daemon restart).
+--
+-- Adds a `background_tasks` table that mirrors the in-memory
+-- `BackgroundTaskRegistry` rows so a daemon restart can sweep abandoned
+-- tasks instead of silently losing them. See the issue body and
+-- `docs/architecture-evolution.md` Phase 2 for the wider motivation.
+--
+-- Why a parallel table rather than extending `turns`
+--   The `turns` table (migration 017) tracks one row per *conversation
+--   turn* — a single LLM-call lifecycle that may suspend on a client
+--   tool call. A background task is a longer-lived unit: a Standalone
+--   agent may run several turns over its lifetime, a Subagent has its
+--   own turn(s), and a Conversation task is 1:1 with a turn. The two
+--   concepts have different status enums (TurnStatus vs TaskStatus),
+--   different parent/child relationships (TurnStatus parents nothing;
+--   TaskKind::Subagent links to a parent task), and different terminal
+--   semantics (a task can be `Cancelled`; a turn can only `Complete`
+--   or `Fail`). Cramming both into a single row conflates concerns
+--   that we already have to keep separate in the in-memory registry.
+--
+-- Why `kind_json` is a JSON column rather than a discriminator + columns
+--   `TaskKind` is a tagged enum (Conversation / Subagent / Standalone)
+--   whose payload differs per-variant. A normalized schema would need
+--   per-variant columns plus null-checks; storing the variant as JSON
+--   matches the same pattern `turns.state_json` uses for similar
+--   reasons. The `(user_id, task_status)` index covers every hot query
+--   path identified so far (cold-restart sweep + per-user list).
+--
+-- Parent linkage
+--   `parent_task_id` references the same table, nullable. We do NOT
+--   declare a FOREIGN KEY: the parent might be cleaned up before the
+--   child in pathological cases (cancelled parent, child still
+--   draining). The application layer is responsible for not following
+--   stale parent ids; tests cover the case.
+--
+-- Backfill / reversibility
+--   Brand-new table; nothing to backfill. The `pool::run_migrations`
+--   harness is forward-only; reversing requires `DROP TABLE
+--   background_tasks` plus dropping indexes.
+
+CREATE TABLE IF NOT EXISTS background_tasks (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL,
+    -- JSON payload mirroring `api_model::TaskKind` (tagged snake_case).
+    kind_json       JSONB NOT NULL,
+    -- One of: 'pending', 'running', 'completed', 'failed', 'cancelled'.
+    -- Mirrors `api_model::TaskStatus` rename_all = "snake_case".
+    task_status     TEXT NOT NULL,
+    -- Self-reference for `TaskKind::Subagent` parents. No FK on purpose;
+    -- see header.
+    parent_task_id  TEXT,
+    title           TEXT NOT NULL,
+    last_error      TEXT,
+    progress_hint   TEXT,
+    -- Unix epoch millis the task transitioned to `Running`. Mirrors
+    -- `TaskView.started_at` for restart-survival.
+    started_at      BIGINT NOT NULL,
+    -- Unix epoch millis the task reached a terminal state. NULL while
+    -- non-terminal.
+    ended_at        BIGINT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Per-user listing — covers `registry.list(user_id, …)` and the per-user
+-- subset of the cold-restart sweep.
+CREATE INDEX IF NOT EXISTS background_tasks_user_id_started_at_idx
+    ON background_tasks (user_id, started_at DESC);
+
+-- Cold-restart sweep: scan every non-terminal row across all users.
+-- A partial index keeps the index small (most rows end up terminal).
+CREATE INDEX IF NOT EXISTS background_tasks_non_terminal_status_idx
+    ON background_tasks (task_status)
+    WHERE task_status NOT IN ('completed', 'failed', 'cancelled');
+
+-- Parent → child traversal (cheap when fully indexed). The list of a
+-- task's children is rebuilt at restart by joining against this index.
+CREATE INDEX IF NOT EXISTS background_tasks_parent_task_id_idx
+    ON background_tasks (parent_task_id)
+    WHERE parent_task_id IS NOT NULL;

--- a/crates/storage/src/background_tasks.rs
+++ b/crates/storage/src/background_tasks.rs
@@ -1,0 +1,316 @@
+//! Postgres-backed adapter for `BackgroundTaskStore` (issue #115).
+//!
+//! Mirrors the patterns established by `PgTurnStateStore`:
+//! - `(user_id, …)` scoped queries for everything except the
+//!   `scan_non_terminal` system hook
+//! - cross-user reads return `Ok(None)`, not an error (#105)
+//! - `current_user_id()` from the task-local; user-id is only passed
+//!   in explicitly on `create_task` (the row's owner is supplied by
+//!   the caller) and on `list_tasks_for_user` (a small ergonomic
+//!   exception — the registry already has the owning user in hand).
+
+use async_trait::async_trait;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_core::ports::store::{
+    BackgroundTaskRow, BackgroundTaskStatus, BackgroundTaskStore,
+};
+use sqlx::PgPool;
+
+/// Postgres adapter for the `background_tasks` table.
+pub struct PgBackgroundTaskStore {
+    pool: PgPool,
+}
+
+impl PgBackgroundTaskStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+// Tuple-to-row helper. Argument count matches the column list; folding
+// these into a struct would just shift the verbosity into the caller.
+#[allow(clippy::too_many_arguments)]
+fn row_from_db(
+    id: String,
+    user_id: String,
+    kind_json: serde_json::Value,
+    status_key: String,
+    parent_task_id: Option<String>,
+    title: String,
+    last_error: Option<String>,
+    progress_hint: Option<String>,
+    started_at: i64,
+    ended_at: Option<i64>,
+) -> Result<BackgroundTaskRow, CoreError> {
+    let status = BackgroundTaskStatus::from_key(&status_key).ok_or_else(|| {
+        CoreError::Storage(format!(
+            "unknown background task status in DB: {status_key} for task {id}"
+        ))
+    })?;
+    Ok(BackgroundTaskRow {
+        id,
+        user_id,
+        kind_json,
+        status,
+        parent_task_id,
+        title,
+        last_error,
+        progress_hint,
+        started_at,
+        ended_at,
+    })
+}
+
+#[async_trait]
+impl BackgroundTaskStore for PgBackgroundTaskStore {
+    async fn create_task(&self, row: BackgroundTaskRow) -> Result<(), CoreError> {
+        // The caller owns the identity decision — typically the
+        // application layer reads `current_user_id()` and bakes it
+        // into the row before calling. Mirrors `PgTurnStateStore::create_turn`.
+        let result = sqlx::query(
+            "INSERT INTO background_tasks (\
+                id, user_id, kind_json, task_status, parent_task_id, title, \
+                last_error, progress_hint, started_at, ended_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        )
+        .bind(&row.id)
+        .bind(&row.user_id)
+        .bind(&row.kind_json)
+        .bind(row.status.as_key())
+        .bind(row.parent_task_id.as_deref())
+        .bind(&row.title)
+        .bind(row.last_error.as_deref())
+        .bind(row.progress_hint.as_deref())
+        .bind(row.started_at)
+        .bind(row.ended_at)
+        .execute(&self.pool)
+        .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => Err(
+                CoreError::Storage(format!("background task id already exists: {}", row.id)),
+            ),
+            Err(e) => Err(CoreError::Storage(e.to_string())),
+        }
+    }
+
+    async fn get_task(&self, id: &str) -> Result<Option<BackgroundTaskRow>, CoreError> {
+        let user_id = current_user_id();
+        // (user_id, id) — the composite filter keeps cross-user probes
+        // from leaking existence.
+        let row: Option<(
+            String,
+            String,
+            serde_json::Value,
+            String,
+            Option<String>,
+            String,
+            Option<String>,
+            Option<String>,
+            i64,
+            Option<i64>,
+        )> = sqlx::query_as(
+            "SELECT id, user_id, kind_json, task_status, parent_task_id, \
+                    title, last_error, progress_hint, started_at, ended_at \
+             FROM background_tasks \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        match row {
+            None => Ok(None),
+            Some((
+                id,
+                user_id,
+                kind_json,
+                status_key,
+                parent_task_id,
+                title,
+                last_error,
+                progress_hint,
+                started_at,
+                ended_at,
+            )) => Ok(Some(row_from_db(
+                id,
+                user_id,
+                kind_json,
+                status_key,
+                parent_task_id,
+                title,
+                last_error,
+                progress_hint,
+                started_at,
+                ended_at,
+            )?)),
+        }
+    }
+
+    async fn update_task(
+        &self,
+        id: &str,
+        status: BackgroundTaskStatus,
+        last_error: Option<&str>,
+        progress_hint: Option<&str>,
+        ended_at: Option<i64>,
+    ) -> Result<(), CoreError> {
+        let user_id = current_user_id();
+        let result = sqlx::query(
+            "UPDATE background_tasks \
+             SET task_status = $3, last_error = $4, progress_hint = $5, \
+                 ended_at = $6, updated_at = now() \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(id)
+        .bind(status.as_key())
+        .bind(last_error)
+        .bind(progress_hint)
+        .bind(ended_at)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            // Same opacity rule as `get_task`: don't distinguish
+            // "doesn't exist" from "not yours".
+            return Err(CoreError::Storage(format!(
+                "background task not found for current user: {id}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn list_tasks_for_user(
+        &self,
+        user_id: &str,
+        include_finished: bool,
+        limit: Option<u32>,
+    ) -> Result<Vec<BackgroundTaskRow>, CoreError> {
+        // Build the query in two parts so the optional WHERE clause
+        // stays statically typed in sqlx.
+        let limit_value: i64 = limit.map(|l| l as i64).unwrap_or(i64::MAX);
+        let rows: Vec<(
+            String,
+            String,
+            serde_json::Value,
+            String,
+            Option<String>,
+            String,
+            Option<String>,
+            Option<String>,
+            i64,
+            Option<i64>,
+        )> = if include_finished {
+            sqlx::query_as(
+                "SELECT id, user_id, kind_json, task_status, parent_task_id, \
+                        title, last_error, progress_hint, started_at, ended_at \
+                 FROM background_tasks \
+                 WHERE user_id = $1 \
+                 ORDER BY started_at DESC \
+                 LIMIT $2",
+            )
+            .bind(user_id)
+            .bind(limit_value)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?
+        } else {
+            sqlx::query_as(
+                "SELECT id, user_id, kind_json, task_status, parent_task_id, \
+                        title, last_error, progress_hint, started_at, ended_at \
+                 FROM background_tasks \
+                 WHERE user_id = $1 AND task_status IN ('pending', 'running') \
+                 ORDER BY started_at DESC \
+                 LIMIT $2",
+            )
+            .bind(user_id)
+            .bind(limit_value)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?
+        };
+        let mut out = Vec::with_capacity(rows.len());
+        for (
+            id,
+            user_id,
+            kind_json,
+            status_key,
+            parent_task_id,
+            title,
+            last_error,
+            progress_hint,
+            started_at,
+            ended_at,
+        ) in rows
+        {
+            out.push(row_from_db(
+                id,
+                user_id,
+                kind_json,
+                status_key,
+                parent_task_id,
+                title,
+                last_error,
+                progress_hint,
+                started_at,
+                ended_at,
+            )?);
+        }
+        Ok(out)
+    }
+
+    async fn scan_non_terminal(&self) -> Result<Vec<BackgroundTaskRow>, CoreError> {
+        // No user_id filter — see method doc on the trait.
+        let rows: Vec<(
+            String,
+            String,
+            serde_json::Value,
+            String,
+            Option<String>,
+            String,
+            Option<String>,
+            Option<String>,
+            i64,
+            Option<i64>,
+        )> = sqlx::query_as(
+            "SELECT id, user_id, kind_json, task_status, parent_task_id, \
+                    title, last_error, progress_hint, started_at, ended_at \
+             FROM background_tasks \
+             WHERE task_status NOT IN ('completed', 'failed', 'cancelled')",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for (
+            id,
+            user_id,
+            kind_json,
+            status_key,
+            parent_task_id,
+            title,
+            last_error,
+            progress_hint,
+            started_at,
+            ended_at,
+        ) in rows
+        {
+            out.push(row_from_db(
+                id,
+                user_id,
+                kind_json,
+                status_key,
+                parent_task_id,
+                title,
+                last_error,
+                progress_hint,
+                started_at,
+                ended_at,
+            )?);
+        }
+        Ok(out)
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod background_tasks;
 pub mod conversation;
 pub mod conversation_search;
 pub mod database;
@@ -18,6 +19,7 @@ pub mod turn_state;
 pub use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 pub use desktop_assistant_auth_jwt::{DEFAULT_USER_ID, UserId};
 
+pub use background_tasks::PgBackgroundTaskStore;
 pub use conversation::PgConversationStore;
 pub use conversation_search::PgConversationSearchStore;
 pub use database::execute_database_query;

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -141,5 +141,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // Background tasks (issue #115) — persistent mirror of the in-memory
+    // `BackgroundTaskRegistry`. On daemon restart the cold-restart sweep
+    // reads this table to surface tasks that were running when the
+    // previous daemon died.
+    sqlx::raw_sql(include_str!("../migrations/018_background_tasks.sql"))
+        .execute(pool)
+        .await?;
+
     Ok(())
 }

--- a/crates/storage/tests/user_id_scoping.rs
+++ b/crates/storage/tests/user_id_scoping.rs
@@ -33,11 +33,12 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Conversation, ConversationId, KnowledgeEntry, Message, Role};
 use desktop_assistant_core::ports::knowledge::KnowledgeBaseStore;
 use desktop_assistant_core::ports::store::{
-    ConversationStore, PendingClientToolCall, TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
+    BackgroundTaskRow, BackgroundTaskStatus, BackgroundTaskStore, ConversationStore,
+    PendingClientToolCall, TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
 };
 use desktop_assistant_storage::{
-    PgConversationStore, PgKnowledgeBaseStore, PgTurnStateStore, UserId, run_migrations,
-    with_user_id,
+    PgBackgroundTaskStore, PgConversationStore, PgKnowledgeBaseStore, PgTurnStateStore, UserId,
+    run_migrations, with_user_id,
 };
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
@@ -587,6 +588,237 @@ async fn turn_state_scan_non_terminal_walks_all_users() {
         rows.sort_by(|a, b| a.id.cmp(&b.id));
         let ids: Vec<_> = rows.iter().map(|r| r.id.clone()).collect();
         assert_eq!(ids, vec!["t-a-pending".to_string(), "t-b-pending".to_string()]);
+        fx
+    })
+    .await;
+}
+
+// -- background tasks (issue #115) ------------------------------------------
+
+fn task_row(id: &str, user_id: &str, status: BackgroundTaskStatus) -> BackgroundTaskRow {
+    BackgroundTaskRow {
+        id: id.into(),
+        user_id: user_id.into(),
+        // The store treats `kind_json` opaquely; any well-formed JSON is
+        // fine. We pick a `standalone` shape because the registry tests
+        // hammer that branch hardest.
+        kind_json: serde_json::json!({
+            "standalone": {"name": "test", "conversation_id": "c"}
+        }),
+        status,
+        parent_task_id: None,
+        title: format!("title for {id}"),
+        last_error: None,
+        progress_hint: None,
+        started_at: 1_700_000_000,
+        ended_at: None,
+    }
+}
+
+#[tokio::test]
+async fn background_task_row_round_trips_through_postgres() {
+    with_fixture("background_task_row_round_trips_through_postgres", |fx| async move {
+        let store = PgBackgroundTaskStore::new(fx.pool.clone());
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_task(task_row("bt-1", "alice", BackgroundTaskStatus::Running))
+                .await
+                .expect("create");
+            let row = store.get_task("bt-1").await.unwrap().expect("row");
+            assert_eq!(row.status, BackgroundTaskStatus::Running);
+            assert_eq!(row.title, "title for bt-1");
+
+            store
+                .update_task(
+                    "bt-1",
+                    BackgroundTaskStatus::Failed,
+                    Some("daemon restarted mid-turn"),
+                    Some("step 2/4"),
+                    Some(1_700_000_555),
+                )
+                .await
+                .expect("update");
+            let row = store.get_task("bt-1").await.unwrap().unwrap();
+            assert_eq!(row.status, BackgroundTaskStatus::Failed);
+            assert_eq!(row.last_error.as_deref(), Some("daemon restarted mid-turn"));
+            assert_eq!(row.progress_hint.as_deref(), Some("step 2/4"));
+            assert_eq!(row.ended_at, Some(1_700_000_555));
+        })
+        .await;
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn background_task_user_b_cannot_read_user_a_row() {
+    // Cross-user isolation: Bob's get_task returns None and his
+    // update_task errors — the same opacity rule applied elsewhere.
+    with_fixture("background_task_user_b_cannot_read_user_a_row", |fx| async move {
+        let store = PgBackgroundTaskStore::new(fx.pool.clone());
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_task(task_row("bt-x", "alice", BackgroundTaskStatus::Running))
+                .await
+                .expect("create");
+        })
+        .await;
+
+        let bob_get =
+            with_user_id(UserId::new("bob"), async { store.get_task("bt-x").await })
+                .await
+                .expect("ok");
+        assert!(bob_get.is_none(), "bob must not see alice's task");
+
+        let bob_update = with_user_id(UserId::new("bob"), async {
+            store
+                .update_task(
+                    "bt-x",
+                    BackgroundTaskStatus::Failed,
+                    Some("nope"),
+                    None,
+                    Some(1_700_000_999),
+                )
+                .await
+        })
+        .await;
+        assert!(bob_update.is_err(), "bob must not be able to update alice's row");
+
+        // Alice's row is unaffected.
+        let alice_get = with_user_id(UserId::new("alice"), async {
+            store.get_task("bt-x").await
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(alice_get.status, BackgroundTaskStatus::Running);
+        assert!(alice_get.last_error.is_none());
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn background_task_scan_non_terminal_walks_all_users() {
+    // Cold-restart sweep must see every user's non-terminal rows in a
+    // single pass — without a JWT scope installed, just like the
+    // turn-state sweep does.
+    with_fixture("background_task_scan_non_terminal_walks_all_users", |fx| async move {
+        let store = PgBackgroundTaskStore::new(fx.pool.clone());
+        with_user_id(UserId::new("alice"), async {
+            store
+                .create_task(task_row("a-running", "alice", BackgroundTaskStatus::Running))
+                .await
+                .unwrap();
+            store
+                .create_task(task_row("a-done", "alice", BackgroundTaskStatus::Completed))
+                .await
+                .unwrap();
+        })
+        .await;
+        with_user_id(UserId::new("bob"), async {
+            store
+                .create_task(task_row("b-running", "bob", BackgroundTaskStatus::Running))
+                .await
+                .unwrap();
+            store
+                .create_task(task_row("b-cancelled", "bob", BackgroundTaskStatus::Cancelled))
+                .await
+                .unwrap();
+        })
+        .await;
+
+        // No scope installed for the sweep call.
+        let mut rows = store.scan_non_terminal().await.expect("scan");
+        rows.sort_by(|a, b| a.id.cmp(&b.id));
+        let ids: Vec<_> = rows.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            ids,
+            vec!["a-running".to_string(), "b-running".to_string()],
+            "only non-terminal rows from both users surface"
+        );
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn background_task_list_for_user_filters_to_owner() {
+    // The list path used by the registry must produce only the calling
+    // user's rows, in started_at DESC order. This audits the SQL: a
+    // missing `WHERE user_id = $1` would let one user see another's
+    // tasks.
+    with_fixture("background_task_list_for_user_filters_to_owner", |fx| async move {
+        let store = PgBackgroundTaskStore::new(fx.pool.clone());
+        with_user_id(UserId::new("alice"), async {
+            let mut row1 = task_row("a-1", "alice", BackgroundTaskStatus::Running);
+            row1.started_at = 1_700_000_001;
+            let mut row2 = task_row("a-2", "alice", BackgroundTaskStatus::Completed);
+            row2.started_at = 1_700_000_002;
+            store.create_task(row1).await.unwrap();
+            store.create_task(row2).await.unwrap();
+        })
+        .await;
+        with_user_id(UserId::new("bob"), async {
+            let mut row = task_row("b-1", "bob", BackgroundTaskStatus::Running);
+            row.started_at = 1_700_000_003;
+            store.create_task(row).await.unwrap();
+        })
+        .await;
+
+        let alice_list = store
+            .list_tasks_for_user("alice", /*include_finished*/ true, None)
+            .await
+            .unwrap();
+        let alice_ids: Vec<_> = alice_list.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(alice_ids, vec!["a-2".to_string(), "a-1".to_string()]);
+
+        // include_finished=false trims to non-terminal rows.
+        let alice_active = store
+            .list_tasks_for_user("alice", false, None)
+            .await
+            .unwrap();
+        let alice_active_ids: Vec<_> = alice_active.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(alice_active_ids, vec!["a-1".to_string()]);
+
+        let bob_list = store
+            .list_tasks_for_user("bob", true, None)
+            .await
+            .unwrap();
+        let bob_ids: Vec<_> = bob_list.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(bob_ids, vec!["b-1".to_string()]);
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn background_task_parent_link_persists_through_postgres() {
+    // The parent_task_id column round-trips and supports a future
+    // children join. We don't declare a FK constraint (see migration
+    // header), so a parent that was deleted before the child surfaces
+    // as a dangling reference rather than a FK violation.
+    with_fixture("background_task_parent_link_persists_through_postgres", |fx| async move {
+        let store = PgBackgroundTaskStore::new(fx.pool.clone());
+        with_user_id(UserId::new("alice"), async {
+            let parent = task_row("parent", "alice", BackgroundTaskStatus::Running);
+            store.create_task(parent).await.unwrap();
+
+            let mut child = task_row("child", "alice", BackgroundTaskStatus::Running);
+            child.parent_task_id = Some("parent".into());
+            child.kind_json = serde_json::json!({
+                "subagent": {
+                    "parent_task_id": "parent",
+                    "conversation_id": "c",
+                    "name": "ch"
+                }
+            });
+            store.create_task(child).await.unwrap();
+
+            let read = store.get_task("child").await.unwrap().unwrap();
+            assert_eq!(read.parent_task_id.as_deref(), Some("parent"));
+        })
+        .await;
         fx
     })
     .await;


### PR DESCRIPTION
Closes #115. Net: every spawned task gets a Postgres mirror; a daemon restart sweeps the leftovers into a clean `Failed` so the UI can show "we lost this one" instead of silently abandoning them. Real cold-restart resume of standalones is followed up in #129.

## Summary

- New `background_tasks` Postgres table (migration `018_background_tasks.sql`) keyed by `task_id` with `kind_json`, `task_status`, `parent_task_id`, `title`, `last_error`, `progress_hint`, `started_at`/`ended_at` epoch-millis. Indexed for `(user_id, started_at DESC)` list, partial-status non-terminal sweep, and parent → child traversal.
- New `BackgroundTaskStore` port (`core::ports::store`) + `PgBackgroundTaskStore` adapter. `(user_id, …)`-scoped reads/updates; `scan_non_terminal` walks across users like the turn-state sweep does.
- `BackgroundTaskRegistry::with_store(...)` attaches the store at construction time. Existing callers without a store keep the previous in-memory-only path; every #111 test still passes unchanged.
- `BackgroundTaskRegistry::sweep_non_terminal_on_startup()` is the daemon-startup hook: marks each non-terminal row `Failed`, surfaces it in the in-memory map, emits a single `Lifecycle` log entry. Rows are processed parents-before-children so the parent's `children` vector is rebuilt correctly.
- `TaskError::AlreadyTerminal` distinguishes a post-restart `cancel` from `NotFound` so transports can return a clean error instead of pretending the cancel succeeded.
- `crates/daemon/src/main.rs` attaches the store and runs the sweep when a Postgres pool is available.

## Design choice: parallel table vs. extending `turns`

The issue body left this as the implementer's call. I went with a parallel `background_tasks` table because the two concepts have different lifecycles: a Standalone agent may run several turns; a turn can't be `Cancelled` but a task can; `TaskKind::Subagent` references a parent task with no turn analogue. The migration header explains in detail; the schema for `turns` is untouched so #107's invariants are preserved.

## Resume policy (best-effort, until #129)

- `Conversation` / `Subagent`: `Failed { last_error: "daemon restarted mid-turn" }`. Conversation history is intact in `conversations` / `messages`; the user re-prompts to continue.
- `Standalone`: `Failed { last_error: "daemon restarted; resume not yet implemented" }`. **#129 replaces this branch with a real resume from persisted turn state — that's the deeper `send_prompt` refactor this PR explicitly defers.**

## Out of scope (follow-ups)

- Real cold-restart resume of standalones — **#129** (this PR's resume policy is the placeholder).
- Persistent log replay (the in-memory log starts fresh on resume).
- Scheduled / cron task launching.
- Cross-machine task migration.

## Coordination with parallel agents

- #112 / #113 also touch `crates/application/src/background_tasks.rs`. This PR does NOT change any public method signature of `BackgroundTaskRegistry`; it only adds `with_store` and `sweep_non_terminal_on_startup`, and an internal `Inner.store` field. #112's `registry.spawn(TaskKind::Subagent, …)` and #113's `registry.spawn(TaskKind::Standalone, …)` continue to work unchanged.
- #113 has already merged; this branch is rebased on top.

## Test plan

- [x] `cargo test -p desktop-assistant-application --test durable_background_tasks` — 10 new tests: spawn writes a row, terminal transitions update it, sweep marks non-terminal rows Failed with kind-specific messages, cancelled rows stay Cancelled, completed rows stay Completed, user scoping survives restart, parent-child links survive, `cancel` on post-restart row returns `AlreadyTerminal`, concurrent spawn vs. sweep doesn't corrupt state, business outcome: user sees Failed in list after restart.
- [x] `TEST_DATABASE_URL=… cargo test -p desktop-assistant-storage --test user_id_scoping background_task -- --test-threads=1` — 5 new Postgres tests: round-trip, cross-user opacity, scan-non-terminal walks all users, per-user list ordering, parent-link persistence.
- [x] `cargo test --workspace --tests` — all existing tests pass.
- [x] `cargo clippy --workspace --all-targets` — no new warnings introduced by this diff.
- [x] `cargo build --workspace` — daemon, all transports, all adapters compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)