### PR TITLE
ws-interface: wire background-task commands and event subscription (#114)

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -21,7 +21,7 @@ use desktop_assistant_core::ports::inbound::{
 use thiserror::Error;
 use tracing::warn;
 
-use crate::background_tasks::BackgroundTaskRegistry;
+use crate::background_tasks::{BackgroundTaskRegistry, TaskError};
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -30,6 +30,23 @@ pub enum ApiError {
 
     #[error("unsupported command")]
     Unsupported,
+
+    /// The targeted entity is unknown to the caller. Used by background-
+    /// task arms to surface both "id never existed" and "id belongs to
+    /// another user" (the existence-hiding rule from #105) under a
+    /// single, intentionally opaque variant. Renders to "not found" so
+    /// adapters can forward the message verbatim without leaking the
+    /// distinction.
+    #[error("not found")]
+    NotFound,
+
+    /// The targeted task is already in a terminal state — e.g. a
+    /// `Cancel` on a task the registry already marked `Failed` after
+    /// the cold-restart sweep (#115). Distinct from `NotFound` so
+    /// transport adapters can return a clean 409-style error to the
+    /// client instead of pretending the operation succeeded.
+    #[error("task is already terminal")]
+    AlreadyTerminal,
 }
 
 pub type ApiResult<T> = Result<T, ApiError>;
@@ -183,6 +200,57 @@ pub trait AssistantApiHandler: Send + Sync {
             ),
         )
         .await
+    }
+
+    /// Subscribe to background-task events for the current task-local
+    /// user id (#114). Returning `Some(receiver)` lets the transport
+    /// layer spawn a forwarder that pumps `Event::Task*` frames out to
+    /// a single connection until the connection drops or
+    /// `UnsubscribeBackgroundTasks` arrives.
+    ///
+    /// The default implementation returns `None`, which tells the
+    /// dispatcher to surface `SubscribeBackgroundTasks` as a clean
+    /// error frame instead of acking and then never streaming
+    /// anything. Handlers that wrap a `BackgroundTaskRegistry`
+    /// override this method to return a real receiver.
+    ///
+    /// Contract: callers MUST install the per-request user id via
+    /// `with_user_id` before invoking this method. The dispatcher does
+    /// that as part of its per-request scope-installation discipline
+    /// (#105) — handlers that read `current_user_id()` here can rely
+    /// on it being set.
+    async fn subscribe_user_events(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<api::Event>> {
+        None
+    }
+
+    /// Register a `SendMessage` request as a background task and
+    /// return the new task id synchronously. The body runs in the
+    /// background; events stream through `sink` as before.
+    ///
+    /// Returning `Some(task_id)` tells the dispatcher to reply with
+    /// `CommandResult::SendMessageAck { task_id }`. Returning `None`
+    /// (the default) tells the dispatcher to fall back to the legacy
+    /// bare-Ack flow and dispatch `handle_send_message_with_override`
+    /// directly — used by tests and single-tenant deploys that don't
+    /// attach a registry to the handler.
+    async fn start_send_message(
+        &self,
+        conversation_id: String,
+        content: String,
+        override_selection: Option<api::SendPromptOverride>,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<Option<api::TaskId>> {
+        let _ = (
+            conversation_id,
+            content,
+            override_selection,
+            request_id,
+            sink,
+        );
+        Ok(None)
     }
 }
 
@@ -961,16 +1029,83 @@ where
             // Streamed commands are handled elsewhere.
             api::Command::SendMessage { .. } => Err(ApiError::Unsupported),
 
-            // Background-task commands (issue #110) for which the
-            // registry-side wiring lands in a later issue (ws-interface
-            // hookup is #114). Each arm is listed explicitly (no
-            // wildcard) so a future PR can't silently miss one.
-            api::Command::ListBackgroundTasks { .. }
-            | api::Command::GetBackgroundTask { .. }
-            | api::Command::CancelBackgroundTask { .. }
-            | api::Command::GetBackgroundTaskLogs { .. }
-            | api::Command::SubscribeBackgroundTasks
-            | api::Command::UnsubscribeBackgroundTasks => Err(ApiError::Unsupported),
+            // Background-task commands (#114) — read-side arms that
+            // dispatch through the in-memory registry attached to the
+            // handler. Subscribe/Unsubscribe Ack here at the
+            // protocol level; the transport-side forwarder that
+            // actually pushes `Event::Task*` to the connection is
+            // hooked up by `dispatch_loop` via
+            // [`Self::subscribe_user_events`] (transport-dispatch).
+            api::Command::ListBackgroundTasks {
+                include_finished,
+                limit,
+            } => {
+                let registry = self.registry.as_ref().ok_or_else(|| {
+                    ApiError::Core(
+                        "background task registry not attached to handler".to_string(),
+                    )
+                })?;
+                let user_id = desktop_assistant_core::ports::auth::current_user_id();
+                Ok(api::CommandResult::BackgroundTasks(
+                    registry.list(&user_id, include_finished, limit),
+                ))
+            }
+            api::Command::GetBackgroundTask { id } => {
+                let registry = self.registry.as_ref().ok_or_else(|| {
+                    ApiError::Core(
+                        "background task registry not attached to handler".to_string(),
+                    )
+                })?;
+                let user_id = desktop_assistant_core::ports::auth::current_user_id();
+                registry
+                    .get(&user_id, &api::TaskId(id))
+                    .map(api::CommandResult::BackgroundTask)
+                    .ok_or(ApiError::NotFound)
+            }
+            api::Command::CancelBackgroundTask { id } => {
+                let registry = self.registry.as_ref().ok_or_else(|| {
+                    ApiError::Core(
+                        "background task registry not attached to handler".to_string(),
+                    )
+                })?;
+                let user_id = desktop_assistant_core::ports::auth::current_user_id();
+                match registry.cancel(&user_id, &api::TaskId(id)) {
+                    Ok(()) => Ok(api::CommandResult::Ack),
+                    Err(TaskError::NotFound) => Err(ApiError::NotFound),
+                    Err(TaskError::AlreadyTerminal) => Err(ApiError::AlreadyTerminal),
+                }
+            }
+            api::Command::GetBackgroundTaskLogs {
+                id,
+                after_seq,
+                limit,
+            } => {
+                let registry = self.registry.as_ref().ok_or_else(|| {
+                    ApiError::Core(
+                        "background task registry not attached to handler".to_string(),
+                    )
+                })?;
+                let user_id = desktop_assistant_core::ports::auth::current_user_id();
+                match registry.logs(
+                    &user_id,
+                    &api::TaskId(id),
+                    after_seq.unwrap_or(0),
+                    limit.unwrap_or(200),
+                ) {
+                    Ok((entries, next_seq)) => Ok(api::CommandResult::BackgroundTaskLogs {
+                        entries,
+                        next_seq,
+                    }),
+                    Err(TaskError::NotFound) => Err(ApiError::NotFound),
+                    Err(TaskError::AlreadyTerminal) => Err(ApiError::AlreadyTerminal),
+                }
+            }
+            // Subscribe / Unsubscribe Ack at the handler level. The
+            // dispatcher inspects [`Self::subscribe_user_events`] to
+            // spawn (or tear down) the forwarder that actually streams
+            // `Event::Task*` frames to the connection.
+            api::Command::SubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            api::Command::UnsubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
 
             // Standalone agent spawn (issue #113). Creates a fresh
             // conversation scoped to the calling user, registers a
@@ -1090,6 +1225,80 @@ where
             .await
             .map_err(Self::map_core_err)
         }
+    }
+
+    /// Register a `SendMessage` with the attached registry so the
+    /// dispatcher can return `SendMessageAck { task_id }` synchronously
+    /// while the body still runs in the background (#114). The body
+    /// holds the same `sink`, so streaming chunks reach the connection
+    /// exactly as before — only the wire-level ack changes shape.
+    ///
+    /// Returns `None` when no registry is attached so callers
+    /// (transport-dispatch) can fall back to the legacy
+    /// `handle_send_message_with_override` + bare-`Ack` flow.
+    async fn start_send_message(
+        &self,
+        conversation_id: String,
+        content: String,
+        override_selection: Option<api::SendPromptOverride>,
+        request_id: String,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<Option<api::TaskId>> {
+        let Some(registry) = self.registry.clone() else {
+            return Ok(None);
+        };
+        let user_id = desktop_assistant_core::ports::auth::current_user_id();
+        let conversations = Arc::clone(&self.conversations);
+        let kind = api::TaskKind::Conversation {
+            conversation_id: conversation_id.clone(),
+        };
+        let title = format!("Conversation: {conversation_id}");
+
+        let conv_id_for_body = conversation_id.clone();
+        let request_id_for_body = request_id.clone();
+        let sink_for_body = Arc::clone(&sink);
+
+        // `registry.spawn` is sync; the body runs on its own
+        // `tokio::spawn` so we can return the new task id immediately.
+        let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
+            ctx.logs.append(
+                api::LogLevel::Info,
+                api::LogCategory::Status,
+                format!("send_prompt conversation_id={conv_id_for_body}"),
+                None,
+            );
+
+            let result = run_send_turn(
+                conversations,
+                conv_id_for_body,
+                content,
+                override_selection,
+                request_id_for_body,
+                sink_for_body,
+                ctx.token.clone(),
+            )
+            .await;
+
+            match result {
+                Ok(()) => Ok(()),
+                Err(desktop_assistant_core::CoreError::Cancelled) => Ok(()),
+                Err(other) => Err(anyhow::Error::new(other)),
+            }
+        });
+
+        Ok(Some(task_id))
+    }
+
+    /// Hand the dispatcher (or any transport-level forwarder) a
+    /// `broadcast::Receiver` so it can fan `Event::Task*` frames out
+    /// to a single connection. Reads the per-request user id from the
+    /// task-local installed by [`handle_command_for`] (#105).
+    async fn subscribe_user_events(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<api::Event>> {
+        let registry = self.registry.as_ref()?;
+        let user_id = desktop_assistant_core::ports::auth::current_user_id();
+        Some(registry.subscribe(&user_id))
     }
 }
 

--- a/crates/application/tests/ws_background_task_wiring.rs
+++ b/crates/application/tests/ws_background_task_wiring.rs
@@ -313,6 +313,7 @@ impl SettingsService for FakeSettings {
 
 #[derive(Debug, Clone)]
 struct SendCall {
+    #[allow(dead_code)]
     conversation_id: String,
     prompt: String,
 }

--- a/crates/application/tests/ws_background_task_wiring.rs
+++ b/crates/application/tests/ws_background_task_wiring.rs
@@ -1,0 +1,1016 @@
+//! Acceptance tests for the background-task command arms wired into
+//! [`DefaultAssistantApiHandler`] (#114).
+//!
+//! These exercise the *handler-level* contract — given a registry and a
+//! per-user request context, each `Command::*BackgroundTask*` arm must
+//! consult the registry and return the documented `CommandResult` (or a
+//! structured error). The transport-level wiring (Subscribe forwarder,
+//! SendMessageAck plumbing) lives in `transport-dispatch` and is exercised
+//! by tests in that crate; the arms below are the building blocks that
+//! the dispatcher composes against.
+//!
+//! TDD: written before the stubs in `application/src/lib.rs` are replaced
+//! with real registry calls. Every test asserts a documented business
+//! outcome from the #114 issue body.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::{
+    AssistantApiHandler, DefaultAssistantApiHandler, RequestContext, UserId,
+    background_tasks::BackgroundTaskRegistry,
+};
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{
+    Conversation, ConversationId, ConversationSummary, KnowledgeEntry, Message, Role,
+};
+use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
+use desktop_assistant_core::ports::inbound::{
+    AssistantService, BackendTasksSettingsView, ConnectionConfigPayload, ConnectionsService,
+    ConnectorDefaultsView, ConversationService, DatabaseSettingsView, EmbeddingsSettingsView,
+    KnowledgeService, LlmSettingsView, ModelListing as CoreModelListing, PersistenceSettingsView,
+    PromptDispatchOutcome, PromptSelectionOverride, PurposeConfigPayload, PurposeKind,
+    PurposesView as CorePurposesView, SettingsService, WsAuthSettingsView,
+};
+use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+// ---------- Minimal fakes ----------
+
+struct FakeAssistant;
+impl AssistantService for FakeAssistant {
+    fn version(&self) -> &str {
+        "0.0.0-test"
+    }
+    fn ping(&self) -> &str {
+        "pong"
+    }
+}
+
+struct FakeKnowledge;
+impl KnowledgeService for FakeKnowledge {
+    async fn list_entries(
+        &self,
+        _l: usize,
+        _o: usize,
+        _t: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_entry(&self, _id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        Ok(None)
+    }
+    async fn search_entries(
+        &self,
+        _q: String,
+        _t: Option<Vec<String>>,
+        _l: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let mut e = KnowledgeEntry::new("kb", content, tags);
+        e.metadata = metadata;
+        Ok(e)
+    }
+    async fn update_entry(
+        &self,
+        id: String,
+        content: String,
+        tags: Vec<String>,
+        metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        let mut e = KnowledgeEntry::new(id, content, tags);
+        e.metadata = metadata;
+        Ok(e)
+    }
+    async fn delete_entry(&self, _id: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+struct FakeConnections;
+impl ConnectionsService for FakeConnections {
+    async fn list_connections(
+        &self,
+    ) -> Result<Vec<desktop_assistant_core::ports::inbound::ConnectionView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_connection(
+        &self,
+        _id: String,
+        _c: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn update_connection(
+        &self,
+        _id: String,
+        _c: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn delete_connection(&self, _id: String, _f: bool) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn list_available_models(
+        &self,
+        _c: Option<String>,
+        _r: bool,
+    ) -> Result<Vec<CoreModelListing>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_purposes(&self) -> Result<CorePurposesView, CoreError> {
+        Ok(CorePurposesView::default())
+    }
+    async fn set_purpose(
+        &self,
+        _p: PurposeKind,
+        _c: PurposeConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+struct FakeSettings;
+impl SettingsService for FakeSettings {
+    async fn get_llm_settings(&self) -> Result<LlmSettingsView, CoreError> {
+        Ok(LlmSettingsView {
+            connector: "x".into(),
+            model: "y".into(),
+            base_url: "z".into(),
+            has_api_key: false,
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            hosted_tool_search: None,
+        })
+    }
+    async fn set_llm_settings(
+        &self,
+        _c: String,
+        _m: Option<String>,
+        _b: Option<String>,
+        _t: Option<f64>,
+        _p: Option<f64>,
+        _x: Option<u32>,
+        _h: Option<bool>,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn set_api_key(&self, _k: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn generate_ws_jwt(&self, _s: Option<String>) -> Result<String, CoreError> {
+        Ok("t".into())
+    }
+    async fn validate_ws_jwt(&self, _t: String) -> Result<bool, CoreError> {
+        Ok(true)
+    }
+    async fn get_embeddings_settings(&self) -> Result<EmbeddingsSettingsView, CoreError> {
+        Ok(EmbeddingsSettingsView {
+            connector: "x".into(),
+            model: "y".into(),
+            base_url: "z".into(),
+            has_api_key: false,
+            available: false,
+            is_default: true,
+        })
+    }
+    async fn set_embeddings_settings(
+        &self,
+        _c: Option<String>,
+        _m: Option<String>,
+        _b: Option<String>,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_connector_defaults(
+        &self,
+        _c: String,
+    ) -> Result<ConnectorDefaultsView, CoreError> {
+        Ok(ConnectorDefaultsView {
+            llm_model: "m".into(),
+            llm_base_url: "u".into(),
+            backend_llm_model: "bm".into(),
+            embeddings_model: "em".into(),
+            embeddings_base_url: "eu".into(),
+            embeddings_available: false,
+            hosted_tool_search_available: false,
+        })
+    }
+    async fn get_persistence_settings(&self) -> Result<PersistenceSettingsView, CoreError> {
+        Ok(PersistenceSettingsView {
+            enabled: false,
+            remote_url: "".into(),
+            remote_name: "origin".into(),
+            push_on_update: false,
+        })
+    }
+    async fn set_persistence_settings(
+        &self,
+        _e: bool,
+        _u: Option<String>,
+        _n: Option<String>,
+        _p: bool,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_database_settings(&self) -> Result<DatabaseSettingsView, CoreError> {
+        Ok(DatabaseSettingsView {
+            url: String::new(),
+            max_connections: 5,
+        })
+    }
+    async fn set_database_settings(
+        &self,
+        _u: Option<String>,
+        _m: u32,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_backend_tasks_settings(&self) -> Result<BackendTasksSettingsView, CoreError> {
+        Ok(BackendTasksSettingsView {
+            has_separate_llm: false,
+            llm_connector: "x".into(),
+            llm_model: "y".into(),
+            llm_base_url: "z".into(),
+            dreaming_enabled: false,
+            dreaming_interval_secs: 0,
+            archive_after_days: 0,
+        })
+    }
+    async fn set_backend_tasks_settings(
+        &self,
+        _c: Option<String>,
+        _m: Option<String>,
+        _b: Option<String>,
+        _e: bool,
+        _i: u64,
+        _a: u32,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn list_mcp_servers(
+        &self,
+    ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn add_mcp_server(
+        &self,
+        _n: String,
+        _c: String,
+        _a: Vec<String>,
+        _ns: Option<String>,
+        _e: bool,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn remove_mcp_server(&self, _n: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn set_mcp_server_enabled(&self, _n: String, _e: bool) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn mcp_server_action(
+        &self,
+        _a: String,
+        _s: Option<String>,
+    ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_ws_auth_settings(&self) -> Result<WsAuthSettingsView, CoreError> {
+        Ok(WsAuthSettingsView {
+            methods: vec![],
+            oidc_issuer: String::new(),
+            oidc_auth_endpoint: String::new(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+            oidc_scopes: String::new(),
+        })
+    }
+    async fn set_ws_auth_settings(
+        &self,
+        _m: Vec<String>,
+        _i: String,
+        _a: String,
+        _t: String,
+        _c: String,
+        _s: String,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SendCall {
+    conversation_id: String,
+    prompt: String,
+}
+
+struct RecordingConversations {
+    sends: Mutex<Vec<SendCall>>,
+    next_conv_id: AtomicU32,
+    cancelled: Arc<AtomicBool>,
+    /// When `Some`, send_prompt_with_override blocks on this notify before
+    /// returning. Used to assert that ListBackgroundTasks sees the task as
+    /// `Running` while the LLM is still working.
+    block_until: Mutex<Option<Arc<Notify>>>,
+}
+
+impl RecordingConversations {
+    fn new() -> Self {
+        Self {
+            sends: Mutex::new(vec![]),
+            next_conv_id: AtomicU32::new(0),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            block_until: Mutex::new(None),
+        }
+    }
+
+    fn block_on(&self, n: Arc<Notify>) {
+        *self.block_until.lock().unwrap() = Some(n);
+    }
+}
+
+impl ConversationService for RecordingConversations {
+    async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+        let id = format!(
+            "conv-{}",
+            self.next_conv_id.fetch_add(1, Ordering::SeqCst)
+        );
+        Ok(Conversation::new(id, title))
+    }
+    async fn list_conversations(
+        &self,
+        _m: Option<u32>,
+        _i: bool,
+    ) -> Result<Vec<ConversationSummary>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+        let mut c = Conversation::new(id.as_str(), "t");
+        if let Some(last) = self.sends.lock().unwrap().last().cloned() {
+            c.messages.push(Message::new(Role::User, last.prompt));
+            c.messages
+                .push(Message::new(Role::Assistant, "ok".to_string()));
+        }
+        Ok(c)
+    }
+    async fn delete_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn rename_conversation(
+        &self,
+        _id: &ConversationId,
+        _t: String,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn archive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn unarchive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn clear_all_history(&self) -> Result<u32, CoreError> {
+        Ok(0)
+    }
+    async fn send_prompt(
+        &self,
+        _conversation_id: &ConversationId,
+        _prompt: String,
+        _on_chunk: ChunkCallback,
+        _on_status: StatusCallback,
+    ) -> Result<String, CoreError> {
+        Ok(String::new())
+    }
+    async fn send_prompt_with_override(
+        &self,
+        conversation_id: &ConversationId,
+        prompt: String,
+        _override_selection: Option<PromptSelectionOverride>,
+        mut on_chunk: ChunkCallback,
+        _on_status: StatusCallback,
+        cancellation: CancellationToken,
+    ) -> Result<PromptDispatchOutcome, CoreError> {
+        self.sends.lock().unwrap().push(SendCall {
+            conversation_id: conversation_id.as_str().to_string(),
+            prompt: prompt.clone(),
+        });
+        let block = self.block_until.lock().unwrap().clone();
+        if let Some(block) = block {
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    self.cancelled.store(true, Ordering::SeqCst);
+                    return Err(CoreError::Cancelled);
+                }
+                _ = block.notified() => {}
+            }
+        }
+        on_chunk("ok".into());
+        Ok(PromptDispatchOutcome {
+            response: "ok".into(),
+            warnings: Vec::new(),
+        })
+    }
+}
+
+// ---------- Helpers ----------
+
+fn unique_user(label: &str) -> UserId {
+    use std::sync::atomic::AtomicU64;
+    static N: AtomicU64 = AtomicU64::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    UserId::new(format!("user-{label}-{n}"))
+}
+
+fn make_handler(
+    convs: Arc<RecordingConversations>,
+    registry: Arc<BackgroundTaskRegistry>,
+) -> DefaultAssistantApiHandler<
+    FakeAssistant,
+    RecordingConversations,
+    FakeSettings,
+    FakeConnections,
+    FakeKnowledge,
+> {
+    DefaultAssistantApiHandler::new(
+        Arc::new(FakeAssistant),
+        convs,
+        Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
+    )
+    .with_registry(registry)
+}
+
+fn spawn_dummy_task(registry: &BackgroundTaskRegistry, user: &UserId, title: &str) -> api::TaskId {
+    let release = Arc::new(Notify::new());
+    let r2 = Arc::clone(&release);
+    let id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: title.into(),
+            conversation_id: "c-x".into(),
+        },
+        title.into(),
+        move |_ctx| async move {
+            r2.notified().await;
+            Ok(())
+        },
+    );
+    // Leak the release sender — these test tasks stay running, kept alive
+    // only by the spawn() body holding the notified future. Tests that
+    // need the task in a terminal state should call `registry.cancel`
+    // or use `spawn_completing_task` below.
+    std::mem::forget(release);
+    id
+}
+
+fn spawn_completing_task(
+    registry: &BackgroundTaskRegistry,
+    user: &UserId,
+    title: &str,
+) -> api::TaskId {
+    registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: title.into(),
+            conversation_id: "c-done".into(),
+        },
+        title.into(),
+        |_ctx| async move { Ok(()) },
+    )
+}
+
+// ---------- Tests ----------
+
+/// Acceptance: ListBackgroundTasks returns the user's registered tasks.
+#[tokio::test]
+async fn list_background_tasks_returns_registered_tasks() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let id1 = spawn_dummy_task(&registry, &user, "first");
+    let id2 = spawn_dummy_task(&registry, &user, "second");
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::ListBackgroundTasks {
+                include_finished: false,
+                limit: None,
+            },
+        )
+        .await
+        .expect("list ok");
+
+    let tasks = match result {
+        api::CommandResult::BackgroundTasks(t) => t,
+        other => panic!("unexpected result: {other:?}"),
+    };
+    let ids: std::collections::HashSet<_> = tasks.iter().map(|t| t.id.clone()).collect();
+    assert!(ids.contains(&id1), "first task present");
+    assert!(ids.contains(&id2), "second task present");
+}
+
+/// Acceptance: GetBackgroundTask returns the requested task view.
+#[tokio::test]
+async fn get_background_task_returns_specific_task() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let id = spawn_dummy_task(&registry, &user, "my-task");
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::GetBackgroundTask { id: id.0.clone() },
+        )
+        .await
+        .expect("get ok");
+
+    match result {
+        api::CommandResult::BackgroundTask(t) => {
+            assert_eq!(t.id, id);
+            assert_eq!(t.title, "my-task");
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+/// Unhappy: GetBackgroundTask on an unknown id returns a structured error,
+/// not a panic and not a silent Ok. The transport adapter surfaces this
+/// as a `WsFrame::Error` so the client can render the failure.
+#[tokio::test]
+async fn get_background_task_unknown_id_returns_error() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::GetBackgroundTask {
+                id: "does-not-exist".into(),
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "unknown id must surface as an error, not a silent Ok"
+    );
+}
+
+/// Acceptance: CancelBackgroundTask trips the registry's cancellation
+/// token and the targeted task reaches the `Cancelled` terminal state.
+#[tokio::test]
+async fn cancel_background_task_propagates_to_registry() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+
+    // Spawn a cooperatively-cancellable task that watches its token.
+    let started = Arc::new(Notify::new());
+    let started_clone = Arc::clone(&started);
+    let id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: "cancel-me".into(),
+            conversation_id: "c".into(),
+        },
+        "cancel-me".into(),
+        move |ctx| async move {
+            started_clone.notify_one();
+            ctx.token.cancelled().await;
+            Ok(())
+        },
+    );
+    started.notified().await;
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::CancelBackgroundTask { id: id.0.clone() },
+        )
+        .await
+        .expect("cancel ok");
+    assert!(matches!(result, api::CommandResult::Ack));
+
+    registry.wait(&id).await;
+    let view = registry.get(&user, &id).expect("present");
+    assert_eq!(view.status, api::TaskStatus::Cancelled);
+}
+
+/// Unhappy: cancelling a task that's already in a terminal state surfaces
+/// an error frame instead of pretending the cancel succeeded. This is the
+/// `AlreadyTerminal` rule from #115 — without it, "cancel" on a Failed
+/// row would look like a silent no-op.
+#[tokio::test]
+async fn cancel_already_terminal_task_returns_structured_error() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let id = spawn_completing_task(&registry, &user, "done");
+    registry.wait(&id).await;
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::CancelBackgroundTask { id: id.0.clone() },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "cancelling a terminal task must be an error, got {result:?}"
+    );
+}
+
+/// Unhappy: user B cannot cancel user A's task. The error reads as
+/// NotFound (existence-hiding contract from #105), never as Forbidden,
+/// so the surface doesn't leak that task A exists.
+#[tokio::test]
+async fn cross_user_cancel_returns_not_found() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let alice = unique_user("alice");
+    let bob = unique_user("bob");
+    let id = spawn_dummy_task(&registry, &alice, "alice-task");
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(bob.clone()),
+            api::Command::CancelBackgroundTask { id: id.0.clone() },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "bob must not be able to cancel alice's task; got {result:?}"
+    );
+    // The error message must NOT reveal existence — it must read as
+    // "not found", not "forbidden" or similar.
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.to_lowercase().contains("not found"),
+        "cross-user cancel must surface as 'not found' to avoid leaking existence; got {err:?}",
+    );
+}
+
+/// Acceptance: GetBackgroundTaskLogs paginates by `after_seq`.
+#[tokio::test]
+async fn task_log_pagination_works_via_after_seq() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+
+    // Spawn a task that emits 50 status log lines then waits.
+    let release = Arc::new(Notify::new());
+    let release_clone = Arc::clone(&release);
+    let id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Standalone {
+            name: "logger".into(),
+            conversation_id: "c".into(),
+        },
+        "logger".into(),
+        move |ctx| async move {
+            for i in 0..50 {
+                ctx.logs.append(
+                    api::LogLevel::Info,
+                    api::LogCategory::Status,
+                    format!("line {i}"),
+                    None,
+                );
+            }
+            release_clone.notified().await;
+            Ok(())
+        },
+    );
+    // Give the task time to emit its log lines.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let first = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::GetBackgroundTaskLogs {
+                id: id.0.clone(),
+                after_seq: Some(0),
+                limit: Some(20),
+            },
+        )
+        .await
+        .expect("logs ok");
+    let (entries1, next_seq1) = match first {
+        api::CommandResult::BackgroundTaskLogs { entries, next_seq } => (entries, next_seq),
+        other => panic!("unexpected result: {other:?}"),
+    };
+    // The first lifecycle "task started" entry uses seq=1; the 50 status
+    // lines occupy seq=2..=51. A page with after_seq=0 limit=20 returns
+    // seq=1..=20 inclusive — so 20 entries, next_seq=21.
+    assert_eq!(entries1.len(), 20);
+    assert_eq!(next_seq1, 21);
+
+    let second = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::GetBackgroundTaskLogs {
+                id: id.0.clone(),
+                after_seq: Some(next_seq1 - 1),
+                limit: Some(20),
+            },
+        )
+        .await
+        .expect("logs ok");
+    let (entries2, _) = match second {
+        api::CommandResult::BackgroundTaskLogs { entries, next_seq } => (entries, next_seq),
+        other => panic!("unexpected result: {other:?}"),
+    };
+    // No log entry should be returned twice across pages.
+    let seqs1: std::collections::HashSet<_> = entries1.iter().map(|e| e.seq).collect();
+    let seqs2: std::collections::HashSet<_> = entries2.iter().map(|e| e.seq).collect();
+    assert!(seqs1.is_disjoint(&seqs2), "pages must not overlap");
+    assert_eq!(entries2.len(), 20);
+
+    release.notify_one();
+    registry.wait(&id).await;
+}
+
+/// Default limits: when `after_seq` and `limit` are omitted the daemon
+/// returns the recent slice (up to the documented default of 200) without
+/// failing. Pinning this protects clients that send the minimal payload.
+#[tokio::test]
+async fn task_log_defaults_apply_when_optional_fields_omitted() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let id = spawn_completing_task(&registry, &user, "tiny");
+    registry.wait(&id).await;
+
+    let result = handler
+        .handle_command_for(
+            RequestContext::for_user(user),
+            api::Command::GetBackgroundTaskLogs {
+                id: id.0.clone(),
+                after_seq: None,
+                limit: None,
+            },
+        )
+        .await
+        .expect("logs ok");
+    match result {
+        api::CommandResult::BackgroundTaskLogs { entries, .. } => {
+            // start + completion lifecycle markers.
+            assert!(!entries.is_empty(), "expected lifecycle entries");
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+/// Subscribe and Unsubscribe Ack immediately at the handler level (the
+/// dispatcher attaches the real broadcast forwarder separately, but the
+/// arms themselves must return `Ack`).
+#[tokio::test]
+async fn subscribe_and_unsubscribe_ack_immediately() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+    let user = unique_user("alice");
+
+    let sub = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::SubscribeBackgroundTasks,
+        )
+        .await
+        .expect("subscribe ok");
+    assert!(matches!(sub, api::CommandResult::Ack));
+
+    let unsub = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::UnsubscribeBackgroundTasks,
+        )
+        .await
+        .expect("unsubscribe ok");
+    assert!(matches!(unsub, api::CommandResult::Ack));
+}
+
+/// The default handler exposes the registry's per-user broadcast receiver
+/// so the dispatcher (or any other transport-level forwarder) can fan
+/// `Event::Task*` out to a connection. Without this hook, Subscribe is
+/// a no-op at the wire level.
+#[tokio::test]
+async fn handler_exposes_user_broadcast_receiver_when_registry_attached() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+    let user = unique_user("alice");
+
+    let receiver = with_user_id(user.clone(), async {
+        handler.subscribe_user_events().await
+    })
+    .await;
+    let mut rx = receiver.expect("handler returns receiver when registry attached");
+
+    // Trigger an event by spawning a task — the receiver should observe
+    // TaskStarted.
+    let _id = spawn_completing_task(&registry, &user, "trigger");
+
+    let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("event arrived")
+        .expect("channel open");
+    assert!(matches!(ev, api::Event::TaskStarted { .. }));
+}
+
+/// When no registry is attached, the handler must return None from
+/// `subscribe_user_events` so the dispatcher knows to error out the
+/// Subscribe command rather than spawn a forwarder that would never
+/// receive anything.
+#[tokio::test]
+async fn handler_returns_none_receiver_when_registry_not_attached() {
+    let handler = DefaultAssistantApiHandler::new(
+        Arc::new(FakeAssistant),
+        Arc::new(RecordingConversations::new()),
+        Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
+    );
+    let user = unique_user("alice");
+    let receiver = with_user_id(user, async { handler.subscribe_user_events().await }).await;
+    assert!(receiver.is_none());
+}
+
+/// Acceptance: `SendMessage` is registered as a background task and the
+/// new ack carries the task id. Without it, clients can't correlate the
+/// streaming events back to a `ListBackgroundTasks` row.
+#[tokio::test]
+async fn start_send_message_returns_task_id_that_appears_in_listing() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(convs, Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let sink: Arc<dyn desktop_assistant_application::EventSink> = Arc::new(NoopSink);
+
+    let task_id = with_user_id(user.clone(), async {
+        handler
+            .start_send_message(
+                "conv-x".into(),
+                "hello".into(),
+                None,
+                "req-1".into(),
+                Arc::clone(&sink),
+            )
+            .await
+    })
+    .await
+    .expect("start_send_message ok");
+    let task_id = task_id.expect("registry attached, expected Some(task_id)");
+
+    // The new id is visible to the same user via List.
+    let list = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::ListBackgroundTasks {
+                include_finished: true,
+                limit: None,
+            },
+        )
+        .await
+        .expect("list ok");
+    let tasks = match list {
+        api::CommandResult::BackgroundTasks(t) => t,
+        other => panic!("unexpected: {other:?}"),
+    };
+    assert!(tasks.iter().any(|t| t.id == task_id));
+
+    registry.wait(&task_id).await;
+}
+
+/// Without a registry the handler's `start_send_message` returns `None`
+/// so the dispatcher knows to fall back to the pre-#114 streaming path.
+#[tokio::test]
+async fn start_send_message_returns_none_without_registry() {
+    let handler = DefaultAssistantApiHandler::new(
+        Arc::new(FakeAssistant),
+        Arc::new(RecordingConversations::new()),
+        Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
+    );
+    let user = unique_user("alice");
+    let sink: Arc<dyn desktop_assistant_application::EventSink> = Arc::new(NoopSink);
+
+    let result = with_user_id(user, async {
+        handler
+            .start_send_message(
+                "conv-x".into(),
+                "hello".into(),
+                None,
+                "req-1".into(),
+                sink,
+            )
+            .await
+    })
+    .await
+    .expect("start ok");
+    assert!(result.is_none(), "no registry → no task id");
+}
+
+/// Business outcome: a user can list their running standalone agent.
+/// This is the end-user-facing acceptance test from #114.
+#[tokio::test]
+async fn business_outcome_user_can_list_their_running_standalone_agent() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let release = Arc::new(Notify::new());
+    convs.block_on(Arc::clone(&release));
+    let handler = make_handler(Arc::clone(&convs), Arc::clone(&registry));
+
+    let user = unique_user("alice");
+
+    // Spawn a standalone agent.
+    let spawn_result = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::SpawnStandaloneAgent {
+                name: "researcher".into(),
+                initial_prompt: "go".into(),
+                override_selection: None,
+                tools: None,
+            },
+        )
+        .await
+        .expect("spawn ok");
+    let task_id = match spawn_result {
+        api::CommandResult::BackgroundTaskSpawned { id } => api::TaskId(id),
+        other => panic!("unexpected: {other:?}"),
+    };
+
+    // Briefly wait for the registered row to settle into Running.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let list = handler
+        .handle_command_for(
+            RequestContext::for_user(user.clone()),
+            api::Command::ListBackgroundTasks {
+                include_finished: false,
+                limit: None,
+            },
+        )
+        .await
+        .expect("list ok");
+    let tasks = match list {
+        api::CommandResult::BackgroundTasks(t) => t,
+        other => panic!("unexpected: {other:?}"),
+    };
+    let me = tasks
+        .iter()
+        .find(|t| t.id == task_id)
+        .expect("standalone visible in list");
+    assert_eq!(me.status, api::TaskStatus::Running);
+    assert!(me.title.contains("researcher"), "title: {}", me.title);
+
+    release.notify_one();
+    registry.wait(&task_id).await;
+}
+
+struct NoopSink;
+#[async_trait::async_trait]
+impl desktop_assistant_application::EventSink for NoopSink {
+    async fn emit(&self, _event: api::Event) -> bool {
+        true
+    }
+}
+
+#[allow(dead_code)]
+fn _silence_unused(c: &RecordingConversations) -> &Mutex<Vec<SendCall>> {
+    let _ = current_user_id();
+    &c.sends
+}

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -268,12 +268,18 @@ impl WsClient {
                 override_selection,
             })
             .await?;
-        let api::CommandResult::Ack = result else {
-            return Err(anyhow!("unexpected websocket response for send_prompt"));
-        };
-
-        // WS send-message ack does not include request id; first stream event carries it.
-        Ok(String::new())
+        // Post-#114 the daemon returns `SendMessageAck { task_id }`
+        // when its handler is wired with a `BackgroundTaskRegistry`;
+        // older / test daemons may still return the legacy bare `Ack`.
+        // Both are valid wire-level acks for this call site — the
+        // task id is surfaced via streaming events, not the ack.
+        match result {
+            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
+            api::CommandResult::Ack => Ok(String::new()),
+            other => Err(anyhow!(
+                "unexpected websocket response for send_prompt: {other:?}"
+            )),
+        }
     }
 
     /// List models across every healthy connection. Pass `connection_id =

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -131,6 +131,14 @@ pub async fn dispatch_loop<R, W>(
     // across `tokio::spawn`).
     let user_id = UserId::new(auth.user_id.clone());
 
+    // Per-connection state for `SubscribeBackgroundTasks` (#114).
+    // At most one forwarder runs per connection — Subscribe is
+    // idempotent (a second one observes the existing handle and Acks
+    // without spawning a duplicate). Unsubscribe aborts the handle;
+    // when the connection drops we abort it as part of the loop's
+    // teardown so the broadcast receiver is dropped cleanly.
+    let mut bg_subscription: Option<tokio::task::JoinHandle<()>> = None;
+
     while let Some(item) = inbound.next().await {
         let req = match item {
             Ok(req) => req,
@@ -153,9 +161,172 @@ pub async fn dispatch_loop<R, W>(
                 let sink: Arc<dyn EventSink> =
                     Arc::new(ChannelEventSink::new(out_tx.clone()));
 
+                // Prefer the new `start_send_message` registration
+                // path so the ack can carry the registered task id
+                // (#114). When the handler opts out (no registry
+                // attached — single-tenant tests and the like) we
+                // fall back to the legacy bare-`Ack` + inline
+                // streaming path that pre-#114 transports used.
+                let task_id = with_user_id(
+                    user_id.clone(),
+                    handler.start_send_message(
+                        conversation_id.clone(),
+                        content.clone(),
+                        override_selection.clone(),
+                        request_id.clone(),
+                        Arc::clone(&sink),
+                    ),
+                )
+                .await;
+
+                match task_id {
+                    Ok(Some(id)) => {
+                        // Handler registered the turn via the registry
+                        // and the body is already running in the
+                        // background — emit the new typed ack and
+                        // continue the loop.
+                        if out_tx
+                            .send(WsFrame::Result {
+                                id: req.id.clone(),
+                                result: api::CommandResult::SendMessageAck {
+                                    task_id: id.0,
+                                },
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        // Legacy path: ack first, then drive the
+                        // streaming send on a spawned task so the
+                        // dispatcher remains responsive.
+                        if out_tx
+                            .send(WsFrame::Result {
+                                id: req.id.clone(),
+                                result: api::CommandResult::Ack,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        let handler = Arc::clone(&handler);
+                        let user_id_for_task = user_id.clone();
+                        tokio::spawn(async move {
+                            let _ = with_user_id(
+                                user_id_for_task,
+                                handler.handle_send_message_with_override(
+                                    conversation_id,
+                                    content,
+                                    override_selection,
+                                    request_id,
+                                    sink,
+                                ),
+                            )
+                            .await;
+                        });
+                    }
+                    Err(ApiError::Core(e)) => {
+                        if out_tx
+                            .send(WsFrame::Error {
+                                id: req.id,
+                                error: e,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        if out_tx
+                            .send(WsFrame::Error {
+                                id: req.id,
+                                error: e.to_string(),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Subscribe/Unsubscribe for background-task events (#114).
+            // The handler's command arm only Acks at the protocol
+            // level; the actual broadcast→connection forwarder is a
+            // dispatcher concern because it owns the outbound channel
+            // and the per-connection lifetime.
+            api::Command::SubscribeBackgroundTasks => {
+                if bg_subscription.is_some() {
+                    // Idempotent: a second subscribe on a connection
+                    // that already has a live forwarder just Acks.
+                    if out_tx
+                        .send(WsFrame::Result {
+                            id: req.id,
+                            result: api::CommandResult::Ack,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    continue;
+                }
+                let receiver = with_user_id(
+                    user_id.clone(),
+                    handler.subscribe_user_events(),
+                )
+                .await;
+                let Some(mut receiver) = receiver else {
+                    // No-op handler → no event source. Surface as a
+                    // clean error frame so the client knows
+                    // subscription is unsupported here.
+                    if out_tx
+                        .send(WsFrame::Error {
+                            id: req.id,
+                            error: "background-task subscription not supported by this handler"
+                                .to_string(),
+                        })
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    continue;
+                };
+                let out_tx_for_forwarder = out_tx.clone();
+                let handle = tokio::spawn(async move {
+                    use tokio::sync::broadcast::error::RecvError;
+                    loop {
+                        match receiver.recv().await {
+                            Ok(event) => {
+                                if out_tx_for_forwarder
+                                    .send(WsFrame::Event { event })
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Err(RecvError::Lagged(n)) => {
+                                warn!(
+                                    "background-task event subscriber lagged \
+                                     by {n} events; oldest dropped"
+                                );
+                                continue;
+                            }
+                            Err(RecvError::Closed) => break,
+                        }
+                    }
+                });
+                bg_subscription = Some(handle);
                 if out_tx
                     .send(WsFrame::Result {
-                        id: req.id.clone(),
+                        id: req.id,
                         result: api::CommandResult::Ack,
                     })
                     .await
@@ -163,27 +334,21 @@ pub async fn dispatch_loop<R, W>(
                 {
                     break;
                 }
-
-                let handler = Arc::clone(&handler);
-                let user_id_for_task = user_id.clone();
-                tokio::spawn(async move {
-                    // Re-install the per-connection user id inside the
-                    // spawned task — `task_local` scopes do not inherit
-                    // across `tokio::spawn`. Without this, the streaming
-                    // path would resolve to `UserId::default` and write
-                    // messages under the sentinel partition.
-                    let _ = with_user_id(
-                        user_id_for_task,
-                        handler.handle_send_message_with_override(
-                            conversation_id,
-                            content,
-                            override_selection,
-                            request_id,
-                            sink,
-                        ),
-                    )
-                    .await;
-                });
+            }
+            api::Command::UnsubscribeBackgroundTasks => {
+                if let Some(handle) = bg_subscription.take() {
+                    handle.abort();
+                }
+                if out_tx
+                    .send(WsFrame::Result {
+                        id: req.id,
+                        result: api::CommandResult::Ack,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
             }
 
             api::Command::SetConfig { changes } => {
@@ -290,6 +455,15 @@ pub async fn dispatch_loop<R, W>(
                 }
             }
         }
+    }
+
+    // Abort the background-task forwarder (if any) so the broadcast
+    // receiver is dropped synchronously rather than waiting on a
+    // future Lagged/Closed observation. Without this the receiver
+    // would buffer events nobody is listening for until the registry
+    // shuts down (#114).
+    if let Some(handle) = bg_subscription.take() {
+        handle.abort();
     }
 
     // Drop the inbound side's `out_tx` so the writer can finish

--- a/crates/transport-dispatch/tests/background_task_wiring.rs
+++ b/crates/transport-dispatch/tests/background_task_wiring.rs
@@ -203,12 +203,10 @@ async fn try_next_frame(rx: &mut mpsc::Receiver<WsFrame>) -> Option<WsFrame> {
 /// loop alive across multiple sends so we can trigger registry events
 /// out-of-band. Returns `'static`-friendly types so the resulting future
 /// can be `tokio::spawn`ed.
-fn open_inbound() -> (
-    mpsc::Sender<anyhow::Result<WsRequest>>,
-    std::pin::Pin<
-        Box<dyn futures::Stream<Item = anyhow::Result<WsRequest>> + Send + 'static>,
-    >,
-) {
+type InboundStream =
+    std::pin::Pin<Box<dyn futures::Stream<Item = anyhow::Result<WsRequest>> + Send + 'static>>;
+
+fn open_inbound() -> (mpsc::Sender<anyhow::Result<WsRequest>>, InboundStream) {
     let (tx, rx) = mpsc::channel::<anyhow::Result<WsRequest>>(8);
     let stream = futures::stream::unfold(rx, |mut rx| async move {
         use futures::StreamExt;
@@ -265,18 +263,16 @@ async fn subscribe_then_registry_event_streams_to_connection() {
     // connection.
     let mut saw_task_event = false;
     for _ in 0..10 {
-        if let Some(frame) = try_next_frame(&mut out_rx).await {
-            if let WsFrame::Event { event } = frame {
-                if matches!(
-                    event,
-                    api::Event::TaskStarted { .. }
-                        | api::Event::TaskCompleted { .. }
-                        | api::Event::TaskLogAppended { .. }
-                ) {
-                    saw_task_event = true;
-                    break;
-                }
-            }
+        if let Some(WsFrame::Event { event }) = try_next_frame(&mut out_rx).await
+            && matches!(
+                event,
+                api::Event::TaskStarted { .. }
+                    | api::Event::TaskCompleted { .. }
+                    | api::Event::TaskLogAppended { .. }
+            )
+        {
+            saw_task_event = true;
+            break;
         }
     }
     assert!(saw_task_event, "expected a Task* event on the connection");
@@ -339,18 +335,16 @@ async fn unsubscribe_stops_event_stream() {
 
     // Poll for a window — there should be no Task* events.
     for _ in 0..10 {
-        if let Some(frame) = try_next_frame(&mut out_rx).await {
-            if let WsFrame::Event { event } = frame {
-                assert!(
-                    !matches!(
-                        event,
-                        api::Event::TaskStarted { .. }
-                            | api::Event::TaskCompleted { .. }
-                            | api::Event::TaskLogAppended { .. }
-                    ),
-                    "no Task* event should arrive after Unsubscribe; got {event:?}"
-                );
-            }
+        if let Some(WsFrame::Event { event }) = try_next_frame(&mut out_rx).await {
+            assert!(
+                !matches!(
+                    event,
+                    api::Event::TaskStarted { .. }
+                        | api::Event::TaskCompleted { .. }
+                        | api::Event::TaskLogAppended { .. }
+                ),
+                "no Task* event should arrive after Unsubscribe; got {event:?}"
+            );
         }
     }
 

--- a/crates/transport-dispatch/tests/background_task_wiring.rs
+++ b/crates/transport-dispatch/tests/background_task_wiring.rs
@@ -1,0 +1,582 @@
+//! Dispatcher-level wiring tests for the background-task command surface
+//! (#114). These exercise the transport-agnostic `dispatch_loop` against a
+//! stub handler that exposes a real `BackgroundTaskRegistry` so the tests
+//! pin down the wire behaviour both the WS and UDS adapters inherit:
+//!
+//! - Subscribe spawns a forwarder that pumps the registry's per-user
+//!   broadcast channel into the outbound `WsFrame::Event` sink, until
+//!   Unsubscribe arrives or the connection drops.
+//! - Subscribe is idempotent at the per-connection level — a second
+//!   Subscribe on a connection that already has a live forwarder Acks
+//!   without leaking a second receiver.
+//! - SendMessage's response carries `SendMessageAck { task_id }` when
+//!   the handler registered the turn with the registry; the legacy bare
+//!   `Ack` is preserved for handlers that don't opt into registration.
+//! - When the handler exposes no broadcast hook (no registry attached)
+//!   Subscribe surfaces a clean error frame rather than spawning a dead
+//!   forwarder.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::background_tasks::BackgroundTaskRegistry;
+use desktop_assistant_application::{
+    ApiError, ApiResult, AssistantApiHandler, EventSink, UserId,
+};
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_transport_dispatch::{AuthContext, WsFrame, WsRequest, dispatch_loop};
+use futures::channel::mpsc;
+use futures::stream;
+use tokio::sync::broadcast;
+
+// ---------- Stub handler ----------
+
+/// Stub that routes the new background-task arms through a real
+/// `BackgroundTaskRegistry`. Other commands return `Unsupported` — the
+/// dispatcher tests only exercise the new surface.
+struct RegistryHandler {
+    registry: Arc<BackgroundTaskRegistry>,
+    /// Set when `start_send_message` is called, so tests can assert
+    /// whether the dispatcher routed through the new entry point.
+    start_send_calls: Mutex<u32>,
+}
+
+impl RegistryHandler {
+    fn new(registry: Arc<BackgroundTaskRegistry>) -> Self {
+        Self {
+            registry,
+            start_send_calls: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for RegistryHandler {
+    async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+        let user_id = current_user_id();
+        match cmd {
+            api::Command::ListBackgroundTasks {
+                include_finished,
+                limit,
+            } => {
+                let tasks = self.registry.list(&user_id, include_finished, limit);
+                Ok(api::CommandResult::BackgroundTasks(tasks))
+            }
+            api::Command::GetBackgroundTask { id } => self
+                .registry
+                .get(&user_id, &api::TaskId(id))
+                .map(api::CommandResult::BackgroundTask)
+                .ok_or_else(|| ApiError::Core("task not found".into())),
+            api::Command::CancelBackgroundTask { id } => self
+                .registry
+                .cancel(&user_id, &api::TaskId(id))
+                .map(|_| api::CommandResult::Ack)
+                .map_err(|e| ApiError::Core(e.to_string())),
+            api::Command::GetBackgroundTaskLogs {
+                id,
+                after_seq,
+                limit,
+            } => self
+                .registry
+                .logs(
+                    &user_id,
+                    &api::TaskId(id),
+                    after_seq.unwrap_or(0),
+                    limit.unwrap_or(200),
+                )
+                .map(|(entries, next_seq)| {
+                    api::CommandResult::BackgroundTaskLogs { entries, next_seq }
+                })
+                .map_err(|e| ApiError::Core(e.to_string())),
+            api::Command::SubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            api::Command::UnsubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            _ => Err(ApiError::Unsupported),
+        }
+    }
+
+    async fn handle_send_message(
+        &self,
+        _conversation_id: String,
+        _content: String,
+        _request_id: String,
+        _sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+
+    async fn subscribe_user_events(&self) -> Option<broadcast::Receiver<api::Event>> {
+        let user = current_user_id();
+        Some(self.registry.subscribe(&user))
+    }
+
+    async fn start_send_message(
+        &self,
+        conversation_id: String,
+        content: String,
+        _override_selection: Option<api::SendPromptOverride>,
+        _request_id: String,
+        _sink: Arc<dyn EventSink>,
+    ) -> ApiResult<Option<api::TaskId>> {
+        *self.start_send_calls.lock().unwrap() += 1;
+        let user = current_user_id();
+        let id = self.registry.spawn(
+            user,
+            api::TaskKind::Conversation {
+                conversation_id: conversation_id.clone(),
+            },
+            format!("Conversation: {conversation_id}"),
+            move |_ctx| async move {
+                let _ = content;
+                Ok(())
+            },
+        );
+        Ok(Some(id))
+    }
+}
+
+/// Handler with no event-subscription hook (mirrors a single-tenant
+/// deploy without an attached registry).
+struct NoSubscribeHandler;
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for NoSubscribeHandler {
+    async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+        match cmd {
+            api::Command::SubscribeBackgroundTasks | api::Command::UnsubscribeBackgroundTasks => {
+                Ok(api::CommandResult::Ack)
+            }
+            _ => Err(ApiError::Unsupported),
+        }
+    }
+    async fn handle_send_message(
+        &self,
+        _c: String,
+        _t: String,
+        _r: String,
+        _s: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+    // Default impl of subscribe_user_events returns None.
+}
+
+// ---------- Helpers ----------
+
+fn user(label: &str) -> AuthContext {
+    AuthContext::new(label)
+}
+
+/// Drive `dispatch_loop` against an in-memory stream of requests; return
+/// a receiver of outbound frames and the join handle for the loop.
+fn drive(
+    handler: Arc<dyn AssistantApiHandler>,
+    auth: AuthContext,
+    requests: Vec<WsRequest>,
+) -> (mpsc::Receiver<WsFrame>, tokio::task::JoinHandle<()>) {
+    let inbound = stream::iter(requests.into_iter().map(Ok::<_, anyhow::Error>));
+    let (out_tx, out_rx) = mpsc::channel::<WsFrame>(64);
+    let handle = tokio::spawn(dispatch_loop(handler, auth, inbound, out_tx));
+    (out_rx, handle)
+}
+
+async fn next_frame(rx: &mut mpsc::Receiver<WsFrame>) -> WsFrame {
+    use futures::StreamExt;
+    tokio::time::timeout(Duration::from_secs(2), rx.next())
+        .await
+        .expect("no frame within 2s")
+        .expect("outbound closed")
+}
+
+async fn try_next_frame(rx: &mut mpsc::Receiver<WsFrame>) -> Option<WsFrame> {
+    use futures::StreamExt;
+    tokio::time::timeout(Duration::from_millis(100), rx.next())
+        .await
+        .ok()
+        .flatten()
+}
+
+// ---------- Tests ----------
+
+/// Open-ended inbound stream backed by an mpsc — keeps the dispatcher
+/// loop alive across multiple sends so we can trigger registry events
+/// out-of-band. Returns `'static`-friendly types so the resulting future
+/// can be `tokio::spawn`ed.
+fn open_inbound() -> (
+    mpsc::Sender<anyhow::Result<WsRequest>>,
+    std::pin::Pin<
+        Box<dyn futures::Stream<Item = anyhow::Result<WsRequest>> + Send + 'static>,
+    >,
+) {
+    let (tx, rx) = mpsc::channel::<anyhow::Result<WsRequest>>(8);
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        use futures::StreamExt;
+        rx.next().await.map(|item| (item, rx))
+    });
+    (tx, Box::pin(stream))
+}
+
+/// Subscribe immediately Acks; subsequent registry events fan out to the
+/// connection as `WsFrame::Event` frames.
+#[tokio::test]
+async fn subscribe_then_registry_event_streams_to_connection() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> =
+        Arc::new(RegistryHandler::new(Arc::clone(&registry)));
+
+    let (mut in_tx, inbound) = open_inbound();
+    let (out_tx, mut out_rx) = mpsc::channel::<WsFrame>(64);
+
+    let dispatch = tokio::spawn(dispatch_loop(handler, user("alice"), inbound, out_tx));
+
+    // Subscribe.
+    use futures::SinkExt;
+    in_tx
+        .send(Ok(WsRequest {
+            id: "sub-1".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+
+    let ack = next_frame(&mut out_rx).await;
+    match ack {
+        WsFrame::Result { id, result } => {
+            assert_eq!(id, "sub-1");
+            assert!(matches!(result, api::CommandResult::Ack));
+        }
+        other => panic!("unexpected: {other:?}"),
+    }
+
+    // Trigger a TaskStarted by spawning a task under the same user
+    // identity as the connection.
+    let _id = registry.spawn(
+        UserId::new("alice"),
+        api::TaskKind::Standalone {
+            name: "x".into(),
+            conversation_id: "c".into(),
+        },
+        "x".into(),
+        |_ctx| async move { Ok(()) },
+    );
+
+    // The forwarder should push at least one Task* event onto the
+    // connection.
+    let mut saw_task_event = false;
+    for _ in 0..10 {
+        if let Some(frame) = try_next_frame(&mut out_rx).await {
+            if let WsFrame::Event { event } = frame {
+                if matches!(
+                    event,
+                    api::Event::TaskStarted { .. }
+                        | api::Event::TaskCompleted { .. }
+                        | api::Event::TaskLogAppended { .. }
+                ) {
+                    saw_task_event = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(saw_task_event, "expected a Task* event on the connection");
+
+    drop(in_tx);
+    let _ = dispatch.await;
+}
+
+/// Unsubscribe stops the forwarder; further registry events do not
+/// arrive on the connection.
+#[tokio::test]
+async fn unsubscribe_stops_event_stream() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> =
+        Arc::new(RegistryHandler::new(Arc::clone(&registry)));
+
+    let (mut in_tx, inbound) = open_inbound();
+    let (out_tx, mut out_rx) = mpsc::channel::<WsFrame>(64);
+
+    let dispatch = tokio::spawn(dispatch_loop(handler, user("alice"), inbound, out_tx));
+
+    use futures::SinkExt;
+    in_tx
+        .send(Ok(WsRequest {
+            id: "sub-1".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+    let _ = next_frame(&mut out_rx).await; // subscribe ack
+
+    in_tx
+        .send(Ok(WsRequest {
+            id: "unsub-1".into(),
+            command: api::Command::UnsubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+    let unsub_ack = next_frame(&mut out_rx).await;
+    match unsub_ack {
+        WsFrame::Result { id, result } => {
+            assert_eq!(id, "unsub-1");
+            assert!(matches!(result, api::CommandResult::Ack));
+        }
+        other => panic!("unexpected: {other:?}"),
+    }
+
+    // Spawn a task AFTER unsubscribe — its events must not arrive on this
+    // connection. Give the dispatcher time to process the Unsubscribe.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let _id = registry.spawn(
+        UserId::new("alice"),
+        api::TaskKind::Standalone {
+            name: "post-unsub".into(),
+            conversation_id: "c".into(),
+        },
+        "post-unsub".into(),
+        |_ctx| async move { Ok(()) },
+    );
+
+    // Poll for a window — there should be no Task* events.
+    for _ in 0..10 {
+        if let Some(frame) = try_next_frame(&mut out_rx).await {
+            if let WsFrame::Event { event } = frame {
+                assert!(
+                    !matches!(
+                        event,
+                        api::Event::TaskStarted { .. }
+                            | api::Event::TaskCompleted { .. }
+                            | api::Event::TaskLogAppended { .. }
+                    ),
+                    "no Task* event should arrive after Unsubscribe; got {event:?}"
+                );
+            }
+        }
+    }
+
+    drop(in_tx);
+    let _ = dispatch.await;
+}
+
+/// Dropping the connection cleanly tears down the forwarder. We assert
+/// this indirectly by verifying that subsequent registry broadcasts to
+/// the same user observe no broadcast lag (i.e. the per-connection
+/// receiver has been dropped — otherwise it would buffer forever and
+/// eventually overflow the channel).
+#[tokio::test]
+async fn connection_drop_cancels_event_subscription_cleanly() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> =
+        Arc::new(RegistryHandler::new(Arc::clone(&registry)));
+
+    let (mut in_tx, inbound) = open_inbound();
+    let (out_tx, mut out_rx) = mpsc::channel::<WsFrame>(64);
+
+    let dispatch = tokio::spawn(dispatch_loop(handler, user("alice"), inbound, out_tx));
+
+    use futures::SinkExt;
+    in_tx
+        .send(Ok(WsRequest {
+            id: "sub-1".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+    let _ = next_frame(&mut out_rx).await;
+
+    // Drop the inbound sender so the dispatcher exits cleanly; drop
+    // the outbound receiver to force the writer to bail.
+    drop(in_tx);
+    drop(out_rx);
+
+    // The dispatcher should exit within the timeout; if it hangs, the
+    // forwarder is leaking and holding the loop open.
+    tokio::time::timeout(Duration::from_secs(2), dispatch)
+        .await
+        .expect("dispatcher should exit after the connection drops")
+        .expect("dispatcher join error");
+}
+
+/// SendMessage with a handler that registers via `start_send_message`
+/// produces `SendMessageAck { task_id }` — and the id matches a row in
+/// the registry.
+#[tokio::test]
+async fn send_message_ack_carries_a_real_task_id() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> =
+        Arc::new(RegistryHandler::new(Arc::clone(&registry)));
+
+    let (mut out_rx, handle) = drive(
+        handler,
+        user("alice"),
+        vec![WsRequest {
+            id: "send-1".into(),
+            command: api::Command::SendMessage {
+                conversation_id: "conv-1".into(),
+                content: "hello".into(),
+                override_selection: None,
+            },
+        }],
+    );
+
+    let frame = next_frame(&mut out_rx).await;
+    let task_id = match frame {
+        WsFrame::Result {
+            id,
+            result: api::CommandResult::SendMessageAck { task_id },
+        } => {
+            assert_eq!(id, "send-1");
+            api::TaskId(task_id)
+        }
+        other => panic!("expected SendMessageAck, got {other:?}"),
+    };
+
+    // The id must point to a real row in the registry.
+    assert!(registry.get(&UserId::new("alice"), &task_id).is_some());
+
+    let _ = handle.await;
+}
+
+/// When the handler does NOT opt into `start_send_message` (default impl
+/// returns `None`), the dispatcher falls back to the legacy bare-Ack
+/// flow so existing transports keep working.
+#[tokio::test]
+async fn send_message_falls_back_to_legacy_ack_when_handler_opts_out() {
+    /// Stub that only implements `handle_send_message` (no
+    /// `start_send_message` override) — the dispatcher should not panic
+    /// and should send `CommandResult::Ack` back.
+    struct LegacyHandler;
+    #[async_trait::async_trait]
+    impl AssistantApiHandler for LegacyHandler {
+        async fn handle_command(&self, _cmd: api::Command) -> ApiResult<api::CommandResult> {
+            Err(ApiError::Unsupported)
+        }
+        async fn handle_send_message(
+            &self,
+            _c: String,
+            _t: String,
+            _r: String,
+            _s: Arc<dyn EventSink>,
+        ) -> ApiResult<()> {
+            Ok(())
+        }
+    }
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(LegacyHandler);
+    let (mut out_rx, handle) = drive(
+        handler,
+        user("alice"),
+        vec![WsRequest {
+            id: "send-2".into(),
+            command: api::Command::SendMessage {
+                conversation_id: "conv-2".into(),
+                content: "hello".into(),
+                override_selection: None,
+            },
+        }],
+    );
+
+    let frame = next_frame(&mut out_rx).await;
+    match frame {
+        WsFrame::Result {
+            id,
+            result: api::CommandResult::Ack,
+        } => assert_eq!(id, "send-2"),
+        other => panic!("expected legacy Ack, got {other:?}"),
+    }
+
+    let _ = handle.await;
+}
+
+/// A handler with no event-subscription support surfaces Subscribe as
+/// an error frame rather than a silent Ack that wouldn't stream
+/// anything. This protects clients that rely on the Ack-meaning-"I'll
+/// stream events".
+#[tokio::test]
+async fn subscribe_returns_error_when_handler_opts_out() {
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(NoSubscribeHandler);
+    let (mut out_rx, handle) = drive(
+        handler,
+        user("alice"),
+        vec![WsRequest {
+            id: "sub-1".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }],
+    );
+    let frame = next_frame(&mut out_rx).await;
+    match frame {
+        WsFrame::Error { id, .. } => assert_eq!(id, "sub-1"),
+        other => panic!("expected Error frame for unsupported subscribe, got {other:?}"),
+    }
+    let _ = handle.await;
+}
+
+/// A second Subscribe on a connection that already has a live forwarder
+/// is idempotent — it Acks without spawning a duplicate forwarder. Tests
+/// that no duplicate event arrives downstream when a single registry
+/// broadcast fires.
+#[tokio::test]
+async fn subscribe_is_idempotent_per_connection() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> =
+        Arc::new(RegistryHandler::new(Arc::clone(&registry)));
+
+    let (mut in_tx, inbound) = open_inbound();
+    let (out_tx, mut out_rx) = mpsc::channel::<WsFrame>(64);
+
+    let dispatch = tokio::spawn(dispatch_loop(handler, user("alice"), inbound, out_tx));
+
+    use futures::SinkExt;
+    in_tx
+        .send(Ok(WsRequest {
+            id: "sub-1".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+    let _ = next_frame(&mut out_rx).await; // first ack
+
+    in_tx
+        .send(Ok(WsRequest {
+            id: "sub-2".into(),
+            command: api::Command::SubscribeBackgroundTasks,
+        }))
+        .await
+        .unwrap();
+    let frame = next_frame(&mut out_rx).await;
+    match frame {
+        WsFrame::Result { id, result } => {
+            assert_eq!(id, "sub-2");
+            assert!(matches!(result, api::CommandResult::Ack));
+        }
+        other => panic!("unexpected: {other:?}"),
+    }
+
+    // Spawn a single task and count Task* events arriving on the
+    // connection — there must be exactly one TaskStarted (not two).
+    let _id = registry.spawn(
+        UserId::new("alice"),
+        api::TaskKind::Standalone {
+            name: "once".into(),
+            conversation_id: "c".into(),
+        },
+        "once".into(),
+        |_ctx| async move { Ok(()) },
+    );
+
+    let mut started_count = 0;
+    for _ in 0..20 {
+        if let Some(WsFrame::Event {
+            event: api::Event::TaskStarted { .. },
+        }) = try_next_frame(&mut out_rx).await
+        {
+            started_count += 1;
+        }
+    }
+    assert_eq!(
+        started_count, 1,
+        "second Subscribe must not duplicate the forwarder; expected 1 TaskStarted, got {started_count}"
+    );
+
+    drop(in_tx);
+    let _ = dispatch.await;
+}

--- a/crates/uds-interface/tests/background_tasks.rs
+++ b/crates/uds-interface/tests/background_tasks.rs
@@ -1,0 +1,202 @@
+//! End-to-end UDS smoke test for the background-task command surface.
+//!
+//! Per #114 acceptance: the dispatcher refactor (#103) means both WS
+//! and UDS share the same `dispatch_loop`. This test drives a
+//! real UDS listener with a registry-backed handler and verifies the
+//! same `ListBackgroundTasks` + `SubscribeBackgroundTasks` story works
+//! over the framed byte-stream transport. If a future change wires the
+//! arms only on the WS side, this test breaks.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::background_tasks::BackgroundTaskRegistry;
+use desktop_assistant_application::{
+    ApiError, ApiResult, AssistantApiHandler, EventSink, UserId,
+};
+use desktop_assistant_auth_jwt as jwt;
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_uds::{
+    UdsAuthValidator, UdsServer, UdsServerConfig, read_frame, write_frame,
+};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::sync::broadcast;
+use tokio::time::{Duration, timeout};
+
+const ISS: &str = "test-uds-iss";
+const AUD: &str = "test-uds-aud";
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn mint_test_jwt(signing_key: &str, subject: &str) -> String {
+    let now = unix_now();
+    let claims = jwt::Claims {
+        iss: ISS.into(),
+        sub: subject.into(),
+        aud: AUD.into(),
+        exp: now + 600,
+        iat: now,
+        nbf: now.saturating_sub(1),
+        jti: uuid::Uuid::new_v4().to_string(),
+    };
+    jwt::encode(&claims, signing_key).expect("encode jwt")
+}
+
+/// Handler with the same background-task wiring as the dispatcher test.
+struct RegistryHandler {
+    registry: Arc<BackgroundTaskRegistry>,
+}
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for RegistryHandler {
+    async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+        let user_id = current_user_id();
+        match cmd {
+            api::Command::ListBackgroundTasks {
+                include_finished,
+                limit,
+            } => Ok(api::CommandResult::BackgroundTasks(self.registry.list(
+                &user_id,
+                include_finished,
+                limit,
+            ))),
+            api::Command::SubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            _ => Err(ApiError::Unsupported),
+        }
+    }
+    async fn handle_send_message(
+        &self,
+        _c: String,
+        _t: String,
+        _r: String,
+        _s: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+    async fn subscribe_user_events(&self) -> Option<broadcast::Receiver<api::Event>> {
+        Some(self.registry.subscribe(&current_user_id()))
+    }
+}
+
+struct StaticJwtAuth {
+    signing_key: String,
+}
+
+#[async_trait::async_trait]
+impl UdsAuthValidator for StaticJwtAuth {
+    async fn validate_bearer_token(&self, token: &str) -> bool {
+        jwt::decode(token, &self.signing_key, ISS, AUD).is_ok()
+    }
+    async fn extract_user_id(&self, token: &str) -> Option<UserId> {
+        jwt::decode(token, &self.signing_key, ISS, AUD)
+            .ok()
+            .map(|claims| UserId::new(claims.sub))
+    }
+}
+
+fn socket_path(dir: &TempDir) -> PathBuf {
+    dir.path().join("adelie.sock")
+}
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if path.exists() && UnixStream::connect(path).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("uds socket {path:?} did not appear");
+}
+
+/// Acceptance: the new ListBackgroundTasks arm works over UDS end-to-end.
+/// This proves the dispatcher refactor (#103) is the single point of
+/// truth — a regression that only wires WS gets caught here.
+#[tokio::test]
+async fn uds_list_background_tasks_through_shared_dispatcher() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = socket_path(&dir);
+
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(RegistryHandler {
+        registry: Arc::clone(&registry),
+    });
+    let auth: Arc<dyn UdsAuthValidator> = Arc::new(StaticJwtAuth {
+        signing_key: signing_key.clone(),
+    });
+    let config = UdsServerConfig::new(path.clone());
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = UdsServer::new(Arc::clone(&handler), auth, config);
+    let server_join = tokio::spawn(async move {
+        server
+            .serve_with_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+    wait_for_socket(&path).await;
+
+    // Spawn two tasks under alice in the registry before the client
+    // connects — proves the dispatcher reads from the live registry.
+    let alice = UserId::new("alice");
+    for i in 0..2 {
+        registry.spawn(
+            alice.clone(),
+            api::TaskKind::Standalone {
+                name: format!("task-{i}"),
+                conversation_id: "c".into(),
+            },
+            format!("task-{i}"),
+            |_ctx| async move {
+                // Hold the task alive for the test by waiting forever; the
+                // server task will be aborted at the end of the test.
+                std::future::pending::<()>().await;
+                Ok(())
+            },
+        );
+    }
+
+    let mut stream = UnixStream::connect(&path).await.unwrap();
+    let token = mint_test_jwt(&signing_key, "alice");
+    let handshake = serde_json::json!({ "jwt": token });
+    write_frame(&mut stream, &serde_json::to_vec(&handshake).unwrap())
+        .await
+        .unwrap();
+
+    let req = api::WsRequest {
+        id: "list-1".into(),
+        command: api::Command::ListBackgroundTasks {
+            include_finished: false,
+            limit: None,
+        },
+    };
+    write_frame(&mut stream, &serde_json::to_vec(&req).unwrap())
+        .await
+        .unwrap();
+
+    let raw = timeout(Duration::from_secs(2), read_frame(&mut stream))
+        .await
+        .expect("no response within 2s")
+        .expect("io error");
+    let frame: api::WsFrame = serde_json::from_slice(&raw).unwrap();
+    match frame {
+        api::WsFrame::Result {
+            id,
+            result: api::CommandResult::BackgroundTasks(tasks),
+        } => {
+            assert_eq!(id, "list-1");
+            assert_eq!(tasks.len(), 2, "expected the two alice tasks");
+        }
+        other => panic!("unexpected frame: {other:?}"),
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = server_join.await;
+}

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -14,7 +14,9 @@ use desktop_assistant_api_model as api;
 use desktop_assistant_application::{AssistantApiHandler, UserId};
 use desktop_assistant_transport_dispatch::{AuthContext, dispatch_loop};
 use futures::{SinkExt, StreamExt};
-use tracing::{debug, warn};
+#[cfg(feature = "tls")]
+use tracing::debug;
+use tracing::warn;
 
 pub use api::{WsFrame, WsRequest};
 

--- a/crates/ws-interface/tests/background_tasks.rs
+++ b/crates/ws-interface/tests/background_tasks.rs
@@ -1,0 +1,235 @@
+//! End-to-end WebSocket smoke tests for the background-task command
+//! surface (#114). The dispatcher-level contract is covered by tests in
+//! `desktop-assistant-transport-dispatch`; this file verifies the wiring
+//! survives the full WS upgrade + JSON framing round-trip.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::background_tasks::BackgroundTaskRegistry;
+use desktop_assistant_application::{
+    ApiError, ApiResult, AssistantApiHandler, EventSink, UserId,
+};
+use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_ws::{WsAuthValidator, WsFrame, WsRequest, router};
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::broadcast;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+/// Handler exposing a real `BackgroundTaskRegistry` for the new
+/// background-task arms. The other arms are not exercised here.
+struct RegistryHandler {
+    registry: Arc<BackgroundTaskRegistry>,
+}
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for RegistryHandler {
+    async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+        let user_id = current_user_id();
+        match cmd {
+            api::Command::ListBackgroundTasks {
+                include_finished,
+                limit,
+            } => Ok(api::CommandResult::BackgroundTasks(self.registry.list(
+                &user_id,
+                include_finished,
+                limit,
+            ))),
+            api::Command::SubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            _ => Err(ApiError::Unsupported),
+        }
+    }
+    async fn handle_send_message(
+        &self,
+        _c: String,
+        _t: String,
+        _r: String,
+        _s: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+    async fn subscribe_user_events(&self) -> Option<broadcast::Receiver<api::Event>> {
+        Some(self.registry.subscribe(&current_user_id()))
+    }
+}
+
+struct StaticJwtAuth;
+
+#[async_trait::async_trait]
+impl WsAuthValidator for StaticJwtAuth {
+    async fn validate_bearer_token(&self, token: &str) -> bool {
+        token == "test-jwt"
+    }
+    async fn extract_user_id(&self, _token: &str) -> Option<UserId> {
+        Some(UserId::new("alice"))
+    }
+}
+
+fn ws_request(
+    url: &str,
+    bearer: Option<&str>,
+) -> tokio_tungstenite::tungstenite::http::Request<()> {
+    let mut request = url.into_client_request().unwrap();
+    if let Some(token) = bearer {
+        request.headers_mut().insert(
+            tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+    }
+    request
+}
+
+async fn start_server(handler: Arc<dyn AssistantApiHandler>) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = router(handler, Arc::new(StaticJwtAuth));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (addr, server)
+}
+
+/// Acceptance: ListBackgroundTasks round-trips over a real WS upgrade.
+#[tokio::test]
+async fn ws_list_background_tasks_roundtrip() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(RegistryHandler {
+        registry: Arc::clone(&registry),
+    });
+    let alice = UserId::new("alice");
+
+    // Pre-populate two tasks under alice.
+    for i in 0..2 {
+        registry.spawn(
+            alice.clone(),
+            api::TaskKind::Standalone {
+                name: format!("t-{i}"),
+                conversation_id: "c".into(),
+            },
+            format!("t-{i}"),
+            |_ctx| async move {
+                std::future::pending::<()>().await;
+                Ok(())
+            },
+        );
+    }
+
+    let (addr, server) = start_server(handler).await;
+    let url = format!("ws://{}/ws", addr);
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&url, Some("test-jwt")))
+        .await
+        .unwrap();
+
+    let req = WsRequest {
+        id: "list-1".into(),
+        command: api::Command::ListBackgroundTasks {
+            include_finished: false,
+            limit: None,
+        },
+    };
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::to_string(&req).unwrap().into(),
+    ))
+    .await
+    .unwrap();
+
+    let msg = timeout(Duration::from_secs(2), ws.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let frame: WsFrame = serde_json::from_str(&msg.into_text().unwrap()).unwrap();
+    match frame {
+        WsFrame::Result {
+            id,
+            result: api::CommandResult::BackgroundTasks(tasks),
+        } => {
+            assert_eq!(id, "list-1");
+            assert_eq!(tasks.len(), 2);
+        }
+        other => panic!("unexpected frame: {other:?}"),
+    }
+
+    server.abort();
+}
+
+/// Acceptance: subscribe over WS, then trigger a registry spawn — the
+/// connection observes `TaskStarted` (and eventually `TaskCompleted`)
+/// for the new task. This is the end-to-end equivalent of the
+/// dispatcher-level test in `transport-dispatch`.
+#[tokio::test]
+async fn ws_subscribe_streams_task_events() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(RegistryHandler {
+        registry: Arc::clone(&registry),
+    });
+    let (addr, server) = start_server(handler).await;
+    let url = format!("ws://{}/ws", addr);
+    let (mut ws, _) = tokio_tungstenite::connect_async(ws_request(&url, Some("test-jwt")))
+        .await
+        .unwrap();
+
+    // Subscribe.
+    let sub = WsRequest {
+        id: "sub-1".into(),
+        command: api::Command::SubscribeBackgroundTasks,
+    };
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::to_string(&sub).unwrap().into(),
+    ))
+    .await
+    .unwrap();
+    let ack = timeout(Duration::from_secs(2), ws.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let frame: WsFrame = serde_json::from_str(&ack.into_text().unwrap()).unwrap();
+    assert!(matches!(
+        frame,
+        WsFrame::Result {
+            result: api::CommandResult::Ack,
+            ..
+        }
+    ));
+
+    // Trigger a spawn on the SAME user (the WS validator pins alice).
+    let _id = registry.spawn(
+        UserId::new("alice"),
+        api::TaskKind::Standalone {
+            name: "spawned-after-subscribe".into(),
+            conversation_id: "c".into(),
+        },
+        "spawned-after-subscribe".into(),
+        |_ctx| async move { Ok(()) },
+    );
+
+    // Look for a TaskStarted event in the next few frames.
+    let mut saw_started = false;
+    for _ in 0..10 {
+        let next = timeout(Duration::from_millis(500), ws.next()).await;
+        let Ok(Some(Ok(msg))) = next else {
+            continue;
+        };
+        let frame: WsFrame = match msg {
+            tokio_tungstenite::tungstenite::Message::Text(t) => {
+                serde_json::from_str(&t).unwrap()
+            }
+            _ => continue,
+        };
+        if let WsFrame::Event {
+            event: api::Event::TaskStarted { task },
+        } = frame
+        {
+            assert_eq!(task.title, "spawned-after-subscribe");
+            saw_started = true;
+            break;
+        }
+    }
+    assert!(saw_started, "expected TaskStarted event on the connection");
+
+    server.abort();
+}


### PR DESCRIPTION
Closes #114.

## Summary
- Replaces the `Unsupported` stubs for `ListBackgroundTasks` / `GetBackgroundTask` / `CancelBackgroundTask` / `GetBackgroundTaskLogs` / `SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks` in `DefaultAssistantApiHandler` with real `BackgroundTaskRegistry` calls.
- Teaches the shared `transport-dispatch::dispatch_loop` to spawn a per-connection forwarder that pumps the registry's per-user `Event::Task*` broadcast into the outbound `WsFrame::Event` channel. Idempotent Subscribe, clean Unsubscribe, automatic teardown on connection drop. Both WS and UDS inherit this for free thanks to the #103 refactor.
- Changes `Command::SendMessage`'s ack from bare `CommandResult::Ack` to `CommandResult::SendMessageAck { task_id }` whenever the handler registered the turn via the registry — gated by a new `start_send_message` trait method whose default `None` preserves the legacy bare-`Ack` path for handlers without a registry.
- Adds two structured `ApiError` variants (`NotFound`, `AlreadyTerminal`) so transport adapters can surface clean error frames for cross-user cancels and post-terminal cancels.

## Trait surface
Two new methods on `AssistantApiHandler`, each with `None`-returning defaults so existing handlers keep working unchanged:
- `subscribe_user_events()` returns `Option<broadcast::Receiver<api::Event>>` for the current task-local user id.
- `start_send_message(...)` returns `Option<TaskId>`; `Some` opts into the new `SendMessageAck` ack shape.

`DefaultAssistantApiHandler` implements both when a `BackgroundTaskRegistry` is attached; otherwise returns `None` and the dispatcher falls back gracefully.

## Test plan
- [x] `cargo test --workspace` — all suites green (no regressions in pre-existing WS/UDS/application/registry tests).
- [x] `cargo clippy --workspace --all-targets` — new code is clippy-clean; remaining warnings are pre-existing in core/llm-openai/llm-bedrock/daemon.
- [x] New tests pin every acceptance criterion from the issue:
  - `application/tests/ws_background_task_wiring.rs` (14 tests) — handler-level arms, cross-user opacity, log pagination, `subscribe_user_events` / `start_send_message` hooks, and the business-outcome "user can list their running standalone agent".
  - `transport-dispatch/tests/background_task_wiring.rs` (7 tests) — Subscribe forwarder, Unsubscribe teardown, idempotency, connection-drop cleanup, `SendMessageAck { task_id }`, legacy-fallback for handlers without registry, error-on-unsupported-subscribe.
  - `ws-interface/tests/background_tasks.rs` (2 tests) — end-to-end WS roundtrip for ListBackgroundTasks and Subscribe + spawn + event streaming.
  - `uds-interface/tests/background_tasks.rs` (1 test) — `uds_list_background_tasks_through_shared_dispatcher` proves the dispatcher refactor stays the single point of truth.

## Out of scope
Per the issue body:
- D-Bus BackgroundTasks interface — #116 depends on this PR.
- Frontend UI consumers — adele-tui#45 / adele-gtk#19 / adele-kde#7 depend on this PR.