### PR TITLE
feat(client-common): surface background-task events on SignalEvent

### DIFF
--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -28,6 +28,32 @@ pub enum SignalEvent {
         conversation_id: String,
         warning: api::ConversationWarning,
     },
+    /// A background task transitioned to `Pending`/`Running`. Carries the
+    /// full `TaskView` so process-manager UIs can populate a list row
+    /// without an extra round-trip. Sent in response to
+    /// `Command::SubscribeBackgroundTasks` (issue #110).
+    TaskStarted {
+        task: api::TaskView,
+    },
+    /// Lightweight progress signal — typically used to update a per-row
+    /// "progress hint" string without writing a log entry.
+    TaskProgress {
+        id: String,
+        progress_hint: Option<String>,
+    },
+    /// A new log entry was appended to a task's bounded log buffer.
+    TaskLogAppended {
+        id: String,
+        entry: api::TaskLogEntry,
+    },
+    /// Terminal event: the task reached `Completed`, `Failed`, or
+    /// `Cancelled`. `last_error` is set for `Failed` and may be set for
+    /// `Cancelled` when cancellation was driven by an upstream error.
+    TaskCompleted {
+        id: String,
+        status: api::TaskStatus,
+        last_error: Option<String>,
+    },
     Disconnected {
         reason: String,
     },

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -536,6 +536,93 @@ mod tests {
     }
 
     #[test]
+    fn maps_task_started_event() {
+        let task = api::TaskView {
+            id: api::TaskId("t-1".into()),
+            kind: api::TaskKind::Standalone {
+                name: "researcher".into(),
+                conversation_id: "c-1".into(),
+            },
+            status: api::TaskStatus::Running,
+            started_at: 1,
+            ended_at: None,
+            last_error: None,
+            parent: None,
+            children: Vec::new(),
+            title: "Researcher: pricing data".into(),
+            progress_hint: None,
+        };
+        let signal = map_event_to_signal(api::Event::TaskStarted { task });
+        match signal {
+            Some(SignalEvent::TaskStarted { task }) => {
+                assert_eq!(task.id, api::TaskId("t-1".into()));
+                assert_eq!(task.title, "Researcher: pricing data");
+            }
+            other => panic!("expected SignalEvent::TaskStarted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_task_progress_event() {
+        let signal = map_event_to_signal(api::Event::TaskProgress {
+            id: "t-1".into(),
+            progress_hint: Some("step 2/5".into()),
+        });
+        match signal {
+            Some(SignalEvent::TaskProgress { id, progress_hint }) => {
+                assert_eq!(id, "t-1");
+                assert_eq!(progress_hint.as_deref(), Some("step 2/5"));
+            }
+            other => panic!("expected SignalEvent::TaskProgress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_task_log_appended_event() {
+        let entry = api::TaskLogEntry {
+            seq: 7,
+            timestamp: 1_700_000_000,
+            level: api::LogLevel::Info,
+            category: api::LogCategory::Status,
+            message: "fetching".into(),
+            data: None,
+        };
+        let signal = map_event_to_signal(api::Event::TaskLogAppended {
+            id: "t-1".into(),
+            entry,
+        });
+        match signal {
+            Some(SignalEvent::TaskLogAppended { id, entry }) => {
+                assert_eq!(id, "t-1");
+                assert_eq!(entry.seq, 7);
+                assert_eq!(entry.message, "fetching");
+            }
+            other => panic!("expected SignalEvent::TaskLogAppended, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_task_completed_event() {
+        let signal = map_event_to_signal(api::Event::TaskCompleted {
+            id: "t-1".into(),
+            status: api::TaskStatus::Failed,
+            last_error: Some("LLM rate limit".into()),
+        });
+        match signal {
+            Some(SignalEvent::TaskCompleted {
+                id,
+                status,
+                last_error,
+            }) => {
+                assert_eq!(id, "t-1");
+                assert!(matches!(status, api::TaskStatus::Failed));
+                assert_eq!(last_error.as_deref(), Some("LLM rate limit"));
+            }
+            other => panic!("expected SignalEvent::TaskCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn ignores_non_stream_config_events() {
         let event = map_event_to_signal(api::Event::ConfigChanged {
             config: api::Config {

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -480,15 +480,26 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             conversation_id,
             warning,
         }),
-        // Background-task events (issue #110) are not yet mapped onto the
-        // legacy SignalEvent stream; the process-manager UIs subscribe
-        // directly to Task* events via a dedicated channel introduced
-        // alongside the registry (see #111/#112/#113). Each arm is listed
-        // explicitly so future variants force a deliberate decision.
-        api::Event::TaskStarted { .. }
-        | api::Event::TaskProgress { .. }
-        | api::Event::TaskLogAppended { .. }
-        | api::Event::TaskCompleted { .. } => None,
+        // Background-task events (issue #110) — surfaced verbatim on the
+        // signal channel so process-manager UIs (adele-tui#45, adele-gtk
+        // follow-up) can react. The TaskView/TaskLogEntry types are
+        // re-exported from `api-model`; clients consume them directly.
+        api::Event::TaskStarted { task } => Some(SignalEvent::TaskStarted { task }),
+        api::Event::TaskProgress { id, progress_hint } => {
+            Some(SignalEvent::TaskProgress { id, progress_hint })
+        }
+        api::Event::TaskLogAppended { id, entry } => {
+            Some(SignalEvent::TaskLogAppended { id, entry })
+        }
+        api::Event::TaskCompleted {
+            id,
+            status,
+            last_error,
+        } => Some(SignalEvent::TaskCompleted {
+            id,
+            status,
+            last_error,
+        }),
         // Client-side tool execution (#107): handled by clients that
         // implement the client-tool protocol directly; the legacy
         // `SignalEvent` stream is for the GTK desktop UI and does not


### PR DESCRIPTION
## Summary

The background-task registry (#110) emits four event variants
(`TaskStarted` / `TaskProgress` / `TaskLogAppended` / `TaskCompleted`)
over the WS event stream. `map_event_to_signal` was previously dropping
them on the floor, leaving process-manager UIs no way to consume them
through the shared signal channel.

This PR adds matching `SignalEvent::Task*` variants and routes each
event verbatim. `TaskView` and `TaskLogEntry` are re-used from
`api-model` so consumers depend only on the existing protocol crate.

Unblocks adelie-ai/adele-tui#45 (process manager pane) and the future
adele-gtk follow-up. Part of the desktop-assistant#117 epic.

## Test plan

- [x] `cargo test -p desktop-assistant-client-common` (unit tests for
      all four event mappings: `maps_task_started_event`,
      `maps_task_progress_event`, `maps_task_log_appended_event`,
      `maps_task_completed_event`).
- [x] `cargo clippy -p desktop-assistant-client-common --lib --tests`
      (no new warnings).
- [x] `cargo build -p desktop-assistant-client-common`.

## Notes

Additive only. Existing variants and their wire mapping are unchanged.
No other workspace crate matches exhaustively on `SignalEvent`, so this
does not break any downstream consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)