### PR TITLE
auth: drop jsonwebtoken rust_crypto feature; removes rsa Marvin (#143)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -716,12 +717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,18 +1015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,33 +1040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1525,71 +1481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1692,22 +1589,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1879,7 +1760,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1932,17 +1812,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2534,25 +2403,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac 0.12.1",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2835,30 +2699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,15 +2847,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -3284,16 +3115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,7 +3124,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3447,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3459,7 +3280,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3505,21 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4527,6 +4334,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5439,6 +5252,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-pki-types = { version = "1", features = ["std"] }
 tokio-rustls = "0.26"
 chrono = { version = "0.4", features = ["clock"] }
-jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }

--- a/crates/auth-jwt/tests/no_rsa_in_lockfile.rs
+++ b/crates/auth-jwt/tests/no_rsa_in_lockfile.rs
@@ -1,0 +1,103 @@
+//! Issue #143: assert that `jsonwebtoken` is no longer pulling in the
+//! `rsa` crate (RUSTSEC-2023-0071, Marvin timing attack, no upstream
+//! fix).
+//!
+//! Background: `jsonwebtoken`'s `rust_crypto` feature pulled in the
+//! pure-Rust `rsa` crate. The codebase uses HS256 (in this crate) and
+//! RS256 (in the daemon's OIDC validator). Switching the `jsonwebtoken`
+//! backend from `rust_crypto` to `aws_lc_rs` preserves both algorithms
+//! while routing all crypto through `aws-lc-rs` (already in the tree via
+//! `rustls`) and drops the `rsa` build-graph contribution.
+//!
+//! Scope note (intentionally narrow): we check that `jsonwebtoken` no
+//! longer declares `rsa` as a dependency in `Cargo.lock`, AND that `rsa`
+//! is no longer in our compiled dependency graph. We deliberately do
+//! NOT assert "`rsa` is fully absent from `Cargo.lock`" because a
+//! separate, non-active path (`sqlx-mysql` declared as an optional dep
+//! of `sqlx-macros-core`) still lists `rsa` in the lockfile even though
+//! the `mysql` Cargo feature is never enabled and `sqlx-mysql` is never
+//! compiled into our binary. Eliminating that record-only-in-lockfile
+//! path is a separate cargo/sqlx-resolver concern outside #143's scope.
+//!
+//! Implementation note: we parse the workspace `Cargo.lock` from disk
+//! relative to `CARGO_MANIFEST_DIR` rather than using `include_str!`. The
+//! latter would freeze the lockfile contents at build time and produce
+//! stale results after `cargo update`; reading at test runtime always
+//! sees the live file. We also shell out to `cargo tree` to assert
+//! `rsa` is absent from the *active* build graph — that's the
+//! security-relevant property.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("workspace root must exist")
+}
+
+#[test]
+fn jsonwebtoken_does_not_depend_on_rsa_in_lockfile() {
+    let lock_path = workspace_root().join("Cargo.lock");
+    let lock = std::fs::read_to_string(&lock_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", lock_path.display()));
+
+    // Find the `[[package]]` block whose `name = "jsonwebtoken"` and
+    // inspect its `dependencies = [ ... ]` list for `rsa`. The block
+    // ends at the next `[[package]]` header or EOF.
+    let header = "name = \"jsonwebtoken\"";
+    let start = lock
+        .find(header)
+        .expect("Cargo.lock must contain a jsonwebtoken package entry");
+    let rest = &lock[start..];
+    let block_end = rest[header.len()..]
+        .find("[[package]]")
+        .map(|i| header.len() + i)
+        .unwrap_or(rest.len());
+    let block = &rest[..block_end];
+
+    let has_rsa_dep = block
+        .lines()
+        .any(|line| line.trim() == "\"rsa\",");
+
+    assert!(
+        !has_rsa_dep,
+        "Cargo.lock shows `jsonwebtoken` still depends on `rsa` \
+         (RUSTSEC-2023-0071). The `rust_crypto` feature must be off; \
+         use `default-features = false` plus `aws_lc_rs`. Offending \
+         block:\n{block}"
+    );
+}
+
+#[test]
+fn rsa_crate_absent_from_compiled_workspace_tree() {
+    // `cargo tree -p rsa -i` prints the reverse dependency tree for
+    // `rsa` if it's in the compiled graph, or warns "nothing to print"
+    // if it's not. We use --quiet to suppress the warning so a clean
+    // tree yields an empty stdout/stderr (modulo the warning).
+    //
+    // This guards against a future change re-adding any consumer of
+    // `rsa` to the active build graph — whether through `jsonwebtoken`
+    // regaining `rust_crypto` or another crate adopting `rsa`.
+    let output = Command::new(env!("CARGO"))
+        .args(["tree", "--workspace", "-i", "rsa"])
+        .current_dir(workspace_root())
+        .output()
+        .expect("failed to invoke cargo tree");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // `cargo tree` emits "warning: nothing to print." to stderr when
+    // the requested package isn't in the active graph; that's the
+    // success signal here.
+    let absent = stderr.contains("nothing to print") && stdout.trim().is_empty();
+
+    assert!(
+        absent,
+        "`rsa` is present in the compiled workspace dependency graph \
+         (RUSTSEC-2023-0071). cargo tree stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #143.

Switches `jsonwebtoken`'s crypto backend from `rust_crypto` to `aws_lc_rs` to remove the `rsa` crate (RUSTSEC-2023-0071, Marvin timing attack, no upstream fix) from the active build graph.

Workspace `Cargo.toml` change:

```diff
-jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }
```

### Why `aws_lc_rs` and not "HMAC only"

The issue suggested re-enabling only HMAC features. `jsonwebtoken` ships exactly two backend features (`rust_crypto` and `aws_lc_rs`); there is no HMAC-only feature. We also need RS256 — the daemon's OIDC validator (`crates/daemon/src/config/oidc.rs`) uses `DecodingKey::from_rsa_components` and `Validation::new(Algorithm::RS256)`. So the choice is between the two backends, and `aws_lc_rs` is the safe one. `aws-lc-rs` is already in our tree via `rustls` so the net dep delta is negative (drops `rsa`, `ed25519-dalek`, `p256`, `p384`, `elliptic-curve`, and friends).

`cargo update -p jsonwebtoken` opportunistically bumped 10.3.0 -> 10.4.0 within the existing `"10.3.0"` caret.

## Tests

- New `crates/auth-jwt/tests/no_rsa_in_lockfile.rs`:
  - `jsonwebtoken_does_not_depend_on_rsa_in_lockfile` — parses `Cargo.lock` and asserts the `jsonwebtoken` `[[package]]` block does not list `rsa` as a dep. Fails before fix, passes after.
  - `rsa_crate_absent_from_compiled_workspace_tree` — shells out to `cargo tree --workspace -i rsa` and requires "nothing to print". Catches future regressions that re-add any `rsa` consumer.
- Existing `auth-jwt` HS256 round-trip and signature-rejection tests serve as regression coverage (still pass unchanged).
- `cargo test --workspace`: 1,000+ tests, 0 failures.

## `cargo audit` before / after

**Before:** `rsa` reachable via both `jsonwebtoken` and `sqlx-mysql`:

```
rsa 0.9.10
├── sqlx-mysql 0.8.6
│   └── sqlx-macros-core 0.8.6 → sqlx-macros → sqlx → pgvector → desktop-assistant-storage → daemon
└── jsonwebtoken 10.3.0
    ├── desktop-assistant-daemon 0.1.0
    └── desktop-assistant-auth-jwt 0.1.0 → (many)
```

**After:** only the inactive `sqlx-mysql` lockfile entry remains:

```
rsa 0.9.10
└── sqlx-mysql 0.8.6
    ├── sqlx-macros-core 0.8.6 → sqlx-macros → sqlx → pgvector → desktop-assistant-storage → daemon
    └── sqlx 0.8.6
```

`cargo tree --workspace -i rsa` returns "nothing to print" — `rsa` is no longer compiled. The remaining lockfile entry is a Cargo quirk: `sqlx-macros-core` declares `sqlx-mysql` as an optional dep, and our `sqlx = { features = [..., "postgres", ...] }` never enables the `mysql` feature, but Cargo still records the optional dep in `Cargo.lock`. Eliminating that lockfile-only entry is a separate sqlx-resolver concern outside #143's scope.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo build --workspace` green
- [x] `cargo clippy -p desktop-assistant-auth-jwt --all-targets -- -D warnings` clean
- [x] `cargo build -p desktop-assistant-daemon` green (RS256 OIDC path)
- [x] `cargo tree --workspace -i rsa` → "nothing to print"
- [x] `cargo audit` no longer reports `rsa` via `jsonwebtoken`

(Workspace-wide `cargo clippy --workspace --all-targets -- -D warnings` reports pre-existing errors in `desktop-assistant-core`, unrelated to this change.)

Generated with [Claude Code](https://claude.com/claude-code)