### PR TITLE
fix(application): re-install with_user_id inside SendMessage spawn body

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1257,9 +1257,13 @@ where
         let conv_id_for_body = conversation_id.clone();
         let request_id_for_body = request_id.clone();
         let sink_for_body = Arc::clone(&sink);
+        let user_id_for_body = user_id.clone();
 
         // `registry.spawn` is sync; the body runs on its own
         // `tokio::spawn` so we can return the new task id immediately.
+        // `tokio::spawn` does not propagate task-locals, so the body
+        // must re-install `with_user_id` for storage queries inside
+        // `run_send_turn` to scope to the right user (#154).
         let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
             ctx.logs.append(
                 api::LogLevel::Info,
@@ -1268,14 +1272,17 @@ where
                 None,
             );
 
-            let result = run_send_turn(
-                conversations,
-                conv_id_for_body,
-                content,
-                override_selection,
-                request_id_for_body,
-                sink_for_body,
-                ctx.token.clone(),
+            let result = with_user_id(
+                user_id_for_body,
+                run_send_turn(
+                    conversations,
+                    conv_id_for_body,
+                    content,
+                    override_selection,
+                    request_id_for_body,
+                    sink_for_body,
+                    ctx.token.clone(),
+                ),
             )
             .await;
 
@@ -1335,7 +1342,11 @@ where
         let conv_id_for_body = conversation_id.clone();
         let request_id_for_body = request_id.clone();
         let sink_for_body = Arc::clone(&sink);
+        let user_id_for_body = user_id.clone();
 
+        // `tokio::spawn` does not propagate task-locals, so the body
+        // must re-install `with_user_id` for storage queries inside
+        // `run_send_turn` to scope to the right user (#154).
         let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
             // Lifecycle log so the UI knows the foreground turn is
             // tracked — Status category keeps it distinct from the
@@ -1347,14 +1358,17 @@ where
                 None,
             );
 
-            let result = run_send_turn(
-                conversations,
-                conv_id_for_body,
-                content,
-                override_selection,
-                request_id_for_body,
-                sink_for_body,
-                ctx.token.clone(),
+            let result = with_user_id(
+                user_id_for_body,
+                run_send_turn(
+                    conversations,
+                    conv_id_for_body,
+                    content,
+                    override_selection,
+                    request_id_for_body,
+                    sink_for_body,
+                    ctx.token.clone(),
+                ),
             )
             .await;
 

--- a/crates/application/tests/ws_background_task_wiring.rs
+++ b/crates/application/tests/ws_background_task_wiring.rs
@@ -316,6 +316,10 @@ struct SendCall {
     #[allow(dead_code)]
     conversation_id: String,
     prompt: String,
+    /// `current_user_id()` observed inside `send_prompt_with_override`.
+    /// Used by #154 to assert that the registry-spawned send body
+    /// inherits the caller's user_id scope.
+    seen_user_id: String,
 }
 
 struct RecordingConversations {
@@ -336,6 +340,15 @@ impl RecordingConversations {
             cancelled: Arc::new(AtomicBool::new(false)),
             block_until: Mutex::new(None),
         }
+    }
+
+    fn seen_user_ids(&self) -> Vec<String> {
+        self.sends
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|c| c.seen_user_id.clone())
+            .collect()
     }
 
     fn block_on(&self, n: Arc<Notify>) {
@@ -407,6 +420,7 @@ impl ConversationService for RecordingConversations {
         self.sends.lock().unwrap().push(SendCall {
             conversation_id: conversation_id.as_str().to_string(),
             prompt: prompt.clone(),
+            seen_user_id: current_user_id().as_str().to_string(),
         });
         let block = self.block_until.lock().unwrap().clone();
         if let Some(block) = block {
@@ -912,6 +926,82 @@ async fn start_send_message_returns_task_id_that_appears_in_listing() {
     assert!(tasks.iter().any(|t| t.id == task_id));
 
     registry.wait(&task_id).await;
+}
+
+/// Issue #154: the registry-spawned `SendMessage` body must observe the
+/// caller's user_id scope. `tokio::spawn` doesn't propagate task-locals,
+/// so the body has to re-install `with_user_id`. Without that, storage
+/// queries inside the body see the `"default"` sentinel and a
+/// per-user-scoped `WHERE user_id = $1` lookup misses the row, surfacing
+/// as `ConversationNotFound` to the user.
+#[tokio::test]
+async fn start_send_message_propagates_user_id_to_spawned_body() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(Arc::clone(&convs), Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let sink: Arc<dyn desktop_assistant_application::EventSink> = Arc::new(NoopSink);
+
+    let task_id = with_user_id(user.clone(), async {
+        handler
+            .start_send_message(
+                "conv-x".into(),
+                "hello".into(),
+                None,
+                "req-1".into(),
+                Arc::clone(&sink),
+            )
+            .await
+    })
+    .await
+    .expect("start_send_message ok")
+    .expect("registry attached, expected Some(task_id)");
+
+    registry.wait(&task_id).await;
+
+    let seen = convs.seen_user_ids();
+    assert_eq!(
+        seen,
+        vec![user.as_str().to_string()],
+        "spawned body must observe the caller's user_id, not the default sentinel"
+    );
+}
+
+/// Issue #154 sibling: the same scope requirement applies to
+/// `handle_send_message_with_override`, which routes through
+/// `send_message_via_registry` when a registry is attached. This path
+/// is exercised by the legacy bare-Ack transport adapters and must stay
+/// in sync with the `start_send_message` path.
+#[tokio::test]
+async fn handle_send_message_with_override_propagates_user_id_to_spawned_body() {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let convs = Arc::new(RecordingConversations::new());
+    let handler = make_handler(Arc::clone(&convs), Arc::clone(&registry));
+
+    let user = unique_user("alice");
+    let sink: Arc<dyn desktop_assistant_application::EventSink> = Arc::new(NoopSink);
+
+    with_user_id(user.clone(), async {
+        handler
+            .handle_send_message_with_override(
+                "conv-y".into(),
+                "hello".into(),
+                None,
+                "req-2".into(),
+                sink,
+            )
+            .await
+    })
+    .await
+    .expect("handle_send_message_with_override ok");
+
+    let seen = convs.seen_user_ids();
+    assert_eq!(
+        seen,
+        vec![user.as_str().to_string()],
+        "spawned body must observe the caller's user_id, not the default sentinel"
+    );
 }
 
 /// Without a registry the handler's `start_send_message` returns `None`


### PR DESCRIPTION
## Summary
- Re-install `with_user_id` inside `start_send_message` and `send_message_via_registry` spawn bodies so per-user-scoped storage queries see the caller's id instead of the `"default"` sentinel.
- Add two acceptance tests in `ws_background_task_wiring.rs` that assert the spawned body observes the caller's user_id (failing before the fix, passing after).
- `RecordingConversations` test fake now captures `current_user_id()` at the call site so the assertion can read it back.

## Why
`tokio::spawn` does not propagate task-locals. Both spawn sites in `crates/application/src/lib.rs` captured `user_id` outside the spawn for the registry's ownership tracking, but the body ran with the auth task-local unset. After the multi-tenant migration (#102, #105), storage queries inside the body filtered by `WHERE user_id = 'default'` instead of the authenticated caller, surfacing as `ConversationNotFound` for every send from a non-default user.

This made adele-gtk completely unable to send messages once authentication shipped — the row existed, was owned by the caller, but was invisible to the spawned body.

## Test plan
- [x] `cargo test -p desktop-assistant-application --test ws_background_task_wiring` (16 tests pass, including the 2 new ones)
- [x] `cargo test -p desktop-assistant-application` (full crate suite green)
- [x] `cargo test -p desktop-assistant-daemon` (integration smoke green)
- [x] `cargo test -p desktop-assistant-core` (green)
- [x] `cargo build --workspace` (green)
- [x] Adversarial diff read: fix only adds `with_user_id` wrappers around an existing call — no new attack surface, no new endpoints, no lockfile delta.
- [x] Verified the sibling pattern at `spawn_subagent_internal` (lib.rs:1510) and cold-restart resume (`background_tasks.rs:657, 934`) are already correct — confirmed audit found no other production `registry.spawn` sites missing the scope.

## Pre-existing (out of scope)
- 5 clippy warnings in `desktop-assistant-core/ports/llm_profiling.rs` from newer clippy lints (`collapsible_if`, `manual_strip`, `redundant_closure`). Present on `main`; this PR introduces no new warnings.

## Data migration (manual, already applied on Dave's machine)
The migration in #102 backfilled `user_id = 'default'` for all pre-existing rows. After auth ships, those rows become invisible to the real authenticated user. For Dave's machine we ran a one-off `UPDATE ... SET user_id = 'dave' WHERE user_id = 'default'` across `conversations`, `messages`, `dreaming_watermarks`, `knowledge_base`, `tag_registry`. Deploying this PR to other installs may need a similar migration depending on their tenancy model; left out of the PR because the right migration depends on the deploy (single-tenant vs multi-tenant).

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)