### PR TITLE
fix(dbus-interface): install with_user_id at method boundary + spawn body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
 name = "desktop-assistant-dbus"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "desktop-assistant-api-model",
  "desktop-assistant-application",
  "desktop-assistant-core",

--- a/crates/dbus-interface/Cargo.toml
+++ b/crates/dbus-interface/Cargo.toml
@@ -17,4 +17,5 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+async-trait.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/dbus-interface/src/connections.rs
+++ b/crates/dbus-interface/src/connections.rs
@@ -162,3 +162,85 @@ impl DbusConnectionsAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_application::ApiResult;
+    use desktop_assistant_core::ports::auth::current_user_id;
+    use std::sync::Mutex;
+
+    /// Recording fake `AssistantApiHandler` that captures
+    /// `current_user_id()` at command-dispatch time. Used to assert
+    /// that the D-Bus connections adapter installs the per-user scope
+    /// at the method-entry boundary before calling into the handler.
+    struct RecordingHandler {
+        seen: Mutex<Vec<String>>,
+    }
+
+    impl RecordingHandler {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+            })
+        }
+        fn observed(&self) -> Vec<String> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AssistantApiHandler for RecordingHandler {
+        async fn handle_command(&self, _cmd: api::Command) -> ApiResult<api::CommandResult> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(current_user_id().as_str().to_string());
+            Ok(api::CommandResult::Ack)
+        }
+        async fn handle_send_message(
+            &self,
+            _conversation_id: String,
+            _content: String,
+            _request_id: String,
+            _sink: Arc<dyn desktop_assistant_application::EventSink>,
+        ) -> ApiResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Issue #156: every connections D-Bus method must dispatch
+    /// through `handle_command_for(RequestContext::for_user(...))`
+    /// so the per-user scope is installed before the handler runs.
+    #[tokio::test]
+    async fn dbus_connections_methods_install_user_id_scope() {
+        let handler = RecordingHandler::new();
+        let adapter = DbusConnectionsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let saved = std::env::var("USER").ok();
+        unsafe {
+            std::env::set_var("USER", "alice-conn");
+        }
+
+        let _ = adapter.list_connections().await;
+        let _ = adapter.list_available_models("", false).await;
+        let _ = adapter.get_purposes().await;
+        let _ = adapter.delete_connection("c", false).await;
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("USER", v),
+                None => std::env::remove_var("USER"),
+            }
+        }
+
+        let observed = handler.observed();
+        assert!(!observed.is_empty());
+        for seen in observed {
+            assert_eq!(
+                seen, "alice-conn",
+                "every connections D-Bus method must install with_user_id at the method boundary"
+            );
+        }
+    }
+}

--- a/crates/dbus-interface/src/connections.rs
+++ b/crates/dbus-interface/src/connections.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use desktop_assistant_api_model::{self as api};
-use desktop_assistant_application::AssistantApiHandler;
+use desktop_assistant_application::{AssistantApiHandler, RequestContext};
 use zbus::{fdo, interface};
+
+use crate::resolve_dbus_user_id;
 
 fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
     fdo::Error::Failed(error.to_string())
@@ -27,8 +29,16 @@ impl DbusConnectionsAdapter {
     }
 
     async fn dispatch(&self, cmd: api::Command) -> fdo::Result<api::CommandResult> {
+        // #156: install the per-user scope at the D-Bus dispatch
+        // boundary so the inbound handler (and storage queries it
+        // composes downstream) see the local OS user instead of the
+        // `"default"` sentinel. `handle_command_for` is the
+        // context-aware entry point the WS and UDS adapters already
+        // use; routing through it keeps the auth wiring identical
+        // across transports.
+        let ctx = RequestContext::for_user(resolve_dbus_user_id());
         self.handler
-            .handle_command(cmd)
+            .handle_command_for(ctx, cmd)
             .await
             .map_err(|e| fdo::Error::Failed(format!("{e:?}")))
     }
@@ -217,22 +227,12 @@ mod tests {
         let handler = RecordingHandler::new();
         let adapter = DbusConnectionsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
 
-        let saved = std::env::var("USER").ok();
-        unsafe {
-            std::env::set_var("USER", "alice-conn");
-        }
+        let _guard = crate::testing::UserEnvGuard::set("alice-conn");
 
         let _ = adapter.list_connections().await;
         let _ = adapter.list_available_models("", false).await;
         let _ = adapter.get_purposes().await;
         let _ = adapter.delete_connection("c", false).await;
-
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-        }
 
         let observed = handler.observed();
         assert!(!observed.is_empty());

--- a/crates/dbus-interface/src/conversation.rs
+++ b/crates/dbus-interface/src/conversation.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use desktop_assistant_core::domain::ConversationId;
+use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 use desktop_assistant_core::ports::inbound::ConversationService;
 use tokio::sync::mpsc;
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
+
+use crate::resolve_dbus_user_id;
 
 /// D-Bus adapter for the ConversationService.
 ///
@@ -76,10 +79,13 @@ pub(crate) async fn run_send_prompt_llm_task<S>(
 /// Schedule the LLM-call body on a fresh tokio task.
 ///
 /// `tokio::spawn` does not propagate task-locals, so this helper is
-/// the single fix surface for #156: the spawned future must
-/// re-install the `with_user_id` scope captured at the call site,
-/// otherwise the storage queries inside the LLM turn fall through to
-/// the `"default"` sentinel and miss rows owned by the real user.
+/// the single fix surface for #156: it captures `current_user_id()`
+/// at the call site (which the outer D-Bus method has installed via
+/// [`with_user_id`]) and re-installs that scope inside the spawned
+/// future. Without that wrap, storage queries inside the LLM turn
+/// fall through to the `"default"` sentinel and miss rows owned by
+/// the real user — the exact failure mode the analogous WS fix in
+/// #155 addressed.
 pub(crate) fn spawn_send_prompt_llm_task<S>(
     service: Arc<S>,
     conversation_id: String,
@@ -89,11 +95,10 @@ pub(crate) fn spawn_send_prompt_llm_task<S>(
 where
     S: ConversationService + 'static,
 {
-    tokio::spawn(run_send_prompt_llm_task(
-        service,
-        conversation_id,
-        prompt,
-        tx,
+    let user_id_for_body = current_user_id();
+    tokio::spawn(with_user_id(
+        user_id_for_body,
+        run_send_prompt_llm_task(service, conversation_id, prompt, tx),
     ))
 }
 
@@ -101,12 +106,15 @@ where
 impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
     /// Create a new conversation and return its ID.
     async fn create_conversation(&self, title: &str) -> fdo::Result<String> {
-        let conv = self
-            .service
-            .create_conversation(title.to_string())
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
-        Ok(conv.id.0)
+        with_user_id(resolve_dbus_user_id(), async {
+            let conv = self
+                .service
+                .create_conversation(title.to_string())
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+            Ok(conv.id.0)
+        })
+        .await
     }
 
     /// List conversations as an array of (id, title, message_count, updated_at, archived),
@@ -116,40 +124,49 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
         max_age_days: i32,
         include_archived: bool,
     ) -> fdo::Result<Vec<(String, String, u32, String, bool)>> {
-        let max_age = u32::try_from(max_age_days).ok().filter(|days| *days > 0);
-        let summaries = self
-            .service
-            .list_conversations(max_age, include_archived)
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
-        Ok(summaries
-            .into_iter()
-            .map(|s| {
-                (
-                    s.id.0,
-                    s.title,
-                    s.message_count as u32,
-                    s.updated_at,
-                    s.archived,
-                )
-            })
-            .collect())
+        with_user_id(resolve_dbus_user_id(), async {
+            let max_age = u32::try_from(max_age_days).ok().filter(|days| *days > 0);
+            let summaries = self
+                .service
+                .list_conversations(max_age, include_archived)
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+            Ok(summaries
+                .into_iter()
+                .map(|s| {
+                    (
+                        s.id.0,
+                        s.title,
+                        s.message_count as u32,
+                        s.updated_at,
+                        s.archived,
+                    )
+                })
+                .collect())
+        })
+        .await
     }
 
     /// Archive a conversation by ID.
     async fn archive_conversation(&self, id: &str) -> fdo::Result<()> {
-        self.service
-            .archive_conversation(&ConversationId::from(id))
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .archive_conversation(&ConversationId::from(id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
     }
 
     /// Unarchive a conversation by ID.
     async fn unarchive_conversation(&self, id: &str) -> fdo::Result<()> {
-        self.service
-            .unarchive_conversation(&ConversationId::from(id))
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .unarchive_conversation(&ConversationId::from(id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
     }
 
     /// Get a conversation by ID, returns (id, title, messages) where
@@ -158,25 +175,28 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
         &self,
         id: &str,
     ) -> fdo::Result<(String, String, Vec<(String, String)>)> {
-        let conv = self
-            .service
-            .get_conversation(&ConversationId::from(id))
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
-        let messages: Vec<(String, String)> = conv
-            .messages
-            .iter()
-            .map(|m| {
-                let role = match m.role {
-                    desktop_assistant_core::domain::Role::User => "user",
-                    desktop_assistant_core::domain::Role::Assistant => "assistant",
-                    desktop_assistant_core::domain::Role::System => "system",
-                    desktop_assistant_core::domain::Role::Tool => "tool",
-                };
-                (role.to_string(), m.content.clone())
-            })
-            .collect();
-        Ok((conv.id.0, conv.title, messages))
+        with_user_id(resolve_dbus_user_id(), async {
+            let conv = self
+                .service
+                .get_conversation(&ConversationId::from(id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+            let messages: Vec<(String, String)> = conv
+                .messages
+                .iter()
+                .map(|m| {
+                    let role = match m.role {
+                        desktop_assistant_core::domain::Role::User => "user",
+                        desktop_assistant_core::domain::Role::Assistant => "assistant",
+                        desktop_assistant_core::domain::Role::System => "system",
+                        desktop_assistant_core::domain::Role::Tool => "tool",
+                    };
+                    (role.to_string(), m.content.clone())
+                })
+                .collect();
+            Ok((conv.id.0, conv.title, messages))
+        })
+        .await
     }
 
     /// Get messages from a conversation with optional pagination and role filtering.
@@ -197,76 +217,89 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
         after_count: i32,
         include_roles: Vec<String>,
     ) -> fdo::Result<(u32, bool, Vec<(String, String)>)> {
-        let conv = self
-            .service
-            .get_conversation(&ConversationId::from(id))
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let conv = self
+                .service
+                .get_conversation(&ConversationId::from(id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?;
 
-        let total = conv.messages.len() as u32;
+            let total = conv.messages.len() as u32;
 
-        let all: Vec<(String, String)> = conv
-            .messages
-            .iter()
-            .map(|m| {
-                let role = match m.role {
-                    desktop_assistant_core::domain::Role::User => "user",
-                    desktop_assistant_core::domain::Role::Assistant => "assistant",
-                    desktop_assistant_core::domain::Role::System => "system",
-                    desktop_assistant_core::domain::Role::Tool => "tool",
+            let all: Vec<(String, String)> = conv
+                .messages
+                .iter()
+                .map(|m| {
+                    let role = match m.role {
+                        desktop_assistant_core::domain::Role::User => "user",
+                        desktop_assistant_core::domain::Role::Assistant => "assistant",
+                        desktop_assistant_core::domain::Role::System => "system",
+                        desktop_assistant_core::domain::Role::Tool => "tool",
+                    };
+                    (role.to_string(), m.content.clone())
+                })
+                .collect();
+
+            // Slice by raw position first so after_count is always a stable index.
+            let use_after = after_count >= 0;
+            let sliced: Vec<(String, String)> = if use_after {
+                let start = (after_count as usize).min(all.len());
+                all[start..].to_vec()
+            } else {
+                all
+            };
+
+            // Apply role allowlist (empty = no filtering).
+            let filtered: Vec<(String, String)> = sliced
+                .into_iter()
+                .filter(|(role, _)| include_roles.is_empty() || include_roles.contains(role))
+                .collect();
+
+            // Apply tail limit to the filtered set (tail mode only).
+            let (truncated, messages) =
+                if !use_after && tail > 0 && filtered.len() > tail as usize {
+                    let start = filtered.len() - tail as usize;
+                    (true, filtered[start..].to_vec())
+                } else {
+                    (false, filtered)
                 };
-                (role.to_string(), m.content.clone())
-            })
-            .collect();
 
-        // Slice by raw position first so after_count is always a stable index.
-        let use_after = after_count >= 0;
-        let sliced: Vec<(String, String)> = if use_after {
-            let start = (after_count as usize).min(all.len());
-            all[start..].to_vec()
-        } else {
-            all
-        };
-
-        // Apply role allowlist (empty = no filtering).
-        let filtered: Vec<(String, String)> = sliced
-            .into_iter()
-            .filter(|(role, _)| include_roles.is_empty() || include_roles.contains(role))
-            .collect();
-
-        // Apply tail limit to the filtered set (tail mode only).
-        let (truncated, messages) = if !use_after && tail > 0 && filtered.len() > tail as usize {
-            let start = filtered.len() - tail as usize;
-            (true, filtered[start..].to_vec())
-        } else {
-            (false, filtered)
-        };
-
-        Ok((total, truncated, messages))
+            Ok((total, truncated, messages))
+        })
+        .await
     }
 
     /// Delete a conversation by ID.
     async fn delete_conversation(&self, id: &str) -> fdo::Result<()> {
-        self.service
-            .delete_conversation(&ConversationId::from(id))
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .delete_conversation(&ConversationId::from(id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
     }
 
     /// Rename a conversation.
     async fn rename_conversation(&self, id: &str, title: &str) -> fdo::Result<()> {
-        self.service
-            .rename_conversation(&ConversationId::from(id), title.to_string())
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .rename_conversation(&ConversationId::from(id), title.to_string())
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
     }
 
     /// Delete every conversation and return how many were removed.
     async fn clear_all_history(&self) -> fdo::Result<u32> {
-        self.service
-            .clear_all_history()
-            .await
-            .map_err(|e| fdo::Error::Failed(e.to_string()))
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .clear_all_history()
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
     }
 
     /// Send a prompt and stream the response via signals.
@@ -285,21 +318,22 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
 
         let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
-        // Spawn the LLM call task. The body delegates to
-        // `spawn_send_prompt_llm_task` so the spawn-body user_id
-        // wrap (#156) can be unit-tested independently of the bus.
-        // We drop the returned `JoinHandle` deliberately — the signal
-        // emitter task below drains the channel until the LLM task
-        // closes it.
+        // Install the D-Bus user_id scope before spawning the LLM
+        // task so `spawn_send_prompt_llm_task` captures the right id
+        // for the in-spawn `with_user_id` wrap (#156).
         let llm_conv_id = conv_id.clone();
-        drop(spawn_send_prompt_llm_task(
-            service,
-            llm_conv_id,
-            prompt,
-            tx,
-        ));
+        with_user_id(resolve_dbus_user_id(), async {
+            drop(spawn_send_prompt_llm_task(
+                service,
+                llm_conv_id,
+                prompt,
+                tx,
+            ));
+        })
+        .await;
 
-        // Spawn the signal emitter task
+        // Spawn the signal emitter task. Signal emission does not
+        // touch per-user storage, so it doesn't need the scope.
         let emitter = emitter.to_owned();
         let signal_conv_id = conv_id.clone();
         let signal_req_id = req_id.clone();
@@ -470,37 +504,15 @@ mod tests {
     /// policy so a reviewer can challenge it.
     #[test]
     fn resolve_dbus_user_id_uses_user_env_var() {
-        // Safety: env access is process-global. The test sets a unique
-        // value, asserts, then restores. We don't run this in parallel
-        // with the fallback test because both touch the same env var.
-        let saved = std::env::var("USER").ok();
-        // SAFETY: tests in this binary do not race on env reads with
-        // production code; the value is restored before the test ends.
-        unsafe {
-            std::env::set_var("USER", "alice-from-env");
-        }
+        let _guard = crate::testing::UserEnvGuard::set("alice-from-env");
         let resolved = crate::resolve_dbus_user_id();
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-        }
         assert_eq!(resolved, UserId::new("alice-from-env"));
     }
 
     #[test]
     fn resolve_dbus_user_id_falls_back_to_default_when_user_env_missing() {
-        let saved = std::env::var("USER").ok();
-        unsafe {
-            std::env::remove_var("USER");
-        }
+        let _guard = crate::testing::UserEnvGuard::unset();
         let resolved = crate::resolve_dbus_user_id();
-        unsafe {
-            if let Some(v) = saved {
-                std::env::set_var("USER", v);
-            }
-        }
         assert_eq!(resolved, UserId::default());
         assert_eq!(resolved.as_str(), "default");
     }
@@ -519,10 +531,7 @@ mod tests {
         let service = Arc::new(RecordingConversationService::new());
         let adapter = DbusConversationAdapter::new(Arc::clone(&service));
 
-        let saved = std::env::var("USER").ok();
-        unsafe {
-            std::env::set_var("USER", "alice-dbus");
-        }
+        let _guard = crate::testing::UserEnvGuard::set("alice-dbus");
 
         // Exercise every non-streaming D-Bus interface method. These
         // are the ones called by adele-kde for conversation listing,
@@ -536,13 +545,6 @@ mod tests {
         adapter.rename_conversation("c", "x").await.unwrap();
         adapter.delete_conversation("c").await.unwrap();
         let _count = adapter.clear_all_history().await.unwrap();
-
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-        }
 
         let observed = service.observed();
         assert!(

--- a/crates/dbus-interface/src/conversation.rs
+++ b/crates/dbus-interface/src/conversation.rs
@@ -21,10 +21,80 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
 }
 
 /// Messages sent from the streaming task to the signal emitter.
-enum StreamEvent {
+pub(crate) enum StreamEvent {
     Chunk(String),
     Complete(String),
     Error(String),
+}
+
+/// LLM-call body extracted from `send_prompt` so the spawn-body fix
+/// (#156) can be unit-tested without standing up a real D-Bus
+/// connection. Production code wraps this future in
+/// `with_user_id(user_id, ...)` before handing it to `tokio::spawn` so
+/// storage queries inside the LLM turn scope to the caller's user_id
+/// instead of the `"default"` sentinel.
+///
+/// The function is generic over `ConversationService` rather than
+/// boxed because the trait uses RPITIT (`impl Future`) which isn't
+/// dyn-compatible.
+pub(crate) async fn run_send_prompt_llm_task<S>(
+    service: Arc<S>,
+    conversation_id: String,
+    prompt: String,
+    tx: mpsc::UnboundedSender<StreamEvent>,
+) where
+    S: ConversationService + 'static,
+{
+    let tx_chunk = tx.clone();
+    let callback: desktop_assistant_core::ports::llm::ChunkCallback =
+        Box::new(move |chunk| tx_chunk.send(StreamEvent::Chunk(chunk)).is_ok());
+
+    let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(|_| {});
+
+    match service
+        .send_prompt(
+            &ConversationId::from(conversation_id.as_str()),
+            prompt,
+            callback,
+            on_status,
+        )
+        .await
+    {
+        Ok(full_response) => {
+            let _ = tx.send(StreamEvent::Complete(full_response));
+        }
+        Err(e) => {
+            tracing::error!(
+                conversation_id = %conversation_id,
+                "I hit an LLM backend error and could not complete this request. Details: {e}"
+            );
+            let _ = tx.send(StreamEvent::Error(e.to_string()));
+        }
+    }
+}
+
+/// Schedule the LLM-call body on a fresh tokio task.
+///
+/// `tokio::spawn` does not propagate task-locals, so this helper is
+/// the single fix surface for #156: the spawned future must
+/// re-install the `with_user_id` scope captured at the call site,
+/// otherwise the storage queries inside the LLM turn fall through to
+/// the `"default"` sentinel and miss rows owned by the real user.
+pub(crate) fn spawn_send_prompt_llm_task<S>(
+    service: Arc<S>,
+    conversation_id: String,
+    prompt: String,
+    tx: mpsc::UnboundedSender<StreamEvent>,
+) -> tokio::task::JoinHandle<()>
+where
+    S: ConversationService + 'static,
+{
+    tokio::spawn(run_send_prompt_llm_task(
+        service,
+        conversation_id,
+        prompt,
+        tx,
+    ))
 }
 
 #[interface(name = "org.desktopAssistant.Conversations")]
@@ -215,36 +285,19 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
 
         let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
 
-        // Spawn the LLM call task
+        // Spawn the LLM call task. The body delegates to
+        // `spawn_send_prompt_llm_task` so the spawn-body user_id
+        // wrap (#156) can be unit-tested independently of the bus.
+        // We drop the returned `JoinHandle` deliberately — the signal
+        // emitter task below drains the channel until the LLM task
+        // closes it.
         let llm_conv_id = conv_id.clone();
-        tokio::spawn(async move {
-            let tx_chunk = tx.clone();
-            let callback: desktop_assistant_core::ports::llm::ChunkCallback =
-                Box::new(move |chunk| tx_chunk.send(StreamEvent::Chunk(chunk)).is_ok());
-
-            let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(|_| {});
-
-            match service
-                .send_prompt(
-                    &ConversationId::from(llm_conv_id.as_str()),
-                    prompt,
-                    callback,
-                    on_status,
-                )
-                .await
-            {
-                Ok(full_response) => {
-                    let _ = tx.send(StreamEvent::Complete(full_response));
-                }
-                Err(e) => {
-                    tracing::error!(
-                        conversation_id = %llm_conv_id,
-                        "I hit an LLM backend error and could not complete this request. Details: {e}"
-                    );
-                    let _ = tx.send(StreamEvent::Error(e.to_string()));
-                }
-            }
-        });
+        drop(spawn_send_prompt_llm_task(
+            service,
+            llm_conv_id,
+            prompt,
+            tx,
+        ));
 
         // Spawn the signal emitter task
         let emitter = emitter.to_owned();
@@ -323,7 +376,248 @@ mod tests {
     use super::*;
     use desktop_assistant_core::CoreError;
     use desktop_assistant_core::domain::{Conversation, ConversationSummary, Message, Role};
+    use desktop_assistant_core::ports::auth::{UserId, current_user_id, with_user_id};
     use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
+    use std::sync::Mutex;
+
+    /// Recording fake that captures `current_user_id()` at every inbound
+    /// service call so #156 acceptance tests can assert the D-Bus
+    /// boundary installed a `with_user_id` scope before invoking the
+    /// service. Mirrors the `RecordingConversations` fake added in #155.
+    struct RecordingConversationService {
+        seen: Mutex<Vec<String>>,
+    }
+
+    impl RecordingConversationService {
+        fn new() -> Self {
+            Self {
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn record(&self) {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(current_user_id().as_str().to_string());
+        }
+
+        fn observed(&self) -> Vec<String> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    impl ConversationService for RecordingConversationService {
+        async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+            self.record();
+            Ok(Conversation::new("rec-id", title))
+        }
+        async fn list_conversations(
+            &self,
+            _max_age_days: Option<u32>,
+            _include_archived: bool,
+        ) -> Result<Vec<ConversationSummary>, CoreError> {
+            self.record();
+            Ok(vec![])
+        }
+        async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+            self.record();
+            Ok(Conversation::new(id.as_str(), "rec"))
+        }
+        async fn delete_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            self.record();
+            Ok(())
+        }
+        async fn rename_conversation(
+            &self,
+            _id: &ConversationId,
+            _title: String,
+        ) -> Result<(), CoreError> {
+            self.record();
+            Ok(())
+        }
+        async fn archive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            self.record();
+            Ok(())
+        }
+        async fn unarchive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            self.record();
+            Ok(())
+        }
+        async fn clear_all_history(&self) -> Result<u32, CoreError> {
+            self.record();
+            Ok(0)
+        }
+        async fn send_prompt(
+            &self,
+            _conversation_id: &ConversationId,
+            _prompt: String,
+            mut on_chunk: ChunkCallback,
+            _on_status: StatusCallback,
+        ) -> Result<String, CoreError> {
+            self.record();
+            on_chunk("ok".to_string());
+            Ok("ok".to_string())
+        }
+    }
+
+    /// `resolve_dbus_user_id` reads the local OS user from `$USER`
+    /// because the D-Bus session bus is local-only (no JWT to extract
+    /// from). When `$USER` is unset, the helper falls through to
+    /// `UserId::default()` — the schema sentinel `"default"` — which
+    /// matches the single-tenant fallback used everywhere else in the
+    /// codebase. Documenting this trust boundary in a test pins the
+    /// policy so a reviewer can challenge it.
+    #[test]
+    fn resolve_dbus_user_id_uses_user_env_var() {
+        // Safety: env access is process-global. The test sets a unique
+        // value, asserts, then restores. We don't run this in parallel
+        // with the fallback test because both touch the same env var.
+        let saved = std::env::var("USER").ok();
+        // SAFETY: tests in this binary do not race on env reads with
+        // production code; the value is restored before the test ends.
+        unsafe {
+            std::env::set_var("USER", "alice-from-env");
+        }
+        let resolved = crate::resolve_dbus_user_id();
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("USER", v),
+                None => std::env::remove_var("USER"),
+            }
+        }
+        assert_eq!(resolved, UserId::new("alice-from-env"));
+    }
+
+    #[test]
+    fn resolve_dbus_user_id_falls_back_to_default_when_user_env_missing() {
+        let saved = std::env::var("USER").ok();
+        unsafe {
+            std::env::remove_var("USER");
+        }
+        let resolved = crate::resolve_dbus_user_id();
+        unsafe {
+            if let Some(v) = saved {
+                std::env::set_var("USER", v);
+            }
+        }
+        assert_eq!(resolved, UserId::default());
+        assert_eq!(resolved.as_str(), "default");
+    }
+
+    /// Issue #156: every D-Bus method must install `with_user_id` at
+    /// the dispatch boundary so per-user-scoped storage queries see
+    /// the local OS user instead of the `"default"` sentinel. Without
+    /// the wrap, `current_user_id()` returns `"default"` and rows owned
+    /// by the local user (after the multi-tenant migration) are
+    /// invisible to adele-kde. This test fixes `$USER` to a known
+    /// value, calls each non-streaming D-Bus method, and asserts the
+    /// inbound service observed the same value at SQL composition
+    /// time.
+    #[tokio::test]
+    async fn dbus_methods_install_user_id_scope_at_method_entry() {
+        let service = Arc::new(RecordingConversationService::new());
+        let adapter = DbusConversationAdapter::new(Arc::clone(&service));
+
+        let saved = std::env::var("USER").ok();
+        unsafe {
+            std::env::set_var("USER", "alice-dbus");
+        }
+
+        // Exercise every non-streaming D-Bus interface method. These
+        // are the ones called by adele-kde for conversation listing,
+        // titling, archival, and deletion.
+        let _id = adapter.create_conversation("Test").await.unwrap();
+        let _list = adapter.list_conversations(0, false).await.unwrap();
+        let _conv = adapter.get_conversation("c").await.unwrap();
+        let _msgs = adapter.get_messages("c", 0, -1, vec![]).await.unwrap();
+        adapter.archive_conversation("c").await.unwrap();
+        adapter.unarchive_conversation("c").await.unwrap();
+        adapter.rename_conversation("c", "x").await.unwrap();
+        adapter.delete_conversation("c").await.unwrap();
+        let _count = adapter.clear_all_history().await.unwrap();
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("USER", v),
+                None => std::env::remove_var("USER"),
+            }
+        }
+
+        let observed = service.observed();
+        assert!(
+            !observed.is_empty(),
+            "expected the inbound service to be called at least once"
+        );
+        for seen in observed {
+            assert_eq!(
+                seen, "alice-dbus",
+                "every D-Bus method must scope storage to the resolved local user, not the default sentinel"
+            );
+        }
+    }
+
+    /// Issue #156 spawn-body fix (mirrors the WS #155 fix). The
+    /// `send_prompt` body spawns a `tokio::spawn` for the LLM call.
+    /// `tokio::spawn` does not propagate task-locals, so the spawn
+    /// body must re-install `with_user_id(user_id, ...)` before
+    /// invoking the service. Without that wrap, even if the outer
+    /// D-Bus method installed the scope, the LLM-call body would see
+    /// `"default"` and storage queries inside the turn would scope
+    /// wrong.
+    ///
+    /// We test the extracted helper directly because constructing a
+    /// `SignalEmitter` requires a real D-Bus connection. The test
+    /// installs `with_user_id` around the *outer* call (simulating the
+    /// method-entry wrap) and then dispatches the helper through
+    /// `tokio::spawn`. The fix wraps the inner future in
+    /// `with_user_id`; without that wrap the spawned body sees
+    /// `"default"` and this test fails the assertion.
+    #[tokio::test]
+    async fn send_prompt_spawn_body_propagates_user_id() {
+        let service = Arc::new(RecordingConversationService::new());
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let svc_for_task = Arc::clone(&service);
+
+        // Simulate the production call site: the outer D-Bus method
+        // entry installs `with_user_id`, then calls a function that
+        // internally does `tokio::spawn(...)`. The spawned body must
+        // observe the same user_id — which only happens if the body
+        // itself is wrapped in `with_user_id`. The outer
+        // `with_user_id` returns the spawned task's `JoinHandle` so
+        // the test can drive it to completion. The lint about an
+        // async block yielding an awaitable is intentional here: the
+        // outer scope yields, the inner JoinHandle is driven
+        // separately.
+        let user = UserId::new("alice-spawn");
+        #[allow(clippy::async_yields_async)]
+        let join = with_user_id(user.clone(), async move {
+            crate::conversation::spawn_send_prompt_llm_task(
+                svc_for_task,
+                "conv-x".to_string(),
+                "hello".to_string(),
+                tx,
+            )
+        })
+        .await;
+        join.await.expect("spawn join");
+
+        // Drain at least the Complete event so we know the body ran.
+        let mut saw_complete = false;
+        while let Some(ev) = rx.recv().await {
+            if matches!(ev, StreamEvent::Complete(_)) {
+                saw_complete = true;
+            }
+        }
+        assert!(saw_complete, "spawn body must reach completion");
+
+        let observed = service.observed();
+        assert_eq!(
+            observed,
+            vec!["alice-spawn".to_string()],
+            "spawned LLM-call body must observe the caller's user_id, not the default sentinel"
+        );
+    }
 
     struct FakeConversationService;
 

--- a/crates/dbus-interface/src/knowledge.rs
+++ b/crates/dbus-interface/src/knowledge.rs
@@ -10,8 +10,10 @@
 use std::sync::Arc;
 
 use desktop_assistant_api_model::{self as api};
-use desktop_assistant_application::AssistantApiHandler;
+use desktop_assistant_application::{AssistantApiHandler, RequestContext};
 use zbus::{fdo, interface};
+
+use crate::resolve_dbus_user_id;
 
 fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
     fdo::Error::Failed(error.to_string())
@@ -27,8 +29,14 @@ impl DbusKnowledgeAdapter {
     }
 
     async fn dispatch(&self, cmd: api::Command) -> fdo::Result<api::CommandResult> {
+        // #156: install the per-user scope at the D-Bus dispatch
+        // boundary. Without this, per-user-scoped storage queries
+        // (`WHERE user_id = $1`) inside the handler see the
+        // `"default"` sentinel and miss every row owned by the
+        // local user.
+        let ctx = RequestContext::for_user(resolve_dbus_user_id());
         self.handler
-            .handle_command(cmd)
+            .handle_command_for(ctx, cmd)
             .await
             .map_err(|e| fdo::Error::Failed(format!("{e:?}")))
     }
@@ -309,10 +317,7 @@ mod tests {
         let handler = RecordingHandler::new();
         let adapter = DbusKnowledgeAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
 
-        let saved = std::env::var("USER").ok();
-        unsafe {
-            std::env::set_var("USER", "alice-kb");
-        }
+        let _guard = crate::testing::UserEnvGuard::set("alice-kb");
 
         let _ = adapter.list_entries(10, 0, "").await;
         let _ = adapter.get_entry("kb-1").await;
@@ -320,13 +325,6 @@ mod tests {
         let _ = adapter.create_entry("c", "", "").await;
         let _ = adapter.update_entry("kb-1", "c2", "", "").await;
         let _ = adapter.delete_entry("kb-1").await;
-
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-        }
 
         let observed = handler.observed();
         assert!(!observed.is_empty());

--- a/crates/dbus-interface/src/knowledge.rs
+++ b/crates/dbus-interface/src/knowledge.rs
@@ -232,4 +232,109 @@ mod tests {
             serde_json::json!({"k": 1})
         );
     }
+
+    /// Issue #156: every knowledge D-Bus method must dispatch through
+    /// `handle_command_for(RequestContext::for_user(...))` so the
+    /// per-user scope is installed before the handler runs. Without
+    /// this, the storage layer's `WHERE user_id = $1` filter sees the
+    /// `"default"` sentinel and adele-kde's knowledge browser sees no
+    /// rows.
+    #[tokio::test]
+    async fn dbus_knowledge_methods_install_user_id_scope() {
+        use desktop_assistant_application::ApiResult;
+        use desktop_assistant_core::ports::auth::current_user_id;
+        use std::sync::Mutex;
+
+        struct RecordingHandler {
+            seen: Mutex<Vec<String>>,
+        }
+        impl RecordingHandler {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    seen: Mutex::new(Vec::new()),
+                })
+            }
+            fn observed(&self) -> Vec<String> {
+                self.seen.lock().unwrap().clone()
+            }
+        }
+        #[async_trait::async_trait]
+        impl AssistantApiHandler for RecordingHandler {
+            async fn handle_command(
+                &self,
+                cmd: api::Command,
+            ) -> ApiResult<api::CommandResult> {
+                self.seen
+                    .lock()
+                    .unwrap()
+                    .push(current_user_id().as_str().to_string());
+                // Return a shape compatible with the adapter's
+                // result-matcher so the method returns Ok.
+                Ok(match cmd {
+                    api::Command::ListKnowledgeEntries { .. }
+                    | api::Command::SearchKnowledgeEntries { .. } => {
+                        api::CommandResult::KnowledgeEntries(vec![])
+                    }
+                    api::Command::GetKnowledgeEntry { .. } => {
+                        api::CommandResult::KnowledgeEntry(None)
+                    }
+                    api::Command::CreateKnowledgeEntry { .. }
+                    | api::Command::UpdateKnowledgeEntry { .. } => {
+                        api::CommandResult::KnowledgeEntryWritten(
+                            api::KnowledgeEntryView {
+                                id: "kb".into(),
+                                content: "".into(),
+                                tags: vec![],
+                                metadata: serde_json::Value::Null,
+                                created_at: "2026-05-27T00:00:00Z".into(),
+                                updated_at: "2026-05-27T00:00:00Z".into(),
+                            },
+                        )
+                    }
+                    api::Command::DeleteKnowledgeEntry { .. } => api::CommandResult::Ack,
+                    _ => api::CommandResult::Ack,
+                })
+            }
+            async fn handle_send_message(
+                &self,
+                _conversation_id: String,
+                _content: String,
+                _request_id: String,
+                _sink: Arc<dyn desktop_assistant_application::EventSink>,
+            ) -> ApiResult<()> {
+                Ok(())
+            }
+        }
+
+        let handler = RecordingHandler::new();
+        let adapter = DbusKnowledgeAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let saved = std::env::var("USER").ok();
+        unsafe {
+            std::env::set_var("USER", "alice-kb");
+        }
+
+        let _ = adapter.list_entries(10, 0, "").await;
+        let _ = adapter.get_entry("kb-1").await;
+        let _ = adapter.search_entries("q", "", 5).await;
+        let _ = adapter.create_entry("c", "", "").await;
+        let _ = adapter.update_entry("kb-1", "c2", "", "").await;
+        let _ = adapter.delete_entry("kb-1").await;
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("USER", v),
+                None => std::env::remove_var("USER"),
+            }
+        }
+
+        let observed = handler.observed();
+        assert!(!observed.is_empty());
+        for seen in observed {
+            assert_eq!(
+                seen, "alice-kb",
+                "every knowledge D-Bus method must install with_user_id at the method boundary"
+            );
+        }
+    }
 }

--- a/crates/dbus-interface/src/lib.rs
+++ b/crates/dbus-interface/src/lib.rs
@@ -30,6 +30,66 @@ pub fn resolve_dbus_user_id() -> UserId {
     }
 }
 
+#[cfg(test)]
+pub(crate) mod testing {
+    //! Test-only helpers shared across the per-module test suites.
+    //!
+    //! `$USER` is a process-global env var; the recording-fake tests
+    //! that simulate the D-Bus user_id resolution all touch it, so
+    //! they must serialize through this mutex to avoid trampling
+    //! each other under `cargo test`'s default parallel runner.
+
+    use std::sync::Mutex;
+
+    pub(crate) static USER_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard: lock the env, set `USER` to `value`, restore on
+    /// drop (or remove if it wasn't set). Use this at the top of any
+    /// test that calls `crate::resolve_dbus_user_id()` so concurrent
+    /// tests don't observe each other's mutations.
+    pub(crate) struct UserEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prev: Option<String>,
+    }
+
+    impl UserEnvGuard {
+        pub(crate) fn set(value: &str) -> Self {
+            let lock = USER_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("USER").ok();
+            // SAFETY: env access is process-global; the lock above
+            // serializes every test that touches `$USER`.
+            unsafe {
+                std::env::set_var("USER", value);
+            }
+            Self { _lock: lock, prev }
+        }
+
+        pub(crate) fn unset() -> Self {
+            let lock = USER_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("USER").ok();
+            unsafe {
+                std::env::remove_var("USER");
+            }
+            Self { _lock: lock, prev }
+        }
+    }
+
+    impl Drop for UserEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("USER", v),
+                    None => std::env::remove_var("USER"),
+                }
+            }
+        }
+    }
+}
+
 /// D-Bus adapter that exposes an `AssistantService` over the session bus.
 pub struct DbusAssistantAdapter<S: AssistantService> {
     service: S,

--- a/crates/dbus-interface/src/lib.rs
+++ b/crates/dbus-interface/src/lib.rs
@@ -3,7 +3,32 @@ pub mod conversation;
 pub mod knowledge;
 pub mod settings;
 
+use desktop_assistant_core::ports::auth::UserId;
 use desktop_assistant_core::ports::inbound::AssistantService;
+
+/// Resolve the user id for an inbound D-Bus call (#156).
+///
+/// The D-Bus session bus is local-only — there is no JWT to extract a
+/// `sub` from like the WebSocket transport does, so the daemon takes
+/// the OS-level user from the `USER` environment variable inherited
+/// from the user's session. When `USER` is unset (containerised
+/// deploys, scripted launches), the helper falls through to
+/// [`UserId::default`] — the schema sentinel `"default"` — which
+/// matches the single-tenant fallback every other code path uses.
+///
+/// ## Trust boundary
+///
+/// `$USER` is inherited from the local desktop session and is not
+/// adversary-controlled in a single-tenant deploy. Multi-tenant /
+/// shared-bus deployments need peer-credential lookup
+/// (SO_PEERCRED / `sd_bus_get_credentials`) instead; that's an
+/// explicit follow-up (see issue body) and out of scope for #156.
+pub fn resolve_dbus_user_id() -> UserId {
+    match std::env::var("USER") {
+        Ok(value) if !value.is_empty() => UserId::new(value),
+        _ => UserId::default(),
+    }
+}
 
 /// D-Bus adapter that exposes an `AssistantService` over the session bus.
 pub struct DbusAssistantAdapter<S: AssistantService> {

--- a/crates/dbus-interface/src/settings.rs
+++ b/crates/dbus-interface/src/settings.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
+use desktop_assistant_core::ports::auth::with_user_id;
 use desktop_assistant_core::ports::inbound::SettingsService;
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
+
+use crate::resolve_dbus_user_id;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, zbus::zvariant::Type)]
 pub struct ConfigData {
@@ -315,22 +318,25 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
     async fn get_llm_settings(
         &self,
     ) -> fdo::Result<(String, String, String, bool, f64, f64, u32, i32)> {
-        let settings = self
-            .service
-            .get_llm_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_llm_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            settings.connector,
-            settings.model,
-            settings.base_url,
-            settings.has_api_key,
-            settings.temperature.unwrap_or(-1.0),
-            settings.top_p.unwrap_or(-1.0),
-            settings.max_tokens.unwrap_or(0),
-            settings.hosted_tool_search.map(|v| v as i32).unwrap_or(-1),
-        ))
+            Ok((
+                settings.connector,
+                settings.model,
+                settings.base_url,
+                settings.has_api_key,
+                settings.temperature.unwrap_or(-1.0),
+                settings.top_p.unwrap_or(-1.0),
+                settings.max_tokens.unwrap_or(0),
+                settings.hosted_tool_search.map(|v| v as i32).unwrap_or(-1),
+            ))
+        })
+        .await
     }
 
     /// Update non-sensitive LLM settings.
@@ -340,56 +346,65 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         model: &str,
         base_url: &str,
     ) -> fdo::Result<()> {
-        let model = if model.trim().is_empty() {
-            None
-        } else {
-            Some(model.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let model = if model.trim().is_empty() {
+                None
+            } else {
+                Some(model.to_string())
+            };
 
-        let base_url = if base_url.trim().is_empty() {
-            None
-        } else {
-            Some(base_url.to_string())
-        };
+            let base_url = if base_url.trim().is_empty() {
+                None
+            } else {
+                Some(base_url.to_string())
+            };
 
-        self.service
-            .set_llm_settings(
-                connector.to_string(),
-                model,
-                base_url,
-                None,
-                None,
-                None,
-                None,
-            )
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .set_llm_settings(
+                    connector.to_string(),
+                    model,
+                    base_url,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Write API key to configured secret backend.
     ///
     /// This is intentionally write-only; there is no D-Bus method to read back secrets.
     async fn set_api_key(&self, api_key: &str) -> fdo::Result<()> {
-        self.service
-            .set_api_key(api_key.to_string())
-            .await
-            .map_err(to_fdo_error)
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .set_api_key(api_key.to_string())
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Generate a signed WS JWT for connection authentication.
     ///
     /// Returns the token string. Subject defaults to `desktop-client` when blank.
     async fn generate_ws_jwt(&self, subject: &str) -> fdo::Result<String> {
-        let subject = if subject.trim().is_empty() {
-            None
-        } else {
-            Some(subject.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let subject = if subject.trim().is_empty() {
+                None
+            } else {
+                Some(subject.to_string())
+            };
 
-        self.service
-            .generate_ws_jwt(subject)
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .generate_ws_jwt(subject)
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Return resolved embeddings settings.
@@ -398,20 +413,23 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
     async fn get_embeddings_settings(
         &self,
     ) -> fdo::Result<(String, String, String, bool, bool, bool)> {
-        let settings = self
-            .service
-            .get_embeddings_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_embeddings_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            settings.connector,
-            settings.model,
-            settings.base_url,
-            settings.has_api_key,
-            settings.available,
-            settings.is_default,
-        ))
+            Ok((
+                settings.connector,
+                settings.model,
+                settings.base_url,
+                settings.has_api_key,
+                settings.available,
+                settings.is_default,
+            ))
+        })
+        .await
     }
 
     /// Update embeddings settings. Empty connector clears override (reverts to LLM default).
@@ -421,28 +439,31 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         model: &str,
         base_url: &str,
     ) -> fdo::Result<()> {
-        let connector = if connector.trim().is_empty() {
-            None
-        } else {
-            Some(connector.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let connector = if connector.trim().is_empty() {
+                None
+            } else {
+                Some(connector.to_string())
+            };
 
-        let model = if model.trim().is_empty() {
-            None
-        } else {
-            Some(model.to_string())
-        };
+            let model = if model.trim().is_empty() {
+                None
+            } else {
+                Some(model.to_string())
+            };
 
-        let base_url = if base_url.trim().is_empty() {
-            None
-        } else {
-            Some(base_url.to_string())
-        };
+            let base_url = if base_url.trim().is_empty() {
+                None
+            } else {
+                Some(base_url.to_string())
+            };
 
-        self.service
-            .set_embeddings_settings(connector, model, base_url)
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .set_embeddings_settings(connector, model, base_url)
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Return connector defaults.
@@ -452,39 +473,45 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         &self,
         connector: &str,
     ) -> fdo::Result<(String, String, String, String, bool, bool, String)> {
-        let defaults = self
-            .service
-            .get_connector_defaults(connector.to_string())
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let defaults = self
+                .service
+                .get_connector_defaults(connector.to_string())
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            defaults.llm_model,
-            defaults.llm_base_url,
-            defaults.embeddings_model,
-            defaults.embeddings_base_url,
-            defaults.embeddings_available,
-            defaults.hosted_tool_search_available,
-            defaults.backend_llm_model,
-        ))
+            Ok((
+                defaults.llm_model,
+                defaults.llm_base_url,
+                defaults.embeddings_model,
+                defaults.embeddings_base_url,
+                defaults.embeddings_available,
+                defaults.hosted_tool_search_available,
+                defaults.backend_llm_model,
+            ))
+        })
+        .await
     }
 
     /// Return git persistence settings.
     ///
     /// Returns: (enabled, remote_url, remote_name, push_on_update)
     async fn get_persistence_settings(&self) -> fdo::Result<(bool, String, String, bool)> {
-        let settings = self
-            .service
-            .get_persistence_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_persistence_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            settings.enabled,
-            settings.remote_url,
-            settings.remote_name,
-            settings.push_on_update,
-        ))
+            Ok((
+                settings.enabled,
+                settings.remote_url,
+                settings.remote_name,
+                settings.push_on_update,
+            ))
+        })
+        .await
     }
 
     /// Update git persistence settings.
@@ -495,49 +522,58 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         remote_name: &str,
         push_on_update: bool,
     ) -> fdo::Result<()> {
-        let remote_url = if remote_url.trim().is_empty() {
-            None
-        } else {
-            Some(remote_url.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let remote_url = if remote_url.trim().is_empty() {
+                None
+            } else {
+                Some(remote_url.to_string())
+            };
 
-        let remote_name = if remote_name.trim().is_empty() {
-            None
-        } else {
-            Some(remote_name.to_string())
-        };
+            let remote_name = if remote_name.trim().is_empty() {
+                None
+            } else {
+                Some(remote_name.to_string())
+            };
 
-        self.service
-            .set_persistence_settings(enabled, remote_url, remote_name, push_on_update)
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .set_persistence_settings(enabled, remote_url, remote_name, push_on_update)
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Return database settings.
     ///
     /// Returns: (url, max_connections)
     async fn get_database_settings(&self) -> fdo::Result<(String, u32)> {
-        let settings = self
-            .service
-            .get_database_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_database_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((settings.url, settings.max_connections))
+            Ok((settings.url, settings.max_connections))
+        })
+        .await
     }
 
     /// Update database settings. Empty url clears it.
     async fn set_database_settings(&self, url: &str, max_connections: u32) -> fdo::Result<()> {
-        let url = if url.trim().is_empty() {
-            None
-        } else {
-            Some(url.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let url = if url.trim().is_empty() {
+                None
+            } else {
+                Some(url.to_string())
+            };
 
-        self.service
-            .set_database_settings(url, max_connections)
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .set_database_settings(url, max_connections)
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Return aggregate config tuple:
@@ -545,7 +581,7 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
     ///  embeddings_connector, embeddings_model, embeddings_base_url, embeddings_has_api_key, embeddings_available, embeddings_is_default,
     ///  persistence_enabled, persistence_remote_url, persistence_remote_name, persistence_push_on_update)
     async fn get_config(&self) -> fdo::Result<ConfigData> {
-        self.get_config_tuple().await
+        with_user_id(resolve_dbus_user_id(), self.get_config_tuple()).await
     }
 
     /// Apply a partial aggregate config update and emit `ConfigChanged`.
@@ -557,7 +593,10 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
         changes: ConfigPatchArgs,
     ) -> fdo::Result<ConfigData> {
-        let ConfigPatchArgs {
+        let user_id = resolve_dbus_user_id();
+        let emitter = emitter.to_owned();
+        let updated = with_user_id(user_id, async move {
+            let ConfigPatchArgs {
             set_llm_connector,
             llm_connector,
             set_llm_model,
@@ -590,8 +629,7 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
             llm_hosted_tool_search,
         } = changes;
 
-        let updated = self
-            .apply_config_patch(ConfigPatch {
+            self.apply_config_patch(ConfigPatch {
                 llm_connector: set_llm_connector.then_some(llm_connector),
                 llm_model: set_llm_model.then_some(llm_model),
                 llm_base_url: set_llm_base_url.then_some(llm_base_url),
@@ -612,9 +650,10 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
                 llm_hosted_tool_search: set_llm_hosted_tool_search
                     .then_some(llm_hosted_tool_search == 1),
             })
-            .await?;
+            .await
+        })
+        .await?;
 
-        let emitter = emitter.to_owned();
         Self::config_changed(&emitter, &updated)
             .await
             .map_err(to_fdo_error)?;
@@ -628,21 +667,24 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
     async fn get_backend_tasks_settings(
         &self,
     ) -> fdo::Result<(bool, String, String, String, bool, u64, u32)> {
-        let settings = self
-            .service
-            .get_backend_tasks_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_backend_tasks_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            settings.has_separate_llm,
-            settings.llm_connector,
-            settings.llm_model,
-            settings.llm_base_url,
-            settings.dreaming_enabled,
-            settings.dreaming_interval_secs,
-            settings.archive_after_days,
-        ))
+            Ok((
+                settings.has_separate_llm,
+                settings.llm_connector,
+                settings.llm_model,
+                settings.llm_base_url,
+                settings.dreaming_enabled,
+                settings.dreaming_interval_secs,
+                settings.archive_after_days,
+            ))
+        })
+        .await
     }
 
     /// Update backend-tasks settings. Empty llm_connector clears the LLM override.
@@ -655,51 +697,57 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         dreaming_interval_secs: u64,
         archive_after_days: u32,
     ) -> fdo::Result<()> {
-        let llm_connector = if llm_connector.trim().is_empty() {
-            None
-        } else {
-            Some(llm_connector.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let llm_connector = if llm_connector.trim().is_empty() {
+                None
+            } else {
+                Some(llm_connector.to_string())
+            };
 
-        let llm_model = if llm_model.trim().is_empty() {
-            None
-        } else {
-            Some(llm_model.to_string())
-        };
+            let llm_model = if llm_model.trim().is_empty() {
+                None
+            } else {
+                Some(llm_model.to_string())
+            };
 
-        let llm_base_url = if llm_base_url.trim().is_empty() {
-            None
-        } else {
-            Some(llm_base_url.to_string())
-        };
+            let llm_base_url = if llm_base_url.trim().is_empty() {
+                None
+            } else {
+                Some(llm_base_url.to_string())
+            };
 
-        self.service
-            .set_backend_tasks_settings(
-                llm_connector,
-                llm_model,
-                llm_base_url,
-                dreaming_enabled,
-                dreaming_interval_secs,
-                archive_after_days,
-            )
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .set_backend_tasks_settings(
+                    llm_connector,
+                    llm_model,
+                    llm_base_url,
+                    dreaming_enabled,
+                    dreaming_interval_secs,
+                    archive_after_days,
+                )
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// List configured MCP servers with status.
     ///
     /// Returns: Vec<(name, command, enabled, status, tool_count)>
     async fn list_mcp_servers(&self) -> fdo::Result<Vec<(String, String, bool, String, u32)>> {
-        let servers = self
-            .service
-            .list_mcp_servers()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let servers = self
+                .service
+                .list_mcp_servers()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok(servers
-            .into_iter()
-            .map(|s| (s.name, s.command, s.enabled, s.status, s.tool_count))
-            .collect())
+            Ok(servers
+                .into_iter()
+                .map(|s| (s.name, s.command, s.enabled, s.status, s.tool_count))
+                .collect())
+        })
+        .await
     }
 
     /// Add a new MCP server.
@@ -711,44 +759,53 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         namespace: &str,
         enabled: bool,
     ) -> fdo::Result<()> {
-        let args: Vec<String> = if args.trim().is_empty() {
-            vec![]
-        } else {
-            args.split_whitespace().map(|s| s.to_string()).collect()
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let args: Vec<String> = if args.trim().is_empty() {
+                vec![]
+            } else {
+                args.split_whitespace().map(|s| s.to_string()).collect()
+            };
 
-        let namespace = if namespace.trim().is_empty() {
-            None
-        } else {
-            Some(namespace.to_string())
-        };
+            let namespace = if namespace.trim().is_empty() {
+                None
+            } else {
+                Some(namespace.to_string())
+            };
 
-        self.service
-            .add_mcp_server(
-                name.to_string(),
-                command.to_string(),
-                args,
-                namespace,
-                enabled,
-            )
-            .await
-            .map_err(to_fdo_error)
+            self.service
+                .add_mcp_server(
+                    name.to_string(),
+                    command.to_string(),
+                    args,
+                    namespace,
+                    enabled,
+                )
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Remove an MCP server by name.
     async fn remove_mcp_server(&self, name: &str) -> fdo::Result<()> {
-        self.service
-            .remove_mcp_server(name.to_string())
-            .await
-            .map_err(to_fdo_error)
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .remove_mcp_server(name.to_string())
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Enable or disable an MCP server.
     async fn set_mcp_server_enabled(&self, name: &str, enabled: bool) -> fdo::Result<()> {
-        self.service
-            .set_mcp_server_enabled(name.to_string(), enabled)
-            .await
-            .map_err(to_fdo_error)
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .set_mcp_server_enabled(name.to_string(), enabled)
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Perform an action (status/start/stop/restart) on MCP server(s).
@@ -759,22 +816,25 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         action: &str,
         server: &str,
     ) -> fdo::Result<Vec<(String, String, bool, String, u32)>> {
-        let server = if server.trim().is_empty() {
-            None
-        } else {
-            Some(server.to_string())
-        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let server = if server.trim().is_empty() {
+                None
+            } else {
+                Some(server.to_string())
+            };
 
-        let servers = self
-            .service
-            .mcp_server_action(action.to_string(), server)
-            .await
-            .map_err(to_fdo_error)?;
+            let servers = self
+                .service
+                .mcp_server_action(action.to_string(), server)
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok(servers
-            .into_iter()
-            .map(|s| (s.name, s.command, s.enabled, s.status, s.tool_count))
-            .collect())
+            Ok(servers
+                .into_iter()
+                .map(|s| (s.name, s.command, s.enabled, s.status, s.tool_count))
+                .collect())
+        })
+        .await
     }
 
     /// Return WebSocket auth settings.
@@ -783,20 +843,23 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
     async fn get_ws_auth_settings(
         &self,
     ) -> fdo::Result<(Vec<String>, String, String, String, String, String)> {
-        let settings = self
-            .service
-            .get_ws_auth_settings()
-            .await
-            .map_err(to_fdo_error)?;
+        with_user_id(resolve_dbus_user_id(), async {
+            let settings = self
+                .service
+                .get_ws_auth_settings()
+                .await
+                .map_err(to_fdo_error)?;
 
-        Ok((
-            settings.methods,
-            settings.oidc_issuer,
-            settings.oidc_auth_endpoint,
-            settings.oidc_token_endpoint,
-            settings.oidc_client_id,
-            settings.oidc_scopes,
-        ))
+            Ok((
+                settings.methods,
+                settings.oidc_issuer,
+                settings.oidc_auth_endpoint,
+                settings.oidc_token_endpoint,
+                settings.oidc_client_id,
+                settings.oidc_scopes,
+            ))
+        })
+        .await
     }
 
     /// Update WebSocket auth settings.
@@ -809,17 +872,20 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
         oidc_client_id: &str,
         oidc_scopes: &str,
     ) -> fdo::Result<()> {
-        self.service
-            .set_ws_auth_settings(
-                methods,
-                oidc_issuer.to_string(),
-                oidc_auth_endpoint.to_string(),
-                oidc_token_endpoint.to_string(),
-                oidc_client_id.to_string(),
-                oidc_scopes.to_string(),
-            )
-            .await
-            .map_err(to_fdo_error)
+        with_user_id(resolve_dbus_user_id(), async {
+            self.service
+                .set_ws_auth_settings(
+                    methods,
+                    oidc_issuer.to_string(),
+                    oidc_auth_endpoint.to_string(),
+                    oidc_token_endpoint.to_string(),
+                    oidc_client_id.to_string(),
+                    oidc_scopes.to_string(),
+                )
+                .await
+                .map_err(to_fdo_error)
+        })
+        .await
     }
 
     /// Signal emitted after a successful aggregate config update.
@@ -1403,10 +1469,7 @@ mod tests {
         let service = Arc::new(RecordingSettings::new());
         let adapter = DbusSettingsAdapter::new(Arc::clone(&service));
 
-        let saved = std::env::var("USER").ok();
-        unsafe {
-            std::env::set_var("USER", "alice-settings");
-        }
+        let _guard = crate::testing::UserEnvGuard::set("alice-settings");
 
         // Exercise representative methods: read-paths, write-paths, JWT.
         // We don't need to call every method — one per dispatcher style
@@ -1424,13 +1487,6 @@ mod tests {
         let _bt = adapter.get_backend_tasks_settings().await.unwrap();
         let _mcp = adapter.list_mcp_servers().await.unwrap();
         let _ws = adapter.get_ws_auth_settings().await.unwrap();
-
-        unsafe {
-            match saved {
-                Some(v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-        }
 
         let observed = service.observed();
         assert!(!observed.is_empty());

--- a/crates/dbus-interface/src/settings.rs
+++ b/crates/dbus-interface/src/settings.rs
@@ -1168,4 +1168,278 @@ mod tests {
         let token = adapter.generate_ws_jwt("tui").await.unwrap();
         assert_eq!(token, "jwt-for-tui");
     }
+
+    /// Issue #156: settings methods that touch per-user storage must
+    /// scope to the local OS user, not the `"default"` sentinel. The
+    /// recording fake captures `current_user_id()` at the inbound call
+    /// site so we can assert the D-Bus method entry installed the
+    /// scope before calling into the service.
+    #[tokio::test]
+    async fn dbus_settings_methods_install_user_id_scope_at_method_entry() {
+        use desktop_assistant_core::ports::auth::{UserId, current_user_id};
+        use std::sync::Mutex;
+
+        struct RecordingSettings {
+            seen: Mutex<Vec<String>>,
+        }
+
+        impl RecordingSettings {
+            fn new() -> Self {
+                Self {
+                    seen: Mutex::new(Vec::new()),
+                }
+            }
+            fn record(&self) {
+                self.seen
+                    .lock()
+                    .unwrap()
+                    .push(current_user_id().as_str().to_string());
+            }
+            fn observed(&self) -> Vec<String> {
+                self.seen.lock().unwrap().clone()
+            }
+        }
+
+        impl SettingsService for RecordingSettings {
+            async fn get_llm_settings(&self) -> Result<LlmSettingsView, CoreError> {
+                self.record();
+                Ok(LlmSettingsView {
+                    connector: "x".into(),
+                    model: "y".into(),
+                    base_url: "z".into(),
+                    has_api_key: false,
+                    temperature: None,
+                    top_p: None,
+                    max_tokens: None,
+                    hosted_tool_search: None,
+                })
+            }
+            async fn set_llm_settings(
+                &self,
+                _: String,
+                _: Option<String>,
+                _: Option<String>,
+                _: Option<f64>,
+                _: Option<f64>,
+                _: Option<u32>,
+                _: Option<bool>,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn set_api_key(&self, _: String) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn generate_ws_jwt(&self, _: Option<String>) -> Result<String, CoreError> {
+                self.record();
+                Ok("t".into())
+            }
+            async fn validate_ws_jwt(&self, _: String) -> Result<bool, CoreError> {
+                self.record();
+                Ok(true)
+            }
+            async fn get_embeddings_settings(&self) -> Result<EmbeddingsSettingsView, CoreError> {
+                self.record();
+                Ok(EmbeddingsSettingsView {
+                    connector: "x".into(),
+                    model: "y".into(),
+                    base_url: "z".into(),
+                    has_api_key: false,
+                    available: true,
+                    is_default: true,
+                })
+            }
+            async fn set_embeddings_settings(
+                &self,
+                _: Option<String>,
+                _: Option<String>,
+                _: Option<String>,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn get_connector_defaults(
+                &self,
+                _: String,
+            ) -> Result<ConnectorDefaultsView, CoreError> {
+                self.record();
+                Ok(ConnectorDefaultsView {
+                    llm_model: "m".into(),
+                    llm_base_url: "u".into(),
+                    backend_llm_model: "bm".into(),
+                    embeddings_model: "em".into(),
+                    embeddings_base_url: "eu".into(),
+                    embeddings_available: false,
+                    hosted_tool_search_available: false,
+                })
+            }
+            async fn get_persistence_settings(
+                &self,
+            ) -> Result<PersistenceSettingsView, CoreError> {
+                self.record();
+                Ok(PersistenceSettingsView {
+                    enabled: false,
+                    remote_url: String::new(),
+                    remote_name: "origin".into(),
+                    push_on_update: false,
+                })
+            }
+            async fn set_persistence_settings(
+                &self,
+                _: bool,
+                _: Option<String>,
+                _: Option<String>,
+                _: bool,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn get_database_settings(&self) -> Result<DatabaseSettingsView, CoreError> {
+                self.record();
+                Ok(DatabaseSettingsView {
+                    url: String::new(),
+                    max_connections: 5,
+                })
+            }
+            async fn set_database_settings(
+                &self,
+                _: Option<String>,
+                _: u32,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn get_backend_tasks_settings(
+                &self,
+            ) -> Result<BackendTasksSettingsView, CoreError> {
+                self.record();
+                Ok(BackendTasksSettingsView {
+                    has_separate_llm: false,
+                    llm_connector: "x".into(),
+                    llm_model: "y".into(),
+                    llm_base_url: "z".into(),
+                    dreaming_enabled: false,
+                    dreaming_interval_secs: 0,
+                    archive_after_days: 0,
+                })
+            }
+            async fn set_backend_tasks_settings(
+                &self,
+                _: Option<String>,
+                _: Option<String>,
+                _: Option<String>,
+                _: bool,
+                _: u64,
+                _: u32,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn list_mcp_servers(
+                &self,
+            ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError>
+            {
+                self.record();
+                Ok(vec![])
+            }
+            async fn add_mcp_server(
+                &self,
+                _: String,
+                _: String,
+                _: Vec<String>,
+                _: Option<String>,
+                _: bool,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn remove_mcp_server(&self, _: String) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn set_mcp_server_enabled(
+                &self,
+                _: String,
+                _: bool,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+            async fn mcp_server_action(
+                &self,
+                _: String,
+                _: Option<String>,
+            ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError>
+            {
+                self.record();
+                Ok(vec![])
+            }
+            async fn get_ws_auth_settings(&self) -> Result<WsAuthSettingsView, CoreError> {
+                self.record();
+                Ok(WsAuthSettingsView {
+                    methods: vec![],
+                    oidc_issuer: String::new(),
+                    oidc_auth_endpoint: String::new(),
+                    oidc_token_endpoint: String::new(),
+                    oidc_client_id: String::new(),
+                    oidc_scopes: String::new(),
+                })
+            }
+            async fn set_ws_auth_settings(
+                &self,
+                _: Vec<String>,
+                _: String,
+                _: String,
+                _: String,
+                _: String,
+                _: String,
+            ) -> Result<(), CoreError> {
+                self.record();
+                Ok(())
+            }
+        }
+
+        let service = Arc::new(RecordingSettings::new());
+        let adapter = DbusSettingsAdapter::new(Arc::clone(&service));
+
+        let saved = std::env::var("USER").ok();
+        unsafe {
+            std::env::set_var("USER", "alice-settings");
+        }
+
+        // Exercise representative methods: read-paths, write-paths, JWT.
+        // We don't need to call every method — one per dispatcher style
+        // is enough to pin the contract.
+        let _llm = adapter.get_llm_settings().await.unwrap();
+        adapter
+            .set_llm_settings("openai", "gpt-5.4", "https://api")
+            .await
+            .unwrap();
+        adapter.set_api_key("k").await.unwrap();
+        let _jwt = adapter.generate_ws_jwt("tui").await.unwrap();
+        let _emb = adapter.get_embeddings_settings().await.unwrap();
+        let _persist = adapter.get_persistence_settings().await.unwrap();
+        let _db = adapter.get_database_settings().await.unwrap();
+        let _bt = adapter.get_backend_tasks_settings().await.unwrap();
+        let _mcp = adapter.list_mcp_servers().await.unwrap();
+        let _ws = adapter.get_ws_auth_settings().await.unwrap();
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("USER", v),
+                None => std::env::remove_var("USER"),
+            }
+        }
+
+        let observed = service.observed();
+        assert!(!observed.is_empty());
+        for seen in observed {
+            assert_eq!(
+                seen,
+                UserId::new("alice-settings").as_str(),
+                "every D-Bus settings method must scope storage to the resolved local user"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Wrap every D-Bus method body in `with_user_id(resolve_dbus_user_id(), ...)` so per-user-scoped storage queries see the local OS user instead of the `"default"` sentinel. `conversation.rs` / `settings.rs` wrap each `#[interface]` method; `connections.rs` / `knowledge.rs` route their shared `dispatch` helper through `handle_command_for(RequestContext::for_user(...))` (the same context-aware entry the WS / UDS adapters use).
- Re-install the scope inside the `send_prompt` spawn body, mirroring the WS fix in #155: `tokio::spawn` doesn't propagate task-locals, so the LLM-call body has to carry the wrap itself or storage queries inside the turn fall back to `"default"`.
- New `crate::resolve_dbus_user_id()` helper reads `$USER` (falling through to `UserId::default()` when unset) — documented at the trust boundary.
- Two new test fakes (`RecordingConversationService` and a recording `AssistantApiHandler`) capture `current_user_id()` at the call site so the acceptance tests can assert the scope was installed before the inbound service ran. Tests serialize their `$USER` mutations through a process-wide mutex (`crate::testing::UserEnvGuard`).

## User-id resolution policy (please challenge)

The D-Bus session bus is local-only — there's no JWT to extract from like the WS path does. The fix takes the OS user from `std::env::var("USER")`, which is inherited from the user's desktop session and is not adversary-controlled in single-tenant deploys. When `$USER` is unset (containerised launches, scripted runs), it falls through to `UserId::default()` so behaviour matches every other code path that doesn't have a scope installed.

Shared-bus / multi-tenant deploys need peer-credential lookup (`SO_PEERCRED` / `sd_bus_get_credentials`) instead. That's explicitly out of scope per the #156 issue body and is a follow-up hardening exercise.

## Test plan

- [x] `cargo test -p desktop-assistant-dbus` — 24 passed (19 pre-existing + 5 new acceptance tests for #156).
- [x] All 5 new tests FAIL on the test-only commit (`test(dbus-interface): failing test for #156 user_id scope`) and PASS on the fix commit, demonstrating TDD discipline.
- [x] `cargo test -p desktop-assistant-application -p desktop-assistant-core -p desktop-assistant-daemon -p desktop-assistant-dbus-bridge` — green.
- [x] `cargo build --workspace` — green.
- [x] `cargo clippy -p desktop-assistant-dbus --all-targets` — no new warnings. 5 pre-existing core warnings (collapsible_if, manual_strip, redundant_closure in `llm_profiling.rs`) and 2 pre-existing `useless vec!` warnings in `conversation.rs` are unchanged from main — see PR #155 notes.
- [x] Adversarial diff read: no new SQL, no new endpoints, no new attack surface. Production code uses no `unsafe`; test code's `unsafe { std::env::set_var }` blocks are guarded by a process-wide mutex.
- [x] No new production dependencies (Cargo.lock delta is just `async-trait` moving into `[dev-dependencies]` of `desktop-assistant-dbus`).
- [x] D-Bus signal emission audited: `send_prompt`'s emitter task only forwards channel events as zbus signals; it doesn't read per-user storage, so it doesn't need the scope.

## Data migration

No new migration. The fix is itself the corrective change for users whose data was migrated to a real `user_id` as part of the #155 follow-up — adele-kde regains visibility automatically once the daemon is rebuilt.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)