### PR TITLE
chore: local verification just targets + pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Local-CI gate: run the verification suite before allowing a push.
+# Activated via `just install-hooks` (sets core.hooksPath = .githooks).
+# Bypass in an emergency with: git push --no-verify
+set -euo pipefail
+
+echo "==> pre-push: running 'just check' (bypass with --no-verify)"
+exec just check

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -46,6 +46,14 @@ const DBUS_CONVERSATIONS_PATH: &str = "/org/desktopAssistant/Conversations";
 const DBUS_SETTINGS_PATH: &str = "/org/desktopAssistant/Settings";
 const DBUS_KNOWLEDGE_PATH: &str = "/org/desktopAssistant/Knowledge";
 
+/// Wire shape of a `list_conversations` row: `(id, title, message_count,
+/// updated_at, archived)` — mirrors the D-Bus `a(ssusb)` reply.
+type DbusConversationSummary = (String, String, u32, String, bool);
+
+/// Wire shape of `get_conversation`: `(id, title, messages)` where each message
+/// is `(role, content)` — mirrors the D-Bus `(ssa(ss))` reply.
+type DbusConversationDetail = (String, String, Vec<(String, String)>);
+
 #[zbus::proxy(interface = "org.desktopAssistant.Conversations")]
 trait Conversations {
     async fn create_conversation(&self, title: &str) -> zbus::fdo::Result<String>;
@@ -54,16 +62,13 @@ trait Conversations {
         &self,
         max_age_days: i32,
         include_archived: bool,
-    ) -> zbus::fdo::Result<Vec<(String, String, u32, String, bool)>>;
+    ) -> zbus::fdo::Result<Vec<DbusConversationSummary>>;
 
     async fn archive_conversation(&self, id: &str) -> zbus::fdo::Result<()>;
 
     async fn unarchive_conversation(&self, id: &str) -> zbus::fdo::Result<()>;
 
-    async fn get_conversation(
-        &self,
-        id: &str,
-    ) -> zbus::fdo::Result<(String, String, Vec<(String, String)>)>;
+    async fn get_conversation(&self, id: &str) -> zbus::fdo::Result<DbusConversationDetail>;
 
     async fn delete_conversation(&self, id: &str) -> zbus::fdo::Result<()>;
 

--- a/crates/daemon/src/config/secrets.rs
+++ b/crates/daemon/src/config/secrets.rs
@@ -403,3 +403,129 @@ mod tests {
         assert_eq!(read_secret_from_backend(&secret, "openai"), None);
     }
 }
+
+#[cfg(test)]
+mod integration {
+    //! Real-Secret-Service integration tests. Ignored by default — they need a
+    //! live session bus and `secret-tool`, and they mutate the keyring (under a
+    //! namespaced service, cleaned up afterwards). Run via `just test-integration`.
+    //!
+    //! This covers what the mock store cannot: the legacy `secret-tool`
+    //! `account`→`username` migrate-on-read path against a real backend (the
+    //! mock has no attributes, so `Entry::search` finds nothing there).
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
+    use std::sync::Once;
+
+    static REAL_STORE: Once = Once::new();
+
+    /// Register the real Secret Service store once, or return false (with a
+    /// skip note) when the environment can't support these tests.
+    fn real_store_ready() -> bool {
+        if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+            eprintln!("SKIP: no DBUS_SESSION_BUS_ADDRESS (no session bus)");
+            return false;
+        }
+        if !command_present("secret-tool") {
+            eprintln!("SKIP: secret-tool not installed");
+            return false;
+        }
+        REAL_STORE.call_once(|| match zbus_secret_service_keyring_store::Store::new() {
+            Ok(store) => keyring_core::set_default_store(store),
+            Err(error) => eprintln!("WARN: could not connect to Secret Service: {error}"),
+        });
+        // If Store::new failed above, Entry::new reports NoDefaultStore — skip.
+        match Entry::new("adelie-it-probe", "probe").and_then(|e| e.get_password()) {
+            Ok(_) | Err(keyring_core::Error::NoEntry) => true,
+            Err(error) => {
+                eprintln!("SKIP: Secret Service unavailable: {error}");
+                false
+            }
+        }
+    }
+
+    fn command_present(bin: &str) -> bool {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {bin}"))
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn secret_tool_store(attrs: &[(&str, &str)], value: &str) {
+        let mut cmd = Command::new("secret-tool");
+        cmd.arg("store")
+            .arg("--label")
+            .arg("adelie integration test");
+        for (key, val) in attrs {
+            cmd.arg(key).arg(val);
+        }
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("spawn secret-tool");
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(value.as_bytes())
+            .unwrap();
+        assert!(child.wait().unwrap().success(), "secret-tool store failed");
+    }
+
+    fn secret_tool_clear(attrs: &[(&str, &str)]) {
+        let mut cmd = Command::new("secret-tool");
+        cmd.arg("clear");
+        for (key, val) in attrs {
+            cmd.arg(key).arg(val);
+        }
+        let _ = cmd.output();
+    }
+
+    #[test]
+    #[ignore = "needs a real Secret Service; run via `just test-integration`"]
+    fn legacy_secret_tool_item_migrates_on_read() {
+        if !real_store_ready() {
+            return;
+        }
+        let service = "adelie-it-daemon-legacy";
+        let account = "api_key";
+        let value = "sk-legacy-integration";
+
+        // Start clean, then plant a legacy {service, account} item the way an
+        // old daemon's `secret-tool store` did.
+        secret_tool_clear(&[("service", service), ("account", account)]);
+        let _ = Entry::new(service, account).and_then(|e| e.delete_credential());
+        secret_tool_store(&[("service", service), ("account", account)], value);
+
+        // Act: the daemon's migrate-on-read path.
+        let got = read_and_migrate_legacy_secret(service, account);
+        assert_eq!(got.as_deref(), Some(value), "should read the legacy value");
+
+        // The legacy item is gone and the value now lives under the new
+        // `username` scheme.
+        let legacy_left =
+            Entry::search(&HashMap::from([("service", service), ("account", account)]))
+                .map(|items| items.len())
+                .unwrap_or(0);
+        assert_eq!(
+            legacy_left, 0,
+            "legacy item should be deleted after migration"
+        );
+        assert_eq!(
+            Entry::new(service, account)
+                .unwrap()
+                .get_password()
+                .ok()
+                .as_deref(),
+            Some(value),
+            "migrated value should be readable under the new scheme"
+        );
+
+        // Cleanup.
+        let _ = Entry::new(service, account).unwrap().delete_credential();
+    }
+}

--- a/justfile
+++ b/justfile
@@ -37,6 +37,44 @@ dev-backend:
 build:
     cargo build --workspace
 
+# --- Local verification ("local CI") -----------------------------------------
+# We run these locally instead of GitHub Actions. `install-hooks` wires `check`
+# into a git pre-push hook so it runs automatically before every push.
+
+# Full local gate: formatting, lints, build, tests (on the pinned toolchain)
+check: fmt-check lint build test
+
+# Verify formatting without modifying files
+fmt-check:
+    cargo fmt --all --check
+
+# Apply formatting
+fmt:
+    cargo fmt --all
+
+# Clippy across the workspace; warnings are errors
+lint:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Run the workspace test suite (excludes #[ignore] integration tests)
+test:
+    cargo test --workspace
+
+# Real-Secret-Service integration tests (needs a live session bus; mutates + cleans keyring)
+test-integration:
+    cargo test --workspace -- --ignored
+
+# Rebase onto latest origin/main then run the gate (catches clean-rebase-but-broken-build)
+premerge:
+    git fetch origin
+    git rebase origin/main
+    just check
+
+# Install git hooks (pre-push runs `just check`). Local config; run once per clone.
+install-hooks:
+    git config core.hooksPath .githooks
+    @echo "pre-push hook active — bypass once with: git push --no-verify"
+
 # Install user service file and reload systemd user manager
 install-service:
     [ -f "{{service_src}}" ] || (echo "Missing service file: {{service_src}}" >&2; exit 1)


### PR DESCRIPTION
## Local verification gate ("local CI") — run checks locally instead of GitHub Actions

Follow-up to the keyring-core migration post-mortem. The near-miss there (a clean rebase onto a main that had pruned an unused dep, breaking the build) was caught only by manual re-verification. This makes that gate a one-command, enforced thing — without spending on GitHub Actions.

### What's added
- **`justfile` targets:**
  - `check` → `fmt-check` + `lint` + `build` + `test` (the full gate, on the pinned 1.96.0)
  - `lint` → `cargo clippy --workspace --all-targets -- -D warnings`
  - `test-integration` → `cargo test --workspace -- --ignored` (real-backend tests)
  - `premerge` → `git fetch` + rebase onto `origin/main`, then `check` — institutionalizes the rebase-and-re-verify dance that caught the original break
  - `fmt`, `fmt-check`, `install-hooks`
- **`.githooks/pre-push`** runs `just check` automatically on every push (activate with `just install-hooks`; emergency bypass `git push --no-verify`). Enforced, not just available.
- **Real-Secret-Service integration test** (`#[ignore]`) for the legacy `secret-tool` → keyring-core `account`→`username` migrate-on-read path. The mock store has no attributes, so unit tests can't cover this — exactly the blind spot from the post-mortem. Verified passing locally (`legacy_secret_tool_item_migrates_on_read ... ok`).

### Drive-by fix the new gate surfaced
`clippy --workspace --all-targets -- -D warnings` flagged two pre-existing `type_complexity` warnings in `client-common/dbus_client.rs` (zbus proxy return tuples) that the earlier hygiene pass missed. Factored them into named type aliases (`DbusConversationSummary`, `DbusConversationDetail`) — behaviour-identical, callers unchanged.

### Verified
`just check` passes; `just test-integration` passes against the live Secret Service; `just install-hooks` sets `core.hooksPath`. Same pattern is going into adele-tui and adele-gtk.
