### PR TITLE
feat(api): ConnectionView echoes non-secret connection config

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -662,6 +662,17 @@ pub struct ConnectionView {
     /// check (env var present, keyring lookup succeeded, or Bedrock/Ollama
     /// which auth via ambient credentials / none).
     pub has_credentials: bool,
+    /// Echoed non-secret config, so a client can pre-fill an edit dialog
+    /// without losing the stored endpoint/profile/region or the credential
+    /// env-var *name*. Reuses the create/update input type
+    /// [`ConnectionConfigView`], which has no variant capable of carrying a
+    /// raw secret value — so no secret is ever serialized here. `None` only
+    /// when the daemon has no stored config for the connection.
+    ///
+    /// Added after the initial `ConnectionView` shipped; `#[serde(default)]`
+    /// keeps older daemons (which omit it) deserializable on newer clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<ConnectionConfigView>,
 }
 
 /// A single model enumerated across one or all connections. Mirrors the

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -477,6 +477,40 @@ fn api_connection_config_to_core(c: api::ConnectionConfigView) -> ConnectionConf
     }
 }
 
+/// Inverse of [`api_connection_config_to_core`]: map the non-secret core
+/// payload to its wire view. No variant of either type carries a raw secret,
+/// so this conversion cannot leak one.
+fn core_connection_config_to_api(c: ConnectionConfigPayload) -> api::ConnectionConfigView {
+    match c {
+        ConnectionConfigPayload::Anthropic {
+            base_url,
+            api_key_env,
+        } => api::ConnectionConfigView::Anthropic {
+            base_url,
+            api_key_env,
+        },
+        ConnectionConfigPayload::OpenAi {
+            base_url,
+            api_key_env,
+        } => api::ConnectionConfigView::OpenAi {
+            base_url,
+            api_key_env,
+        },
+        ConnectionConfigPayload::Bedrock {
+            aws_profile,
+            region,
+            base_url,
+        } => api::ConnectionConfigView::Bedrock {
+            aws_profile,
+            region,
+            base_url,
+        },
+        ConnectionConfigPayload::Ollama { base_url } => {
+            api::ConnectionConfigView::Ollama { base_url }
+        }
+    }
+}
+
 fn core_connection_to_api_view(
     v: desktop_assistant_core::ports::inbound::ConnectionView,
 ) -> api::ConnectionView {
@@ -491,6 +525,7 @@ fn core_connection_to_api_view(
             }
         },
         has_credentials: v.has_credentials,
+        config: v.config.map(core_connection_config_to_api),
     }
 }
 

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -326,6 +326,13 @@ pub struct ConnectionView {
     pub display_label: String,
     pub availability: ConnectionAvailability,
     pub has_credentials: bool,
+    /// Echoed non-secret config (endpoint/profile/region and the env-var
+    /// *name* that holds the credential), so clients can pre-fill an edit
+    /// dialog without re-deriving it. Carries the same shape as the
+    /// create/update input ([`ConnectionConfigPayload`]); raw secret values
+    /// and keyring coordinates are never represented in this type.
+    /// `None` only if the connection has no stored config entry.
+    pub config: Option<ConnectionConfigPayload>,
 }
 
 /// A model enumerated under a connection.

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -86,6 +86,14 @@ impl RegistryHandle {
             .into_iter()
             .map(|st| {
                 let healthy = matches!(st.health, ConnectionHealth::Ok);
+                // Echo the stored non-secret config so clients can pre-fill an
+                // edit dialog. `connection_to_payload` drops the keyring
+                // `secret` coordinates; the payload type has no field for them.
+                let config = state
+                    .config
+                    .connections
+                    .get(st.id.as_str())
+                    .map(connection_to_payload);
                 CoreConnectionView {
                     id: st.id.as_str().to_string(),
                     connector_type: st.connector_type.clone(),
@@ -97,6 +105,7 @@ impl RegistryHandle {
                         }
                     },
                     has_credentials: healthy,
+                    config,
                 }
             })
             .collect()
@@ -985,6 +994,38 @@ fn payload_to_connection(payload: ConnectionConfigPayload) -> ConnectionConfig {
         ConnectionConfigPayload::Ollama { base_url } => {
             ConnectionConfig::Ollama(OllamaConnection { base_url })
         }
+    }
+}
+
+/// Inverse of [`payload_to_connection`]: project a stored [`ConnectionConfig`]
+/// down to the protocol-neutral, **non-secret** [`ConnectionConfigPayload`]
+/// echoed back through `ConnectionView`.
+///
+/// Only endpoint/profile/region fields and the credential *env-var name*
+/// (`api_key_env`) cross this boundary. The keyring `secret` coordinates on
+/// the Anthropic/OpenAI variants are deliberately dropped — the payload type
+/// has no field for them, so a raw secret can never be reconstructed from the
+/// echoed value.
+fn connection_to_payload(conn: &ConnectionConfig) -> ConnectionConfigPayload {
+    match conn {
+        ConnectionConfig::Anthropic(c) => ConnectionConfigPayload::Anthropic {
+            base_url: c.base_url.clone(),
+            api_key_env: c.api_key_env.clone(),
+            // `c.secret` (keyring coordinates) intentionally not echoed.
+        },
+        ConnectionConfig::OpenAi(c) => ConnectionConfigPayload::OpenAi {
+            base_url: c.base_url.clone(),
+            api_key_env: c.api_key_env.clone(),
+            // `c.secret` (keyring coordinates) intentionally not echoed.
+        },
+        ConnectionConfig::Bedrock(c) => ConnectionConfigPayload::Bedrock {
+            aws_profile: c.aws_profile.clone(),
+            region: c.region.clone(),
+            base_url: c.base_url.clone(),
+        },
+        ConnectionConfig::Ollama(c) => ConnectionConfigPayload::Ollama {
+            base_url: c.base_url.clone(),
+        },
     }
 }
 

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -1125,6 +1125,22 @@ mod tests {
         })
     }
 
+    /// Anthropic connection carrying a keyring `secret` reference alongside
+    /// the non-secret `base_url` / `api_key_env`. Used to prove the echoed
+    /// view drops the secret coordinates.
+    fn anthropic_with_secret() -> ConnectionConfig {
+        use crate::config::SecretConfig;
+        ConnectionConfig::Anthropic(crate::connections::AnthropicConnection {
+            base_url: Some("https://api.anthropic.com".into()),
+            api_key_env: Some("ANTHROPIC_WORK_KEY".into()),
+            secret: Some(SecretConfig {
+                account: Some("super-secret-account".into()),
+                entry: Some("super-secret-entry".into()),
+                ..SecretConfig::default()
+            }),
+        })
+    }
+
     fn make_handle_with(cfg: DaemonConfig) -> Arc<RegistryHandle> {
         let registry = build_registry(&cfg);
         Arc::new(RegistryHandle::new(cfg, registry).with_config_path(tmp_config_path()))
@@ -1138,6 +1154,63 @@ mod tests {
         assert_eq!(views.len(), 2);
         assert_eq!(views[0].id, "local");
         assert_eq!(views[1].id, "aws");
+    }
+
+    #[tokio::test]
+    async fn list_connections_echoes_non_secret_config() {
+        let cfg = config_with_connections(&[("aws", bedrock_work())]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let views = svc.list_connections().await.unwrap();
+        assert_eq!(views.len(), 1);
+
+        let config = views[0]
+            .config
+            .as_ref()
+            .expect("ConnectionView should echo the stored non-secret config");
+        match config {
+            ConnectionConfigPayload::Bedrock {
+                aws_profile,
+                region,
+                base_url,
+            } => {
+                assert_eq!(aws_profile.as_deref(), Some("work"));
+                assert_eq!(region.as_deref(), Some("us-west-2"));
+                assert_eq!(base_url.as_deref(), None);
+            }
+            other => panic!("expected echoed Bedrock config, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_connections_echoes_config_without_leaking_secret() {
+        let cfg = config_with_connections(&[("work", anthropic_with_secret())]);
+        let svc = DaemonConnectionsService::new(make_handle_with(cfg));
+        let views = svc.list_connections().await.unwrap();
+        assert_eq!(views.len(), 1);
+
+        let config = views[0]
+            .config
+            .as_ref()
+            .expect("ConnectionView should echo the stored non-secret config");
+        match config {
+            ConnectionConfigPayload::Anthropic {
+                base_url,
+                api_key_env,
+            } => {
+                assert_eq!(base_url.as_deref(), Some("https://api.anthropic.com"));
+                assert_eq!(api_key_env.as_deref(), Some("ANTHROPIC_WORK_KEY"));
+            }
+            other => panic!("expected echoed Anthropic config, got {other:?}"),
+        }
+
+        // The keyring `secret` coordinates (account/entry/etc.) must never
+        // surface in the echoed view. The payload type has no field for them,
+        // so prove it via a full debug-string scan of every view.
+        let dump = format!("{views:?}");
+        assert!(
+            !dump.contains("super-secret-account") && !dump.contains("super-secret-entry"),
+            "echoed ConnectionView leaked secret coordinates: {dump}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`ListConnections` / `ConnectionView` now echo the stored **non-secret**
connection config so a client can pre-fill an edit dialog. Previously the
output view carried only `id` / `connector_type` / `display_label` /
`availability` / `has_credentials`, so an edit dialog had nothing to
pre-fill — saving an edit silently wiped `base_url` / `api_key_env` /
`aws_profile` / `region`.

This enables **adelie-ai/adele-gtk#43** (pre-fill the connection edit
dialog). This PR is the daemon side only; the GTK side closes that issue,
so this does **not** close it.

## Shape

- **core** (`crates/core/src/ports/inbound.rs`): add
  `config: Option<ConnectionConfigPayload>` to the inbound `ConnectionView`.
- **api-model** (`crates/api-model/src/lib.rs`): add
  `config: Option<ConnectionConfigView>` to the wire `ConnectionView`,
  **reusing the existing create/update input type** (symmetry — the client
  already renders/parses it on the input side). Marked
  `#[serde(default, skip_serializing_if = "Option::is_none")]` so older
  daemons (which omit it) stay deserializable on newer clients, and existing
  consumers (adele-tui / adele-kde) that ignore the field are unaffected.
- **daemon** (`crates/daemon/src/api_surface.rs`): populate it in
  `connection_views()` from `state.config.connections`, via a new
  `connection_to_payload` projection.
- **application** (`crates/application/src/lib.rs`): map core →wire via a
  new `core_connection_config_to_api`.

## No raw secret is echoed

Neither `ConnectionConfigPayload` (core) nor `ConnectionConfigView`
(api-model) has any variant capable of holding a raw secret value **or** the
keyring `secret` coordinates that live on the stored
`AnthropicConnection`/`OpenAiConnection`. The projection therefore drops the
secret **by construction** — only endpoint/profile/region and the credential
env-var *name* (`api_key_env`) cross the boundary. `has_credentials: bool`
remains the secret-presence signal. A test (`anthropic_with_secret`) stores
a connection with populated keyring `account`/`entry` coordinates and asserts
they never appear in the echoed views.

## API compatibility

Additive optional field; no consumer breaks. Older daemon ↔newer client
and newer daemon ↔older client both round-trip cleanly thanks to
`#[serde(default, skip_serializing_if)]`.

## Verify

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo build --workspace --all-targets` → ok
- `cargo test --workspace` → 1097 passed, 0 failed, 1 ignored (pre-existing
  Secret-Service integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)