### PR TITLE
feat(client-common): expose command channel over UDS (AssistantCommands defaults + TransportClient::as_commands)

### DIFF
--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -139,6 +139,56 @@ pub trait AssistantCommands: Send + Sync {
         }
     }
 
+    /// Send a prompt with an optional per-message model/connection override
+    /// (issue #34). Mirrors [`send_prompt`](AssistantCommands::send_prompt) but
+    /// threads `override_selection` into the `SendMessage` command, so callers
+    /// can pin a single message to a specific model without mutating stored
+    /// conversation settings.
+    async fn send_prompt_with_override(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        override_selection: Option<api::SendPromptOverride>,
+    ) -> Result<String> {
+        let result = self
+            .send_command(api::Command::SendMessage {
+                conversation_id: conversation_id.to_string(),
+                content: prompt.to_string(),
+                override_selection,
+            })
+            .await?;
+        // Post-#114 the daemon returns `SendMessageAck { task_id }` when its
+        // handler is wired with a `BackgroundTaskRegistry`; older / test
+        // daemons may still return the legacy bare `Ack`. Both are valid
+        // wire-level acks for this call site — the task id is surfaced via
+        // streaming events, not the ack.
+        match result {
+            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
+            api::CommandResult::Ack => Ok(String::new()),
+            other => Err(anyhow!("unexpected response for send_prompt: {other:?}")),
+        }
+    }
+
+    /// List models across every healthy connection. Pass `connection_id =
+    /// Some(_)` to scope to a single connection. `refresh = true` bypasses
+    /// connector caches (e.g. Bedrock).
+    async fn list_available_models(
+        &self,
+        connection_id: Option<&str>,
+        refresh: bool,
+    ) -> Result<Vec<api::ModelListing>> {
+        let result = self
+            .send_command(api::Command::ListAvailableModels {
+                connection_id: connection_id.map(str::to_string),
+                refresh,
+            })
+            .await?;
+        let api::CommandResult::Models(items) = result else {
+            return Err(anyhow!("unexpected response for list_available_models"));
+        };
+        Ok(items)
+    }
+
     // --- Knowledge management (issue #73) -------------------------------
 
     async fn list_knowledge_entries(
@@ -237,5 +287,139 @@ pub trait AssistantCommands: Send + Sync {
             return Err(anyhow!("unexpected response for delete_knowledge_entry"));
         };
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Records the last `Command` passed to `send_command` and replies with a
+    /// canned `CommandResult`, so we can assert the wire command a provided
+    /// default method emits without standing up a real transport.
+    struct RecordingClient {
+        last: Mutex<Option<api::Command>>,
+        reply: api::CommandResult,
+    }
+
+    impl RecordingClient {
+        fn new(reply: api::CommandResult) -> Self {
+            Self {
+                last: Mutex::new(None),
+                reply,
+            }
+        }
+
+        fn last(&self) -> api::Command {
+            self.last.lock().unwrap().clone().expect("no command sent")
+        }
+    }
+
+    #[async_trait]
+    impl AssistantCommands for RecordingClient {
+        async fn send_command(&self, command: api::Command) -> Result<api::CommandResult> {
+            *self.last.lock().unwrap() = Some(command);
+            Ok(self.reply.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn send_prompt_with_override_emits_send_message_with_override() {
+        let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            task_id: "task-1".to_string(),
+        });
+        let override_selection = Some(api::SendPromptOverride {
+            connection_id: "conn-1".to_string(),
+            model_id: "model-1".to_string(),
+            effort: None,
+        });
+
+        let task_id = client
+            .send_prompt_with_override("conv-1", "hello", override_selection.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(task_id, "task-1");
+        match client.last() {
+            api::Command::SendMessage {
+                conversation_id,
+                content,
+                override_selection: emitted,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(content, "hello");
+                assert_eq!(emitted, override_selection);
+                assert!(emitted.is_some());
+            }
+            other => panic!("expected Command::SendMessage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_prompt_with_override_accepts_legacy_bare_ack() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        let task_id = client
+            .send_prompt_with_override("conv-1", "hello", None)
+            .await
+            .unwrap();
+        // Legacy daemons reply with a bare `Ack`; the task id is then empty
+        // and surfaced via streaming events instead.
+        assert_eq!(task_id, String::new());
+    }
+
+    #[tokio::test]
+    async fn list_available_models_emits_list_available_models_command() {
+        let client = RecordingClient::new(api::CommandResult::Models(vec![]));
+        let models = client
+            .list_available_models(Some("conn-1"), true)
+            .await
+            .unwrap();
+
+        assert!(models.is_empty());
+        match client.last() {
+            api::Command::ListAvailableModels {
+                connection_id,
+                refresh,
+            } => {
+                assert_eq!(connection_id.as_deref(), Some("conn-1"));
+                assert!(refresh);
+            }
+            other => panic!("expected Command::ListAvailableModels, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn promoted_methods_are_reachable_through_dyn_trait_object() {
+        // The whole point of adele-gtk#49: these commands must be issuable
+        // through a `&dyn AssistantCommands` (which is what `UdsClient` is
+        // reached as via `TransportClient::as_commands`), not only on a
+        // concrete `WsClient`.
+        let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            task_id: "task-2".to_string(),
+        });
+        let commands: &dyn AssistantCommands = &client;
+
+        let task_id = commands
+            .send_prompt_with_override(
+                "conv-2",
+                "hi",
+                Some(api::SendPromptOverride {
+                    connection_id: "conn-2".to_string(),
+                    model_id: "model-2".to_string(),
+                    effort: None,
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(task_id, "task-2");
+        assert!(matches!(
+            client.last(),
+            api::Command::SendMessage {
+                override_selection: Some(_),
+                ..
+            }
+        ));
     }
 }

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -72,6 +72,26 @@ impl TransportClient {
             Self::Uds(_) => None,
         }
     }
+
+    /// Access the transport-agnostic command channel, so callers can issue
+    /// commands that aren't exposed on the high-level [`AssistantClient`]
+    /// facade (config Settings, per-conversation model override, background
+    /// tasks) over *any* socket transport — WebSocket or local UDS.
+    ///
+    /// Returns `Some` for the `Ws` and `Uds` variants, which both speak the
+    /// shared `WsRequest`/`WsFrame` protocol via [`AssistantCommands`], and
+    /// `None` for `Dbus`, which talks a separate typed zbus interface and so
+    /// does not implement that trait. This supersedes [`as_ws`](Self::as_ws)
+    /// for command-channel access (adele-gtk#49); `as_ws` is retained until
+    /// downstream callers migrate.
+    pub fn as_commands(&self) -> Option<&(dyn AssistantCommands + '_)> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => None,
+            Self::Ws(client) => Some(client),
+            Self::Uds(client) => Some(client),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -104,53 +104,41 @@ impl WsClient {
         ))
     }
 
+    /// Send a prompt with an optional per-message model/connection override.
+    ///
+    /// Backward-compatibility shim: the implementation now lives on the
+    /// transport-agnostic [`AssistantCommands`] trait (so `UdsClient` gets it
+    /// too — adele-gtk#49). This inherent delegator is kept so existing
+    /// `ws.send_prompt_with_override(...)` call sites in downstream repos
+    /// (adele-tui, adele-kde) keep compiling whether or not they have the
+    /// trait in scope.
     pub async fn send_prompt_with_override(
         &self,
         conversation_id: &str,
         prompt: &str,
         override_selection: Option<api::SendPromptOverride>,
     ) -> Result<String> {
-        let result = self
-            .send_command(api::Command::SendMessage {
-                conversation_id: conversation_id.to_string(),
-                content: prompt.to_string(),
-                override_selection,
-            })
-            .await?;
-        // Post-#114 the daemon returns `SendMessageAck { task_id }`
-        // when its handler is wired with a `BackgroundTaskRegistry`;
-        // older / test daemons may still return the legacy bare `Ack`.
-        // Both are valid wire-level acks for this call site — the
-        // task id is surfaced via streaming events, not the ack.
-        match result {
-            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
-            api::CommandResult::Ack => Ok(String::new()),
-            other => Err(anyhow!(
-                "unexpected websocket response for send_prompt: {other:?}"
-            )),
-        }
+        AssistantCommands::send_prompt_with_override(
+            self,
+            conversation_id,
+            prompt,
+            override_selection,
+        )
+        .await
     }
 
     /// List models across every healthy connection. Pass `connection_id =
     /// Some(_)` to scope to a single connection. `refresh = true` bypasses
     /// connector caches (e.g. Bedrock).
+    ///
+    /// Backward-compatibility shim delegating to the [`AssistantCommands`]
+    /// trait default (see `send_prompt_with_override` above).
     pub async fn list_available_models(
         &self,
         connection_id: Option<&str>,
         refresh: bool,
     ) -> Result<Vec<api::ModelListing>> {
-        let result = self
-            .send_command(api::Command::ListAvailableModels {
-                connection_id: connection_id.map(str::to_string),
-                refresh,
-            })
-            .await?;
-        let api::CommandResult::Models(items) = result else {
-            return Err(anyhow!(
-                "unexpected websocket response for list_available_models"
-            ));
-        };
-        Ok(items)
+        AssistantCommands::list_available_models(self, connection_id, refresh).await
     }
 }
 

--- a/crates/client-common/tests/transport_command_channel.rs
+++ b/crates/client-common/tests/transport_command_channel.rs
@@ -1,0 +1,85 @@
+//! adele-gtk#49: the generic command channel must be reachable on every
+//! socket transport, so `TransportClient::as_commands` yields a
+//! `&dyn AssistantCommands` for the WebSocket *and* Unix-domain-socket
+//! variants and `None` for D-Bus (which speaks a separate typed zbus
+//! interface).
+//!
+//! The `Uds` arm and the round-trip of the two promoted command methods over
+//! UDS are exercised in `uds_transport.rs` against the real UDS server. This
+//! file covers the `Ws` arm with a minimal in-process WebSocket accept server
+//! (enough to complete the upgrade and own the socket) and documents the
+//! `Dbus` arm, which can't be constructed without a live session bus.
+
+use desktop_assistant_client_common::TransportClient;
+use desktop_assistant_client_common::ws_client::WsClient;
+use tokio::net::TcpListener;
+use tokio::time::{Duration, timeout};
+
+/// A bare `ws://` server: accept one TCP connection, complete the WebSocket
+/// upgrade, and hold the socket open. It never replies to commands — this test
+/// only asserts the transport-capability mapping, not request round-trips.
+async fn spawn_ws_accept_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await
+            && let Ok(ws) = tokio_tungstenite::accept_async(stream).await
+        {
+            // Keep the connection (and the upgraded socket) alive for the
+            // lifetime of the test so the client side stays connected.
+            let _ws = ws;
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    });
+    format!("ws://{addr}/ws")
+}
+
+#[tokio::test]
+async fn as_commands_returns_some_for_ws_transport() {
+    let ws_url = spawn_ws_accept_server().await;
+
+    // No TLS for plain `ws://`; the accept server ignores the bearer token.
+    let (client, _signals) = timeout(
+        Duration::from_secs(5),
+        WsClient::connect(&ws_url, "test-token", None),
+    )
+    .await
+    .expect("ws connect did not complete in time")
+    .expect("ws connect");
+
+    let transport = TransportClient::Ws(client);
+    assert!(
+        transport.as_commands().is_some(),
+        "as_commands must be Some for a WebSocket transport"
+    );
+    // `as_ws` is retained alongside `as_commands` for now.
+    assert!(transport.as_ws().is_some());
+}
+
+/// The D-Bus transport speaks a separate typed zbus interface and does not
+/// implement `AssistantCommands`, so `as_commands` must be `None` for it.
+///
+/// zbus proxies build lazily, so `DbusClient::connect` succeeds against the
+/// session bus without the daemon's service being present. If no session bus
+/// is reachable at all (some CI sandboxes), the capability mapping is still
+/// guaranteed by the type system — the `Dbus` match arm cannot return
+/// `Some(client)` because `DbusClient: !AssistantCommands` — so we skip rather
+/// than fail.
+#[cfg(feature = "dbus")]
+#[tokio::test]
+async fn as_commands_returns_none_for_dbus_transport() {
+    let client = match desktop_assistant_client_common::dbus_client::DbusClient::connect().await {
+        Ok(client) => client,
+        Err(e) => {
+            eprintln!("skipping: no usable session bus ({e})");
+            return;
+        }
+    };
+
+    let transport = TransportClient::Dbus(client);
+    assert!(
+        transport.as_commands().is_none(),
+        "as_commands must be None for a D-Bus transport"
+    );
+    assert!(transport.as_ws().is_none());
+}

--- a/crates/client-common/tests/uds_transport.rs
+++ b/crates/client-common/tests/uds_transport.rs
@@ -58,6 +58,7 @@ impl AssistantApiHandler for TestHandler {
             api::Command::CreateConversation { title } => Ok(api::CommandResult::ConversationId {
                 id: format!("id-for-{title}"),
             }),
+            api::Command::ListAvailableModels { .. } => Ok(api::CommandResult::Models(Vec::new())),
             _ => Err(ApiError::Unsupported),
         }
     }
@@ -144,6 +145,57 @@ async fn uds_transport_round_trips_commands() {
         .expect("no response within 2s")
         .expect("create_conversation over uds");
     assert_eq!(id, "id-for-hello");
+
+    let _ = shutdown.send(());
+}
+
+/// adele-gtk#49: the generic command channel must be reachable over the
+/// local UDS transport, not only WebSocket. `TransportClient::as_commands`
+/// must yield `Some(&dyn AssistantCommands)` for a UDS client, and the two
+/// methods that were previously WebSocket-only inherent methods
+/// (`send_prompt_with_override`, `list_available_models`) must round-trip
+/// through it.
+#[tokio::test]
+async fn uds_transport_exposes_command_channel_via_as_commands() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let shutdown = start_server(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let config = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    let (client, _signals) = connect_transport(&config).await.expect("connect over uds");
+
+    let commands = client
+        .as_commands()
+        .expect("as_commands must be Some for a UDS transport");
+
+    // Per-conversation model override over UDS. The TestHandler uses the
+    // legacy `Ack` send path, so the returned task id is empty — the point is
+    // that the command reaches the daemon over the local socket at all.
+    let override_selection = Some(api::SendPromptOverride {
+        connection_id: "conn-1".to_string(),
+        model_id: "model-1".to_string(),
+        effort: None,
+    });
+    let task_id = timeout(
+        Duration::from_secs(2),
+        commands.send_prompt_with_override("conv-1", "hi", override_selection),
+    )
+    .await
+    .expect("no response within 2s")
+    .expect("send_prompt_with_override over uds");
+    assert_eq!(task_id, String::new());
+
+    // Model listing over UDS.
+    let models = timeout(
+        Duration::from_secs(2),
+        commands.list_available_models(None, false),
+    )
+    .await
+    .expect("no response within 2s")
+    .expect("list_available_models over uds");
+    assert!(models.is_empty());
 
     let _ = shutdown.send(());
 }


### PR DESCRIPTION
## What

Makes the generic command channel reachable on the local Unix-socket (UDS) transport, not just WebSocket, so config Settings / per-conversation model override / background tasks aren't WebSocket-only.

This is the **daemon/client-common side** of adelie-ai/adele-gtk#49 (reference only — the gtk side closes that issue once it migrates onto this API).

## Changes (all in `crates/client-common`)

1. **Promoted two convenience methods to `AssistantCommands` trait defaults** (`commands.rs`): `send_prompt_with_override` and `list_available_models` moved out of `impl WsClient` and into the transport-agnostic `AssistantCommands` trait as provided default methods (same bodies, same return mapping including the `SendMessageAck`/legacy-`Ack` handling). Because `UdsClient` already `impl AssistantCommands`, it now inherits both methods — the UDS client gets per-conversation override and model listing for free.

2. **Kept downstream callers compiling via thin inherent delegators**: the original inherent `WsClient::send_prompt_with_override` / `WsClient::list_available_models` are retained with identical signatures, now delegating to the trait defaults (`AssistantCommands::method(self, ...)`). This means existing `ws.send_prompt_with_override(...)` / `ws.list_available_models(...)` call sites in the separate adele-tui / adele-kde repos keep compiling whether or not they import the trait. (There are zero in-workspace callers of these inherent methods, so the delegators exist purely for backward-compat of the external repos.)

3. **Added `TransportClient::as_commands(&self) -> Option<&dyn AssistantCommands>`** (`transport.rs`): returns `Some` for the `Ws` and `Uds` variants (both speak the shared `WsRequest`/`WsFrame` protocol via `AssistantCommands`) and `None` for `Dbus` (separate typed zbus interface, does not implement the trait). `as_ws()` is left untouched until gtk migrates off it.

## Tests

- `commands.rs`: `send_prompt_with_override_emits_send_message_with_override`, `send_prompt_with_override_accepts_legacy_bare_ack`, `list_available_models_emits_list_available_models_command`, `promoted_methods_are_reachable_through_dyn_trait_object` (mock `AssistantCommands` recording the emitted `Command`).
- `transport_command_channel.rs`: `as_commands_returns_some_for_ws_transport` (real in-process `ws://` accept server), `as_commands_returns_none_for_dbus_transport` (feature-gated; skips if no session bus).
- `uds_transport.rs`: `uds_transport_exposes_command_channel_via_as_commands` — `as_commands()` is `Some` for a real UDS client and both promoted methods round-trip over the real UDS server.

## Backward compatibility

API is **additive**: no public method or signature is removed or renamed. The trait gains two default methods (additive); the `WsClient` inherent methods remain with unchanged signatures. `adele-tui` / `adele-kde` are separate repos that depend on this crate — their call sites are unaffected (verified at the signature level; could not compile those repos from here).

## Verification

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0
- `cargo build --workspace --all-targets` → ok
- `cargo test --workspace` → 1104 passed, 0 failed, 1 ignored (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)