### PR TITLE
feat: evict terminal tasks from BackgroundTaskRegistry; finalize panics; harden tests (#158)

### DIFF
--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -1087,9 +1087,12 @@ mod tests {
     #[tokio::test]
     async fn finalize_sets_failed_on_error() {
         // Internal contract: an Err from the body and a non-cancelled
-        // token yields TaskStatus::Failed with the error message.
+        // token yields TaskStatus::Failed with the error message in the
+        // TaskCompleted event. The entry is evicted immediately, so we
+        // observe status via subscribe rather than `get`.
         let registry = BackgroundTaskRegistry::new();
         let user = UserId::new("alice");
+        let mut events = registry.subscribe(&user);
         let id = registry.spawn(
             user.clone(),
             api::TaskKind::Conversation {
@@ -1098,10 +1101,98 @@ mod tests {
             "failer".into(),
             |_ctx| async move { Err(anyhow::anyhow!("boom")) },
         );
+        let want = id.0.clone();
+        let (status, last_error) = loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+                Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+                    break (status, last_error);
+                }
+                Ok(Ok(_)) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+                Err(_) => panic!("timed out waiting for TaskCompleted"),
+            }
+        };
+        assert_eq!(status, api::TaskStatus::Failed);
+        assert_eq!(last_error.as_deref(), Some("boom"));
+        assert!(registry.get(&user, &id).is_none(), "terminal task must be evicted");
+    }
+
+    #[tokio::test]
+    async fn terminal_task_evicted_on_completion() {
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let id = registry.spawn(
+            user.clone(),
+            api::TaskKind::Conversation {
+                conversation_id: "c".into(),
+            },
+            "ok".into(),
+            |_ctx| async move { Ok(()) },
+        );
         registry.wait(&id).await;
-        let view = registry.get(&user, &id).expect("present");
-        assert_eq!(view.status, api::TaskStatus::Failed);
-        assert_eq!(view.last_error.as_deref(), Some("boom"));
+        assert!(registry.get(&user, &id).is_none());
+        assert!(registry.list(&user, true, None).is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_task_evicted_on_cancellation() {
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let id = registry.spawn(
+            user.clone(),
+            api::TaskKind::Conversation {
+                conversation_id: "c".into(),
+            },
+            "cancellable".into(),
+            |ctx| async move {
+                ctx.token.cancelled().await;
+                Ok(())
+            },
+        );
+        registry.cancel(&user, &id).expect("cancel");
+        registry.wait(&id).await;
+        assert!(registry.get(&user, &id).is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_subagent_unlinked_from_parent_children() {
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let parent_release = Arc::new(tokio::sync::Notify::new());
+        let parent_release_for_task = Arc::clone(&parent_release);
+        let parent = registry.spawn(
+            user.clone(),
+            api::TaskKind::Conversation {
+                conversation_id: "c".into(),
+            },
+            "parent".into(),
+            move |_ctx| async move {
+                parent_release_for_task.notified().await;
+                Ok(())
+            },
+        );
+        let child = registry.spawn(
+            user.clone(),
+            api::TaskKind::Subagent {
+                parent_task_id: parent.clone(),
+                conversation_id: "c-child".into(),
+                name: "sub".into(),
+            },
+            "child".into(),
+            |_ctx| async move { Ok(()) },
+        );
+        registry.wait(&child).await;
+
+        let parent_view = registry.get(&user, &parent).expect("parent still running");
+        assert!(
+            !parent_view.children.contains(&child),
+            "evicted child should be unlinked from parent.children, got {:?}",
+            parent_view.children
+        );
+
+        parent_release.notify_one();
+        registry.wait(&parent).await;
     }
 
     #[tokio::test]
@@ -1140,9 +1231,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lifecycle_log_entries_emitted_on_start_and_completion() {
+    async fn start_lifecycle_log_entry_is_broadcast_to_subscribers() {
+        // The start-of-task Lifecycle marker is appended via TaskLogSink
+        // and so is broadcast to subscribers. The completion is signaled
+        // by the TaskCompleted event itself; a separate completion
+        // lifecycle log would only live in state.logs which is wiped on
+        // eviction, so we don't emit one.
         let registry = BackgroundTaskRegistry::new();
         let user = UserId::new("alice");
+        let mut events = registry.subscribe(&user);
         let id = registry.spawn(
             user.clone(),
             api::TaskKind::Conversation {
@@ -1151,15 +1248,25 @@ mod tests {
             "lifecycle".into(),
             |_ctx| async move { Ok(()) },
         );
-        registry.wait(&id).await;
-        let (entries, _) = registry.logs(&user, &id, 0, 100).unwrap();
-        let categories: Vec<_> = entries.iter().map(|e| e.category).collect();
-        assert!(categories.contains(&api::LogCategory::Lifecycle));
-        // Both start and completion lifecycle markers should be present.
-        let count = categories
-            .iter()
-            .filter(|c| **c == api::LogCategory::Lifecycle)
-            .count();
-        assert_eq!(count, 2, "expected start + completion lifecycle markers");
+        let want = id.0.clone();
+        let mut saw_start_marker = false;
+        let mut saw_completed = false;
+        while !saw_completed {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+                Ok(Ok(api::Event::TaskLogAppended { id, entry }))
+                    if id == want && entry.category == api::LogCategory::Lifecycle =>
+                {
+                    saw_start_marker = true;
+                }
+                Ok(Ok(api::Event::TaskCompleted { id, .. })) if id == want => {
+                    saw_completed = true;
+                }
+                Ok(Ok(_)) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+                Err(_) => panic!("timed out waiting for events"),
+            }
+        }
+        assert!(saw_start_marker, "expected start lifecycle marker");
     }
 }

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -957,7 +957,7 @@ impl Inner {
         user_id: &UserId,
         result: anyhow::Result<()>,
     ) {
-        let (status, last_error) = {
+        let (status, last_error, progress_hint, ended_at, parent_id) = {
             let mut tasks = self.tasks.lock().expect("tasks poisoned");
             let Some(state) = tasks.get_mut(task_id) else {
                 return;
@@ -972,41 +972,20 @@ impl Inner {
                 (Err(e), false) => (api::TaskStatus::Failed, Some(e.to_string())),
             };
             state.view.status = status;
-            state.view.ended_at = Some(now_ms());
+            let ended_at = now_ms();
+            state.view.ended_at = Some(ended_at);
             state.view.last_error = err.clone();
             state.completed = true;
-            (status, err)
+            // Snapshot the fields needed for the post-broadcast persist
+            // and eviction passes; the lock is released at scope end.
+            (
+                status,
+                err,
+                state.view.progress_hint.clone(),
+                ended_at,
+                state.view.parent.clone(),
+            )
         };
-
-        // Emit a lifecycle log line so a late subscriber that only reads
-        // logs still sees the terminal marker.
-        {
-            let mut tasks = self.tasks.lock().expect("tasks poisoned");
-            if let Some(state) = tasks.get_mut(task_id) {
-                let entry = api::TaskLogEntry {
-                    seq: state.next_seq,
-                    timestamp: now_ms(),
-                    level: match status {
-                        api::TaskStatus::Failed => api::LogLevel::Error,
-                        api::TaskStatus::Cancelled => api::LogLevel::Warn,
-                        _ => api::LogLevel::Info,
-                    },
-                    category: api::LogCategory::Lifecycle,
-                    message: match status {
-                        api::TaskStatus::Completed => "task completed".into(),
-                        api::TaskStatus::Cancelled => "task cancelled".into(),
-                        api::TaskStatus::Failed => "task failed".into(),
-                        _ => "task terminated".into(),
-                    },
-                    data: None,
-                };
-                state.next_seq += 1;
-                if state.logs.len() == self.config.log_ring_capacity {
-                    state.logs.pop_front();
-                }
-                state.logs.push_back(entry);
-            }
-        }
 
         self.broadcast(
             user_id,
@@ -1020,26 +999,35 @@ impl Inner {
         // Persist the terminal state. The in-memory broadcast happens
         // first because subscribers don't care about durability — they
         // care about the lifecycle event. Persistence happens after so
-        // a slow DB doesn't gate the wake. The progress_hint snapshot
-        // is read under a tiny critical section, decoupled from the
-        // broadcast above.
-        let (progress_hint, ended_at) = {
-            let tasks = self.tasks.lock().expect("tasks poisoned");
-            let view = tasks.get(task_id).map(|s| s.view.clone());
-            (
-                view.as_ref().and_then(|v| v.progress_hint.clone()),
-                view.and_then(|v| v.ended_at),
-            )
-        };
+        // a slow DB doesn't gate the wake.
         self.persist_update(
             task_id,
             user_id,
             api_status_to_db(status),
             last_error.as_deref(),
             progress_hint.as_deref(),
-            ended_at,
+            Some(ended_at),
         )
         .await;
+
+        // Evict the terminal entry from the in-memory map (#158). The
+        // broadcast has already fired and persistence has completed; a
+        // missed broadcast subscriber can still recover the terminal
+        // state from the persisted row. Holding terminal entries forever
+        // would let the registry grow unbounded over the daemon's
+        // lifetime.
+        //
+        // Done before notify_waiters so that any `wait`er that loops
+        // back into `get`/`list` immediately observes the eviction.
+        {
+            let mut tasks = self.tasks.lock().expect("tasks poisoned");
+            tasks.remove(task_id);
+            if let Some(parent_id) = &parent_id
+                && let Some(parent) = tasks.get_mut(parent_id)
+            {
+                parent.view.children.retain(|c| c != task_id);
+            }
+        }
 
         // Wake waiters.
         let waiter = {

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -385,12 +385,29 @@ impl BackgroundTaskRegistry {
             // Run the body inside a `CURRENT_TASK_ID` task-local scope so
             // nested tool dispatches (the `spawn_subagent` builtin, in
             // particular) can read the running task's id without threading
-            // it through every signature. We always finalize, even on
-            // panic, so the registry never gets stuck with a row in
-            // `Running` after the task disappears.
-            let result = CURRENT_TASK_ID
-                .scope(task_id_for_scope, body(ctx_for_body))
-                .await;
+            // it through every signature.
+            //
+            // The body runs in a *child* task so that a panic surfaces as a
+            // `JoinError` we can finalize on, instead of unwinding this
+            // finalizer task. If a panicking body skipped `finalize`, the
+            // row would be stuck `Running` forever — never broadcast, never
+            // evicted — and every `wait()` on it would hang (#171). A panic
+            // is recorded as a terminal `Failed`.
+            let body_task =
+                tokio::spawn(CURRENT_TASK_ID.scope(task_id_for_scope, body(ctx_for_body)));
+            let result = match body_task.await {
+                Ok(outcome) => outcome,
+                Err(join_err) if join_err.is_panic() => {
+                    let payload = join_err.into_panic();
+                    let msg = payload
+                        .downcast_ref::<&str>()
+                        .map(|s| (*s).to_string())
+                        .or_else(|| payload.downcast_ref::<String>().cloned())
+                        .unwrap_or_else(|| "task body panicked".to_string());
+                    Err(anyhow::anyhow!("task body panicked: {msg}"))
+                }
+                Err(join_err) => Err(anyhow::anyhow!("task body aborted: {join_err}")),
+            };
             inner
                 .finalize(&task_id_for_body, &user_id_for_body, result)
                 .await;
@@ -1093,6 +1110,60 @@ mod tests {
         assert_eq!(status, api::TaskStatus::Failed);
         assert_eq!(last_error.as_deref(), Some("boom"));
         assert!(registry.get(&user, &id).is_none(), "terminal task must be evicted");
+    }
+
+    #[tokio::test]
+    async fn panicking_body_finalizes_as_failed_and_wakes_waiters() {
+        // #171: a body that panics must still finalize (as Failed) rather
+        // than leaving the row stuck `Running` and hanging every waiter
+        // forever. The `tokio::time::timeout` around `wait()` is the
+        // hang-detector: if this regresses, `wait()` never resolves and the
+        // test fails fast instead of hanging the whole suite.
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let mut events = registry.subscribe(&user);
+        let id = registry.spawn(
+            user.clone(),
+            api::TaskKind::Conversation {
+                conversation_id: "c".into(),
+            },
+            "panicker".into(),
+            |_ctx| async move {
+                panic!("kaboom");
+            },
+        );
+
+        // The bug: this `wait()` hung indefinitely. It must now resolve.
+        tokio::time::timeout(std::time::Duration::from_secs(5), registry.wait(&id))
+            .await
+            .expect("wait() on a panicked task must resolve, not hang");
+
+        let want = id.0.clone();
+        let (status, last_error) = loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+                Ok(Ok(api::Event::TaskCompleted {
+                    id,
+                    status,
+                    last_error,
+                })) if id == want => break (status, last_error),
+                Ok(Ok(_)) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+                Err(_) => panic!("timed out waiting for TaskCompleted"),
+            }
+        };
+        assert_eq!(status, api::TaskStatus::Failed);
+        assert!(
+            last_error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("panicked"),
+            "last_error should note the panic, got {last_error:?}"
+        );
+        assert!(
+            registry.get(&user, &id).is_none(),
+            "panicked task must be evicted like any terminal task"
+        );
     }
 
     #[tokio::test]

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -1098,7 +1098,11 @@ mod tests {
         let want = id.0.clone();
         let (status, last_error) = loop {
             match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
-                Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+                Ok(Ok(api::Event::TaskCompleted {
+                    id,
+                    status,
+                    last_error,
+                })) if id == want => {
                     break (status, last_error);
                 }
                 Ok(Ok(_)) => continue,
@@ -1109,7 +1113,10 @@ mod tests {
         };
         assert_eq!(status, api::TaskStatus::Failed);
         assert_eq!(last_error.as_deref(), Some("boom"));
-        assert!(registry.get(&user, &id).is_none(), "terminal task must be evicted");
+        assert!(
+            registry.get(&user, &id).is_none(),
+            "terminal task must be evicted"
+        );
     }
 
     #[tokio::test]

--- a/crates/application/tests/background_tasks.rs
+++ b/crates/application/tests/background_tasks.rs
@@ -60,7 +60,11 @@ async fn wait_for_completion(
     let want = task_id.0.clone();
     loop {
         match timeout(Duration::from_secs(5), events.recv()).await {
-            Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+            Ok(Ok(api::Event::TaskCompleted {
+                id,
+                status,
+                last_error,
+            })) if id == want => {
                 return (status, last_error);
             }
             Ok(Ok(_)) => continue,
@@ -134,10 +138,17 @@ async fn registry_evicts_terminal_tasks_so_list_returns_only_in_flight() {
     // surfaces sweep-resurrected rows after a daemon restart.
     for include_finished in [false, true] {
         let listing = registry.list(&user, include_finished, None);
-        assert_eq!(listing.len(), 1, "include_finished={include_finished} {listing:?}");
+        assert_eq!(
+            listing.len(),
+            1,
+            "include_finished={include_finished} {listing:?}"
+        );
         assert_eq!(listing[0].id, running);
     }
-    assert!(registry.get(&user, &done).is_none(), "terminal task must be evicted");
+    assert!(
+        registry.get(&user, &done).is_none(),
+        "terminal task must be evicted"
+    );
 
     // Let the running task complete so the test doesn't leak it.
     release.notify_one();
@@ -212,9 +223,15 @@ async fn registry_user_scope_isolates_listings() {
     r_a1.notify_one();
     r_a2.notify_one();
     r_b1.notify_one();
-    registry.wait(&a1).await;
-    registry.wait(&a2).await;
-    registry.wait(&b1).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&a1))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&a2))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&b1))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 // ----------------------------------------------------------------------
@@ -401,7 +418,9 @@ async fn registry_log_ring_drops_oldest_when_bounded() {
     assert_eq!(next_resumed, last_seq + 1);
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 // ----------------------------------------------------------------------
@@ -1033,7 +1052,9 @@ async fn slow_subscriber_does_not_block_other_subscribers() {
     }
     // Let all of them complete so events flush through.
     for id in &ids {
-        registry.wait(id).await;
+        tokio::time::timeout(Duration::from_secs(5), registry.wait(id))
+            .await
+            .expect("wait() must resolve once the task finalizes, not hang");
     }
 
     // The fast subscriber must still receive at least one event despite
@@ -1111,7 +1132,9 @@ async fn log_sink_emits_log_appended_event() {
     assert!(saw, "no TaskLogAppended event received");
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 // ----------------------------------------------------------------------
@@ -1135,10 +1158,15 @@ async fn concurrent_spawns_under_same_user_are_thread_safe() {
         let registry = Arc::clone(&registry);
         let user = user.clone();
         handles.push(tokio::spawn(async move {
-            registry.spawn(user, conv_kind("c"), "concurrent".into(), move |_| async move {
-                release.notified().await;
-                Ok(())
-            })
+            registry.spawn(
+                user,
+                conv_kind("c"),
+                "concurrent".into(),
+                move |_| async move {
+                    release.notified().await;
+                    Ok(())
+                },
+            )
         }));
     }
 
@@ -1158,7 +1186,9 @@ async fn concurrent_spawns_under_same_user_are_thread_safe() {
         release.notify_one();
     }
     for id in &ids {
-        registry.wait(id).await;
+        tokio::time::timeout(Duration::from_secs(5), registry.wait(id))
+            .await
+            .expect("wait() must resolve once the task finalizes, not hang");
     }
 }
 
@@ -1198,7 +1228,9 @@ async fn task_view_progress_hint_updates_via_context() {
     .await;
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 // ----------------------------------------------------------------------
@@ -1276,8 +1308,14 @@ async fn business_outcome_subagent_or_standalone_kinds_compile_and_are_listable_
     // parented in `children` until they evict), then parent.
     sub_release.notify_one();
     standalone_release.notify_one();
-    registry.wait(&sub).await;
-    registry.wait(&standalone).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&sub))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&standalone))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
     parent_release.notify_one();
-    registry.wait(&parent).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&parent))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }

--- a/crates/application/tests/background_tasks.rs
+++ b/crates/application/tests/background_tasks.rs
@@ -49,6 +49,28 @@ async fn wait_until<F: FnMut() -> bool>(mut pred: F, label: &str) {
     panic!("predicate '{label}' never became true within timeout");
 }
 
+/// Drain events for `task_id` from a broadcast receiver until a terminal
+/// `TaskCompleted` arrives, then return its `(status, last_error)`. Used
+/// by tests now that terminal entries are evicted from the registry —
+/// callers can no longer inspect post-completion state via `get`/`list`.
+async fn wait_for_completion(
+    events: &mut tokio::sync::broadcast::Receiver<api::Event>,
+    task_id: &api::TaskId,
+) -> (api::TaskStatus, Option<String>) {
+    let want = task_id.0.clone();
+    loop {
+        match timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+                return (status, last_error);
+            }
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed before TaskCompleted: {e:?}"),
+            Err(_) => panic!("timed out waiting for TaskCompleted({})", want),
+        }
+    }
+}
+
 // ----------------------------------------------------------------------
 // 1. Unique task ids
 // ----------------------------------------------------------------------
@@ -72,13 +94,14 @@ async fn registry_spawn_returns_unique_task_id() {
 }
 
 // ----------------------------------------------------------------------
-// 2. include_finished flag controls visibility
+// 2. Terminal tasks are evicted from the registry
 // ----------------------------------------------------------------------
 
 #[tokio::test]
-async fn registry_list_excludes_finished_when_flag_off() {
+async fn registry_evicts_terminal_tasks_so_list_returns_only_in_flight() {
     let registry = BackgroundTaskRegistry::new();
     let user = unique_user("alice");
+    let mut events = registry.subscribe(&user);
 
     // One task that completes immediately.
     let done = registry.spawn(
@@ -101,21 +124,24 @@ async fn registry_list_excludes_finished_when_flag_off() {
         },
     );
 
-    // Wait for the first task to terminate.
-    registry.wait(&done).await;
+    // Observe the completion of `done` via the broadcast channel; the
+    // registry evicts terminal entries, so it's no longer queryable.
+    let (status, _) = wait_for_completion(&mut events, &done).await;
+    assert_eq!(status, api::TaskStatus::Completed);
 
-    let only_active = registry.list(&user, /*include_finished=*/ false, None);
-    assert_eq!(only_active.len(), 1, "{only_active:?}");
-    assert_eq!(only_active[0].id, running);
-
-    let everything = registry.list(&user, /*include_finished=*/ true, None);
-    let ids: HashSet<_> = everything.iter().map(|v| v.id.clone()).collect();
-    assert!(ids.contains(&done));
-    assert!(ids.contains(&running));
+    // Both flag values now return only the in-flight task. The
+    // include_finished flag is retained as a public API but only ever
+    // surfaces sweep-resurrected rows after a daemon restart.
+    for include_finished in [false, true] {
+        let listing = registry.list(&user, include_finished, None);
+        assert_eq!(listing.len(), 1, "include_finished={include_finished} {listing:?}");
+        assert_eq!(listing[0].id, running);
+    }
+    assert!(registry.get(&user, &done).is_none(), "terminal task must be evicted");
 
     // Let the running task complete so the test doesn't leak it.
     release.notify_one();
-    registry.wait(&running).await;
+    let _ = wait_for_completion(&mut events, &running).await;
 }
 
 // ----------------------------------------------------------------------
@@ -230,9 +256,9 @@ async fn registry_cancel_fires_token_and_transitions_status() {
     assert!(saw_cancel_complete, "did not see TaskCompleted{{Cancelled}}");
     assert!(observed_cancel.load(Ordering::SeqCst));
 
-    let view = registry.get(&user, &task_id).expect("task exists");
-    assert_eq!(view.status, api::TaskStatus::Cancelled);
-    assert!(view.ended_at.is_some());
+    // Terminal entries are evicted; the broadcast event above is the
+    // authoritative resolution of the cancel.
+    assert!(registry.get(&user, &task_id).is_none());
 }
 
 // ----------------------------------------------------------------------
@@ -244,6 +270,8 @@ async fn registry_cancel_cross_user_returns_not_found() {
     let registry = BackgroundTaskRegistry::new();
     let alice = unique_user("alice");
     let bob = unique_user("bob");
+
+    let mut alice_events = registry.subscribe(&alice);
 
     let observed_cancel = Arc::new(AtomicBool::new(false));
     let observed_for_task = Arc::clone(&observed_cancel);
@@ -274,14 +302,12 @@ async fn registry_cancel_cross_user_returns_not_found() {
 
     // Alice's task continued — let it complete normally.
     release.notify_one();
-    registry.wait(&task_id).await;
+    let (status, _) = wait_for_completion(&mut alice_events, &task_id).await;
+    assert_eq!(status, api::TaskStatus::Completed);
     assert!(
         !observed_cancel.load(Ordering::SeqCst),
         "token was tripped by cross-user cancel"
     );
-
-    let view = registry.get(&alice, &task_id).expect("alice can see her task");
-    assert_eq!(view.status, api::TaskStatus::Completed);
 }
 
 // ----------------------------------------------------------------------
@@ -874,16 +900,22 @@ mod foreground_send {
         assert!(registry.list(&bob, true, None).is_empty());
         assert!(registry.get(&bob, &task_id).is_none());
 
-        // Let the underlying call finish.
+        // Let the underlying call finish. After completion the task is
+        // evicted from the registry — `list` (either flag) returns it
+        // no longer, and `get` is None.
+        let mut alice_events = registry.subscribe(&alice);
         release.notify_one();
         join.await.expect("join");
-
-        // After completion the task is visible only when include_finished=true.
-        let post = registry.list(&alice, /*include_finished=*/ true, None);
-        let view = post.into_iter().find(|v| v.id == task_id).expect("present");
-        assert_eq!(view.status, api::TaskStatus::Completed);
-        let only_running = registry.list(&alice, /*include_finished=*/ false, None);
-        assert!(only_running.iter().all(|v| v.id != task_id));
+        let (status, _) = wait_for_completion(&mut alice_events, &task_id).await;
+        assert_eq!(status, api::TaskStatus::Completed);
+        for include_finished in [false, true] {
+            let listing = registry.list(&alice, include_finished, None);
+            assert!(
+                listing.iter().all(|v| v.id != task_id),
+                "evicted task surfaced with include_finished={include_finished}: {listing:?}"
+            );
+        }
+        assert!(registry.get(&alice, &task_id).is_none());
     }
 
     #[tokio::test]
@@ -934,6 +966,7 @@ mod foreground_send {
         };
 
         // Cancel via the registry — must trip the token and end the call.
+        let mut alice_events = registry.subscribe(&alice);
         registry.cancel(&alice, &task_id).expect("cancel ok");
         join.await.expect("join");
 
@@ -942,8 +975,11 @@ mod foreground_send {
             "the underlying LLM call did not observe cancellation"
         );
 
-        let view = registry.get(&alice, &task_id).expect("present");
-        assert_eq!(view.status, api::TaskStatus::Cancelled);
+        // Terminal entries are evicted; the broadcast event is the
+        // authoritative status indicator.
+        let (status, _) = wait_for_completion(&mut alice_events, &task_id).await;
+        assert_eq!(status, api::TaskStatus::Cancelled);
+        assert!(registry.get(&alice, &task_id).is_none());
     }
 }
 
@@ -1068,12 +1104,20 @@ async fn concurrent_spawns_under_same_user_are_thread_safe() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
     let user = unique_user("alice");
 
+    // Each task gets its own Notify so we can keep them all in-flight
+    // simultaneously for the visibility check (terminal entries are now
+    // evicted, so a task that returns Ok immediately disappears before
+    // we can list it).
+    let mut releases: Vec<Arc<Notify>> = Vec::with_capacity(100);
     let mut handles = Vec::new();
     for _ in 0..100 {
+        let release = Arc::new(Notify::new());
+        releases.push(Arc::clone(&release));
         let registry = Arc::clone(&registry);
         let user = user.clone();
         handles.push(tokio::spawn(async move {
-            registry.spawn(user, conv_kind("c"), "concurrent".into(), |_| async move {
+            registry.spawn(user, conv_kind("c"), "concurrent".into(), move |_| async move {
+                release.notified().await;
                 Ok(())
             })
         }));
@@ -1085,10 +1129,18 @@ async fn concurrent_spawns_under_same_user_are_thread_safe() {
         assert!(ids.insert(id), "duplicate id under concurrent spawn");
     }
 
-    // All ids visible from `list`.
+    // While all 100 are still running, every id is visible from `list`.
     let listing = registry.list(&user, true, None);
     let listed: HashSet<_> = listing.iter().map(|v| v.id.clone()).collect();
     assert_eq!(listed, ids);
+
+    // Release everything so the runtime tasks exit cleanly.
+    for release in &releases {
+        release.notify_one();
+    }
+    for id in &ids {
+        registry.wait(id).await;
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -1135,18 +1187,29 @@ async fn task_view_progress_hint_updates_via_context() {
 // ----------------------------------------------------------------------
 
 #[tokio::test]
-async fn business_outcome_subagent_or_standalone_kinds_compile_but_are_not_used_yet() {
+async fn business_outcome_subagent_or_standalone_kinds_compile_and_are_listable_while_in_flight() {
     let registry = BackgroundTaskRegistry::new();
     let user = unique_user("alice");
 
+    // Subagent needs a parent task that's still in-flight so its parent
+    // id resolves. Block all three on per-task Notifies; inspect kinds
+    // while running, then release so they evict cleanly.
+    let parent_release = Arc::new(Notify::new());
+    let sub_release = Arc::new(Notify::new());
+    let standalone_release = Arc::new(Notify::new());
+
+    let parent_release_for_task = Arc::clone(&parent_release);
     let parent = registry.spawn(
         user.clone(),
         conv_kind("conv-parent"),
         "parent".into(),
-        |_ctx| async move { Ok(()) },
+        move |_ctx| async move {
+            parent_release_for_task.notified().await;
+            Ok(())
+        },
     );
-    registry.wait(&parent).await;
 
+    let sub_release_for_task = Arc::clone(&sub_release);
     let sub = registry.spawn(
         user.clone(),
         api::TaskKind::Subagent {
@@ -1155,8 +1218,12 @@ async fn business_outcome_subagent_or_standalone_kinds_compile_but_are_not_used_
             name: "researcher".into(),
         },
         "subagent".into(),
-        |_ctx| async move { Ok(()) },
+        move |_ctx| async move {
+            sub_release_for_task.notified().await;
+            Ok(())
+        },
     );
+    let standalone_release_for_task = Arc::clone(&standalone_release);
     let standalone = registry.spawn(
         user.clone(),
         api::TaskKind::Standalone {
@@ -1164,11 +1231,11 @@ async fn business_outcome_subagent_or_standalone_kinds_compile_but_are_not_used_
             conversation_id: "conv-standalone".into(),
         },
         "standalone".into(),
-        |_ctx| async move { Ok(()) },
+        move |_ctx| async move {
+            standalone_release_for_task.notified().await;
+            Ok(())
+        },
     );
-
-    registry.wait(&sub).await;
-    registry.wait(&standalone).await;
 
     let everything = registry.list(&user, true, None);
     let kinds: Vec<_> = everything.iter().map(|v| v.kind.clone()).collect();
@@ -1181,4 +1248,13 @@ async fn business_outcome_subagent_or_standalone_kinds_compile_but_are_not_used_
 
     let sub_view = registry.get(&user, &sub).expect("present");
     assert_eq!(sub_view.parent, Some(parent.clone()));
+
+    // Drain: release subs/standalone first (parent still keeps them
+    // parented in `children` until they evict), then parent.
+    sub_release.notify_one();
+    standalone_release.notify_one();
+    registry.wait(&sub).await;
+    registry.wait(&standalone).await;
+    parent_release.notify_one();
+    registry.wait(&parent).await;
 }

--- a/crates/application/tests/durable_background_tasks.rs
+++ b/crates/application/tests/durable_background_tasks.rs
@@ -321,7 +321,9 @@ async fn cancelled_tasks_persist_as_cancelled() {
         .await
         .unwrap();
     registry.cancel(&user, &task_id).expect("cancel");
-    registry.wait(&task_id).await;
+    timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the cancelled task finalizes, not hang");
     wait_until(
         || {
             store
@@ -363,7 +365,9 @@ async fn completed_tasks_persist_as_completed() {
         "stan".into(),
         move |_ctx| async move { Ok(()) },
     );
-    registry.wait(&task_id).await;
+    timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
     wait_until(
         || {
             store

--- a/crates/application/tests/spawn_standalone_agent.rs
+++ b/crates/application/tests/spawn_standalone_agent.rs
@@ -572,7 +572,9 @@ async fn spawn_standalone_returns_task_id_synchronously() {
 
     // Release the LLM so the task wraps up and the test doesn't leak.
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 /// Acceptance: a standalone task appears in the registry's listing for
@@ -616,7 +618,9 @@ async fn standalone_appears_in_registry_with_no_parent() {
     }
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 /// Acceptance: `override_selection.connection_id` is threaded into the
@@ -646,7 +650,9 @@ async fn standalone_runs_initial_prompt_against_chosen_connection() {
         .await
         .expect("ok");
     let task_id = task_id_from(result);
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     let calls = convs.sends.lock().unwrap().clone();
     assert_eq!(calls.len(), 1, "exactly one send_prompt call");
@@ -738,7 +744,9 @@ async fn standalone_tool_allowlist_enforced() {
         .await
         .expect("ok");
     let task_id = task_id_from(result);
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     let calls = convs.sends.lock().unwrap().clone();
     assert_eq!(calls.len(), 1);
@@ -781,7 +789,9 @@ async fn standalone_under_user_a_invisible_to_user_b() {
     assert!(registry.list(&bob, true, None).is_empty());
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 /// Acceptance: tripping the registry's cancel for a running standalone
@@ -821,7 +831,9 @@ async fn cancelling_standalone_aborts_the_turn() {
     // terminal entries are evicted from the registry on finalize (#158).
     let mut events = registry.subscribe(&user);
     registry.cancel(&user, &task_id).expect("cancel ok");
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     assert!(
         cancelled_flag.load(Ordering::SeqCst),
@@ -880,7 +892,11 @@ async fn standalone_with_invalid_connection_returns_clean_error_in_task_status()
     let want = task_id.0.clone();
     let (status, last_error) = loop {
         match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
-            Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+            Ok(Ok(api::Event::TaskCompleted {
+                id,
+                status,
+                last_error,
+            })) if id == want => {
                 break (status, last_error);
             }
             Ok(Ok(_)) => continue,
@@ -920,7 +936,9 @@ async fn spawn_standalone_creates_new_conversation_scoped_to_user_id() {
         .await
         .expect("ok");
     let task_id = task_id_from(result);
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     let creates = convs.creates.lock().unwrap().clone();
     assert_eq!(creates.len(), 1, "exactly one conversation created");
@@ -961,7 +979,9 @@ async fn business_outcome_standalone_conversation_contains_initial_prompt_then_r
         .await
         .expect("ok");
     let task_id = task_id_from(result);
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     // The send actually ran with the user's prompt.
     let sends = convs.sends.lock().unwrap().clone();

--- a/crates/application/tests/spawn_standalone_agent.rs
+++ b/crates/application/tests/spawn_standalone_agent.rs
@@ -827,6 +827,9 @@ async fn cancelling_standalone_aborts_the_turn() {
     )
     .await;
 
+    // Subscribe BEFORE cancel so we observe the TaskCompleted event —
+    // terminal entries are evicted from the registry on finalize (#158).
+    let mut events = registry.subscribe(&user);
     registry.cancel(&user, &task_id).expect("cancel ok");
     registry.wait(&task_id).await;
 
@@ -834,8 +837,18 @@ async fn cancelling_standalone_aborts_the_turn() {
         cancelled_flag.load(Ordering::SeqCst),
         "underlying LLM call did not observe cancellation"
     );
-    let view = registry.get(&user, &task_id).expect("present");
-    assert_eq!(view.status, api::TaskStatus::Cancelled);
+    let want = task_id.0.clone();
+    let status = loop {
+        match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted { id, status, .. })) if id == want => break status,
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+            Err(_) => panic!("timed out waiting for TaskCompleted"),
+        }
+    };
+    assert_eq!(status, api::TaskStatus::Cancelled);
+    assert!(registry.get(&user, &task_id).is_none());
 }
 
 /// Acceptance: if the underlying dispatch fails (e.g. invalid
@@ -858,6 +871,13 @@ async fn standalone_with_invalid_connection_returns_clean_error_in_task_status()
         model_id: "anything".into(),
         effort: None,
     };
+
+    // Subscribe BEFORE spawning so we can't possibly miss the
+    // TaskCompleted event — terminal entries are evicted from the
+    // registry on finalize (#158), so the broadcast is the only way to
+    // observe the failure status post-completion.
+    let mut events = registry.subscribe(&user);
+
     let result = handler
         .handle_command_for(
             RequestContext::for_user(user.clone()),
@@ -867,11 +887,20 @@ async fn standalone_with_invalid_connection_returns_clean_error_in_task_status()
         .expect("handler must not surface the LLM error synchronously");
     let task_id = task_id_from(result);
 
-    registry.wait(&task_id).await;
-    let view = registry.get(&user, &task_id).expect("present");
-    assert_eq!(view.status, api::TaskStatus::Failed);
-    let err = view
-        .last_error
+    let want = task_id.0.clone();
+    let (status, last_error) = loop {
+        match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted { id, status, last_error })) if id == want => {
+                break (status, last_error);
+            }
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+            Err(_) => panic!("timed out waiting for TaskCompleted"),
+        }
+    };
+    assert_eq!(status, api::TaskStatus::Failed);
+    let err = last_error
         .as_deref()
         .expect("Failed task must record last_error");
     assert!(

--- a/crates/application/tests/spawn_subagent.rs
+++ b/crates/application/tests/spawn_subagent.rs
@@ -278,13 +278,89 @@ where
             Ok(())
         },
     );
-    registry.wait(&parent_id).await;
+    timeout(Duration::from_secs(5), registry.wait(&parent_id))
+        .await
+        .expect("parent task must finish, not hang");
     let value = result_slot
         .lock()
         .unwrap()
         .take()
         .expect("body produced a value");
     (parent_id, value)
+}
+
+/// Like [`under_parent_task`] but the parent body does NOT return until
+/// the caller fires the returned release `Notify`. The body runs `body`,
+/// publishes its produced value, then parks — so the parent (and any
+/// `wait=false` child it left running) stay live in the registry while
+/// the test inspects them. Terminal entries are evicted immediately on
+/// finalize (#158), so live inspection requires the producing task to
+/// still be running. Returns the parent id, the body's value, and the
+/// release handle; the test must fire it (and drain) to avoid leaks.
+async fn under_live_parent_task<F, Fut, T>(
+    registry: &BackgroundTaskRegistry,
+    user: UserId,
+    parent_conv: &str,
+    body: F,
+) -> (api::TaskId, T, Arc<Notify>)
+where
+    F: FnOnce(api::TaskId) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let release = Arc::new(Notify::new());
+    let release_for_task = Arc::clone(&release);
+    let (value_tx, value_rx) = tokio::sync::oneshot::channel::<T>();
+    let parent_id = registry.spawn(
+        user,
+        api::TaskKind::Conversation {
+            conversation_id: parent_conv.into(),
+        },
+        "parent".into(),
+        move |ctx| async move {
+            let parent_id = ctx.task_id.clone();
+            let token = ctx.token.clone();
+            // Install the per-turn cancellation token the same way
+            // `send_prompt_with_override` would.
+            let value =
+                desktop_assistant_core::ports::llm::with_cancellation_token(token, body(parent_id))
+                    .await;
+            // Publish the value, then park so the parent (and any live
+            // child) remain registered for the test to inspect.
+            let _ = value_tx.send(value);
+            release_for_task.notified().await;
+            Ok(())
+        },
+    );
+    let value = timeout(Duration::from_secs(5), value_rx)
+        .await
+        .expect("parent body must publish its value, not hang")
+        .expect("parent body produced a value");
+    (parent_id, value, release)
+}
+
+/// Drain `events` until a terminal `TaskCompleted` for `task_id` arrives,
+/// returning its `(status, last_error)`. Used by tests that inspect
+/// terminal status now that finalize evicts the entry from `list`/`get`
+/// (#158) — the broadcast event is the surviving record.
+async fn wait_for_completion(
+    events: &mut tokio::sync::broadcast::Receiver<api::Event>,
+    task_id: &api::TaskId,
+) -> (api::TaskStatus, Option<String>) {
+    let want = task_id.0.clone();
+    loop {
+        match timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted {
+                id,
+                status,
+                last_error,
+            })) if id == want => return (status, last_error),
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed before TaskCompleted: {e:?}"),
+            Err(_) => panic!("timed out waiting for TaskCompleted({want})"),
+        }
+    }
 }
 
 // --------------------------------------------------------------------
@@ -350,11 +426,18 @@ async fn spawn_subagent_with_wait_false_returns_task_id_immediately() {
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let user = unique_user("alice");
 
+    // Subscribe before anything spawns so we never miss the child's
+    // terminal event — finalize evicts the entry (#158), so the broadcast
+    // is the authoritative post-completion status.
+    let mut events = registry.subscribe(&user);
+
+    // Keep the parent live (it returns wait=false immediately, but we need
+    // the child still in-flight so we can observe its Running status).
     let user_for_body = user.clone();
     let tools_for_body = tools.clone();
     let registry_for_body = Arc::clone(&registry);
-    let (_parent_id, result) =
-        under_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
+    let (_parent_id, child_task_id, parent_release) =
+        under_live_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
             let tools = tools_for_body;
             let user = user_for_body;
             let registry = registry_for_body;
@@ -383,7 +466,8 @@ async fn spawn_subagent_with_wait_false_returns_task_id_immediately() {
                 let child_task_id = parsed["child_task_id"].as_str().unwrap().to_string();
                 assert!(parsed["child_conversation_id"].as_str().is_some());
 
-                // The child should still be Running until we release it.
+                // The child is still Running until we release it — it's
+                // visible because it hasn't reached a terminal state.
                 let view = registry
                     .get(&user, &api::TaskId(child_task_id.clone()))
                     .expect("child registered");
@@ -394,13 +478,19 @@ async fn spawn_subagent_with_wait_false_returns_task_id_immediately() {
         })
         .await;
 
-    // Now release the child and let it finish.
+    // Now release the child and observe it complete via the broadcast
+    // stream (the entry is evicted on finalize, so we can't `get` it).
     release.notify_one();
-    // Drain so the child completes before assertions.
-    let child_id = api::TaskId(result);
-    registry.wait(&child_id).await;
-    let view = registry.get(&user, &child_id).unwrap();
-    assert_eq!(view.status, api::TaskStatus::Completed);
+    let child_id = api::TaskId(child_task_id);
+    let (status, _) = wait_for_completion(&mut events, &child_id).await;
+    assert_eq!(status, api::TaskStatus::Completed);
+    assert!(
+        registry.get(&user, &child_id).is_none(),
+        "completed child must be evicted"
+    );
+
+    // Drain the parent so the test doesn't leak it.
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -410,30 +500,49 @@ async fn spawn_subagent_with_wait_false_returns_task_id_immediately() {
 #[tokio::test]
 async fn subagent_appears_in_registry_with_parent_link() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
-    let conversations = Arc::new(FakeConversations::new("ok"));
+    // The child conversation (conv-0) blocks so the child stays Running
+    // and remains visible in the registry while we inspect it (terminal
+    // tasks are evicted on finalize, #158).
+    let release = Arc::new(Notify::new());
+    let release_for_conv = Arc::clone(&release);
+    let conversations = Arc::new(FakeConversations::new("ok").with_behaviour(
+        "conv-0",
+        move |_cid, _p| {
+            let r = Arc::clone(&release_for_conv);
+            async move {
+                r.notified().await;
+                Ok("done".to_string())
+            }
+        },
+    ));
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let user = unique_user("alice");
 
+    // Spawn the child wait=false and keep the parent live so both stay in
+    // the registry for inspection.
     let user_for_body = user.clone();
     let tools_for_body = tools.clone();
-    let (parent_id, _result) =
-        under_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
+    let (parent_id, _child_id, parent_release) =
+        under_live_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
             let tools = tools_for_body;
             let user = user_for_body;
             async move {
-                with_user_id(user, async move {
+                let r = with_user_id(user, async move {
                     tools
                         .execute_tool(
                             TOOL_SPAWN_SUBAGENT,
                             serde_json::json!({
                                 "name": "researcher",
                                 "prompt": "go",
-                                "wait": true,
+                                "wait": false,
                             }),
                         )
                         .await
+                        .expect("spawn ok")
                 })
-                .await
+                .await;
+                let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+                parsed["child_task_id"].as_str().unwrap().to_string()
             }
         })
         .await;
@@ -455,6 +564,10 @@ async fn subagent_appears_in_registry_with_parent_link() {
     assert_eq!(parent_task_id, &parent_id);
     assert_eq!(name, "researcher");
     assert_eq!(subagent.parent.as_ref(), Some(&parent_id));
+
+    // Release the child and parent so the test doesn't leak.
+    release.notify_one();
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -468,26 +581,34 @@ async fn parent_log_records_subagent_tool_call_with_child_ids() {
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let user = unique_user("alice");
 
+    // Keep the parent live so its log buffer survives for inspection —
+    // finalize evicts the entry (and its logs) immediately (#158). The
+    // spawn_subagent tool appends the ToolCall log to the parent
+    // regardless of wait, so wait=false (child completes on its own) is
+    // sufficient and keeps the test simple.
     let user_for_body = user.clone();
     let tools_for_body = tools.clone();
-    let (parent_id, _result) =
-        under_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
+    let (parent_id, _child_id, parent_release) =
+        under_live_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
             let tools = tools_for_body;
             let user = user_for_body;
             async move {
-                with_user_id(user, async move {
+                let r = with_user_id(user, async move {
                     tools
                         .execute_tool(
                             TOOL_SPAWN_SUBAGENT,
                             serde_json::json!({
                                 "name": "researcher",
                                 "prompt": "go",
-                                "wait": true,
+                                "wait": false,
                             }),
                         )
                         .await
+                        .expect("spawn ok")
                 })
-                .await
+                .await;
+                let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+                parsed["child_task_id"].as_str().unwrap().to_string()
             }
         })
         .await;
@@ -508,6 +629,9 @@ async fn parent_log_records_subagent_tool_call_with_child_ids() {
         data["child_conversation_id"].is_string(),
         "data has child_conversation_id"
     );
+
+    // Drain the parent so the test doesn't leak.
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -574,6 +698,12 @@ async fn cancelling_parent_cancels_subagents_recursively() {
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conv));
     let user = unique_user("alice");
 
+    // Subscribe before spawning so we observe every TaskCompleted —
+    // terminal entries are evicted on finalize (#158), so `list` can no
+    // longer enumerate the cancelled generations; the broadcast stream is
+    // the surviving record of all three reaching Cancelled.
+    let mut events = registry.subscribe(&user);
+
     // Spawn the parent and have it spawn a (waiting) child.
     let user_for_body = user.clone();
     let tools_for_body = tools.clone();
@@ -619,23 +749,42 @@ async fn cancelling_parent_cancels_subagents_recursively() {
         .cancel(&user, &parent_id)
         .expect("parent cancellable");
 
-    // Wait for all three to wind down.
+    // Wait for the parent to wind down (its `wait` resolving implies the
+    // child it blocked on, and the grandchild that child blocked on, have
+    // all reached a terminal state).
     timeout(Duration::from_secs(5), registry.wait(&parent_id))
         .await
         .expect("parent terminates");
 
-    // All three tasks must be Cancelled.
-    let tasks = registry.list(&user, true, None);
-    assert_eq!(tasks.len(), 3, "parent + child + grandchild registered");
-    for t in tasks {
-        assert_eq!(
-            t.status,
-            api::TaskStatus::Cancelled,
-            "task {} ({:?}) must be cancelled",
-            t.id.0,
-            t.kind
-        );
+    // All three generations (parent + child + grandchild) must reach
+    // Cancelled. We collect the three TaskCompleted events from the
+    // broadcast stream rather than `list()`, because finalize evicts each
+    // terminal entry immediately (#158).
+    let mut cancelled_count = 0;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while cancelled_count < 3 {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .expect("timed out collecting 3 TaskCompleted events");
+        match timeout(remaining, events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted { id, status, .. })) => {
+                assert_eq!(
+                    status,
+                    api::TaskStatus::Cancelled,
+                    "task {id} completed with {status:?}, expected Cancelled"
+                );
+                cancelled_count += 1;
+            }
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed before 3 TaskCompleted: {e:?}"),
+            Err(_) => panic!("timed out collecting 3 TaskCompleted events"),
+        }
     }
+    assert_eq!(
+        cancelled_count, 3,
+        "parent + child + grandchild must each reach Cancelled"
+    );
 }
 
 // --------------------------------------------------------------------
@@ -723,51 +872,77 @@ async fn get_subagent_status_for_unknown_id_returns_not_found() {
 #[tokio::test]
 async fn get_subagent_status_for_other_users_task_returns_not_found() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
-    let conversations = Arc::new(FakeConversations::new("ok"));
+    // Alice's subagent blocks (conv-0) so it stays RUNNING while Bob
+    // probes — this proves the `not_found` Bob sees is genuine cross-user
+    // opacity (#105), not just the post-completion eviction (#158).
+    let release = Arc::new(Notify::new());
+    let release_for_conv = Arc::clone(&release);
+    let conversations = Arc::new(FakeConversations::new("ok").with_behaviour(
+        "conv-0",
+        move |_cid, _p| {
+            let r = Arc::clone(&release_for_conv);
+            async move {
+                r.notified().await;
+                Ok("done".to_string())
+            }
+        },
+    ));
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let alice = unique_user("alice");
     let bob = unique_user("bob");
 
-    // Alice spawns a real subagent that completes immediately.
+    // Alice spawns a subagent that stays in-flight; keep her parent live
+    // so we can capture the (still-Running) child id.
     let alice_for_body = alice.clone();
     let tools_for_body = tools.clone();
     let registry_for_body = Arc::clone(&registry);
-    let (_pid, child_id) = under_parent_task(&registry, alice.clone(), "alice-conv", move |_pid| {
-        let tools = tools_for_body;
-        let user = alice_for_body;
-        let registry = registry_for_body;
-        async move {
-            with_user_id(user.clone(), async move {
-                let _ = tools
-                    .execute_tool(
-                        TOOL_SPAWN_SUBAGENT,
-                        serde_json::json!({
-                            "name": "child",
-                            "prompt": "go",
-                            "wait": true,
-                        }),
-                    )
-                    .await
-                    .unwrap();
-            })
-            .await;
-            // Find the registered subagent id.
-            let tasks = registry.list(&alice, true, None);
-            tasks
-                .iter()
-                .find(|t| matches!(t.kind, api::TaskKind::Subagent { .. }))
-                .map(|t| t.id.clone())
-                .unwrap()
-        }
-    })
-    .await;
+    let alice_for_capture = alice.clone();
+    let (_pid, child_id, parent_release) =
+        under_live_parent_task(&registry, alice.clone(), "alice-conv", move |_pid| {
+            let tools = tools_for_body;
+            let user = alice_for_body;
+            let registry = registry_for_body;
+            let alice = alice_for_capture;
+            async move {
+                with_user_id(user.clone(), async move {
+                    let _ = tools
+                        .execute_tool(
+                            TOOL_SPAWN_SUBAGENT,
+                            serde_json::json!({
+                                "name": "child",
+                                "prompt": "go",
+                                "wait": false,
+                            }),
+                        )
+                        .await
+                        .unwrap();
+                })
+                .await;
+                // Find the still-Running subagent id.
+                let tasks = registry.list(&alice, true, None);
+                tasks
+                    .iter()
+                    .find(|t| matches!(t.kind, api::TaskKind::Subagent { .. }))
+                    .map(|t| t.id.clone())
+                    .expect("subagent registered")
+            }
+        })
+        .await;
 
-    // Bob asks about Alice's child task: must come back as not_found.
+    // Sanity: the child genuinely exists for Alice right now.
+    assert!(
+        registry.get(&alice, &child_id).is_some(),
+        "child must be live so the probe tests opacity, not eviction"
+    );
+
+    // Bob asks about Alice's (live) child task: must come back as
+    // not_found — existence must not leak.
+    let child_id_for_bob = child_id.0.clone();
     let result = with_user_id(bob, async {
         tools
             .execute_tool(
                 TOOL_GET_SUBAGENT_STATUS,
-                serde_json::json!({"task_id": child_id.0}),
+                serde_json::json!({"task_id": child_id_for_bob}),
             )
             .await
             .unwrap()
@@ -775,6 +950,13 @@ async fn get_subagent_status_for_other_users_task_returns_not_found() {
     .await;
     let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
     assert_eq!(parsed["error"], "not_found");
+
+    // Clean up: release the child and parent so the test doesn't leak.
+    release.notify_one();
+    timeout(Duration::from_secs(5), registry.wait(&child_id))
+        .await
+        .expect("child completes");
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -784,33 +966,49 @@ async fn get_subagent_status_for_other_users_task_returns_not_found() {
 #[tokio::test]
 async fn spawn_subagent_inherits_parent_user_id() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
-    let conversations = Arc::new(FakeConversations::new("ok"));
+    // The child blocks (conv-0) so it stays Running and visible while we
+    // assert ownership — terminal tasks are evicted on finalize (#158).
+    let release = Arc::new(Notify::new());
+    let release_for_conv = Arc::clone(&release);
+    let conversations = Arc::new(FakeConversations::new("ok").with_behaviour(
+        "conv-0",
+        move |_cid, _p| {
+            let r = Arc::clone(&release_for_conv);
+            async move {
+                r.notified().await;
+                Ok("done".to_string())
+            }
+        },
+    ));
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let alice = unique_user("alice");
 
     let alice_for_body = alice.clone();
     let tools_for_body = tools.clone();
-    let (_pid, _result) = under_parent_task(&registry, alice.clone(), "parent-conv", move |_pid| {
-        let tools = tools_for_body;
-        let user = alice_for_body;
-        async move {
-            with_user_id(user, async move {
-                tools
-                    .execute_tool(
-                        TOOL_SPAWN_SUBAGENT,
-                        serde_json::json!({
-                            "name": "child",
-                            "prompt": "go",
-                            "wait": true,
-                        }),
-                    )
-                    .await
-                    .unwrap()
-            })
-            .await
-        }
-    })
-    .await;
+    let (_pid, _child_id, parent_release) =
+        under_live_parent_task(&registry, alice.clone(), "parent-conv", move |_pid| {
+            let tools = tools_for_body;
+            let user = alice_for_body;
+            async move {
+                let r = with_user_id(user, async move {
+                    tools
+                        .execute_tool(
+                            TOOL_SPAWN_SUBAGENT,
+                            serde_json::json!({
+                                "name": "child",
+                                "prompt": "go",
+                                "wait": false,
+                            }),
+                        )
+                        .await
+                        .unwrap()
+                })
+                .await;
+                let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+                parsed["child_task_id"].as_str().unwrap().to_string()
+            }
+        })
+        .await;
 
     // The child task must be owned by Alice, not by the default sentinel.
     let alice_tasks = registry.list(&alice, true, None);
@@ -822,6 +1020,10 @@ async fn spawn_subagent_inherits_parent_user_id() {
     let bob = unique_user("bob");
     let bob_view = registry.get(&bob, &subagent.id);
     assert!(bob_view.is_none(), "bob must not see alice's child");
+
+    // Release the child and parent so the test doesn't leak.
+    release.notify_one();
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -831,31 +1033,46 @@ async fn spawn_subagent_inherits_parent_user_id() {
 #[tokio::test]
 async fn spawn_subagent_records_task_kind_subagent_with_correct_link() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
-    let conversations = Arc::new(FakeConversations::new("ok"));
+    // The child blocks (conv-0) so it stays Running and visible while we
+    // inspect its kind — terminal tasks are evicted on finalize (#158).
+    let release = Arc::new(Notify::new());
+    let release_for_conv = Arc::clone(&release);
+    let conversations = Arc::new(FakeConversations::new("ok").with_behaviour(
+        "conv-0",
+        move |_cid, _p| {
+            let r = Arc::clone(&release_for_conv);
+            async move {
+                r.notified().await;
+                Ok("done".to_string())
+            }
+        },
+    ));
     let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
     let user = unique_user("alice");
 
     let user_for_body = user.clone();
     let tools_for_body = tools.clone();
-    let (parent_id, _result) =
-        under_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
+    let (parent_id, _child_id, parent_release) =
+        under_live_parent_task(&registry, user.clone(), "parent-conv", move |_pid| {
             let tools = tools_for_body;
             let user = user_for_body;
             async move {
-                with_user_id(user, async move {
+                let r = with_user_id(user, async move {
                     tools
                         .execute_tool(
                             TOOL_SPAWN_SUBAGENT,
                             serde_json::json!({
                                 "name": "fred",
                                 "prompt": "go",
-                                "wait": true,
+                                "wait": false,
                             }),
                         )
                         .await
                         .unwrap()
                 })
-                .await
+                .await;
+                let parsed: serde_json::Value = serde_json::from_str(&r).unwrap();
+                parsed["child_task_id"].as_str().unwrap().to_string()
             }
         })
         .await;
@@ -878,6 +1095,10 @@ async fn spawn_subagent_records_task_kind_subagent_with_correct_link() {
     // The conversation_id must match a freshly-created conversation.
     assert!(!conversation_id.is_empty());
     assert_ne!(conversation_id, "parent-conv");
+
+    // Release the child and parent so the test doesn't leak.
+    release.notify_one();
+    parent_release.notify_one();
 }
 
 // --------------------------------------------------------------------
@@ -978,6 +1199,8 @@ async fn current_task_id_outside_registry_is_none_inside_is_some() {
             Ok(())
         },
     );
-    registry.wait(&id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
     assert!(seen.load(Ordering::SeqCst));
 }

--- a/crates/application/tests/ws_background_task_wiring.rs
+++ b/crates/application/tests/ws_background_task_wiring.rs
@@ -620,6 +620,11 @@ async fn cancel_background_task_propagates_to_registry() {
     );
     started.notified().await;
 
+    // Subscribe BEFORE cancel so we don't race the TaskCompleted event —
+    // terminal entries are evicted from the registry, so a missed event
+    // would leave us with no way to observe the terminal status.
+    let mut events = registry.subscribe(&user);
+
     let result = handler
         .handle_command_for(
             RequestContext::for_user(user.clone()),
@@ -630,16 +635,30 @@ async fn cancel_background_task_propagates_to_registry() {
     assert!(matches!(result, api::CommandResult::Ack));
 
     registry.wait(&id).await;
-    let view = registry.get(&user, &id).expect("present");
-    assert_eq!(view.status, api::TaskStatus::Cancelled);
+    loop {
+        match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::TaskCompleted { id: ev_id, status, .. })) if ev_id == id.0 => {
+                assert_eq!(status, api::TaskStatus::Cancelled);
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(e)) => panic!("event channel closed: {e:?}"),
+            Err(_) => panic!("timed out waiting for TaskCompleted"),
+        }
+    }
+    assert!(registry.get(&user, &id).is_none());
 }
 
-/// Unhappy: cancelling a task that's already in a terminal state surfaces
-/// an error frame instead of pretending the cancel succeeded. This is the
-/// `AlreadyTerminal` rule from #115 — without it, "cancel" on a Failed
-/// row would look like a silent no-op.
+/// Unhappy: cancelling a task that has already completed surfaces an
+/// error frame instead of pretending the cancel succeeded — without it,
+/// "cancel" on a finished row would look like a silent no-op. Since
+/// terminal entries are evicted from the registry on finalize (#158),
+/// the underlying error is now `NotFound` (existence-hiding contract
+/// from #105) rather than `AlreadyTerminal`. The user-visible outcome —
+/// an error rather than a silent success — is unchanged.
 #[tokio::test]
-async fn cancel_already_terminal_task_returns_structured_error() {
+async fn cancel_completed_task_returns_structured_error() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
     let convs = Arc::new(RecordingConversations::new());
     let handler = make_handler(convs, Arc::clone(&registry));
@@ -656,7 +675,7 @@ async fn cancel_already_terminal_task_returns_structured_error() {
         .await;
     assert!(
         result.is_err(),
-        "cancelling a terminal task must be an error, got {result:?}"
+        "cancelling a completed task must be an error, got {result:?}"
     );
 }
 
@@ -888,6 +907,11 @@ async fn handler_returns_none_receiver_when_registry_not_attached() {
 async fn start_send_message_returns_task_id_that_appears_in_listing() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
     let convs = Arc::new(RecordingConversations::new());
+    // Block the underlying send so the task stays Running long enough to
+    // appear in the list. Terminal entries are evicted from the registry,
+    // so without the block the task can complete before we list it.
+    let release = Arc::new(Notify::new());
+    convs.block_on(Arc::clone(&release));
     let handler = make_handler(convs, Arc::clone(&registry));
 
     let user = unique_user("alice");
@@ -908,12 +932,12 @@ async fn start_send_message_returns_task_id_that_appears_in_listing() {
     .expect("start_send_message ok");
     let task_id = task_id.expect("registry attached, expected Some(task_id)");
 
-    // The new id is visible to the same user via List.
+    // The new id is visible to the same user via List while it's running.
     let list = handler
         .handle_command_for(
             RequestContext::for_user(user.clone()),
             api::Command::ListBackgroundTasks {
-                include_finished: true,
+                include_finished: false,
                 limit: None,
             },
         )
@@ -925,6 +949,7 @@ async fn start_send_message_returns_task_id_that_appears_in_listing() {
     };
     assert!(tasks.iter().any(|t| t.id == task_id));
 
+    release.notify_one();
     registry.wait(&task_id).await;
 }
 

--- a/crates/application/tests/ws_background_task_wiring.rs
+++ b/crates/application/tests/ws_background_task_wiring.rs
@@ -620,10 +620,14 @@ async fn cancel_background_task_propagates_to_registry() {
         .expect("cancel ok");
     assert!(matches!(result, api::CommandResult::Ack));
 
-    registry.wait(&id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
     loop {
         match tokio::time::timeout(Duration::from_secs(5), events.recv()).await {
-            Ok(Ok(api::Event::TaskCompleted { id: ev_id, status, .. })) if ev_id == id.0 => {
+            Ok(Ok(api::Event::TaskCompleted {
+                id: ev_id, status, ..
+            })) if ev_id == id.0 => {
                 assert_eq!(status, api::TaskStatus::Cancelled);
                 break;
             }
@@ -651,7 +655,9 @@ async fn cancel_completed_task_returns_structured_error() {
 
     let user = unique_user("alice");
     let id = spawn_completing_task(&registry, &user, "done");
-    registry.wait(&id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     let result = handler
         .handle_command_for(
@@ -775,7 +781,9 @@ async fn task_log_pagination_works_via_after_seq() {
     assert_eq!(entries2.len(), 20);
 
     release.notify_one();
-    registry.wait(&id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 /// Default limits: when `after_seq` and `limit` are omitted the daemon
@@ -788,8 +796,11 @@ async fn task_log_defaults_apply_when_optional_fields_omitted() {
     let handler = make_handler(convs, Arc::clone(&registry));
 
     let user = unique_user("alice");
-    let id = spawn_completing_task(&registry, &user, "tiny");
-    registry.wait(&id).await;
+    // Query a still-running task: terminal tasks are evicted on finalize
+    // (#158), so their logs would no longer be reachable. A live task
+    // already carries the "task started" lifecycle marker in its log, so
+    // the default-limits query returns a non-empty recent slice.
+    let id = spawn_dummy_task(&registry, &user, "tiny");
 
     let result = handler
         .handle_command_for(
@@ -804,7 +815,7 @@ async fn task_log_defaults_apply_when_optional_fields_omitted() {
         .expect("logs ok");
     match result {
         api::CommandResult::BackgroundTaskLogs { entries, .. } => {
-            // start + completion lifecycle markers.
+            // The "task started" lifecycle marker is present.
             assert!(!entries.is_empty(), "expected lifecycle entries");
         }
         other => panic!("unexpected result: {other:?}"),
@@ -936,7 +947,9 @@ async fn start_send_message_returns_task_id_that_appears_in_listing() {
     assert!(tasks.iter().any(|t| t.id == task_id));
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 /// Issue #154: the registry-spawned `SendMessage` body must observe the
@@ -969,7 +982,9 @@ async fn start_send_message_propagates_user_id_to_spawned_body() {
     .expect("start_send_message ok")
     .expect("registry attached, expected Some(task_id)");
 
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 
     let seen = convs.seen_user_ids();
     assert_eq!(
@@ -1094,7 +1109,9 @@ async fn business_outcome_user_can_list_their_running_standalone_agent() {
     assert!(me.title.contains("researcher"), "title: {}", me.title);
 
     release.notify_one();
-    registry.wait(&task_id).await;
+    tokio::time::timeout(Duration::from_secs(5), registry.wait(&task_id))
+        .await
+        .expect("wait() must resolve once the task finalizes, not hang");
 }
 
 struct NoopSink;

--- a/crates/transport-dispatch/tests/background_task_wiring.rs
+++ b/crates/transport-dispatch/tests/background_task_wiring.rs
@@ -128,8 +128,15 @@ impl AssistantApiHandler for RegistryHandler {
                 conversation_id: conversation_id.clone(),
             },
             format!("Conversation: {conversation_id}"),
-            move |_ctx| async move {
+            move |ctx| async move {
                 let _ = content;
+                // Stay Running until cancelled: terminal tasks are evicted
+                // from the registry on finalize (#158), so a body that
+                // returned immediately would race its own eviction against
+                // the SendMessageAck assertion that the id points to a
+                // live row. Nothing cancels it; the task is torn down with
+                // the test runtime.
+                ctx.token.cancelled().await;
                 Ok(())
             },
         );


### PR DESCRIPTION
## Summary

This branch carries three related background-task fixes.

### Evict terminal tasks from `BackgroundTaskRegistry` (#158)
`finalize()` broadcasts the terminal `TaskCompleted` event, persists the
terminal row, then **immediately evicts** the entry from the in-memory map
and unlinks it from its parent's `children`. `wait()` handles the evicted
(`None`) case. Eviction is **immediate**: terminal tasks leave
`list()`/`get()`/`logs()` right after the terminal broadcast, so the
broadcast stream (or the persisted row) is the surviving record of a
task's final state. This keeps the registry from growing unbounded over
the daemon's lifetime.

### Finalize panicking task bodies as Failed (#171, `ace3e41`)
A body that panics now runs in a child task; the `JoinError` panic is
caught and finalized as a terminal `Failed` (with the panic message in
`last_error`) instead of leaving the row stuck `Running` forever and
hanging every `wait()` on it.

### Test reconciliation + hang-hardening (#172)
With eviction immediate and panics finalizing, tests fail fast rather than
hang — but they're hardened defensively anyway.

**Eviction-contract reconciliation** (intent preserved; no assertions
weakened, impl untouched):
- `spawn_subagent.rs`: added an `under_live_parent_task` helper + a
  `wait_for_completion` broadcast collector. Tests that previously spawned
  `wait=true` subagents then `list()`/`get()`/`logs()` them post-completion
  now either inspect a still-running child (`wait=false` + a blocking child
  conversation) or observe terminal status via the per-user broadcast
  stream. `cancelling_parent_cancels_subagents_recursively` subscribes
  before cancelling and collects the three `TaskCompleted{Cancelled}`
  events instead of `list().len()==3`.
  `get_subagent_status_for_other_users_task_returns_not_found` keeps the
  child genuinely RUNNING so the `not_found` Bob sees proves cross-user
  opacity, not eviction.
- `ws_background_task_wiring.rs::task_log_defaults_apply_when_optional_fields_omitted`:
  queries a live task instead of a completed-then-evicted one.
- transport-dispatch `send_message_ack_carries_a_real_task_id`: the handler
  keeps its task Running so the acked id points to a live row.

**Hang-hardening + audit:** every `registry.wait(...)` and broadcast
collect on an external signal is wrapped in `tokio::time::timeout`
(including two previously-bare waits in `durable_background_tasks.rs`).
Audited `ws-interface`, `dbus-interface`, `daemon`, `uds-interface`:
ws/uds background-task tests already timeout-wrap stream/recv awaits;
dbus-interface has no test module; daemon tests don't touch the registry.

## Verification
- `cargo test -p desktop-assistant-application` — all pass
- `cargo test --workspace` — all pass
- `cargo fmt --all -- --check` — 0
- `cargo clippy --workspace --all-targets -- -D warnings` — 0

Closes #158
Closes #171
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)