### PR TITLE
fix(#174): cap tool-result size at ingestion

### DIFF
--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -93,9 +93,28 @@ pub(crate) fn tool_result_truncation_notice(original_bytes: usize) -> String {
 /// [`tool_result_truncation_notice`], stays within `max_bytes`. Truncation
 /// always lands on a `char` boundary so the result is valid UTF-8.
 pub(crate) fn cap_tool_result(content: &str, max_bytes: usize) -> Option<String> {
-    // Stub (issue #174): real truncation lands in the follow-up commit.
-    let _ = (max_bytes, tool_result_truncation_notice(content.len()));
-    None
+    if content.len() <= max_bytes {
+        return None;
+    }
+
+    let notice = tool_result_truncation_notice(content.len());
+    // Reserve room for the notice. If the cap is so small the notice alone
+    // would not fit, keep no prefix — the notice still tells the model what
+    // happened (a pathological case; real caps dwarf the notice).
+    let body_budget = max_bytes.saturating_sub(notice.len());
+
+    // Largest char boundary at or below the body budget. `is_char_boundary`
+    // is O(1) and at most three steps back from any byte index, so this is
+    // cheap even for a multi-megabyte payload.
+    let mut cut = body_budget.min(content.len());
+    while cut > 0 && !content.is_char_boundary(cut) {
+        cut -= 1;
+    }
+
+    let mut truncated = String::with_capacity(cut + notice.len());
+    truncated.push_str(&content[..cut]);
+    truncated.push_str(&notice);
+    Some(truncated)
 }
 
 /// Fraction of the prompt-token budget the system instruction (static
@@ -1078,9 +1097,16 @@ mod tests {
     fn cap_tool_result_truncates_when_over_cap_with_notice() {
         let content = "x".repeat(10_000);
         let out = cap_tool_result(&content, 1024).expect("over-cap result must truncate");
-        assert!(out.len() <= 1024, "truncated result {} > cap 1024", out.len());
+        assert!(
+            out.len() <= 1024,
+            "truncated result {} > cap 1024",
+            out.len()
+        );
         assert!(out.contains("truncated"), "notice must explain truncation");
-        assert!(out.contains("10000 bytes"), "notice must cite the original size");
+        assert!(
+            out.contains("10000 bytes"),
+            "notice must cite the original size"
+        );
         // The kept prefix is from the original content.
         assert!(out.starts_with("xxxx"));
     }
@@ -1090,7 +1116,11 @@ mod tests {
         for cap in [512usize, 1024, 4096, 50_000] {
             let content = "y".repeat(cap * 4);
             let out = cap_tool_result(&content, cap).expect("over-cap must truncate");
-            assert!(out.len() <= cap, "cap {cap}: result {} exceeds cap", out.len());
+            assert!(
+                out.len() <= cap,
+                "cap {cap}: result {} exceeds cap",
+                out.len()
+            );
         }
     }
 

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -59,6 +59,45 @@ pub(crate) const MAX_OVERFLOW_RETRIES: u32 = 3;
 /// avoid the "notice larger than payload" pathology, not to be precise.
 pub(crate) const MIN_TRUNCATION_TOKENS: u64 = 1024;
 
+/// Maximum byte length a single tool result may occupy before it is
+/// truncated at ingestion (issue #174). A misbehaving tool can return a
+/// multi-megabyte payload (observed: 124 MB across 8 messages); stored
+/// verbatim it wedges the conversation against the model's context window
+/// on *every* subsequent turn and stalls the `messages` INSERT. Capping at
+/// ingestion bounds the blast radius of any single tool call.
+///
+/// Why a byte cap rather than a token cap: it's deterministic, O(1) to
+/// check, requires no estimator pass over a huge string, and directly
+/// bounds what is written to the database. 256 KiB is ~64K tokens at the
+/// chars/4 default — far above any legitimate tool result, so honest tools
+/// are never touched.
+pub(crate) const DEFAULT_MAX_TOOL_RESULT_BYTES: usize = 256 * 1024;
+
+/// Replacement tail appended when a tool result is truncated at ingestion.
+/// Addressed to the model so it learns to re-run the tool with a narrower
+/// request instead of assuming the output was complete.
+pub(crate) fn tool_result_truncation_notice(original_bytes: usize) -> String {
+    format!(
+        "\n\n<tool output truncated: {original_bytes} bytes exceeded the per-result \
+         storage cap; only the beginning is shown. Re-run the tool with a narrower \
+         request — e.g. a smaller byte/line range, a filtered listing, or only the \
+         fields you need — to see the rest.>"
+    )
+}
+
+/// Cap a tool result to `max_bytes` before it is stored as a message.
+///
+/// Returns `None` when `content` already fits (the common case — no
+/// allocation, caller stores the original). Returns `Some(truncated)` when
+/// it is over the cap: the longest UTF-8 prefix that, together with
+/// [`tool_result_truncation_notice`], stays within `max_bytes`. Truncation
+/// always lands on a `char` boundary so the result is valid UTF-8.
+pub(crate) fn cap_tool_result(content: &str, max_bytes: usize) -> Option<String> {
+    // Stub (issue #174): real truncation lands in the follow-up commit.
+    let _ = (max_bytes, tool_result_truncation_notice(content.len()));
+    None
+}
+
 /// Fraction of the prompt-token budget the system instruction (static
 /// prompt + tool availability listing) is allowed to consume before the
 /// listing is demoted to a namespace-only summary.
@@ -1015,6 +1054,57 @@ mod tests {
         let notice = overflow_truncation_notice(500, None, None);
         assert!(notice.contains("500 bytes"));
         assert!(!notice.contains("prompt was"));
+    }
+
+    // --- Tool-result ingestion cap (issue #174) ---
+
+    #[test]
+    fn cap_tool_result_returns_none_when_under_cap() {
+        assert_eq!(cap_tool_result("small output", 1024), None);
+    }
+
+    #[test]
+    fn cap_tool_result_empty_is_unchanged() {
+        assert_eq!(cap_tool_result("", 1024), None);
+    }
+
+    #[test]
+    fn cap_tool_result_exactly_at_cap_is_unchanged() {
+        let content = "x".repeat(1024);
+        assert_eq!(cap_tool_result(&content, 1024), None);
+    }
+
+    #[test]
+    fn cap_tool_result_truncates_when_over_cap_with_notice() {
+        let content = "x".repeat(10_000);
+        let out = cap_tool_result(&content, 1024).expect("over-cap result must truncate");
+        assert!(out.len() <= 1024, "truncated result {} > cap 1024", out.len());
+        assert!(out.contains("truncated"), "notice must explain truncation");
+        assert!(out.contains("10000 bytes"), "notice must cite the original size");
+        // The kept prefix is from the original content.
+        assert!(out.starts_with("xxxx"));
+    }
+
+    #[test]
+    fn cap_tool_result_stays_within_byte_cap_across_sizes() {
+        for cap in [512usize, 1024, 4096, 50_000] {
+            let content = "y".repeat(cap * 4);
+            let out = cap_tool_result(&content, cap).expect("over-cap must truncate");
+            assert!(out.len() <= cap, "cap {cap}: result {} exceeds cap", out.len());
+        }
+    }
+
+    #[test]
+    fn cap_tool_result_truncates_on_char_boundary_no_panic() {
+        // Dense multi-byte content: every char is 4 bytes. A naive byte cut
+        // would land mid-codepoint and panic; the cap must snap to a
+        // boundary and always yield valid UTF-8.
+        let content = "🚀".repeat(2_000); // 8_000 bytes
+        let out = cap_tool_result(&content, 1024).expect("over-cap must truncate");
+        assert!(out.len() <= 1024);
+        // Valid UTF-8 by construction (String), and the kept prefix is whole rockets.
+        assert!(out.starts_with('🚀'));
+        assert!(out.contains("truncated"));
     }
 
     // --- Pure assembly tests (issue #65 + earlier) ---

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -1,7 +1,8 @@
 use crate::CoreError;
 use crate::context::{
-    COMPACTION_TOKEN_RATIO, MAX_CONTEXT_MESSAGES, MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES,
-    compaction_range, generate_context_summary, llm_messages_for_turn, recover_from_overflow,
+    COMPACTION_TOKEN_RATIO, DEFAULT_MAX_TOOL_RESULT_BYTES, MAX_CONTEXT_MESSAGES,
+    MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES, cap_tool_result, compaction_range,
+    generate_context_summary, llm_messages_for_turn, recover_from_overflow,
 };
 use crate::domain::{
     Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition, ToolNamespace,
@@ -163,6 +164,11 @@ pub struct ConversationHandler<S, L, T = NoopToolExecutor> {
     /// windowing/compaction. `None` (the default) preserves the prior
     /// verbatim-prompt-only anchor behaviour.
     scratchpad_goal_read: Option<ScratchpadGetManyFn>,
+    /// Maximum byte length a single tool result may occupy before it is
+    /// truncated at ingestion (issue #174). Defaults to
+    /// [`DEFAULT_MAX_TOOL_RESULT_BYTES`]; override via
+    /// [`Self::with_max_tool_result_bytes`].
+    max_tool_result_bytes: usize,
 }
 
 impl<S, L> ConversationHandler<S, L, NoopToolExecutor> {
@@ -175,6 +181,7 @@ impl<S, L> ConversationHandler<S, L, NoopToolExecutor> {
             id_generator,
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
+            max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
         }
     }
 }
@@ -194,6 +201,7 @@ impl<S, L, T> ConversationHandler<S, L, T> {
             id_generator,
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
+            max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
         }
     }
 
@@ -211,6 +219,14 @@ impl<S, L, T> ConversationHandler<S, L, T> {
     /// evolving goal keeps showing up even after history is compacted away.
     pub fn with_scratchpad_goal(mut self, goal_read: ScratchpadGetManyFn) -> Self {
         self.scratchpad_goal_read = Some(goal_read);
+        self
+    }
+
+    /// Override the per-tool-result ingestion cap (issue #174). Results
+    /// larger than this are truncated with a notice before being stored so a
+    /// single runaway tool call can't wedge the conversation or the database.
+    pub fn with_max_tool_result_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_tool_result_bytes = max_bytes;
         self
     }
 }
@@ -796,8 +812,26 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     }
                 }
 
+                // Cap the result at ingestion (issue #174): a runaway tool can
+                // return a multi-megabyte payload that, stored verbatim, wedges
+                // the conversation against the model's context window on every
+                // later turn and stalls the messages INSERT. Truncate with a
+                // notice so the model still sees what ran and how to narrow it.
+                let stored = match cap_tool_result(&result, self.max_tool_result_bytes) {
+                    Some(truncated) => {
+                        tracing::warn!(
+                            tool = %tool_call.name,
+                            original_bytes = result.len(),
+                            kept_bytes = truncated.len(),
+                            cap_bytes = self.max_tool_result_bytes,
+                            "tool result exceeded the ingestion cap — truncated"
+                        );
+                        truncated
+                    }
+                    None => result,
+                };
                 conv.messages
-                    .push(Message::tool_result(&tool_call.id, &result));
+                    .push(Message::tool_result(&tool_call.id, &stored));
             }
 
             // Create a new noop callback for subsequent rounds
@@ -1359,6 +1393,40 @@ mod tests {
             updated.messages[3].content,
             "The file contains: hello world"
         );
+    }
+
+    #[tokio::test]
+    async fn oversized_tool_result_is_truncated_at_ingestion_and_stays_paired() {
+        // Issue #174: a tool returning a huge payload must be truncated before
+        // it is stored, so it can't wedge the conversation on later turns. The
+        // tool_call_id pairing must survive truncation.
+        let tool_def = ToolDefinition::new("dump", "Dumps a lot", serde_json::json!({}));
+        let responses = vec![
+            LlmResponse::with_tool_calls("", vec![ToolCall::new("call-1", "dump", "{}")]),
+            LlmResponse::text("ok"),
+        ];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("dump".to_string(), "A".repeat(5_000));
+
+        let handler = make_tool_handler(responses, vec![tool_def], tool_results)
+            .with_max_tool_result_bytes(1_024);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        handler
+            .send_prompt(&conv.id, "dump it".into(), noop_callback(), noop_status())
+            .await
+            .unwrap();
+
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let tool_msg = &updated.messages[2];
+        assert_eq!(tool_msg.role, Role::Tool);
+        assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call-1"));
+        assert!(
+            tool_msg.content.len() <= 1_024,
+            "stored tool result {} exceeds cap",
+            tool_msg.content.len()
+        );
+        assert!(tool_msg.content.contains("truncated"));
+        assert!(tool_msg.content.starts_with("AAAA"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Caps each tool result at **ingestion** so a single misbehaving tool call can't wedge a conversation or stall the database.

Root cause of the gpt-oss context-overflow reports: tool results were pushed into the conversation verbatim with no size limit (`core/service.rs`), so a tool that returned a giant payload (observed in the wild: **124 MB across 8 messages**, `model=openai.gpt-oss-120b-1:0`) was stored *and re-sent on every subsequent turn*, permanently exceeding the model's context window:

```
LLM request payload msg_chars=124678961 msg_count=8 tool_count=17 ...
Bedrock converse_stream error: validation error: Input is too long for requested model.
```

## How

- `cap_tool_result(content, max_bytes) -> Option<String>` (core `context` module): `None` when it already fits (no allocation); otherwise the longest UTF-8 prefix that, with a truncation notice, stays within the cap. Truncation lands on a `char` boundary (multi-byte safe) and the boundary snap is O(1), so it's cheap even on a multi-MB payload.
- `tool_result_truncation_notice` is addressed to the model ("re-run with a narrower request…") so it learns to chunk instead of assuming the output was complete.
- New `max_tool_result_bytes` field on `ConversationHandler` (default **256 KiB** ≈ 64K tokens at chars/4 — far above any honest tool result) + `with_max_tool_result_bytes` builder.
- Applied at the tool-result push site in the dispatch loop, with a `warn!` recording original/kept/cap sizes.

## Design note

Implemented as a **byte** cap (issue floated bytes-or-tokens): deterministic, O(1) to check, no estimator pass over a huge string, and it directly bounds what's written to Postgres — which is the other half of the problem (see #177, the FTS INSERT stall).

## Tests (TDD — failing tests committed first)

Named per acceptance criterion, in `context::tests`:
- under-cap unchanged · empty · exactly-at-cap unchanged
- over-cap truncates with notice + cites original size
- stays within the byte cap across a range of cap sizes
- truncates on a `char` boundary for dense multi-byte (🚀) content — no panic

Plus a `service::tests` integration test: an oversized tool result is stored truncated **and** keeps its `tool_call_id` pairing.

`cargo fmt --check`, `clippy --all-targets` (clean), full `desktop-assistant-core` suite (221 lib tests) and `cargo check --workspace` all green.

## Related

Part of the gpt-oss overflow fix set: #175 (recognize Bedrock overflow strings so the recovery ladder fires), #176 (curated context windows / surface window in UI), #177 (FTS INSERT guard). Epic #178.

Closes #174
🤖 Generated with [Claude Code](https://claude.com/claude-code)
