### PR TITLE
fix(#177): guard message FTS column against the 1 MB tsvector INSERT failure

### DIFF
--- a/crates/storage/migrations/021_message_fts_guard.sql
+++ b/crates/storage/migrations/021_message_fts_guard.sql
@@ -1,0 +1,45 @@
+-- Issue #177: a multi-megabyte message breaks the `messages` INSERT.
+--
+-- Migration 013 (#71) added a generated, stored FTS column over the full
+-- message content:
+--
+--     tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+--
+-- On every INSERT Postgres tokenizes the entire content and updates the GIN
+-- index. For a large/high-entropy message this is multi-second AND can exceed
+-- Postgres's hard 1 MB tsvector limit, which aborts the INSERT outright:
+--
+--     ERROR: string is too long for tsvector (N bytes, max 1048575 bytes)
+--
+-- Observed in production: the five largest message rows were all `tool`
+-- results, the largest 1.65 MB — over the ceiling. The failed write
+-- (rows_affected=0) is a likely contributor to "the assistant forgot the
+-- turn that overflowed".
+--
+-- Fix: don't FTS-index `tool`-role rows (they are by far the largest and are
+-- low value for conversation search — searching tool *output* is rarely what
+-- a user wants), and bound the indexed input for every other role to 256 KiB
+-- so the generated tsvector can never approach the 1 MB ceiling. 256 KiB of
+-- input yields well under a 1 MB tsvector even for all-distinct tokens
+-- (verified empirically against Postgres). FTS over the first 256 KiB of a
+-- user/assistant message is more than sufficient.
+--
+-- A generated column's expression cannot be ALTERed in place, so the column
+-- is dropped and re-added. This rewrites the table and takes a write lock
+-- proportional to history size — run during a quiet window on large installs
+-- (same caveat #71/013 carried). Existing oversized rows are safe: the new
+-- expression skips/bounds them, so the rewrite itself cannot hit the limit.
+
+ALTER TABLE messages DROP COLUMN IF EXISTS tsv;
+
+ALTER TABLE messages
+    ADD COLUMN tsv tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector(
+            'english',
+            CASE WHEN role = 'tool' THEN '' ELSE left(content, 262144) END
+        )
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_messages_tsv
+    ON messages USING GIN(tsv);

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -163,5 +163,14 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // Message FTS INSERT guard (issue #177) — the migration-013 generated
+    // `tsv` column ran `to_tsvector` over full message content, which on a
+    // large/high-entropy message exceeds Postgres's 1 MB tsvector limit and
+    // aborts the INSERT. Redefine it to skip `tool`-role rows and bound the
+    // indexed input so a large message can always be stored.
+    sqlx::raw_sql(include_str!("../migrations/021_message_fts_guard.sql"))
+        .execute(pool)
+        .await?;
+
     Ok(())
 }

--- a/crates/storage/tests/message_fts_guard.rs
+++ b/crates/storage/tests/message_fts_guard.rs
@@ -2,7 +2,7 @@
 //!
 //! Migration 013 added a generated `tsv` column over the full message
 //! content. A multi-megabyte / high-entropy message could exceed Postgres's
-//! hard 1 MB tsvector limit and abort the INSERT. Migration 019 stops
+//! hard 1 MB tsvector limit and abort the INSERT. Migration 021 stops
 //! FTS-indexing `tool`-role rows and bounds the indexed input for other roles,
 //! so a large message can always be stored while normal full-text search keeps
 //! working.
@@ -102,7 +102,7 @@ async fn large_message_insert_succeeds_and_fts_still_works() {
 
     run_migrations(&fixture.pool)
         .await
-        .expect("migrations (incl. 019) apply against the test schema");
+        .expect("migrations (incl. 021) apply against the test schema");
 
     // A parent conversation (all NOT NULL columns supplied).
     sqlx::query(
@@ -126,7 +126,7 @@ async fn large_message_insert_succeeds_and_fts_still_works() {
     .await;
     assert!(
         big_tool.is_ok(),
-        "large tool-result INSERT must succeed post-019, got {big_tool:?}"
+        "large tool-result INSERT must succeed post-021, got {big_tool:?}"
     );
 
     // The same oversized payload as a non-tool role must also store (the
@@ -138,7 +138,7 @@ async fn large_message_insert_succeeds_and_fts_still_works() {
     )
     .execute(&fixture.pool)
     .await
-    .expect("large user-message INSERT must succeed post-019");
+    .expect("large user-message INSERT must succeed post-021");
 
     // A normal message must remain full-text searchable.
     sqlx::query(

--- a/crates/storage/tests/message_fts_guard.rs
+++ b/crates/storage/tests/message_fts_guard.rs
@@ -1,0 +1,168 @@
+//! Integration test for the message FTS INSERT guard (issue #177).
+//!
+//! Migration 013 added a generated `tsv` column over the full message
+//! content. A multi-megabyte / high-entropy message could exceed Postgres's
+//! hard 1 MB tsvector limit and abort the INSERT. Migration 019 stops
+//! FTS-indexing `tool`-role rows and bounds the indexed input for other roles,
+//! so a large message can always be stored while normal full-text search keeps
+//! working.
+//!
+//! ## Running locally
+//!
+//! Set `TEST_DATABASE_URL` to a Postgres URL whose role can `CREATE SCHEMA`
+//! (the `vector` extension must already be available in the target database):
+//!
+//! ```sh
+//! TEST_DATABASE_URL="postgres://user:pw@localhost/db" \
+//!     cargo test -p desktop-assistant-storage --test message_fts_guard
+//! ```
+//!
+//! When `TEST_DATABASE_URL` is unset the test pass-skips with a log line.
+
+use std::sync::Arc;
+
+use desktop_assistant_storage::run_migrations;
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+/// RAII-ish fixture owning a freshly-created schema and a pool whose
+/// connections have `search_path` pinned to it. `cleanup` drops the schema.
+struct SchemaFixture {
+    pool: PgPool,
+    schema: String,
+    admin_url: String,
+}
+
+impl SchemaFixture {
+    async fn try_new() -> Option<Self> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let schema = format!("fts_test_{}", Uuid::now_v7().simple());
+
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
+            .execute(&admin)
+            .await
+            .expect("create test schema");
+        admin.close().await;
+
+        let schema_for_hook = Arc::new(schema.clone());
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .after_connect(move |conn, _meta| {
+                let schema = Arc::clone(&schema_for_hook);
+                Box::pin(async move {
+                    let sql = format!("SET search_path TO \"{schema}\", public");
+                    sqlx::query(sqlx::AssertSqlSafe(sql)).execute(conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect per-test pool");
+
+        Some(Self {
+            pool,
+            schema,
+            admin_url: url,
+        })
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        if let Ok(admin) = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&self.admin_url)
+            .await
+        {
+            let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+                "DROP SCHEMA \"{}\" CASCADE",
+                self.schema
+            )))
+            .execute(&admin)
+            .await;
+            admin.close().await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn large_message_insert_succeeds_and_fts_still_works() {
+    let Some(fixture) = SchemaFixture::try_new().await else {
+        eprintln!(
+            "skip: TEST_DATABASE_URL not set; large_message_insert_succeeds_and_fts_still_works \
+             pass-skipped"
+        );
+        return;
+    };
+
+    run_migrations(&fixture.pool)
+        .await
+        .expect("migrations (incl. 019) apply against the test schema");
+
+    // A parent conversation (all NOT NULL columns supplied).
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, title, created_at, updated_at, context_summary, compacted_through) \
+         VALUES ('c1', 'default', 't', now(), now(), '', 0)",
+    )
+    .execute(&fixture.pool)
+    .await
+    .expect("insert conversation");
+
+    // ~4 MB of all-distinct tokens — under the OLD definition this produces a
+    // >1 MB tsvector and the INSERT errors with "string is too long for
+    // tsvector". Built in SQL so we don't ship megabytes from the test binary.
+    let big_tool = sqlx::query(
+        "INSERT INTO messages (id, conversation_id, user_id, ordinal, role, content) \
+         SELECT 'm1', 'c1', 'default', 1, 'tool', string_agg('tok' || g, ' ') \
+         FROM generate_series(1, 300000) g",
+    )
+    .execute(&fixture.pool)
+    .await;
+    assert!(
+        big_tool.is_ok(),
+        "large tool-result INSERT must succeed post-019, got {big_tool:?}"
+    );
+
+    // The same oversized payload as a non-tool role must also store (the
+    // indexed input is bounded to 256 KiB so the tsvector stays under 1 MB).
+    sqlx::query(
+        "INSERT INTO messages (id, conversation_id, user_id, ordinal, role, content) \
+         SELECT 'm2', 'c1', 'default', 2, 'user', string_agg('tok' || g, ' ') \
+         FROM generate_series(1, 300000) g",
+    )
+    .execute(&fixture.pool)
+    .await
+    .expect("large user-message INSERT must succeed post-019");
+
+    // A normal message must remain full-text searchable.
+    sqlx::query(
+        "INSERT INTO messages (id, conversation_id, user_id, ordinal, role, content) \
+         VALUES ('m3', 'c1', 'default', 3, 'user', 'the quick brown fox')",
+    )
+    .execute(&fixture.pool)
+    .await
+    .expect("insert normal message");
+
+    let tool_not_indexed: bool =
+        sqlx::query_scalar("SELECT tsv = ''::tsvector FROM messages WHERE role = 'tool'")
+            .fetch_one(&fixture.pool)
+            .await
+            .expect("read tool tsv");
+    assert!(tool_not_indexed, "tool-role rows must not be FTS-indexed");
+
+    let fts_hits: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM messages WHERE tsv @@ to_tsquery('english', 'fox')",
+    )
+    .fetch_one(&fixture.pool)
+    .await
+    .expect("run FTS query");
+    assert_eq!(fts_hits, 1, "FTS must still match normal message content");
+
+    fixture.cleanup().await;
+}


### PR DESCRIPTION
## What

Stops a large message from stalling — or outright **failing** — the `messages` INSERT.

Migration 013 (#71) added a generated, stored FTS column over the *full* message content:

```sql
tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
```

On every INSERT Postgres tokenizes the entire content and updates the GIN index. For a large/high-entropy message this is multi-second **and** can exceed Postgres's hard **1 MB tsvector limit**, which aborts the INSERT:

```
ERROR: string is too long for tsvector (3997986 bytes, max 1048575 bytes)
```

This matches the production symptom: `slow statement: INSERT INTO messages … elapsed=9.47s … rows_affected=0`. **Confirmed against the live DB** — the five largest message rows were all `tool` results, the largest **1.65 MB**, over the ceiling.

## How (migration 019)

Redefine `messages.tsv` to:
- **skip `tool`-role rows** (`CASE WHEN role = 'tool' THEN '' …`) — they're by far the largest and searching tool *output* is low value, and
- **bound the indexed input to 256 KiB** for every other role (`left(content, 262144)`), so the generated tsvector can never approach the 1 MB ceiling.

A generated column's expression can't be `ALTER`ed in place, so it's dropped and re-added (table rewrite — write lock proportional to history; documented in the migration header like #71 did). Existing oversized rows are safe: the new expression skips/bounds them, so the rewrite itself can't hit the limit. Wired into `run_migrations`, which `include_str!`s each migration explicitly (not `sqlx::migrate!`).

## Tests (TDD — failing test committed first, validated on real Postgres)

`crates/storage/tests/message_fts_guard.rs` (gated on `TEST_DATABASE_URL`, pass-skips without a DB), run against a real Postgres in an isolated throwaway schema:
- **pre-019** the large tool INSERT aborts with `string is too long for tsvector (3997986 bytes, max 1048575 bytes)` (the red commit)
- **post-019** the large tool INSERT *and* a large non-tool INSERT both succeed, tool rows are not indexed, and a normal message is still full-text matchable

Full `desktop-assistant-storage` suite (102 tests across 6 binaries) green against the DB; fmt, clippy `--all-targets`, `cargo check --workspace` clean.

## Related

Defense-in-depth with #174 (cap tool results at 256 KiB) — together a runaway tool can neither wedge the context window nor break the write path. Epic #178.

Closes #177
🤖 Generated with [Claude Code](https://claude.com/claude-code)
