### PR TITLE
Scratchpad: per-note type, sequence & done (ordered plan TODOs)

### DIFF
--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -7,5 +7,5 @@ pub mod tool;
 pub use conversation::{Conversation, ConversationId, ConversationSummary, MessageSummary};
 pub use knowledge::KnowledgeEntry;
 pub use message::{Message, Role};
-pub use scratchpad::ScratchpadNote;
+pub use scratchpad::{DEFAULT_NOTE_TYPE, ScratchpadNote};
 pub use tool::{ToolCall, ToolDefinition, ToolNamespace, ToolResult};

--- a/crates/core/src/domain/scratchpad.rs
+++ b/crates/core/src/domain/scratchpad.rs
@@ -13,13 +13,31 @@ pub struct ScratchpadNote {
     pub conversation_id: String,
     pub key: String,
     pub content: String,
+    /// Free-text category the assistant assigns to organise its notes —
+    /// suggested values are `todo` / `note` / `other`, but it is not
+    /// constrained so the assistant may invent its own. Defaults to `note`.
+    /// Mainly exists so notes can be filtered/grouped (e.g. an ordered plan
+    /// of `todo`s) without affecting the keyed-upsert semantics.
+    pub note_type: String,
+    /// Optional ordering hint, sorted ascending **within a `note_type`**
+    /// (nulls last). Lets the assistant keep a sequenced plan of `todo`s.
+    pub sequence: Option<i32>,
+    /// Whether the assistant (or the user, via a client) has checked this
+    /// note off. Orthogonal to `note_type`; a checked-off `todo` stays
+    /// visible so completed work isn't redone.
+    pub done: bool,
     pub created_at: String,
     pub updated_at: String,
 }
 
+/// Default `note_type` when a writer doesn't specify one.
+pub const DEFAULT_NOTE_TYPE: &str = "note";
+
 impl ScratchpadNote {
-    /// Construct a note. `created_at` / `updated_at` are left empty for the
-    /// storage layer to populate from the database clock on write.
+    /// Construct a `note`-typed, unsequenced, not-done note. `created_at` /
+    /// `updated_at` are left empty for the storage layer to populate from the
+    /// database clock on write. Use the field setters (or struct update
+    /// syntax) for `note_type` / `sequence` / `done`.
     pub fn new(
         id: impl Into<String>,
         conversation_id: impl Into<String>,
@@ -31,6 +49,9 @@ impl ScratchpadNote {
             conversation_id: conversation_id.into(),
             key: key.into(),
             content: content.into(),
+            note_type: DEFAULT_NOTE_TYPE.to_string(),
+            sequence: None,
+            done: false,
             created_at: String::new(),
             updated_at: String::new(),
         }
@@ -48,18 +69,28 @@ mod tests {
         assert_eq!(note.conversation_id, "conv-1");
         assert_eq!(note.key, "goal");
         assert_eq!(note.content, "Ship the scratchpad feature");
+        // New fields default to a plain, unsequenced, not-done note.
+        assert_eq!(note.note_type, DEFAULT_NOTE_TYPE);
+        assert_eq!(note.sequence, None);
+        assert!(!note.done);
         assert!(note.created_at.is_empty());
         assert!(note.updated_at.is_empty());
     }
 
     #[test]
     fn scratchpad_note_serialization_roundtrip() {
-        let mut note = ScratchpadNote::new("sp-1", "conv-1", "open-questions", "Q: which db?");
+        let mut note = ScratchpadNote::new("sp-1", "conv-1", "step-1", "wire the migration");
+        note.note_type = "todo".to_string();
+        note.sequence = Some(2);
+        note.done = true;
         note.created_at = "2026-06-03 00:00:00".to_string();
         note.updated_at = "2026-06-03 00:00:00".to_string();
 
         let json = serde_json::to_string(&note).unwrap();
         let deserialized: ScratchpadNote = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, note);
+        assert_eq!(deserialized.note_type, "todo");
+        assert_eq!(deserialized.sequence, Some(2));
+        assert!(deserialized.done);
     }
 }

--- a/crates/core/src/ports/scratchpad.rs
+++ b/crates/core/src/ports/scratchpad.rs
@@ -3,7 +3,34 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::CoreError;
-use crate::domain::ScratchpadNote;
+use crate::domain::{DEFAULT_NOTE_TYPE, ScratchpadNote};
+
+/// A note to upsert into the scratchpad. Carries the structured fields that
+/// don't fit a bare `(key, content)` pair: a free-text `note_type`
+/// (default `note`), an optional `sequence` (sorted within a type), and a
+/// `done` flag. Construct via [`NewScratchpadNote::new`] and the field
+/// setters, or as a struct literal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewScratchpadNote {
+    pub key: String,
+    pub content: String,
+    pub note_type: String,
+    pub sequence: Option<i32>,
+    pub done: bool,
+}
+
+impl NewScratchpadNote {
+    /// A `note`-typed, unsequenced, not-done upsert for `key` / `content`.
+    pub fn new(key: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            content: content.into(),
+            note_type: DEFAULT_NOTE_TYPE.to_string(),
+            sequence: None,
+            done: false,
+        }
+    }
+}
 
 /// Reserved note key whose content the service auto-surfaces as the
 /// conversation's task anchor each turn (see `crate::service`). The model
@@ -44,13 +71,13 @@ pub const RESPONSE_BYTE_BUDGET: usize = 20 * 1024;
 /// through the multi-entity forms (`get_many`/`delete_many`) — the goal
 /// anchor reads via `get_many(conv, &["goal"], 1)`.
 pub trait ScratchpadStore: Send + Sync {
-    /// Upsert a batch of `(key, content)` notes for a conversation, replacing
-    /// the content of any existing note with the same key. Returns the saved
-    /// notes (with populated timestamps).
+    /// Upsert a batch of notes for a conversation, replacing the content (and
+    /// `note_type` / `sequence` / `done`) of any existing note with the same
+    /// key. Returns the saved notes (with populated timestamps).
     fn write(
         &self,
         conversation_id: &str,
-        notes: &[(String, String)],
+        notes: &[NewScratchpadNote],
     ) -> impl Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send;
 
     /// Fetch the notes for the given keys (in `updated_at DESC` order),
@@ -62,19 +89,25 @@ pub trait ScratchpadStore: Send + Sync {
         limit: usize,
     ) -> impl Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send;
 
-    /// List all notes for a conversation, newest first, capped at `limit`.
+    /// List a conversation's notes, capped at `limit`. Ordered by `note_type`,
+    /// then `sequence` ascending (nulls last), then `updated_at` descending —
+    /// so a sequenced plan of `todo`s reads in order. When `note_type` is
+    /// `Some`, only notes of that type are returned.
     fn list(
         &self,
         conversation_id: &str,
+        note_type: Option<&str>,
         limit: usize,
     ) -> impl Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send;
 
     /// Full-text search over a conversation's notes (key + content), ranked,
-    /// capped at `limit`.
+    /// capped at `limit`. When `note_type` is `Some`, results are restricted
+    /// to that type.
     fn search(
         &self,
         conversation_id: &str,
         query: &str,
+        note_type: Option<&str>,
         limit: usize,
     ) -> impl Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send;
 
@@ -94,7 +127,7 @@ pub trait ScratchpadStore: Send + Sync {
 pub type ScratchpadWriteFn = Arc<
     dyn Fn(
             String,
-            Vec<(String, String)>,
+            Vec<NewScratchpadNote>,
         ) -> Pin<Box<dyn Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send>>
         + Send
         + Sync,
@@ -111,21 +144,25 @@ pub type ScratchpadGetManyFn = Arc<
         + Sync,
 >;
 
-/// Boxed async closure for listing all notes (newest first).
+/// Boxed async closure for listing notes (optionally filtered by `note_type`),
+/// ordered by type then sequence.
 pub type ScratchpadListFn = Arc<
     dyn Fn(
             String,
+            Option<String>,
             usize,
         ) -> Pin<Box<dyn Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send>>
         + Send
         + Sync,
 >;
 
-/// Boxed async closure for full-text searching notes.
+/// Boxed async closure for full-text searching notes (optionally filtered by
+/// `note_type`).
 pub type ScratchpadSearchFn = Arc<
     dyn Fn(
             String,
             String,
+            Option<String>,
             usize,
         ) -> Pin<Box<dyn Future<Output = Result<Vec<ScratchpadNote>, CoreError>> + Send>>
         + Send
@@ -154,12 +191,19 @@ mod tests {
         async fn write(
             &self,
             conversation_id: &str,
-            notes: &[(String, String)],
+            notes: &[NewScratchpadNote],
         ) -> Result<Vec<ScratchpadNote>, CoreError> {
             Ok(notes
                 .iter()
                 .enumerate()
-                .map(|(i, (k, c))| ScratchpadNote::new(format!("id-{i}"), conversation_id, k, c))
+                .map(|(i, n)| {
+                    let mut note =
+                        ScratchpadNote::new(format!("id-{i}"), conversation_id, &n.key, &n.content);
+                    note.note_type = n.note_type.clone();
+                    note.sequence = n.sequence;
+                    note.done = n.done;
+                    note
+                })
                 .collect())
         }
 
@@ -175,6 +219,7 @@ mod tests {
         async fn list(
             &self,
             _conversation_id: &str,
+            _note_type: Option<&str>,
             _limit: usize,
         ) -> Result<Vec<ScratchpadNote>, CoreError> {
             Ok(vec![])
@@ -184,6 +229,7 @@ mod tests {
             &self,
             _conversation_id: &str,
             _query: &str,
+            _note_type: Option<&str>,
             _limit: usize,
         ) -> Result<Vec<ScratchpadNote>, CoreError> {
             Ok(vec![])
@@ -205,14 +251,17 @@ mod tests {
     #[tokio::test]
     async fn mock_store_write_roundtrips_batch() {
         let store = MockScratchpadStore;
-        let notes = vec![
-            ("goal".to_string(), "ship it".to_string()),
-            ("q".to_string(), "which db".to_string()),
-        ];
+        let mut todo = NewScratchpadNote::new("step-1", "wire it");
+        todo.note_type = "todo".to_string();
+        todo.sequence = Some(1);
+        let notes = vec![NewScratchpadNote::new("goal", "ship it"), todo];
         let saved = store.write("conv-1", &notes).await.unwrap();
         assert_eq!(saved.len(), 2);
         assert_eq!(saved[0].key, "goal");
-        assert_eq!(saved[1].content, "which db");
+        assert_eq!(saved[0].note_type, DEFAULT_NOTE_TYPE);
+        assert_eq!(saved[1].content, "wire it");
+        assert_eq!(saved[1].note_type, "todo");
+        assert_eq!(saved[1].sequence, Some(1));
     }
 
     #[tokio::test]

--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -38,6 +38,11 @@ Current goal:
 - Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
 - Evolve it as the objective shifts; clear it when the task is done.
 
+Plan and TODOs:
+- For any multi-step task, keep your plan in the scratchpad as notes with type "todo" and an integer "sequence" (1, 2, 3, …). Notes of the same type come back sorted by sequence, so your plan always reads in order.
+- As you finish a step, set that todo's "done": true (re-write the same key) to check it off — it stays visible so you don't redo it — or delete it. Add, re-sequence, or revise todos as the plan changes.
+- Use builtin_scratchpad_search with type "todo" to read just your plan.
+
 Work incrementally:
 - Prefer many small, targeted lookups over one giant context pull. After each fact search (knowledge base, past conversations, tools), record the outcome as its own note rather than holding everything in your head — batch-write several notes when a step yields multiple facts.
 

--- a/crates/core/src/prompts/sections/scratchpad.txt
+++ b/crates/core/src/prompts/sections/scratchpad.txt
@@ -5,6 +5,11 @@ Current goal:
 - Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
 - Evolve it as the objective shifts; clear it when the task is done.
 
+Plan and TODOs:
+- For any multi-step task, keep your plan in the scratchpad as notes with type "todo" and an integer "sequence" (1, 2, 3, …). Notes of the same type come back sorted by sequence, so your plan always reads in order.
+- As you finish a step, set that todo's "done": true (re-write the same key) to check it off — it stays visible so you don't redo it — or delete it. Add, re-sequence, or revise todos as the plan changes.
+- Use builtin_scratchpad_search with type "todo" to read just your plan.
+
 Work incrementally:
 - Prefer many small, targeted lookups over one giant context pull. After each fact search (knowledge base, past conversations, tools), record the outcome as its own note rather than holding everything in your head — batch-write several notes when a step yields multiple facts.
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1001,13 +1001,17 @@ async fn main() -> Result<()> {
                 let store = Arc::clone(&sp_g);
                 Box::pin(async move { store.get_many(&conv, &keys, limit).await })
             }),
-            Arc::new(move |conv, limit| {
+            Arc::new(move |conv, note_type: Option<String>, limit| {
                 let store = Arc::clone(&sp_l);
-                Box::pin(async move { store.list(&conv, limit).await })
+                Box::pin(async move { store.list(&conv, note_type.as_deref(), limit).await })
             }),
-            Arc::new(move |conv, query, limit| {
+            Arc::new(move |conv, query, note_type: Option<String>, limit| {
                 let store = Arc::clone(&sp_s);
-                Box::pin(async move { store.search(&conv, &query, limit).await })
+                Box::pin(async move {
+                    store
+                        .search(&conv, &query, note_type.as_deref(), limit)
+                        .await
+                })
             }),
             Arc::new(move |conv, keys| {
                 let store = Arc::clone(&sp_d);

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -1701,6 +1701,121 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scratchpad_write_persists_type_sequence_done() {
+        let (service, _store) = scratchpad_service();
+        with_conversation_id(ConversationId::from("c1"), async {
+            service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_WRITE,
+                    serde_json::json!({
+                        "key": "t1", "content": "wire the migration",
+                        "type": "todo", "sequence": 2, "done": false
+                    }),
+                )
+                .await
+                .unwrap();
+
+            let by_key = service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_SEARCH,
+                    serde_json::json!({"keys": ["t1"], "max_results": 10}),
+                )
+                .await
+                .unwrap();
+            let note = &parse(&by_key)["results"][0];
+            assert_eq!(note["type"], "todo");
+            assert_eq!(note["sequence"], 2);
+            assert_eq!(note["done"], false);
+
+            // Re-writing the same key flips `done` (the check-off path).
+            service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_WRITE,
+                    serde_json::json!({
+                        "key": "t1", "content": "wire the migration",
+                        "type": "todo", "sequence": 2, "done": true
+                    }),
+                )
+                .await
+                .unwrap();
+            let after = service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_SEARCH,
+                    serde_json::json!({"keys": ["t1"], "max_results": 10}),
+                )
+                .await
+                .unwrap();
+            assert_eq!(parse(&after)["results"][0]["done"], true);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scratchpad_search_filters_by_type() {
+        let (service, _store) = scratchpad_service();
+        with_conversation_id(ConversationId::from("c1"), async {
+            service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_WRITE,
+                    serde_json::json!({"notes": [
+                        {"key": "t1", "content": "do a thing", "type": "todo", "sequence": 1},
+                        {"key": "n1", "content": "a plain note", "type": "note"}
+                    ]}),
+                )
+                .await
+                .unwrap();
+
+            let todos = service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_SEARCH,
+                    serde_json::json!({"type": "todo", "max_results": 10}),
+                )
+                .await
+                .unwrap();
+            let results = parse(&todos);
+            assert_eq!(results["results"].as_array().unwrap().len(), 1);
+            assert_eq!(results["results"][0]["key"], "t1");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn scratchpad_list_orders_todos_by_sequence() {
+        let (service, _store) = scratchpad_service();
+        with_conversation_id(ConversationId::from("c1"), async {
+            // Written out of order; expect list to return them sorted by `seq`.
+            service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_WRITE,
+                    serde_json::json!({"notes": [
+                        {"key": "c", "content": "third",  "type": "todo", "sequence": 3},
+                        {"key": "a", "content": "first",  "type": "todo", "sequence": 1},
+                        {"key": "b", "content": "second", "type": "todo", "sequence": 2}
+                    ]}),
+                )
+                .await
+                .unwrap();
+
+            let listed = service
+                .execute_tool(
+                    TOOL_SCRATCHPAD_SEARCH,
+                    serde_json::json!({"type": "todo", "max_results": 10}),
+                )
+                .await
+                .unwrap();
+            let results = parse(&listed);
+            let keys: Vec<String> = results["results"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|n| n["key"].as_str().unwrap().to_string())
+                .collect();
+            assert_eq!(keys, vec!["a", "b", "c"], "todos sort by sequence");
+        })
+        .await;
+    }
+
+    #[tokio::test]
     async fn conversation_search_without_store_returns_error() {
         let service = BuiltinToolService::new();
         let result = service

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -13,7 +13,7 @@ use desktop_assistant_core::ports::knowledge::{
     KnowledgeDeleteFn, KnowledgeSearchFn, KnowledgeWriteFn,
 };
 use desktop_assistant_core::ports::scratchpad::{
-    MAX_KEYS_PER_CALL, MAX_NOTE_BYTES, MAX_NOTES_PER_WRITE, MAX_RESULTS_CEILING,
+    MAX_KEYS_PER_CALL, MAX_NOTE_BYTES, MAX_NOTES_PER_WRITE, MAX_RESULTS_CEILING, NewScratchpadNote,
     RESPONSE_BYTE_BUDGET, ScratchpadClearFn, ScratchpadDeleteManyFn, ScratchpadGetManyFn,
     ScratchpadListFn, ScratchpadSearchFn, ScratchpadWriteFn,
 };
@@ -388,10 +388,13 @@ impl BuiltinToolService {
                  keyed; writing the same key again replaces it. Pass `notes` to upsert several \
                  at once. Use the reserved key 'goal' for the current objective: it is \
                  auto-surfaced as your task anchor every turn (so it survives compaction), and \
-                 you should evolve it as the goal shifts and delete it when done. The scratchpad \
-                 is discarded when the conversation is deleted and is NOT durable across \
-                 conversations — promote anything worth keeping to the knowledge base with \
-                 builtin_knowledge_base_write, then delete the note here.",
+                 you should evolve it as the goal shifts and delete it when done. Each note has \
+                 a `type` (default \"note\"; use \"todo\" for plan steps) and an optional integer \
+                 `sequence` — notes of the same type are returned sorted by `sequence`, so keep \
+                 your plan as `todo` notes numbered in order. Set `done: true` to check a todo \
+                 off (it stays visible). The scratchpad is discarded when the conversation is \
+                 deleted and is NOT durable across conversations — promote anything worth keeping \
+                 to the knowledge base with builtin_knowledge_base_write, then delete the note here.",
                 serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -401,24 +404,33 @@ impl BuiltinToolService {
                                 "type": "object",
                                 "properties": {
                                     "key": {"type": "string", "description": "Short handle for the note; upserts by key."},
-                                    "content": {"type": "string", "description": "The note body (keep it small and high-signal)."}
+                                    "content": {"type": "string", "description": "The note body (keep it small and high-signal)."},
+                                    "type": {"type": "string", "description": "Category, e.g. \"todo\"/\"note\"/\"other\". Defaults to \"note\". Used for filtering/grouping; same-type notes sort by `sequence`."},
+                                    "sequence": {"type": "integer", "description": "Optional ordering hint within the type (ascending). Use for ordered todos."},
+                                    "done": {"type": "boolean", "description": "Whether this note (e.g. a todo) is checked off. Defaults to false."}
                                 },
                                 "required": ["key", "content"]
                             },
                             "description": "One or more notes to add/update in a single call."
                         },
                         "key": {"type": "string", "description": "Single-note convenience: the note key (use with `content`)."},
-                        "content": {"type": "string", "description": "Single-note convenience: the note body (use with `key`)."}
+                        "content": {"type": "string", "description": "Single-note convenience: the note body (use with `key`)."},
+                        "type": {"type": "string", "description": "Single-note convenience: the note type (default \"note\")."},
+                        "sequence": {"type": "integer", "description": "Single-note convenience: ordering hint within the type."},
+                        "done": {"type": "boolean", "description": "Single-note convenience: checked-off flag."}
                     }
                 }),
             ),
             ToolDefinition::new(
                 TOOL_SCRATCHPAD_SEARCH,
                 "Read this conversation's scratchpad. Omit `query` and `keys` to list all notes \
-                 newest-first; pass `query` for a full-text search over note keys and content; \
-                 pass `keys` to fetch specific notes. `max_results` is required. Results are \
-                 bounded — if the response is truncated you'll get `truncated: true` and should \
-                 narrow with a `query` or a smaller key set.",
+                 (ordered by type, then `sequence`); pass `query` for a full-text search over \
+                 note keys and content; pass `keys` to fetch specific notes. Pass `type` to \
+                 restrict a list/search to one category, e.g. `type: \"todo\"` for just your \
+                 plan. Each returned note includes its `type`, `sequence`, and `done`. \
+                 `max_results` is required. Results are bounded — if the response is truncated \
+                 you'll get `truncated: true` and should narrow with a `query`, a `type`, or a \
+                 smaller key set.",
                 serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -428,6 +440,7 @@ impl BuiltinToolService {
                             "items": {"type": "string"},
                             "description": "Fetch specific notes by key. Takes precedence over `query`."
                         },
+                        "type": {"type": "string", "description": "Restrict a list/search to one note type, e.g. \"todo\". Ignored when `keys` is given."},
                         "max_results": {
                             "type": "integer",
                             "minimum": 1,
@@ -827,21 +840,16 @@ impl BuiltinToolService {
             .as_ref()
             .ok_or_else(|| CoreError::ToolExecution("scratchpad not configured".to_string()))?;
 
-        // Accept either a `notes` array or a single `key`+`content`.
-        let raw: Vec<(String, String)> =
+        // Accept either a `notes` array or a single `key`+`content`. Each note
+        // may carry an optional `type` (default "note"), `sequence`, and `done`.
+        let raw: Vec<NewScratchpadNote> =
             if let Some(arr) = arguments.get("notes").and_then(serde_json::Value::as_array) {
-                arr.iter()
-                    .filter_map(|n| {
-                        let key = n.get("key").and_then(serde_json::Value::as_str)?;
-                        let content = n.get("content").and_then(serde_json::Value::as_str)?;
-                        Some((key.trim().to_string(), content.to_string()))
-                    })
-                    .collect()
-            } else if let (Some(key), Some(content)) = (
-                arguments.get("key").and_then(serde_json::Value::as_str),
-                arguments.get("content").and_then(serde_json::Value::as_str),
-            ) {
-                vec![(key.trim().to_string(), content.to_string())]
+                arr.iter().filter_map(parse_new_note).collect()
+            } else if arguments.get("key").is_some() || arguments.get("content").is_some() {
+                match parse_new_note(&arguments) {
+                    Some(note) => vec![note],
+                    None => Vec::new(),
+                }
             } else {
                 return Err(CoreError::ToolExecution(
                 "scratchpad_write requires `notes: [{key, content}]` or a single `key` + `content`"
@@ -859,23 +867,23 @@ impl BuiltinToolService {
         // INSERT can't carry a duplicate ON CONFLICT target). Invalid notes
         // are reported individually rather than failing the whole call.
         let mut rejected: Vec<serde_json::Value> = Vec::new();
-        let mut accepted: Vec<(String, String)> = Vec::new();
-        for (key, content) in raw {
-            if key.is_empty() {
-                rejected.push(serde_json::json!({"key": key, "reason": "empty key"}));
+        let mut accepted: Vec<NewScratchpadNote> = Vec::new();
+        for note in raw {
+            if note.key.is_empty() {
+                rejected.push(serde_json::json!({"key": note.key, "reason": "empty key"}));
                 continue;
             }
-            if content.len() > MAX_NOTE_BYTES {
+            if note.content.len() > MAX_NOTE_BYTES {
                 rejected.push(serde_json::json!({
-                    "key": key,
+                    "key": note.key,
                     "reason": format!("content exceeds {MAX_NOTE_BYTES} bytes")
                 }));
                 continue;
             }
-            if let Some(existing) = accepted.iter_mut().find(|(k, _)| *k == key) {
-                existing.1 = content;
+            if let Some(existing) = accepted.iter_mut().find(|n| n.key == note.key) {
+                *existing = note;
             } else {
-                accepted.push((key, content));
+                accepted.push(note);
             }
         }
 
@@ -887,7 +895,7 @@ impl BuiltinToolService {
             skipped = accepted
                 .split_off(MAX_NOTES_PER_WRITE)
                 .into_iter()
-                .map(|(k, _)| k)
+                .map(|n| n.key)
                 .collect();
         }
 
@@ -930,6 +938,9 @@ impl BuiltinToolService {
 
         let keys = optional_string_array(&arguments, "keys");
         let query = optional_string(&arguments, "query");
+        // Optional structured filter restricting list/search to one note_type
+        // (e.g. only `todo`s). Ignored on the by-keys path (keys are explicit).
+        let note_type = optional_string(&arguments, "type");
 
         // Mode precedence: keys -> query -> list-all. Each path is bounded.
         let mut keys_truncated = false;
@@ -948,12 +959,12 @@ impl BuiltinToolService {
                 let search = self.scratchpad_search_fn.as_ref().ok_or_else(|| {
                     CoreError::ToolExecution("scratchpad not configured".to_string())
                 })?;
-                search(conversation_id, query, limit).await?
+                search(conversation_id, query, note_type, limit).await?
             } else {
                 let list = self.scratchpad_list_fn.as_ref().ok_or_else(|| {
                     CoreError::ToolExecution("scratchpad not configured".to_string())
                 })?;
-                list(conversation_id, limit).await?
+                list(conversation_id, note_type, limit).await?
             };
 
         let hit_limit = results.len() >= limit;
@@ -967,6 +978,9 @@ impl BuiltinToolService {
             let entry = serde_json::json!({
                 "key": note.key,
                 "content": note.content,
+                "type": note.note_type,
+                "sequence": note.sequence,
+                "done": note.done,
                 "updated_at": note.updated_at,
             });
             let size = entry.to_string().len();
@@ -1111,6 +1125,37 @@ fn optional_string_array_nonempty(args: &serde_json::Value, key: &str) -> Option
     } else {
         Some(values)
     }
+}
+
+/// Parse one scratchpad note object (`{key, content, type?, sequence?, done?}`)
+/// into a [`NewScratchpadNote`]. Returns `None` when `key` or `content` is
+/// absent (the caller treats that as a malformed note). `type` defaults to
+/// [`DEFAULT_NOTE_TYPE`]; the key is trimmed (emptiness is validated upstream).
+fn parse_new_note(obj: &serde_json::Value) -> Option<NewScratchpadNote> {
+    let key = obj.get("key").and_then(serde_json::Value::as_str)?;
+    let content = obj.get("content").and_then(serde_json::Value::as_str)?;
+    let note_type = obj
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(desktop_assistant_core::domain::DEFAULT_NOTE_TYPE)
+        .to_string();
+    let sequence = obj
+        .get("sequence")
+        .and_then(serde_json::Value::as_i64)
+        .map(|v| v as i32);
+    let done = obj
+        .get("done")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    Some(NewScratchpadNote {
+        key: key.trim().to_string(),
+        content: content.to_string(),
+        note_type,
+        sequence,
+        done,
+    })
 }
 
 fn detect_username() -> Option<String> {
@@ -1353,22 +1398,32 @@ mod tests {
 
         let w = Arc::clone(&store);
         let write_fn: ScratchpadWriteFn =
-            Arc::new(move |conv: String, notes: Vec<(String, String)>| {
+            Arc::new(move |conv: String, notes: Vec<NewScratchpadNote>| {
                 let store = Arc::clone(&w);
                 Box::pin(async move {
                     let mut guard = store.lock().unwrap();
                     let mut saved = Vec::new();
-                    for (i, (key, content)) in notes.into_iter().enumerate() {
+                    for (i, note) in notes.into_iter().enumerate() {
                         if let Some(existing) = guard
                             .iter_mut()
-                            .find(|n| n.conversation_id == conv && n.key == key)
+                            .find(|n| n.conversation_id == conv && n.key == note.key)
                         {
-                            existing.content = content;
+                            existing.content = note.content;
+                            existing.note_type = note.note_type;
+                            existing.sequence = note.sequence;
+                            existing.done = note.done;
                             existing.updated_at = "t1".into();
                             saved.push(existing.clone());
                         } else {
-                            let mut n =
-                                ScratchpadNote::new(format!("id-{i}-{key}"), &conv, &key, &content);
+                            let mut n = ScratchpadNote::new(
+                                format!("id-{i}-{}", note.key),
+                                &conv,
+                                &note.key,
+                                &note.content,
+                            );
+                            n.note_type = note.note_type;
+                            n.sequence = note.sequence;
+                            n.done = note.done;
                             n.updated_at = "t0".into();
                             guard.push(n.clone());
                             saved.push(n);
@@ -1400,22 +1455,38 @@ mod tests {
             });
 
         let l = Arc::clone(&store);
-        let list_fn: ScratchpadListFn = Arc::new(move |conv: String, limit: usize| {
-            let store = Arc::clone(&l);
-            Box::pin(async move {
-                let guard = store.lock().unwrap();
-                Ok(guard
-                    .iter()
-                    .filter(|n| n.conversation_id == conv)
-                    .take(limit)
-                    .cloned()
-                    .collect())
-            })
-        });
+        let list_fn: ScratchpadListFn = Arc::new(
+            move |conv: String, note_type: Option<String>, limit: usize| {
+                let store = Arc::clone(&l);
+                Box::pin(async move {
+                    let guard = store.lock().unwrap();
+                    let mut notes: Vec<ScratchpadNote> = guard
+                        .iter()
+                        .filter(|n| n.conversation_id == conv)
+                        .filter(|n| note_type.as_deref().is_none_or(|t| n.note_type == t))
+                        .cloned()
+                        .collect();
+                    // Mirror the store ordering: type, then sequence ascending
+                    // (nulls last), then recency (timestamps omitted here).
+                    notes.sort_by(|a, b| {
+                        a.note_type
+                            .cmp(&b.note_type)
+                            .then_with(|| match (a.sequence, b.sequence) {
+                                (Some(x), Some(y)) => x.cmp(&y),
+                                (Some(_), None) => std::cmp::Ordering::Less,
+                                (None, Some(_)) => std::cmp::Ordering::Greater,
+                                (None, None) => std::cmp::Ordering::Equal,
+                            })
+                    });
+                    notes.truncate(limit);
+                    Ok(notes)
+                })
+            },
+        );
 
         let s = Arc::clone(&store);
-        let search_fn: ScratchpadSearchFn =
-            Arc::new(move |conv: String, query: String, limit: usize| {
+        let search_fn: ScratchpadSearchFn = Arc::new(
+            move |conv: String, query: String, note_type: Option<String>, limit: usize| {
                 let store = Arc::clone(&s);
                 Box::pin(async move {
                     let guard = store.lock().unwrap();
@@ -1424,12 +1495,14 @@ mod tests {
                         .filter(|n| {
                             n.conversation_id == conv
                                 && (n.content.contains(&query) || n.key.contains(&query))
+                                && note_type.as_deref().is_none_or(|t| n.note_type == t)
                         })
                         .take(limit)
                         .cloned()
                         .collect())
                 })
-            });
+            },
+        );
 
         let d = Arc::clone(&store);
         let delete_many_fn: ScratchpadDeleteManyFn =

--- a/crates/storage/migrations/020_scratchpad_type_sequence_done.sql
+++ b/crates/storage/migrations/020_scratchpad_type_sequence_done.sql
@@ -1,0 +1,19 @@
+-- Scratchpad note kind/order/done (issue #188).
+--
+-- Adds three per-note fields so a conversation's scratchpad can hold an
+-- ordered, checkable plan of TODOs alongside plain notes:
+--   * note_type — free-text category (suggested: todo / note / other). NOT
+--     constrained by a CHECK so the assistant may invent its own; defaults to
+--     'note' so existing rows and bare writes keep working.
+--   * seq       — optional ordering hint, sorted ascending within a note_type.
+--   * done      — check-off flag; a checked-off todo stays visible.
+--
+-- The composite index backs the list ordering (per-conversation, by type then
+-- sequence). The generated `tsv` FTS column is intentionally left as
+-- (note_key || ' ' || content) — note_type is a structured filter, not FTS.
+ALTER TABLE scratchpads ADD COLUMN IF NOT EXISTS note_type TEXT NOT NULL DEFAULT 'note';
+ALTER TABLE scratchpads ADD COLUMN IF NOT EXISTS seq       INTEGER;
+ALTER TABLE scratchpads ADD COLUMN IF NOT EXISTS done      BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS scratchpads_conv_type_seq_idx
+    ON scratchpads (conversation_id, note_type, seq);

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -155,5 +155,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // Scratchpad note kind/order/done (issue #188) — note_type / seq / done
+    // columns so a scratchpad can hold an ordered, checkable plan of TODOs.
+    sqlx::raw_sql(include_str!(
+        "../migrations/020_scratchpad_type_sequence_done.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }

--- a/crates/storage/src/scratchpad.rs
+++ b/crates/storage/src/scratchpad.rs
@@ -12,7 +12,7 @@
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::ScratchpadNote;
 use desktop_assistant_core::ports::auth::current_user_id;
-use desktop_assistant_core::ports::scratchpad::ScratchpadStore;
+use desktop_assistant_core::ports::scratchpad::{NewScratchpadNote, ScratchpadStore};
 use sqlx::PgPool;
 
 /// Postgres adapter for the per-conversation scratchpad table.
@@ -32,6 +32,9 @@ struct SpRow {
     conversation_id: String,
     note_key: String,
     content: String,
+    note_type: String,
+    seq: Option<i32>,
+    done: bool,
     created_at: chrono::DateTime<chrono::Utc>,
     updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -43,6 +46,9 @@ impl SpRow {
             conversation_id: self.conversation_id,
             key: self.note_key,
             content: self.content,
+            note_type: self.note_type,
+            sequence: self.seq,
+            done: self.done,
             created_at: self.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
             updated_at: self.updated_at.format("%Y-%m-%d %H:%M:%S").to_string(),
         }
@@ -53,7 +59,7 @@ impl ScratchpadStore for PgScratchpadStore {
     async fn write(
         &self,
         conversation_id: &str,
-        notes: &[(String, String)],
+        notes: &[NewScratchpadNote],
     ) -> Result<Vec<ScratchpadNote>, CoreError> {
         if notes.is_empty() {
             return Ok(vec![]);
@@ -63,29 +69,40 @@ impl ScratchpadStore for PgScratchpadStore {
         // Batch upsert via UNNEST so a variable-length batch is a single
         // prepared statement. Zipping the parallel arrays yields one row per
         // note; the conflict target is `(conversation_id, note_key)` so a
-        // repeated key replaces content and bumps `updated_at`. `id` and
-        // `user_id` are only used on insert — an existing note keeps its
-        // original id/owner on update.
+        // repeated key replaces content/type/sequence/done and bumps
+        // `updated_at`. `id` and `user_id` are only used on insert — an
+        // existing note keeps its original id/owner on update.
         let ids: Vec<String> = (0..notes.len())
             .map(|_| uuid::Uuid::now_v7().to_string())
             .collect();
         let user_ids: Vec<String> = vec![user_id.as_str().to_string(); notes.len()];
         let conv_ids: Vec<String> = vec![conversation_id.to_string(); notes.len()];
-        let keys: Vec<String> = notes.iter().map(|(k, _)| k.clone()).collect();
-        let contents: Vec<String> = notes.iter().map(|(_, c)| c.clone()).collect();
+        let keys: Vec<String> = notes.iter().map(|n| n.key.clone()).collect();
+        let contents: Vec<String> = notes.iter().map(|n| n.content.clone()).collect();
+        let types: Vec<String> = notes.iter().map(|n| n.note_type.clone()).collect();
+        // `seq` is nullable; UNNEST of a `Vec<Option<i32>>` preserves NULLs.
+        let seqs: Vec<Option<i32>> = notes.iter().map(|n| n.sequence).collect();
+        let dones: Vec<bool> = notes.iter().map(|n| n.done).collect();
 
         let rows: Vec<SpRow> = sqlx::query_as(
-            "INSERT INTO scratchpads (id, user_id, conversation_id, note_key, content) \
-             SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], $5::text[]) \
+            "INSERT INTO scratchpads \
+                 (id, user_id, conversation_id, note_key, content, note_type, seq, done) \
+             SELECT * FROM UNNEST($1::text[], $2::text[], $3::text[], $4::text[], \
+                                  $5::text[], $6::text[], $7::int4[], $8::bool[]) \
              ON CONFLICT (conversation_id, note_key) \
-             DO UPDATE SET content = EXCLUDED.content, updated_at = NOW() \
-             RETURNING id, conversation_id, note_key, content, created_at, updated_at",
+             DO UPDATE SET content = EXCLUDED.content, note_type = EXCLUDED.note_type, \
+                           seq = EXCLUDED.seq, done = EXCLUDED.done, updated_at = NOW() \
+             RETURNING id, conversation_id, note_key, content, note_type, seq, done, \
+                       created_at, updated_at",
         )
         .bind(&ids)
         .bind(&user_ids)
         .bind(&conv_ids)
         .bind(&keys)
         .bind(&contents)
+        .bind(&types)
+        .bind(&seqs)
+        .bind(&dones)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| CoreError::Storage(e.to_string()))?;
@@ -104,7 +121,8 @@ impl ScratchpadStore for PgScratchpadStore {
         }
         let user_id = current_user_id();
         let rows: Vec<SpRow> = sqlx::query_as(
-            "SELECT id, conversation_id, note_key, content, created_at, updated_at \
+            "SELECT id, conversation_id, note_key, content, note_type, seq, done, \
+                    created_at, updated_at \
              FROM scratchpads \
              WHERE user_id = $1 AND conversation_id = $2 AND note_key = ANY($3) \
              ORDER BY updated_at DESC LIMIT $4",
@@ -122,17 +140,24 @@ impl ScratchpadStore for PgScratchpadStore {
     async fn list(
         &self,
         conversation_id: &str,
+        note_type: Option<&str>,
         limit: usize,
     ) -> Result<Vec<ScratchpadNote>, CoreError> {
         let user_id = current_user_id();
+        // Order by type, then sequence ascending (nulls last), then recency —
+        // so a sequenced plan of `todo`s reads in order. The optional
+        // `note_type` filter rides a single static query via `IS NULL OR`.
         let rows: Vec<SpRow> = sqlx::query_as(
-            "SELECT id, conversation_id, note_key, content, created_at, updated_at \
+            "SELECT id, conversation_id, note_key, content, note_type, seq, done, \
+                    created_at, updated_at \
              FROM scratchpads \
              WHERE user_id = $1 AND conversation_id = $2 \
-             ORDER BY updated_at DESC LIMIT $3",
+               AND ($3::text IS NULL OR note_type = $3) \
+             ORDER BY note_type ASC, seq ASC NULLS LAST, updated_at DESC LIMIT $4",
         )
         .bind(user_id.as_str())
         .bind(conversation_id)
+        .bind(note_type)
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await
@@ -144,20 +169,26 @@ impl ScratchpadStore for PgScratchpadStore {
         &self,
         conversation_id: &str,
         query: &str,
+        note_type: Option<&str>,
         limit: usize,
     ) -> Result<Vec<ScratchpadNote>, CoreError> {
         let user_id = current_user_id();
         // plainto_tsquery + ts_rank_cd, scoped — mirrors PgConversationSearchStore.
+        // Search stays relevance-ranked; the optional `note_type` filter rides
+        // a single static query via `IS NULL OR`.
         let rows: Vec<SpRow> = sqlx::query_as(
             "WITH q AS (SELECT plainto_tsquery('english', $3) AS query) \
-             SELECT id, conversation_id, note_key, content, created_at, updated_at \
+             SELECT id, conversation_id, note_key, content, note_type, seq, done, \
+                    created_at, updated_at \
              FROM scratchpads, q \
              WHERE user_id = $1 AND conversation_id = $2 AND tsv @@ q.query \
-             ORDER BY ts_rank_cd(tsv, q.query) DESC, updated_at DESC LIMIT $4",
+               AND ($4::text IS NULL OR note_type = $4) \
+             ORDER BY ts_rank_cd(tsv, q.query) DESC, updated_at DESC LIMIT $5",
         )
         .bind(user_id.as_str())
         .bind(conversation_id)
         .bind(query)
+        .bind(note_type)
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await

--- a/crates/storage/tests/scratchpad.rs
+++ b/crates/storage/tests/scratchpad.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use desktop_assistant_core::domain::{Conversation, ConversationId, Message, Role};
-use desktop_assistant_core::ports::scratchpad::ScratchpadStore;
+use desktop_assistant_core::ports::scratchpad::{NewScratchpadNote, ScratchpadStore};
 use desktop_assistant_core::ports::store::ConversationStore;
 use desktop_assistant_storage::{
     PgConversationStore, PgScratchpadStore, UserId, run_migrations, with_user_id,
@@ -117,8 +117,17 @@ fn make_conversation(id: &str) -> Conversation {
     conv
 }
 
-fn note(key: &str, content: &str) -> (String, String) {
-    (key.to_string(), content.to_string())
+/// A plain (`note`-typed, unsequenced) upsert.
+fn note(key: &str, content: &str) -> NewScratchpadNote {
+    NewScratchpadNote::new(key, content)
+}
+
+/// A `todo`-typed upsert with an explicit `sequence`.
+fn todo(key: &str, content: &str, sequence: i32) -> NewScratchpadNote {
+    let mut n = NewScratchpadNote::new(key, content);
+    n.note_type = "todo".to_string();
+    n.sequence = Some(sequence);
+    n
 }
 
 #[tokio::test]
@@ -139,14 +148,14 @@ async fn write_upserts_and_list_returns_all() {
                 .expect("batch write");
             assert_eq!(saved.len(), 2);
 
-            let listed = pad.list("c1", 50).await.expect("list");
+            let listed = pad.list("c1", None, 50).await.expect("list");
             assert_eq!(listed.len(), 2);
 
             // Re-writing an existing key updates content, not row count.
             pad.write("c1", &[note("goal", "ship it well")])
                 .await
                 .expect("upsert");
-            let after = pad.list("c1", 50).await.expect("list after upsert");
+            let after = pad.list("c1", None, 50).await.expect("list after upsert");
             assert_eq!(after.len(), 2, "upsert must not create a duplicate row");
             let goal = after.iter().find(|n| n.key == "goal").expect("goal note");
             assert_eq!(goal.content, "ship it well");
@@ -210,11 +219,14 @@ async fn search_matches_full_text() {
             .await
             .expect("write");
 
-            let hits = pad.search("c1", "deploy", 50).await.expect("search");
+            let hits = pad.search("c1", "deploy", None, 50).await.expect("search");
             assert_eq!(hits.len(), 1, "only the deploy note should match");
             assert_eq!(hits[0].key, "deploy");
 
-            let none = pad.search("c1", "bicycle", 50).await.expect("search empty");
+            let none = pad
+                .search("c1", "bicycle", None, 50)
+                .await
+                .expect("search empty");
             assert!(none.is_empty());
         })
         .await;
@@ -243,11 +255,11 @@ async fn delete_many_and_clear_return_counts() {
                 .await
                 .expect("delete_many");
             assert_eq!(deleted, 1, "only the existing key is deleted");
-            assert_eq!(pad.list("c1", 50).await.unwrap().len(), 2);
+            assert_eq!(pad.list("c1", None, 50).await.unwrap().len(), 2);
 
             let cleared = pad.clear("c1").await.expect("clear");
             assert_eq!(cleared, 2);
-            assert!(pad.list("c1", 50).await.unwrap().is_empty());
+            assert!(pad.list("c1", None, 50).await.unwrap().is_empty());
         })
         .await;
         fx
@@ -269,7 +281,7 @@ async fn deleting_conversation_cascades_to_notes() {
             pad.write("c1", &[note("goal", "ship it")])
                 .await
                 .expect("write");
-            assert_eq!(pad.list("c1", 50).await.unwrap().len(), 1);
+            assert_eq!(pad.list("c1", None, 50).await.unwrap().len(), 1);
 
             // Deleting the parent conversation must cascade to its notes.
             convs
@@ -277,7 +289,7 @@ async fn deleting_conversation_cascades_to_notes() {
                 .await
                 .expect("delete conversation");
             assert!(
-                pad.list("c1", 50).await.unwrap().is_empty(),
+                pad.list("c1", None, 50).await.unwrap().is_empty(),
                 "notes must be cascade-deleted with their conversation"
             );
         })
@@ -307,14 +319,19 @@ async fn cross_user_isolation() {
 
         // Bob, scoping to his own identity, can see / search / delete none of it.
         with_user_id(UserId::new("bob"), async {
-            assert!(pad.list("c1", 50).await.unwrap().is_empty());
+            assert!(pad.list("c1", None, 50).await.unwrap().is_empty());
             assert!(
                 pad.get_many("c1", &["goal".to_string()], 50)
                     .await
                     .unwrap()
                     .is_empty()
             );
-            assert!(pad.search("c1", "secret", 50).await.unwrap().is_empty());
+            assert!(
+                pad.search("c1", "secret", None, 50)
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
             assert_eq!(
                 pad.delete_many("c1", &["goal".to_string()]).await.unwrap(),
                 0,
@@ -326,7 +343,127 @@ async fn cross_user_isolation() {
 
         // Alice still has her note intact.
         with_user_id(UserId::new("alice"), async {
-            assert_eq!(pad.list("c1", 50).await.unwrap().len(), 1);
+            assert_eq!(pad.list("c1", None, 50).await.unwrap().len(), 1);
+        })
+        .await;
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn list_orders_by_type_then_sequence_nulls_last() {
+    with_fixture(
+        "list_orders_by_type_then_sequence_nulls_last",
+        |fx| async move {
+            let convs = PgConversationStore::new(fx.pool.clone());
+            let pad = PgScratchpadStore::new(fx.pool.clone());
+
+            with_user_id(UserId::new("alice"), async {
+                convs
+                    .create(make_conversation("c1"))
+                    .await
+                    .expect("create conv");
+                // Write todos out of sequence order, plus an unsequenced todo and a
+                // plain note. Expect: type ascending ("note" < "todo"); within a
+                // type, sequence ascending with NULLs last.
+                let mut unseq = NewScratchpadNote::new("z", "no sequence");
+                unseq.note_type = "todo".to_string();
+                pad.write(
+                    "c1",
+                    &[
+                        todo("c", "third", 3),
+                        todo("a", "first", 1),
+                        todo("b", "second", 2),
+                        unseq,
+                        note("n", "a plain note"),
+                    ],
+                )
+                .await
+                .expect("write");
+
+                let listed = pad.list("c1", None, 50).await.expect("list");
+                let keys: Vec<String> = listed.iter().map(|n| n.key.clone()).collect();
+                assert_eq!(
+                    keys,
+                    vec!["n", "a", "b", "c", "z"],
+                    "type then seq, nulls last"
+                );
+            })
+            .await;
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn list_and_search_filter_by_type() {
+    with_fixture("list_and_search_filter_by_type", |fx| async move {
+        let convs = PgConversationStore::new(fx.pool.clone());
+        let pad = PgScratchpadStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            convs
+                .create(make_conversation("c1"))
+                .await
+                .expect("create conv");
+            pad.write(
+                "c1",
+                &[
+                    todo("t1", "deploy the release", 1),
+                    note("n1", "deploy notes from the meeting"),
+                ],
+            )
+            .await
+            .expect("write");
+
+            // Type-filtered list returns only todos.
+            let todos = pad.list("c1", Some("todo"), 50).await.expect("list todos");
+            assert_eq!(todos.len(), 1);
+            assert_eq!(todos[0].key, "t1");
+
+            // Both notes match the FTS query; the type filter narrows to one.
+            let all_hits = pad.search("c1", "deploy", None, 50).await.expect("search");
+            assert_eq!(all_hits.len(), 2);
+            let todo_hits = pad
+                .search("c1", "deploy", Some("todo"), 50)
+                .await
+                .expect("search todos");
+            assert_eq!(todo_hits.len(), 1);
+            assert_eq!(todo_hits[0].key, "t1");
+        })
+        .await;
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn rewrite_toggles_done_and_updates_fields() {
+    with_fixture("rewrite_toggles_done_and_updates_fields", |fx| async move {
+        let convs = PgConversationStore::new(fx.pool.clone());
+        let pad = PgScratchpadStore::new(fx.pool.clone());
+
+        with_user_id(UserId::new("alice"), async {
+            convs
+                .create(make_conversation("c1"))
+                .await
+                .expect("create conv");
+            let saved = pad.write("c1", &[todo("t1", "wire it", 1)]).await.unwrap();
+            assert_eq!(saved[0].note_type, "todo");
+            assert_eq!(saved[0].sequence, Some(1));
+            assert!(!saved[0].done);
+
+            // Re-writing the same key flips `done` (the check-off path) without
+            // creating a duplicate row.
+            let mut checked = todo("t1", "wire it", 1);
+            checked.done = true;
+            pad.write("c1", &[checked]).await.unwrap();
+
+            let after = pad.list("c1", None, 50).await.unwrap();
+            assert_eq!(after.len(), 1, "upsert keeps one row");
+            assert!(after[0].done, "done flips on re-write");
         })
         .await;
         fx


### PR DESCRIPTION
## What & why

Gives the conversation scratchpad (#184) a notion of note **kind** and **order** so Adele can keep an ordered, checkable plan of TODOs — and so a forthcoming client side pane can group/check items. First of three PRs (this one is data-model + tools + prompt; client commands + the adele-gtk pane follow).

## Changes

- **Migration 020** — `note_type TEXT NOT NULL DEFAULT 'note'` (free-text; suggested `todo`/`note`/`other`, **no CHECK** so the model may invent types), `seq INTEGER` (nullable), `done BOOLEAN NOT NULL DEFAULT FALSE`; index `(conversation_id, note_type, seq)`. `tsv` FTS column left as `note_key || content` (type is a structured filter, not FTS).
- **Domain / port** — `ScratchpadNote` gains the three fields (defaults preserve `new`'s arity); new `NewScratchpadNote { key, content, note_type, sequence, done }` input struct; `write(&[NewScratchpadNote])`; `list`/`search` gain an optional `note_type` filter; closure aliases updated.
- **Storage** — `PgScratchpadStore` persists the columns; `list` orders by `note_type, seq ASC NULLS LAST, updated_at DESC`; the optional type filter rides a single static query via `$n IS NULL OR note_type = $n` (sqlx 0.9 needs `&'static str`). All binds parameterized.
- **Builtin tools** — `scratchpad_write` accepts per-note (and single-form) `type`/`sequence`/`done`; `scratchpad_search` accepts an optional `type` filter and returns the fields. Schemas/descriptions updated.
- **Prompt** — new "Plan and TODOs" guidance: keep the plan as sequenced `todo` notes, check them off with `done: true`, read just the plan with `type: "todo"`. Golden file updated.

## Behaviour

- Notes round-trip `type`/`sequence`/`done` through store + tools.
- `list` returns todos ordered by `seq` within `note_type`, NULLS LAST.
- `list`/`search` can filter by `note_type`.
- `done` toggles by re-write (upsert same key); no duplicate row.
- Existing single/batch writes still work (`type` defaults `note`).

## Verification

- 10 builtin + 6 core unit tests; **9 storage integration tests against `pgvector:pg17`** (ordering nulls-last, type filter, done toggle, cascade-delete, cross-user isolation).
- Prompt golden + section tests; full workspace suite **69 ok-blocks, 0 failures**; `fmt` + `clippy -D warnings` clean; pushed with the pre-push hook running end-to-end.

## Security

No new dependencies. `scratchpads` remains in `PERSONAL_DATA_TABLES` (db_query user-scoping + write-refusal tests intact); the new columns add no cross-tenant surface; all SQL parameterized.

Closes #188