### PR TITLE
Client-facing scratchpad commands + ScratchpadChanged event

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -239,6 +239,45 @@ pub enum Command {
         tools: Option<Vec<String>>,
     },
 
+    // --- Conversation scratchpad (issue #190) -----------------------------
+    //
+    // Client-facing read/write/delete for a conversation's scratchpad — the
+    // same per-conversation notes the LLM manages via builtin tools, exposed
+    // so a client (e.g. the adele-gtk side pane) can display and edit them.
+    // All three are user-scoped by the dispatcher's `with_user_id`, like every
+    // other command.
+    /// Read a conversation's scratchpad notes, ordered by type then sequence.
+    /// Returns `CommandResult::Scratchpad`.
+    GetConversationScratchpad {
+        conversation_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_results: Option<u32>,
+    },
+    /// Upsert a single scratchpad note (keyed within the conversation).
+    /// Re-writing an existing key replaces its content/type/sequence/done —
+    /// this is how a client checks a todo off (`done: true`). Returns the saved
+    /// note(s) as `CommandResult::Scratchpad`.
+    SetScratchpadNote {
+        conversation_id: String,
+        key: String,
+        content: String,
+        #[serde(default)]
+        note_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sequence: Option<i32>,
+        #[serde(default)]
+        done: bool,
+    },
+    /// Delete scratchpad notes by key, or clear the whole pad with `all: true`.
+    /// Returns `CommandResult::Ack`.
+    DeleteScratchpadNotes {
+        conversation_id: String,
+        #[serde(default)]
+        keys: Vec<String>,
+        #[serde(default)]
+        all: bool,
+    },
+
     // --- Client-side tool execution (issue #107) ---------------------------
     //
     // Phase-2 architecture (rule #8) executes client-local MCPs on the
@@ -323,6 +362,10 @@ pub enum CommandResult {
     KnowledgeEntry(Option<KnowledgeEntryView>),
     KnowledgeEntryWritten(KnowledgeEntryView),
 
+    /// Response to `GetConversationScratchpad` / `SetScratchpadNote` — the
+    /// requested (or just-saved) scratchpad notes for the conversation.
+    Scratchpad(Vec<ScratchpadNoteView>),
+
     // --- Background tasks (issue #110) ------------------------------------
     /// Response to `ListBackgroundTasks`.
     BackgroundTasks(Vec<TaskView>),
@@ -366,6 +409,27 @@ pub struct KnowledgeEntryView {
     #[serde(default)]
     pub metadata: serde_json::Value,
     pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Wire-format view of a scratchpad note. Mirrors
+/// `desktop_assistant_core::domain::ScratchpadNote` (minus the internal
+/// `conversation_id`/`created_at`) but lives here so transports and clients
+/// depend only on `api-model`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScratchpadNoteView {
+    pub id: String,
+    pub key: String,
+    pub content: String,
+    /// Free-text category (e.g. `todo`/`note`/`other`); defaults to `note`.
+    #[serde(default)]
+    pub note_type: String,
+    /// Optional ordering hint within a `note_type` (ascending, nulls last).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequence: Option<i32>,
+    /// Whether the note (e.g. a todo) is checked off.
+    #[serde(default)]
+    pub done: bool,
     pub updated_at: String,
 }
 
@@ -444,6 +508,15 @@ pub enum Event {
         status: TaskStatus,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         last_error: Option<String>,
+    },
+
+    // --- Conversation scratchpad (issue #190) -----------------------------
+    /// A conversation's scratchpad changed (a note was written or deleted),
+    /// whether by the LLM's builtin tools or by a client command. Delivered to
+    /// connections subscribed via `SubscribeBackgroundTasks`. Carries only the
+    /// `conversation_id`; clients re-read via `GetConversationScratchpad`.
+    ScratchpadChanged {
+        conversation_id: String,
     },
 
     // --- Client-side tool execution (issue #107) --------------------------
@@ -1503,6 +1576,78 @@ mod tests {
         assert_eq!(v, expected);
         let back: CommandResult = serde_json::from_value(v).unwrap();
         assert_eq!(res, back);
+    }
+
+    #[test]
+    fn scratchpad_commands_match_documented_snake_case() {
+        // GetConversationScratchpad
+        let cmd = Command::GetConversationScratchpad {
+            conversation_id: "c-1".into(),
+            max_results: Some(20),
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"get_conversation_scratchpad":{"conversation_id":"c-1","max_results":20}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+
+        // SetScratchpadNote
+        let cmd = Command::SetScratchpadNote {
+            conversation_id: "c-1".into(),
+            key: "t1".into(),
+            content: "wire it".into(),
+            note_type: "todo".into(),
+            sequence: Some(2),
+            done: true,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"set_scratchpad_note":{"conversation_id":"c-1","key":"t1","content":"wire it","note_type":"todo","sequence":2,"done":true}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+
+        // DeleteScratchpadNotes (clear-all form)
+        let cmd = Command::DeleteScratchpadNotes {
+            conversation_id: "c-1".into(),
+            keys: vec![],
+            all: true,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"delete_scratchpad_notes":{"conversation_id":"c-1","keys":[],"all":true}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+    }
+
+    #[test]
+    fn scratchpad_result_and_event_roundtrip() {
+        let res = CommandResult::Scratchpad(vec![ScratchpadNoteView {
+            id: "sp-1".into(),
+            key: "t1".into(),
+            content: "wire it".into(),
+            note_type: "todo".into(),
+            sequence: Some(1),
+            done: false,
+            updated_at: "2026-06-04 00:00:00".into(),
+        }]);
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        assert!(v.get("scratchpad").is_some());
+        assert_eq!(res, serde_json::from_value(v).unwrap());
+
+        let ev = Event::ScratchpadChanged {
+            conversation_id: "c-1".into(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&ev).unwrap();
+        let expected: serde_json::Value =
+            serde_json::from_str(r#"{"scratchpad_changed":{"conversation_id":"c-1"}}"#).unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(ev, serde_json::from_value(v).unwrap());
     }
 
     #[test]

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -534,6 +534,20 @@ impl BackgroundTaskRegistry {
         sender.subscribe()
     }
 
+    /// Notify a user's subscribed connections that a conversation's scratchpad
+    /// changed (#190), reusing the same per-user broadcast the `Task*` events
+    /// ride. Typed so callers (e.g. the daemon's scratchpad closures) don't
+    /// depend on `api-model` to construct the event. Best-effort: dropped if no
+    /// connection for the user is currently subscribed.
+    pub fn notify_scratchpad_changed(&self, user_id: &UserId, conversation_id: impl Into<String>) {
+        self.inner.broadcast(
+            user_id,
+            api::Event::ScratchpadChanged {
+                conversation_id: conversation_id.into(),
+            },
+        );
+    }
+
     /// Append a log entry to `id`'s log ring from outside the task's
     /// body. Used by callers that produce events on behalf of a task
     /// they don't own the body of — for example, the `spawn_subagent`
@@ -1077,6 +1091,45 @@ fn db_status_to_api(s: BackgroundTaskStatus) -> api::TaskStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn notify_scratchpad_changed_reaches_subscribers() {
+        // #190: scratchpad mutations ride the same per-user broadcast as the
+        // Task* events, so a subscribed connection observes the change.
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let mut events = registry.subscribe(&user);
+
+        registry.notify_scratchpad_changed(&user, "conv-1");
+
+        match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::ScratchpadChanged { conversation_id })) => {
+                assert_eq!(conversation_id, "conv-1");
+            }
+            other => panic!("expected ScratchpadChanged, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn notify_scratchpad_changed_is_user_scoped() {
+        let registry = BackgroundTaskRegistry::new();
+        let alice = UserId::new("alice");
+        let bob = UserId::new("bob");
+        let mut alice_events = registry.subscribe(&alice);
+        let mut bob_events = registry.subscribe(&bob);
+
+        registry.notify_scratchpad_changed(&alice, "conv-1");
+
+        // Alice receives it; bob's channel has nothing pending.
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), alice_events.recv()).await,
+            Ok(Ok(api::Event::ScratchpadChanged { .. }))
+        ));
+        assert!(
+            bob_events.try_recv().is_err(),
+            "bob must not receive alice's scratchpad event"
+        );
+    }
 
     #[tokio::test]
     async fn finalize_sets_failed_on_error() {

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -11,12 +11,16 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 pub use desktop_assistant_auth_jwt::UserId;
-use desktop_assistant_core::domain::KnowledgeEntry;
+use desktop_assistant_core::domain::{DEFAULT_NOTE_TYPE, KnowledgeEntry, ScratchpadNote};
 use desktop_assistant_core::ports::auth::with_user_id;
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
     ConversationModelSelection, ConversationService, DispatchWarning, KnowledgeService,
     PromptSelectionOverride, PurposeConfigPayload, SettingsService,
+};
+use desktop_assistant_core::ports::scratchpad::{
+    MAX_KEYS_PER_CALL, MAX_NOTE_BYTES, MAX_RESULTS_CEILING, NewScratchpadNote, ScratchpadClearFn,
+    ScratchpadDeleteManyFn, ScratchpadGetManyFn, ScratchpadListFn, ScratchpadWriteFn,
 };
 use thiserror::Error;
 use tracing::warn;
@@ -285,6 +289,16 @@ where
     /// turn body spawns through the registry so the user has a Cancel
     /// button to trip and the process-manager UI has something to show.
     registry: Option<Arc<BackgroundTaskRegistry>>,
+    /// Optional per-conversation scratchpad closures (#190) so clients can
+    /// read/write/delete a conversation's notes. Threaded as closures (not a
+    /// `dyn ScratchpadStore`, which isn't object-safe). When `None`, the
+    /// scratchpad commands return a clear "not configured" error. The daemon
+    /// wraps the mutating closures so each emits `Event::ScratchpadChanged`.
+    scratchpad_write: Option<ScratchpadWriteFn>,
+    scratchpad_get_many: Option<ScratchpadGetManyFn>,
+    scratchpad_list: Option<ScratchpadListFn>,
+    scratchpad_delete_many: Option<ScratchpadDeleteManyFn>,
+    scratchpad_clear: Option<ScratchpadClearFn>,
 }
 
 impl<A, C, S, N, K> DefaultAssistantApiHandler<A, C, S, N, K>
@@ -309,7 +323,32 @@ where
             connections,
             knowledge,
             registry: None,
+            scratchpad_write: None,
+            scratchpad_get_many: None,
+            scratchpad_list: None,
+            scratchpad_delete_many: None,
+            scratchpad_clear: None,
         }
+    }
+
+    /// Attach the per-conversation scratchpad closures (#190) so the
+    /// `GetConversationScratchpad` / `SetScratchpadNote` / `DeleteScratchpadNotes`
+    /// commands are served. The daemon passes the same store-backed closures the
+    /// builtin tools use (with mutating ones wrapped to emit `ScratchpadChanged`).
+    pub fn with_scratchpad(
+        mut self,
+        write: ScratchpadWriteFn,
+        get_many: ScratchpadGetManyFn,
+        list: ScratchpadListFn,
+        delete_many: ScratchpadDeleteManyFn,
+        clear: ScratchpadClearFn,
+    ) -> Self {
+        self.scratchpad_write = Some(write);
+        self.scratchpad_get_many = Some(get_many);
+        self.scratchpad_list = Some(list);
+        self.scratchpad_delete_many = Some(delete_many);
+        self.scratchpad_clear = Some(clear);
+        self
     }
 
     /// Attach a [`BackgroundTaskRegistry`] so foreground send-message
@@ -603,6 +642,18 @@ fn knowledge_entry_to_view(e: KnowledgeEntry) -> api::KnowledgeEntryView {
         metadata: e.metadata,
         created_at: e.created_at,
         updated_at: e.updated_at,
+    }
+}
+
+fn scratchpad_note_to_view(n: ScratchpadNote) -> api::ScratchpadNoteView {
+    api::ScratchpadNoteView {
+        id: n.id,
+        key: n.key,
+        content: n.content,
+        note_type: n.note_type,
+        sequence: n.sequence,
+        done: n.done,
+        updated_at: n.updated_at,
     }
 }
 
@@ -1196,6 +1247,107 @@ where
             // "feature not enabled" instead of silently dropping the
             // command. The wrapping handler in this crate's
             // `client_tools` module is the supported path.
+            // Conversation scratchpad (issue #190). User scope is already
+            // installed by the dispatcher's `with_user_id`, so the closures
+            // (which read `current_user_id()`) are automatically scoped to the
+            // connection's user and the requested conversation — no extra
+            // scoping here. Mutations emit `Event::ScratchpadChanged` from the
+            // daemon-wrapped closures.
+            api::Command::GetConversationScratchpad {
+                conversation_id,
+                max_results,
+            } => {
+                let list = self
+                    .scratchpad_list
+                    .as_ref()
+                    .ok_or_else(|| ApiError::Core("scratchpad not configured".to_string()))?;
+                let limit = max_results
+                    .map(|n| (n as usize).min(MAX_RESULTS_CEILING))
+                    .unwrap_or(MAX_RESULTS_CEILING);
+                let notes = list(conversation_id, None, limit)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Scratchpad(
+                    notes.into_iter().map(scratchpad_note_to_view).collect(),
+                ))
+            }
+            api::Command::SetScratchpadNote {
+                conversation_id,
+                key,
+                content,
+                note_type,
+                sequence,
+                done,
+            } => {
+                let write = self
+                    .scratchpad_write
+                    .as_ref()
+                    .ok_or_else(|| ApiError::Core("scratchpad not configured".to_string()))?;
+                // Bound the write like the builtin tool path: non-empty key,
+                // content within the per-note byte cap — clients must not be
+                // able to write unbounded notes (#190).
+                let key = key.trim().to_string();
+                if key.is_empty() {
+                    return Err(ApiError::Core(
+                        "scratchpad note key must not be empty".to_string(),
+                    ));
+                }
+                if content.len() > MAX_NOTE_BYTES {
+                    return Err(ApiError::Core(format!(
+                        "scratchpad note content exceeds {MAX_NOTE_BYTES} bytes"
+                    )));
+                }
+                let note_type = if note_type.trim().is_empty() {
+                    DEFAULT_NOTE_TYPE.to_string()
+                } else {
+                    note_type
+                };
+                let saved = write(
+                    conversation_id,
+                    vec![NewScratchpadNote {
+                        key,
+                        content,
+                        note_type,
+                        sequence,
+                        done,
+                    }],
+                )
+                .await
+                .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Scratchpad(
+                    saved.into_iter().map(scratchpad_note_to_view).collect(),
+                ))
+            }
+            api::Command::DeleteScratchpadNotes {
+                conversation_id,
+                keys,
+                all,
+            } => {
+                if all {
+                    let clear = self
+                        .scratchpad_clear
+                        .as_ref()
+                        .ok_or_else(|| ApiError::Core("scratchpad not configured".to_string()))?;
+                    clear(conversation_id).await.map_err(Self::map_core_err)?;
+                } else {
+                    // Bound the key list so one command can't issue an
+                    // unbounded delete (#190).
+                    if keys.len() > MAX_KEYS_PER_CALL {
+                        return Err(ApiError::Core(format!(
+                            "too many keys (max {MAX_KEYS_PER_CALL})"
+                        )));
+                    }
+                    let delete_many = self
+                        .scratchpad_delete_many
+                        .as_ref()
+                        .ok_or_else(|| ApiError::Core("scratchpad not configured".to_string()))?;
+                    delete_many(conversation_id, keys)
+                        .await
+                        .map_err(Self::map_core_err)?;
+                }
+                Ok(api::CommandResult::Ack)
+            }
+
             api::Command::RegisterClientTools { .. } | api::Command::ClientToolResult { .. } => {
                 Err(ApiError::Unsupported)
             }
@@ -2393,6 +2545,371 @@ mod tests {
                 value: "pong".into()
             }
         );
+    }
+
+    // --- Conversation scratchpad commands (issue #190) --------------------
+
+    /// In-memory scratchpad behind the five handler closures, scoped by
+    /// `current_user_id()` exactly like the real `PgScratchpadStore`, so the
+    /// command handlers can be exercised (incl. cross-tenant isolation) without
+    /// Postgres. There is no reusable in-memory `ScratchpadStore` to borrow.
+    #[allow(clippy::type_complexity)]
+    fn in_memory_scratchpad() -> (
+        ScratchpadWriteFn,
+        ScratchpadGetManyFn,
+        ScratchpadListFn,
+        ScratchpadDeleteManyFn,
+        ScratchpadClearFn,
+    ) {
+        use desktop_assistant_core::ports::auth::current_user_id;
+        type Store = Arc<Mutex<Vec<(String, ScratchpadNote)>>>;
+        let store: Store = Arc::new(Mutex::new(Vec::new()));
+
+        let w = Arc::clone(&store);
+        let write: ScratchpadWriteFn =
+            Arc::new(move |conv: String, notes: Vec<NewScratchpadNote>| {
+                let store = Arc::clone(&w);
+                Box::pin(async move {
+                    let user = current_user_id().as_str().to_string();
+                    let mut guard = store.lock().unwrap();
+                    let mut saved = Vec::new();
+                    for (i, n) in notes.into_iter().enumerate() {
+                        if let Some((_, existing)) = guard.iter_mut().find(|(u, e)| {
+                            *u == user && e.conversation_id == conv && e.key == n.key
+                        }) {
+                            existing.content = n.content;
+                            existing.note_type = n.note_type;
+                            existing.sequence = n.sequence;
+                            existing.done = n.done;
+                            existing.updated_at = "t".into();
+                            saved.push(existing.clone());
+                        } else {
+                            let mut note =
+                                ScratchpadNote::new(format!("id-{i}"), &conv, &n.key, &n.content);
+                            note.note_type = n.note_type;
+                            note.sequence = n.sequence;
+                            note.done = n.done;
+                            note.updated_at = "t".into();
+                            guard.push((user.clone(), note.clone()));
+                            saved.push(note);
+                        }
+                    }
+                    Ok(saved)
+                })
+                    as std::pin::Pin<
+                        Box<
+                            dyn std::future::Future<Output = Result<Vec<ScratchpadNote>, CoreError>>
+                                + Send,
+                        >,
+                    >
+            });
+
+        let g = Arc::clone(&store);
+        let get_many: ScratchpadGetManyFn =
+            Arc::new(move |conv: String, keys: Vec<String>, limit| {
+                let store = Arc::clone(&g);
+                Box::pin(async move {
+                    let user = current_user_id().as_str().to_string();
+                    let guard = store.lock().unwrap();
+                    Ok(guard
+                        .iter()
+                        .filter(|(u, n)| {
+                            *u == user && n.conversation_id == conv && keys.contains(&n.key)
+                        })
+                        .take(limit)
+                        .map(|(_, n)| n.clone())
+                        .collect())
+                })
+            });
+
+        let l = Arc::clone(&store);
+        let list: ScratchpadListFn =
+            Arc::new(move |conv: String, note_type: Option<String>, limit| {
+                let store = Arc::clone(&l);
+                Box::pin(async move {
+                    let user = current_user_id().as_str().to_string();
+                    let guard = store.lock().unwrap();
+                    Ok(guard
+                        .iter()
+                        .filter(|(u, n)| {
+                            *u == user
+                                && n.conversation_id == conv
+                                && note_type.as_deref().is_none_or(|t| n.note_type == t)
+                        })
+                        .take(limit)
+                        .map(|(_, n)| n.clone())
+                        .collect())
+                })
+            });
+
+        let d = Arc::clone(&store);
+        let delete_many: ScratchpadDeleteManyFn =
+            Arc::new(move |conv: String, keys: Vec<String>| {
+                let store = Arc::clone(&d);
+                Box::pin(async move {
+                    let user = current_user_id().as_str().to_string();
+                    let mut guard = store.lock().unwrap();
+                    let before = guard.len();
+                    guard.retain(|(u, n)| {
+                        !(*u == user && n.conversation_id == conv && keys.contains(&n.key))
+                    });
+                    Ok((before - guard.len()) as u64)
+                })
+            });
+
+        let c = Arc::clone(&store);
+        let clear: ScratchpadClearFn = Arc::new(move |conv: String| {
+            let store = Arc::clone(&c);
+            Box::pin(async move {
+                let user = current_user_id().as_str().to_string();
+                let mut guard = store.lock().unwrap();
+                let before = guard.len();
+                guard.retain(|(u, n)| !(*u == user && n.conversation_id == conv));
+                Ok((before - guard.len()) as u64)
+            })
+        });
+
+        (write, get_many, list, delete_many, clear)
+    }
+
+    fn scratchpad_handler() -> DefaultAssistantApiHandler<
+        FakeAssistant,
+        FakeConversations,
+        FakeSettings,
+        FakeConnections,
+        FakeKnowledge,
+    > {
+        let (write, get_many, list, delete_many, clear) = in_memory_scratchpad();
+        DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        )
+        .with_scratchpad(write, get_many, list, delete_many, clear)
+    }
+
+    #[tokio::test]
+    async fn scratchpad_set_get_delete_roundtrip() {
+        let h = scratchpad_handler();
+        let ctx = || RequestContext::from(UserId::new("alice"));
+
+        // Upsert a todo.
+        let res = h
+            .handle_command_for(
+                ctx(),
+                api::Command::SetScratchpadNote {
+                    conversation_id: "c1".into(),
+                    key: "t1".into(),
+                    content: "wire it".into(),
+                    note_type: "todo".into(),
+                    sequence: Some(1),
+                    done: false,
+                },
+            )
+            .await
+            .unwrap();
+        let api::CommandResult::Scratchpad(saved) = res else {
+            panic!("expected Scratchpad");
+        };
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].note_type, "todo");
+        assert_eq!(saved[0].sequence, Some(1));
+
+        // Read it back.
+        let api::CommandResult::Scratchpad(notes) = h
+            .handle_command_for(
+                ctx(),
+                api::Command::GetConversationScratchpad {
+                    conversation_id: "c1".into(),
+                    max_results: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Scratchpad");
+        };
+        assert_eq!(notes.len(), 1);
+        assert!(!notes[0].done);
+
+        // Check it off by re-writing the same key.
+        h.handle_command_for(
+            ctx(),
+            api::Command::SetScratchpadNote {
+                conversation_id: "c1".into(),
+                key: "t1".into(),
+                content: "wire it".into(),
+                note_type: "todo".into(),
+                sequence: Some(1),
+                done: true,
+            },
+        )
+        .await
+        .unwrap();
+        let api::CommandResult::Scratchpad(notes) = h
+            .handle_command_for(
+                ctx(),
+                api::Command::GetConversationScratchpad {
+                    conversation_id: "c1".into(),
+                    max_results: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Scratchpad");
+        };
+        assert_eq!(notes.len(), 1, "re-write upserts, not duplicates");
+        assert!(notes[0].done);
+
+        // Delete it.
+        let res = h
+            .handle_command_for(
+                ctx(),
+                api::Command::DeleteScratchpadNotes {
+                    conversation_id: "c1".into(),
+                    keys: vec!["t1".into()],
+                    all: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(res, api::CommandResult::Ack);
+        let api::CommandResult::Scratchpad(notes) = h
+            .handle_command_for(
+                ctx(),
+                api::Command::GetConversationScratchpad {
+                    conversation_id: "c1".into(),
+                    max_results: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Scratchpad");
+        };
+        assert!(notes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scratchpad_commands_are_user_scoped() {
+        let h = scratchpad_handler();
+
+        // Alice writes a note to conversation c1.
+        h.handle_command_for(
+            RequestContext::from(UserId::new("alice")),
+            api::Command::SetScratchpadNote {
+                conversation_id: "c1".into(),
+                key: "goal".into(),
+                content: "alice secret".into(),
+                note_type: String::new(),
+                sequence: None,
+                done: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Bob, asking for the same conversation_id, sees nothing.
+        let api::CommandResult::Scratchpad(notes) = h
+            .handle_command_for(
+                RequestContext::from(UserId::new("bob")),
+                api::Command::GetConversationScratchpad {
+                    conversation_id: "c1".into(),
+                    max_results: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Scratchpad");
+        };
+        assert!(notes.is_empty(), "bob must not read alice's pad");
+
+        // Bob clearing the pad must not touch alice's note.
+        h.handle_command_for(
+            RequestContext::from(UserId::new("bob")),
+            api::Command::DeleteScratchpadNotes {
+                conversation_id: "c1".into(),
+                keys: vec![],
+                all: true,
+            },
+        )
+        .await
+        .unwrap();
+        let api::CommandResult::Scratchpad(notes) = h
+            .handle_command_for(
+                RequestContext::from(UserId::new("alice")),
+                api::Command::GetConversationScratchpad {
+                    conversation_id: "c1".into(),
+                    max_results: None,
+                },
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected Scratchpad");
+        };
+        assert_eq!(notes.len(), 1, "alice's note survives bob's clear");
+        // Empty note_type defaults to the canonical default.
+        assert_eq!(notes[0].note_type, DEFAULT_NOTE_TYPE);
+    }
+
+    #[tokio::test]
+    async fn scratchpad_command_without_closures_errors() {
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        );
+        let res = h
+            .handle_command(api::Command::GetConversationScratchpad {
+                conversation_id: "c1".into(),
+                max_results: None,
+            })
+            .await;
+        assert!(
+            matches!(&res, Err(ApiError::Core(m)) if m.contains("not configured")),
+            "expected not-configured error, got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn scratchpad_set_rejects_empty_key_and_oversize_content() {
+        let h = scratchpad_handler();
+        let empty_key = h
+            .handle_command_for(
+                RequestContext::from(UserId::new("alice")),
+                api::Command::SetScratchpadNote {
+                    conversation_id: "c1".into(),
+                    key: "   ".into(),
+                    content: "x".into(),
+                    note_type: String::new(),
+                    sequence: None,
+                    done: false,
+                },
+            )
+            .await;
+        assert!(matches!(&empty_key, Err(ApiError::Core(m)) if m.contains("must not be empty")));
+
+        let oversize = h
+            .handle_command_for(
+                RequestContext::from(UserId::new("alice")),
+                api::Command::SetScratchpadNote {
+                    conversation_id: "c1".into(),
+                    key: "big".into(),
+                    content: "x".repeat(MAX_NOTE_BYTES + 1),
+                    note_type: String::new(),
+                    sequence: None,
+                    done: false,
+                },
+            )
+            .await;
+        assert!(matches!(&oversize, Err(ApiError::Core(m)) if m.contains("exceeds")));
     }
 
     #[tokio::test]

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -288,6 +288,76 @@ pub trait AssistantCommands: Send + Sync {
         };
         Ok(())
     }
+
+    // --- Conversation scratchpad (issue #190) -----------------------------
+
+    /// Read a conversation's scratchpad notes (ordered by type then sequence).
+    async fn get_conversation_scratchpad(
+        &self,
+        conversation_id: &str,
+        max_results: Option<u32>,
+    ) -> Result<Vec<api::ScratchpadNoteView>> {
+        let result = self
+            .send_command(api::Command::GetConversationScratchpad {
+                conversation_id: conversation_id.to_string(),
+                max_results,
+            })
+            .await?;
+        let api::CommandResult::Scratchpad(items) = result else {
+            return Err(anyhow!(
+                "unexpected response for get_conversation_scratchpad"
+            ));
+        };
+        Ok(items)
+    }
+
+    /// Upsert a single scratchpad note (re-writing a key replaces its fields —
+    /// e.g. set `done` to check a todo off). Returns the saved note(s).
+    #[allow(clippy::too_many_arguments)]
+    async fn set_scratchpad_note(
+        &self,
+        conversation_id: &str,
+        key: &str,
+        content: &str,
+        note_type: &str,
+        sequence: Option<i32>,
+        done: bool,
+    ) -> Result<Vec<api::ScratchpadNoteView>> {
+        let result = self
+            .send_command(api::Command::SetScratchpadNote {
+                conversation_id: conversation_id.to_string(),
+                key: key.to_string(),
+                content: content.to_string(),
+                note_type: note_type.to_string(),
+                sequence,
+                done,
+            })
+            .await?;
+        let api::CommandResult::Scratchpad(items) = result else {
+            return Err(anyhow!("unexpected response for set_scratchpad_note"));
+        };
+        Ok(items)
+    }
+
+    /// Delete scratchpad notes by key, or clear the whole pad with `all: true`.
+    async fn delete_scratchpad_notes(
+        &self,
+        conversation_id: &str,
+        keys: Vec<String>,
+        all: bool,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::DeleteScratchpadNotes {
+                conversation_id: conversation_id.to_string(),
+                keys,
+                all,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!("unexpected response for delete_scratchpad_notes"));
+        };
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -421,5 +491,84 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn get_conversation_scratchpad_emits_command_and_unwraps_notes() {
+        let client = RecordingClient::new(api::CommandResult::Scratchpad(vec![
+            api::ScratchpadNoteView {
+                id: "sp-1".into(),
+                key: "goal".into(),
+                content: "ship it".into(),
+                note_type: "note".into(),
+                sequence: None,
+                done: false,
+                updated_at: "t".into(),
+            },
+        ]));
+        let notes = client
+            .get_conversation_scratchpad("conv-1", Some(20))
+            .await
+            .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].key, "goal");
+        match client.last() {
+            api::Command::GetConversationScratchpad {
+                conversation_id,
+                max_results,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(max_results, Some(20));
+            }
+            other => panic!("expected GetConversationScratchpad, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_scratchpad_note_emits_command() {
+        let client = RecordingClient::new(api::CommandResult::Scratchpad(vec![]));
+        client
+            .set_scratchpad_note("conv-1", "t1", "wire it", "todo", Some(2), true)
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::SetScratchpadNote {
+                conversation_id,
+                key,
+                content,
+                note_type,
+                sequence,
+                done,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(key, "t1");
+                assert_eq!(content, "wire it");
+                assert_eq!(note_type, "todo");
+                assert_eq!(sequence, Some(2));
+                assert!(done);
+            }
+            other => panic!("expected SetScratchpadNote, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_scratchpad_notes_emits_command() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .delete_scratchpad_notes("conv-1", vec!["t1".into()], false)
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::DeleteScratchpadNotes {
+                conversation_id,
+                keys,
+                all,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(keys, vec!["t1".to_string()]);
+                assert!(!all);
+            }
+            other => panic!("expected DeleteScratchpadNotes, got {other:?}"),
+        }
     }
 }

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -54,6 +54,13 @@ pub enum SignalEvent {
         status: api::TaskStatus,
         last_error: Option<String>,
     },
+    /// A conversation's scratchpad changed (note written or deleted), by the
+    /// LLM's tools or a client command. Delivered on connections subscribed via
+    /// `Command::SubscribeBackgroundTasks`; carries only the `conversation_id`
+    /// so the client re-reads via `get_conversation_scratchpad` (issue #190).
+    ScratchpadChanged {
+        conversation_id: String,
+    },
     Disconnected {
         reason: String,
     },

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -255,6 +255,9 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             status,
             last_error,
         }),
+        api::Event::ScratchpadChanged { conversation_id } => {
+            Some(SignalEvent::ScratchpadChanged { conversation_id })
+        }
         // Client-side tool execution (#107): handled by clients that
         // implement the client-tool protocol directly; the legacy
         // `SignalEvent` stream is for the GTK desktop UI and does not
@@ -385,6 +388,19 @@ mod tests {
                 assert_eq!(last_error.as_deref(), Some("LLM rate limit"));
             }
             other => panic!("expected SignalEvent::TaskCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_scratchpad_changed_event() {
+        let signal = map_event_to_signal(api::Event::ScratchpadChanged {
+            conversation_id: "c-1".into(),
+        });
+        match signal {
+            Some(SignalEvent::ScratchpadChanged { conversation_id }) => {
+                assert_eq!(conversation_id, "c-1");
+            }
+            other => panic!("expected SignalEvent::ScratchpadChanged, got {other:?}"),
         }
     }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -949,12 +949,51 @@ async fn main() -> Result<()> {
         );
     }
 
+    // Background-task registry (#111/#115). Constructed BEFORE the scratchpad
+    // wiring below so the scratchpad mutating closures can notify subscribed
+    // connections via `Event::ScratchpadChanged` (#190). Attaches a Postgres-
+    // backed store when a pool is available, then runs the cold-restart sweep
+    // (marks non-terminal rows `Failed` so the user observes them via `list`).
+    let background_task_registry = {
+        let registry =
+            desktop_assistant_application::background_tasks::BackgroundTaskRegistry::new();
+        if let Some(pool) = &pg_pool {
+            let store: std::sync::Arc<
+                dyn desktop_assistant_core::ports::store::BackgroundTaskStore,
+            > = std::sync::Arc::new(desktop_assistant_storage::PgBackgroundTaskStore::new(
+                pool.clone(),
+            ));
+            let registry = registry.with_store(store);
+            if let Err(e) = registry.sweep_non_terminal_on_startup().await {
+                tracing::warn!(
+                    error = %e,
+                    "cold-restart sweep of background tasks failed; continuing",
+                );
+            }
+            Arc::new(registry)
+        } else {
+            Arc::new(registry)
+        }
+    };
+
     // Reader for the reserved scratchpad `goal` note, wired into the
     // conversation handler below so the evolving goal is surfaced as the task
     // anchor each turn. Populated only when a Postgres pool is available.
     let mut scratchpad_goal_fn: Option<
         desktop_assistant_core::ports::scratchpad::ScratchpadGetManyFn,
     > = None;
+
+    // Per-conversation scratchpad command closures (#190) for the API handler,
+    // populated alongside the builtin-tool wiring below. The same emit-wrapped
+    // closures the builtin tools get, so a mutation via either path notifies.
+    type SpHandlerFns = (
+        desktop_assistant_core::ports::scratchpad::ScratchpadWriteFn,
+        desktop_assistant_core::ports::scratchpad::ScratchpadGetManyFn,
+        desktop_assistant_core::ports::scratchpad::ScratchpadListFn,
+        desktop_assistant_core::ports::scratchpad::ScratchpadDeleteManyFn,
+        desktop_assistant_core::ports::scratchpad::ScratchpadClearFn,
+    );
+    let mut scratchpad_handler_fns: Option<SpHandlerFns> = None;
 
     if let Some(pool) = &pg_pool {
         tracing::info!("wiring database query into builtin tools");
@@ -984,27 +1023,43 @@ async fn main() -> Result<()> {
             pool.clone(),
         ));
         tracing::info!("wiring scratchpad store into builtin tools");
-        let (sp_w, sp_g, sp_l, sp_s, sp_d, sp_c) = (
-            Arc::clone(&sp_store),
-            Arc::clone(&sp_store),
-            Arc::clone(&sp_store),
-            Arc::clone(&sp_store),
-            Arc::clone(&sp_store),
-            Arc::clone(&sp_store),
-        );
-        builtin_tools = builtin_tools.with_scratchpad(
-            Arc::new(move |conv, notes| {
-                let store = Arc::clone(&sp_w);
-                Box::pin(async move { store.write(&conv, &notes).await })
-            }),
-            Arc::new(move |conv, keys, limit| {
-                let store = Arc::clone(&sp_g);
-                Box::pin(async move { store.get_many(&conv, &keys, limit).await })
-            }),
-            Arc::new(move |conv, note_type: Option<String>, limit| {
-                let store = Arc::clone(&sp_l);
-                Box::pin(async move { store.list(&conv, note_type.as_deref(), limit).await })
-            }),
+        use desktop_assistant_core::ports::auth::current_user_id;
+        use desktop_assistant_core::ports::scratchpad::{
+            ScratchpadClearFn, ScratchpadDeleteManyFn, ScratchpadGetManyFn, ScratchpadListFn,
+            ScratchpadSearchFn, ScratchpadWriteFn,
+        };
+
+        // The mutating closures (write / delete_many / clear) notify subscribed
+        // connections after a successful change via `Event::ScratchpadChanged`,
+        // reading the per-turn / per-command `current_user_id()`. The SAME
+        // closures back both the builtin tools (Adele's writes) and the API
+        // handler (client writes), so a change from either path emits once.
+        let sp_w = Arc::clone(&sp_store);
+        let reg_w = Arc::clone(&background_task_registry);
+        let write_fn: ScratchpadWriteFn = Arc::new(move |conv: String, notes| {
+            let store = Arc::clone(&sp_w);
+            let reg = Arc::clone(&reg_w);
+            Box::pin(async move {
+                let saved = store.write(&conv, &notes).await?;
+                reg.notify_scratchpad_changed(&current_user_id(), conv);
+                Ok(saved)
+            })
+        });
+
+        let sp_g = Arc::clone(&sp_store);
+        let get_many_fn: ScratchpadGetManyFn = Arc::new(move |conv, keys, limit| {
+            let store = Arc::clone(&sp_g);
+            Box::pin(async move { store.get_many(&conv, &keys, limit).await })
+        });
+
+        let sp_l = Arc::clone(&sp_store);
+        let list_fn: ScratchpadListFn = Arc::new(move |conv, note_type: Option<String>, limit| {
+            let store = Arc::clone(&sp_l);
+            Box::pin(async move { store.list(&conv, note_type.as_deref(), limit).await })
+        });
+
+        let sp_s = Arc::clone(&sp_store);
+        let search_fn: ScratchpadSearchFn =
             Arc::new(move |conv, query, note_type: Option<String>, limit| {
                 let store = Arc::clone(&sp_s);
                 Box::pin(async move {
@@ -1012,24 +1067,54 @@ async fn main() -> Result<()> {
                         .search(&conv, &query, note_type.as_deref(), limit)
                         .await
                 })
-            }),
-            Arc::new(move |conv, keys| {
-                let store = Arc::clone(&sp_d);
-                Box::pin(async move { store.delete_many(&conv, &keys).await })
-            }),
-            Arc::new(move |conv| {
-                let store = Arc::clone(&sp_c);
-                Box::pin(async move { store.clear(&conv).await })
-            }),
+            });
+
+        let sp_d = Arc::clone(&sp_store);
+        let reg_d = Arc::clone(&background_task_registry);
+        let delete_many_fn: ScratchpadDeleteManyFn = Arc::new(move |conv: String, keys| {
+            let store = Arc::clone(&sp_d);
+            let reg = Arc::clone(&reg_d);
+            Box::pin(async move {
+                let deleted = store.delete_many(&conv, &keys).await?;
+                reg.notify_scratchpad_changed(&current_user_id(), conv);
+                Ok(deleted)
+            })
+        });
+
+        let sp_c = Arc::clone(&sp_store);
+        let reg_c = Arc::clone(&background_task_registry);
+        let clear_fn: ScratchpadClearFn = Arc::new(move |conv: String| {
+            let store = Arc::clone(&sp_c);
+            let reg = Arc::clone(&reg_c);
+            Box::pin(async move {
+                let deleted = store.clear(&conv).await?;
+                reg.notify_scratchpad_changed(&current_user_id(), conv);
+                Ok(deleted)
+            })
+        });
+
+        builtin_tools = builtin_tools.with_scratchpad(
+            Arc::clone(&write_fn),
+            Arc::clone(&get_many_fn),
+            Arc::clone(&list_fn),
+            search_fn,
+            Arc::clone(&delete_many_fn),
+            Arc::clone(&clear_fn),
         );
+
+        // Hand the same (emit-wrapped) closures to the API handler so clients
+        // can read/write/delete the scratchpad over the command channel (#190).
+        scratchpad_handler_fns = Some((
+            write_fn,
+            Arc::clone(&get_many_fn),
+            list_fn,
+            delete_many_fn,
+            clear_fn,
+        ));
 
         // Reader for the reserved goal note (a bounded single-key fetch),
         // consumed by `ConversationHandler::with_scratchpad_goal` below.
-        let sp_goal = Arc::clone(&sp_store);
-        scratchpad_goal_fn = Some(Arc::new(move |conv, keys, limit| {
-            let store = Arc::clone(&sp_goal);
-            Box::pin(async move { store.get_many(&conv, &keys, limit).await })
-        }));
+        scratchpad_goal_fn = Some(get_many_fn);
     }
 
     if let Some(tr) = &tool_registry_store {
@@ -1478,51 +1563,25 @@ async fn main() -> Result<()> {
     // adapters can share it (the multi-connection D-Bus interface dispatches
     // through this handler, mirroring the WS adapter).
     //
-    // The handler is wired with a shared [`BackgroundTaskRegistry`] so
-    // foreground turns register as `TaskKind::Conversation` tasks
-    // (#111). #114 will surface the same registry through the
-    // ListBackgroundTasks / CancelBackgroundTask command arms; until
-    // then it powers the existing send path's cancellation hook.
-    //
-    // Issue #115: when a Postgres pool is available, attach a
-    // `PgBackgroundTaskStore` so spawned tasks survive a daemon
-    // restart. The cold-restart sweep marks every non-terminal row
-    // `Failed` immediately after construction so the user observes
-    // them via the existing `list` path instead of silently losing
-    // them. The sweep is best-effort — see the issue body for the
-    // resume policy; #129 will replace the standalone branch with a
-    // real resume.
-    let background_task_registry = {
-        let registry =
-            desktop_assistant_application::background_tasks::BackgroundTaskRegistry::new();
-        if let Some(pool) = &pg_pool {
-            let store: std::sync::Arc<
-                dyn desktop_assistant_core::ports::store::BackgroundTaskStore,
-            > = std::sync::Arc::new(desktop_assistant_storage::PgBackgroundTaskStore::new(
-                pool.clone(),
-            ));
-            let registry = registry.with_store(store);
-            if let Err(e) = registry.sweep_non_terminal_on_startup().await {
-                tracing::warn!(
-                    error = %e,
-                    "cold-restart sweep of background tasks failed; continuing",
-                );
-            }
-            Arc::new(registry)
-        } else {
-            Arc::new(registry)
-        }
-    };
-    let api_handler: Arc<dyn desktop_assistant_application::AssistantApiHandler> = Arc::new(
-        DefaultAssistantApiHandler::new(
-            Arc::new(Assistant),
-            Arc::clone(&conversation_service),
-            Arc::clone(&settings_service),
-            Arc::clone(&connections_service),
-            Arc::clone(&knowledge_service),
-        )
-        .with_registry(Arc::clone(&background_task_registry)),
-    );
+    // The handler is wired with the shared [`BackgroundTaskRegistry`]
+    // (constructed earlier, before the scratchpad wiring) so foreground turns
+    // register as `TaskKind::Conversation` tasks (#111), and — when a Postgres
+    // pool is available — with the per-conversation scratchpad command closures
+    // (#190) so clients can read/write/delete a conversation's notes.
+    let mut api_handler_impl = DefaultAssistantApiHandler::new(
+        Arc::new(Assistant),
+        Arc::clone(&conversation_service),
+        Arc::clone(&settings_service),
+        Arc::clone(&connections_service),
+        Arc::clone(&knowledge_service),
+    )
+    .with_registry(Arc::clone(&background_task_registry));
+    if let Some((write, get_many, list, delete_many, clear)) = scratchpad_handler_fns {
+        api_handler_impl =
+            api_handler_impl.with_scratchpad(write, get_many, list, delete_many, clear);
+    }
+    let api_handler: Arc<dyn desktop_assistant_application::AssistantApiHandler> =
+        Arc::new(api_handler_impl);
 
     let dbus_service_name = std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
         .ok()

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -165,6 +165,13 @@ pub fn translate(event: api::Event) -> ForwardAction {
             status: task_status_str(status).to_string(),
             last_error: last_error.unwrap_or_default(),
         },
+        // Conversation scratchpad (issue #190): not forwarded over D-Bus —
+        // the scratchpad side pane is a WebSocket/UDS-protocol concern
+        // (adele-gtk subscribes via the command channel). A D-Bus client that
+        // wants live scratchpad updates would need its own forwarding arm.
+        api::Event::ScratchpadChanged { .. } => ForwardAction::Ignored {
+            kind: "scratchpad_changed",
+        },
         // Client-side tool execution (issue #107): the bridge does not
         // forward `ClientToolCall` to D-Bus subscribers because client-
         // side execution is a WebSocket-protocol concern. The D-Bus


### PR DESCRIPTION
## What & why

Exposes the per-conversation scratchpad over the client command channel so a client (the forthcoming **adele-gtk side pane**) can display and edit a conversation's notes. Until now the pad was reachable only by the LLM's builtin tools. Second of three PRs (builds on #189).

## Changes

- **api-model** — `ScratchpadNoteView`; commands `GetConversationScratchpad` / `SetScratchpadNote` / `DeleteScratchpadNotes`; `CommandResult::Scratchpad`; `Event::ScratchpadChanged`.
- **client-common** — three `AssistantCommands` default methods (reachable through `as_commands()`) + `SignalEvent::ScratchpadChanged` mapping.
- **application** — `DefaultAssistantApiHandler::with_scratchpad(..)` (optional closures) + three `handle_command` arms. They ride the dispatcher's `with_user_id`, so each is automatically scoped to `(connection user, conversation)`.
- **event bus** — `BackgroundTaskRegistry::notify_scratchpad_changed` publishes on the same per-user broadcast the `Task*` events ride (no new dispatcher arm; clients already subscribe via `SubscribeBackgroundTasks`).
- **daemon** — registry construction hoisted above the scratchpad wiring; the mutating closures (write/delete/clear) are wrapped to emit `ScratchpadChanged` once. The **same** closures back both the builtin tools (Adele's writes) and the API handler (client writes), so a change from either path notifies subscribers.
- **dbus-bridge** — `ScratchpadChanged` is a WS/UDS concern; ignored over D-Bus.

## Security

- **Tenant scoping** is test-proven: a second user cannot read or modify the first's pad for the same `conversation_id` (handlers inherit `with_user_id`; the store binds `WHERE user_id = $1`).
- **Bounded** like the tool path: `SetScratchpadNote` rejects empty key + content over `MAX_NOTE_BYTES`; `DeleteScratchpadNotes` caps the key list at `MAX_KEYS_PER_CALL`; `GetConversationScratchpad` clamps `max_results`.
- No new SQL (handlers call the existing scoped store methods); **no new dependencies**.
- Known low-risk: `SetScratchpadNote` against a non-existent `conversation_id` surfaces an FK error (an existence oracle on UUIDv7 ids); no data leak since rows are user-scoped and cascade with the conversation.

## Verification

- api-model snake_case roundtrips; client-common command emitters + event mapping; application handler roundtrip, cross-tenant scoping, bounds rejection, not-configured error; registry emission delivery + user-scoping.
- Full workspace suite **69 ok-blocks / 0 failures**; `fmt` + `clippy -D warnings` clean; pushed with the pre-push hook running end-to-end.

Closes #190 · blocks the adele-gtk side pane (next PR).