### PR TITLE
Time out embeddings (5s) and fall back to FTS instead of hanging

### DIFF
--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -33,6 +33,13 @@ const TOOL_SCRATCHPAD_WRITE: &str = "builtin_scratchpad_write";
 const TOOL_SCRATCHPAD_SEARCH: &str = "builtin_scratchpad_search";
 const TOOL_SCRATCHPAD_DELETE: &str = "builtin_scratchpad_delete";
 
+/// Hard cap on how long an embedding call may block a real-time request. A
+/// slow/wedged embedding backend (e.g. a stuck Ollama) must not hang the turn:
+/// on timeout we return no embedding, so semantic search falls back to FTS and
+/// KB writes persist without an embedding for the background dreaming/backfill
+/// cycle to fill in later.
+const EMBED_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 fn now_ts() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1062,10 +1069,17 @@ impl BuiltinToolService {
     /// Used for search queries which are always short and don't need chunking.
     async fn embed_text(&self, text: &str) -> Option<Vec<f32>> {
         let embed_fn = self.embed_fn.as_ref()?;
-        match embed_fn(vec![text.to_string()]).await {
-            Ok(mut vecs) => vecs.pop(),
-            Err(e) => {
+        match tokio::time::timeout(EMBED_TIMEOUT, embed_fn(vec![text.to_string()])).await {
+            Ok(Ok(mut vecs)) => vecs.pop(),
+            Ok(Err(e)) => {
                 tracing::warn!("failed to embed text: {e}");
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?EMBED_TIMEOUT,
+                    "embedding timed out; falling back to full-text search"
+                );
                 None
             }
         }
@@ -1078,11 +1092,18 @@ impl BuiltinToolService {
 
         let embed_fn = self.embed_fn.as_ref()?;
         let chunks = chunk_text(text, CHUNK_MAX_CHARS, CHUNK_OVERLAP);
-        match embed_fn(chunks).await {
-            Ok(vecs) if !vecs.is_empty() => Some(vecs),
-            Ok(_) => None,
-            Err(e) => {
+        match tokio::time::timeout(EMBED_TIMEOUT, embed_fn(chunks)).await {
+            Ok(Ok(vecs)) if !vecs.is_empty() => Some(vecs),
+            Ok(Ok(_)) => None,
+            Ok(Err(e)) => {
                 tracing::warn!("failed to embed chunks: {e}");
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?EMBED_TIMEOUT,
+                    "embedding timed out; saving without embedding for backfill to retry"
+                );
                 None
             }
         }
@@ -2163,5 +2184,54 @@ mod tests {
         let tools = json["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0]["name"], "jira__create_issue");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn embedding_timeout_falls_back_to_empty_embedding() {
+        // A wedged embedding backend (a never-completing future, like a stuck
+        // Ollama) must not hang the search: `embed_text` times out after
+        // EMBED_TIMEOUT and the search runs with an empty embedding, which the
+        // store turns into an FTS-only query. With the clock paused, the 5s
+        // timeout elapses immediately so the test is instant.
+        use desktop_assistant_core::domain::ToolDefinition;
+        use desktop_assistant_core::ports::embedding::EmbedFn;
+        use std::sync::{Arc, Mutex};
+
+        let embed_fn: EmbedFn = Arc::new(|_texts| Box::pin(std::future::pending()));
+
+        // Capture the embedding the search closure is handed.
+        let seen: Arc<Mutex<Option<Vec<f32>>>> = Arc::new(Mutex::new(None));
+        let seen_w = Arc::clone(&seen);
+        let search_fn: ToolSearchFn = Arc::new(move |_query, emb, _limit| {
+            *seen_w.lock().unwrap() = Some(emb);
+            Box::pin(async {
+                Ok(vec![ToolDefinition::new(
+                    "weather__forecast",
+                    "Get the forecast",
+                    serde_json::json!({}),
+                )])
+            })
+        });
+        let def_fn: ToolDefinitionFn = Arc::new(|_name| Box::pin(async { Ok(None) }));
+
+        let service = BuiltinToolService::new()
+            .with_embedding(embed_fn)
+            .with_tool_registry(search_fn, def_fn);
+
+        let result = service
+            .execute_tool(
+                TOOL_SEARCH,
+                serde_json::json!({"query": "weather forecast"}),
+            )
+            .await
+            .expect("tool search must return, not hang, when embedding times out");
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            seen.lock().unwrap().as_ref().expect("search ran").len(),
+            0,
+            "a timed-out embedding must yield an empty vector so the store falls back to FTS"
+        );
     }
 }

--- a/crates/storage/src/knowledge.rs
+++ b/crates/storage/src/knowledge.rs
@@ -68,6 +68,14 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
         tags: Option<Vec<String>>,
         limit: usize,
     ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        // No query embedding (e.g. the embedding backend timed out — see
+        // `EMBED_TIMEOUT` in mcp-client): the hybrid query's vector branch
+        // (`chunk <=> $1`) would error on a 0-dimension vector, so fall back to
+        // the full-text-only path.
+        if query_embedding.is_empty() {
+            return self.search_text(query, tags, limit).await;
+        }
+
         let user_id = current_user_id();
         let embedding_vec = Vector::from(query_embedding);
         let fetch_limit = (limit * 2) as i64;

--- a/crates/storage/src/tool_registry.rs
+++ b/crates/storage/src/tool_registry.rs
@@ -91,6 +91,26 @@ impl ToolRegistryStore for PgToolRegistryStore {
         query_embedding: Vec<f32>,
         limit: usize,
     ) -> Result<Vec<ToolDefinition>, CoreError> {
+        // No query embedding (e.g. the embedding backend timed out — see
+        // `EMBED_TIMEOUT` in mcp-client): the hybrid query's vector branch
+        // (`chunk <=> $1`) would error on a 0-dimension vector, so fall back to
+        // full-text search only.
+        if query_embedding.is_empty() {
+            let rows: Vec<ToolSearchRow> = sqlx::query_as(
+                "SELECT name, description, parameters, \
+                        ts_rank_cd(tsv, query)::FLOAT8 AS rrf_score \
+                 FROM tool_definitions, plainto_tsquery('english', $1) query \
+                 WHERE tsv @@ query \
+                 ORDER BY rrf_score DESC LIMIT $2",
+            )
+            .bind(query)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| CoreError::Storage(e.to_string()))?;
+            return Ok(rows.into_iter().map(|r| r.into_definition()).collect());
+        }
+
         let embedding_vec = Vector::from(query_embedding);
         let fetch_limit = (limit * 2) as i64;
         let result_limit = limit as i64;

--- a/crates/storage/tests/user_id_scoping.rs
+++ b/crates/storage/tests/user_id_scoping.rs
@@ -430,6 +430,50 @@ async fn knowledge_search_does_not_leak_across_users() {
 }
 
 #[tokio::test]
+async fn knowledge_search_with_empty_embedding_falls_back_to_fts() {
+    // #194: when the embedding backend times out, the search runs with an empty
+    // query embedding. The hybrid query's vector branch (`chunk <=> $1`) would
+    // error on a 0-dimension vector against rows that DO have embeddings, so the
+    // store must skip straight to FTS. Index a doc WITH an embedding, then
+    // search with an empty embedding and require an FTS hit (and no error).
+    with_fixture(
+        "knowledge_search_with_empty_embedding_falls_back_to_fts",
+        |fx| async move {
+            let store = PgKnowledgeBaseStore::new(fx.pool.clone());
+
+            with_user_id(UserId::new("alice"), async {
+                let entry = KnowledgeEntry::new(
+                    "kb-forecast-doc",
+                    "Quarterly forecast planning for the widget team",
+                    vec!["project".into()],
+                );
+                store
+                    .write(
+                        entry,
+                        Some(vec![vec![0.1_f32, 0.2, 0.3, 0.4]]),
+                        Some("test-model".into()),
+                    )
+                    .await
+                    .expect("write with embedding");
+
+                let hits = store
+                    .search("forecast planning", Vec::new(), None, 10)
+                    .await
+                    .expect("empty-embedding search must fall back to FTS, not error");
+                assert!(
+                    hits.iter().any(|e| e.id == "kb-forecast-doc"),
+                    "FTS fallback must find the indexed doc, got {} hit(s)",
+                    hits.len()
+                );
+            })
+            .await;
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn knowledge_get_by_id_does_not_leak_across_users() {
     with_fixture(
         "knowledge_get_by_id_does_not_leak_across_users",


### PR DESCRIPTION
## Symptom

Asking about the weather hung the daemon: the LLM called `builtin_tool_search` / `builtin_knowledge_base_search`, which embed the query first, and the embed call blocked **indefinitely** on a wedged Ollama (`/api/embed` accepted the connection but never responded — verified hung the full 60s). The turn never progressed, and the task **couldn't be cancelled** (cooperative cancellation can't interrupt a thread parked in a non-cancellable `await`).

## Root cause

`OllamaClient` uses `reqwest::Client::new()` (no timeout), and `embed_text`/`embed_chunks` `await` it unbounded. A slow/stuck embedding backend hangs the whole turn. Not memory (231 GB free), not provider-specific. Same class as #186/#187.

## Fix (requested behaviour: ~5s → FTS, dreaming backfills the rest)

- **5s `EMBED_TIMEOUT`** around `embed_text`/`embed_chunks` (`crates/mcp-client/src/builtin.rs`). On timeout → `None`:
  - search: `unwrap_or_default()` → empty vector → FTS-only.
  - KB write: persists without an embedding; the existing startup/dreaming backfill re-embeds later (already the behaviour on embed *failure*, now also on *timeout*).
- **FTS-only branch when the query embedding is empty** in `PgToolRegistryStore::search_tools` and `PgKnowledgeBaseStore::search`. The hybrid search fuses a vector branch + FTS via RRF; an empty 0-dim vector would *error* in `chunk <=> $1`, so skip to FTS (KB reuses its existing `search_text`).
- **Restores cancellability**: the task was uninterruptible only because it was parked in the unbounded embed `await`; control now returns within 5s so the cancel token (and the rest of the turn) can run.

## Tests

- Paused-clock unit test: a never-completing embed backend yields an empty embedding (→ FTS) and the search returns instead of hanging.
- **Postgres-gated** test: a doc indexed **with** an embedding, searched with an **empty** query embedding, returns via FTS and does **not** error on the 0-dim vector (verified against `pgvector:pg17`).
- `fmt` + `clippy -D warnings` clean.

Already `backend-reinstall`-ed on my machine to unblock testing.

Closes #194