### PR TITLE
feat(#178): ClassifyingLlmClient decorator (5a part 2) — stacked on #183

### DIFF
--- a/crates/core/src/error_classify.rs
+++ b/crates/core/src/error_classify.rs
@@ -1,0 +1,264 @@
+//! Connector-agnostic classification of opaque backend LLM errors (epic #178).
+//!
+//! Connectors surface unrecognized provider failures as
+//! [`crate::CoreError::Llm`] — a bare string the dispatch loop can't act on.
+//! This module normalizes such an error into a small **closed** set of causes
+//! ([`NormalizedCause`]) that map back onto the structured `CoreError`
+//! variants which already have recovery/handling (overflow → recovery ladder,
+//! rate-limit → backoff, …). Routing more errors into the right existing
+//! variant is the whole value: no new recovery code, just better detection.
+//!
+//! This file is **tier 1** of the planned three-tier classifier: deterministic
+//! built-in matchers, refactored from per-connector hardcoded knowledge into
+//! one connector-agnostic table. Tier 2 (a persisted learned cache) and tier 3
+//! (cheap-LLM classification of genuinely novel errors) build on top of this
+//! in later slices of #178; both fall back to [`classify_builtin`] first.
+//!
+//! ## Safety contract
+//! - The cause set is **closed**. Anything unrecognized is
+//!   [`NormalizedCause::Unknown`], which maps to `None` in
+//!   [`cause_to_core_error`] so the caller keeps the original error and
+//!   behavior is unchanged on a miss.
+//! - Terminal causes ([`NormalizedCause::is_terminal`]) — billing/auth — must
+//!   never drive an automatic retry. The classifier only *labels*; enforcing
+//!   "never retry terminal" is the caller's job (the future decorator).
+
+use crate::CoreError;
+
+/// A normalized, connector-agnostic cause for a backend LLM error.
+///
+/// Each variant either maps onto an existing structured [`CoreError`] (see
+/// [`cause_to_core_error`]) or is intentionally left unmapped so the original
+/// error surfaces unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NormalizedCause {
+    /// The prompt exceeded the model's context window. Token counts are
+    /// best-effort — present only when the provider stated them.
+    ContextOverflow {
+        prompt_tokens: Option<u64>,
+        max_tokens: Option<u64>,
+    },
+    /// Provider rate limit / throttling. Retryable with backoff.
+    RateLimited,
+    /// Billing or quota exhausted. **Terminal** — never auto-retry.
+    BillingFatal,
+    /// Authentication / authorization failure. **Terminal** — never auto-retry.
+    Auth,
+    /// The model is loading or warming up. Retryable.
+    ModelLoading,
+    /// The model/endpoint does not support the requested tool use.
+    ToolsUnsupported,
+    /// A transient server-side error (5xx / overloaded). Retryable.
+    Transient,
+    /// Unrecognized — surface the original error unchanged.
+    Unknown,
+}
+
+impl NormalizedCause {
+    /// Whether this cause is terminal: a retry can never succeed and may rack
+    /// up cost (billing) or is futile (auth). The caller must not auto-retry.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::BillingFatal | Self::Auth)
+    }
+}
+
+/// The signals available about a backend error, gathered at the connector
+/// boundary where the provider's HTTP status and error code are still visible
+/// (a bare `CoreError::Llm` string has already lost them).
+#[derive(Debug, Clone, Copy)]
+pub struct ErrorContext<'a> {
+    /// Connector id, e.g. `"bedrock"`, `"anthropic"`, `"openai"`.
+    pub connector: &'a str,
+    /// HTTP status, when the transport exposed one.
+    pub http_status: Option<u16>,
+    /// Provider-specific error code, e.g. `"ValidationException"`.
+    pub provider_code: Option<&'a str>,
+    /// The raw, human-readable error message.
+    pub message: &'a str,
+}
+
+/// Map a [`NormalizedCause`] to the structured [`CoreError`] that carries the
+/// right recovery/handling. Returns `None` when there is no dedicated
+/// variant (or the cause is `Unknown`): the caller keeps the original error,
+/// so an unclassified failure behaves exactly as it does today.
+pub fn cause_to_core_error(cause: NormalizedCause, detail: String) -> Option<CoreError> {
+    match cause {
+        NormalizedCause::ContextOverflow {
+            prompt_tokens,
+            max_tokens,
+        } => Some(CoreError::ContextOverflow {
+            prompt_tokens,
+            max_tokens,
+            detail,
+        }),
+        NormalizedCause::RateLimited => Some(CoreError::RateLimited {
+            retry_after: None,
+            detail,
+        }),
+        NormalizedCause::BillingFatal => Some(CoreError::QuotaExceeded { detail }),
+        NormalizedCause::ModelLoading => Some(CoreError::ModelLoading { detail }),
+        NormalizedCause::ToolsUnsupported => Some(CoreError::ToolsUnsupported { detail }),
+        // No dedicated CoreError variant: surface the original error unchanged.
+        NormalizedCause::Auth | NormalizedCause::Transient | NormalizedCause::Unknown => None,
+    }
+}
+
+/// Tier-1 deterministic classification from built-in matchers. Returns
+/// [`NormalizedCause::Unknown`] when nothing matches — the signal for higher
+/// tiers (learned cache, LLM) to take over, and the safe default that leaves
+/// behavior unchanged.
+pub fn classify_builtin(ctx: &ErrorContext) -> NormalizedCause {
+    // Stub (issue #178, slice 5a): real matchers land in the follow-up commit.
+    let _ = ctx;
+    NormalizedCause::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(message: &str) -> ErrorContext<'_> {
+        ErrorContext {
+            connector: "bedrock",
+            http_status: None,
+            provider_code: None,
+            message,
+        }
+    }
+
+    fn ctx_status(message: &str, status: u16) -> ErrorContext<'_> {
+        ErrorContext {
+            connector: "openai",
+            http_status: Some(status),
+            provider_code: None,
+            message,
+        }
+    }
+
+    #[test]
+    fn classifies_context_overflow_without_counts() {
+        assert_eq!(
+            classify_builtin(&ctx("Input is too long for requested model.")),
+            NormalizedCause::ContextOverflow {
+                prompt_tokens: None,
+                max_tokens: None
+            }
+        );
+    }
+
+    #[test]
+    fn classifies_context_overflow_with_counts() {
+        assert_eq!(
+            classify_builtin(&ctx(
+                "Input length (479258) exceeds model's maximum context length (131072)."
+            )),
+            NormalizedCause::ContextOverflow {
+                prompt_tokens: Some(479_258),
+                max_tokens: Some(131_072)
+            }
+        );
+    }
+
+    #[test]
+    fn classifies_billing_as_terminal_even_with_429() {
+        // OpenAI returns insufficient-quota with HTTP 429; it must be billing
+        // (terminal), not a retryable rate-limit.
+        let c = classify_builtin(&ctx_status(
+            "You exceeded your current quota, please check your plan and billing details.",
+            429,
+        ));
+        assert_eq!(c, NormalizedCause::BillingFatal);
+        assert!(c.is_terminal());
+    }
+
+    #[test]
+    fn classifies_auth_from_status_and_message() {
+        assert_eq!(
+            classify_builtin(&ctx_status("Unauthorized", 401)),
+            NormalizedCause::Auth
+        );
+        assert_eq!(
+            classify_builtin(&ctx("Invalid API key provided")),
+            NormalizedCause::Auth
+        );
+        assert!(NormalizedCause::Auth.is_terminal());
+    }
+
+    #[test]
+    fn classifies_rate_limit_without_quota_words() {
+        assert_eq!(
+            classify_builtin(&ctx_status("Too Many Requests", 429)),
+            NormalizedCause::RateLimited
+        );
+        assert_eq!(
+            classify_builtin(&ctx("ThrottlingException: rate of requests exceeded")),
+            NormalizedCause::RateLimited
+        );
+        assert!(!NormalizedCause::RateLimited.is_terminal());
+    }
+
+    #[test]
+    fn classifies_model_loading_and_tools_unsupported() {
+        assert_eq!(
+            classify_builtin(&ctx("The model is currently loading")),
+            NormalizedCause::ModelLoading
+        );
+        assert_eq!(
+            classify_builtin(&ctx("This model doesn't support tool use in streaming")),
+            NormalizedCause::ToolsUnsupported
+        );
+    }
+
+    #[test]
+    fn classifies_transient_5xx() {
+        assert_eq!(
+            classify_builtin(&ctx_status("internal server error", 500)),
+            NormalizedCause::Transient
+        );
+    }
+
+    #[test]
+    fn unknown_error_stays_unknown() {
+        assert_eq!(
+            classify_builtin(&ctx("a wild and unfamiliar failure appeared")),
+            NormalizedCause::Unknown
+        );
+    }
+
+    #[test]
+    fn cause_maps_to_core_error_variants() {
+        assert!(matches!(
+            cause_to_core_error(
+                NormalizedCause::ContextOverflow {
+                    prompt_tokens: Some(9),
+                    max_tokens: Some(8)
+                },
+                "d".into()
+            ),
+            Some(CoreError::ContextOverflow {
+                prompt_tokens: Some(9),
+                max_tokens: Some(8),
+                ..
+            })
+        ));
+        assert!(matches!(
+            cause_to_core_error(NormalizedCause::BillingFatal, "d".into()),
+            Some(CoreError::QuotaExceeded { .. })
+        ));
+        assert!(matches!(
+            cause_to_core_error(NormalizedCause::RateLimited, "d".into()),
+            Some(CoreError::RateLimited { .. })
+        ));
+        assert!(matches!(
+            cause_to_core_error(NormalizedCause::ModelLoading, "d".into()),
+            Some(CoreError::ModelLoading { .. })
+        ));
+        assert!(matches!(
+            cause_to_core_error(NormalizedCause::ToolsUnsupported, "d".into()),
+            Some(CoreError::ToolsUnsupported { .. })
+        ));
+        // No dedicated variant -> original error surfaces unchanged.
+        assert!(cause_to_core_error(NormalizedCause::Auth, "d".into()).is_none());
+        assert!(cause_to_core_error(NormalizedCause::Unknown, "d".into()).is_none());
+    }
+}

--- a/crates/core/src/error_classify.rs
+++ b/crates/core/src/error_classify.rs
@@ -108,9 +108,96 @@ pub fn cause_to_core_error(cause: NormalizedCause, detail: String) -> Option<Cor
 /// tiers (learned cache, LLM) to take over, and the safe default that leaves
 /// behavior unchanged.
 pub fn classify_builtin(ctx: &ErrorContext) -> NormalizedCause {
-    // Stub (issue #178, slice 5a): real matchers land in the follow-up commit.
-    let _ = ctx;
+    let lower = ctx.message.to_ascii_lowercase();
+
+    // Context overflow — connector-agnostic phrasing across providers.
+    if lower.contains("prompt is too long")
+        || lower.contains("input is too long")
+        || lower.contains("maximum context length")
+        || (lower.contains("context length") && lower.contains("exceed"))
+        || lower.contains("too many tokens")
+    {
+        let (prompt_tokens, max_tokens) = first_two_numbers(ctx.message);
+        return NormalizedCause::ContextOverflow {
+            prompt_tokens,
+            max_tokens,
+        };
+    }
+
+    // Billing / quota — TERMINAL, and checked *before* rate-limit because some
+    // providers return quota exhaustion with HTTP 429 (e.g. OpenAI
+    // insufficient_quota). Misreading that as a retryable rate-limit would
+    // loop and burn money.
+    if lower.contains("quota")
+        || lower.contains("billing")
+        || lower.contains("insufficient_quota")
+        || lower.contains("payment")
+        || lower.contains("credit balance")
+    {
+        return NormalizedCause::BillingFatal;
+    }
+
+    // Auth — TERMINAL.
+    if ctx.http_status == Some(401)
+        || ctx.http_status == Some(403)
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden")
+        || lower.contains("invalid api key")
+        || lower.contains("access denied")
+        || lower.contains("not authorized")
+    {
+        return NormalizedCause::Auth;
+    }
+
+    // Rate limit / throttling.
+    if ctx.http_status == Some(429)
+        || lower.contains("rate limit")
+        || lower.contains("too many requests")
+        || lower.contains("throttl")
+    {
+        return NormalizedCause::RateLimited;
+    }
+
+    // Model loading / warming up.
+    if lower.contains("loading") || lower.contains("warming up") || lower.contains("not ready") {
+        return NormalizedCause::ModelLoading;
+    }
+
+    // Tool use unsupported by the model/endpoint.
+    if lower.contains("tools are not supported")
+        || (lower.contains("tool use")
+            && (lower.contains("not support")
+                || lower.contains("doesn't support")
+                || lower.contains("does not support")))
+    {
+        return NormalizedCause::ToolsUnsupported;
+    }
+
+    // Transient server-side failures.
+    if matches!(ctx.http_status, Some(500..=599))
+        || lower.contains("internal server error")
+        || lower.contains("service unavailable")
+        || lower.contains("overloaded")
+    {
+        return NormalizedCause::Transient;
+    }
+
     NormalizedCause::Unknown
+}
+
+/// Extract the first two base-10 integers from `s`, in order. Across the
+/// recognized overflow phrasings the counts appear as `(prompt, max)`; fewer
+/// than two means the provider stated the overflow without numbers.
+fn first_two_numbers(s: &str) -> (Option<u64>, Option<u64>) {
+    let nums: Vec<u64> = s
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|t| !t.is_empty())
+        .filter_map(|t| t.parse::<u64>().ok())
+        .collect();
+    match nums.as_slice() {
+        [prompt, max, ..] => (Some(*prompt), Some(*max)),
+        _ => (None, None),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod chunking;
 pub mod context;
 pub mod domain;
+pub mod error_classify;
 pub mod ports;
 pub mod prompts;
 pub mod sanitize;

--- a/crates/daemon/src/classifying_llm.rs
+++ b/crates/daemon/src/classifying_llm.rs
@@ -49,10 +49,7 @@ impl<L> ClassifyingLlmClient<L> {
     /// tier-1 matchers recognize it. `Ok` and already-structured errors pass
     /// through untouched, and an unrecognized `Llm` error is returned
     /// verbatim — so behavior is unchanged on a miss.
-    fn reclassify(
-        &self,
-        result: Result<LlmResponse, CoreError>,
-    ) -> Result<LlmResponse, CoreError> {
+    fn reclassify(&self, result: Result<LlmResponse, CoreError>) -> Result<LlmResponse, CoreError> {
         match result {
             Err(CoreError::Llm(detail)) => {
                 let cause = classify_builtin(&ErrorContext {
@@ -141,7 +138,9 @@ impl<L: LlmClient> LlmClient for ClassifyingLlmClient<L> {
     ) -> Result<LlmResponse, CoreError> {
         let result = self
             .inner
-            .stream_completion_with_namespaces(messages, core_tools, namespaces, reasoning, on_chunk)
+            .stream_completion_with_namespaces(
+                messages, core_tools, namespaces, reasoning, on_chunk,
+            )
             .await;
         self.reclassify(result)
     }
@@ -251,7 +250,10 @@ mod tests {
             "You exceeded your current quota; check your billing details.".into(),
         ));
         let err = run(&c).await.expect_err("must be an error");
-        assert!(matches!(err, CoreError::QuotaExceeded { .. }), "got {err:?}");
+        assert!(
+            matches!(err, CoreError::QuotaExceeded { .. }),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -285,7 +287,11 @@ mod tests {
             "Input length (479258) exceeds model's maximum context length (131072).".into(),
         ));
         let _ = run(&c).await;
-        assert_eq!(c.inner.calls(), 1, "inner client must be called exactly once");
+        assert_eq!(
+            c.inner.calls(),
+            1,
+            "inner client must be called exactly once"
+        );
     }
 
     #[test]

--- a/crates/daemon/src/classifying_llm.rs
+++ b/crates/daemon/src/classifying_llm.rs
@@ -1,0 +1,279 @@
+//! Decorator that normalizes opaque backend LLM errors into structured
+//! [`CoreError`] variants (epic #178, slice 5a).
+//!
+//! Connectors surface unrecognized provider failures as `CoreError::Llm(_)` —
+//! a bare string the dispatch loop can't act on. This wrapper runs the
+//! deterministic tier-1 matchers from [`desktop_assistant_core::error_classify`]
+//! over that string and, when they recognize it, swaps in the structured
+//! variant (`ContextOverflow`, `RateLimited`, `QuotaExceeded`, …) that the
+//! core recovery ladder and `RetryingLlmClient` already know how to handle.
+//!
+//! ## Placement & loop-safety
+//! It wraps the **raw connector** (innermost, in `registry::build_llm_client`),
+//! so it sees the connector's own error before `Retrying`/recovery upstream.
+//! Putting it *inside* `RetryingLlmClient` is deliberate: `is_retryable_error`
+//! retries only `RateLimited`, so a billing error mapped to `QuotaExceeded`
+//! (terminal) is never retried, and `ContextOverflow` flows to the bounded
+//! recovery ladder — no new loop is introduced.
+//!
+//! The reclassification is **pure, single-shot, and non-recursive**: it
+//! transforms an already-returned error once and returns; it never retries,
+//! re-enters, or calls an LLM (tier 1 has no I/O). The reentrancy guard the
+//! loop-safety contract calls for becomes relevant only when the LLM-backed
+//! tier 3 lands — there is nothing here that can loop.
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Message, ToolDefinition, ToolNamespace};
+use desktop_assistant_core::ports::llm::{
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
+};
+
+/// Wraps an [`LlmClient`] and remaps opaque `CoreError::Llm` errors into the
+/// structured variant the built-in matchers recognize. See module docs.
+#[derive(Clone)]
+pub struct ClassifyingLlmClient<L> {
+    inner: L,
+    connector: String,
+}
+
+impl<L> ClassifyingLlmClient<L> {
+    pub fn new(inner: L, connector: impl Into<String>) -> Self {
+        Self {
+            inner,
+            connector: connector.into(),
+        }
+    }
+
+    /// Remap an opaque `CoreError::Llm` into a structured variant when the
+    /// tier-1 matchers recognize it. `Ok` and already-structured errors pass
+    /// through untouched, and an unrecognized `Llm` error is returned
+    /// verbatim — so behavior is unchanged on a miss.
+    fn reclassify(
+        &self,
+        result: Result<LlmResponse, CoreError>,
+    ) -> Result<LlmResponse, CoreError> {
+        // Stub (issue #178, slice 5a): real reclassification lands in the
+        // follow-up commit.
+        let _ = &self.connector;
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl<L: LlmClient> LlmClient for ClassifyingLlmClient<L> {
+    // --- Faithful passthrough: every capability comes from `inner`. The
+    // decorator wraps the connector innermost, so masking any of these (e.g.
+    // `max_context_tokens`, which drives budget resolution) would regress
+    // behavior. Only the two completion methods are intercepted. ---
+
+    fn get_default_model(&self) -> Option<&str> {
+        self.inner.get_default_model()
+    }
+
+    fn get_default_base_url(&self) -> Option<&str> {
+        self.inner.get_default_base_url()
+    }
+
+    fn max_context_tokens(&self) -> Option<u64> {
+        self.inner.max_context_tokens()
+    }
+
+    fn estimate_tokens(&self, text: &str) -> u64 {
+        self.inner.estimate_tokens(text)
+    }
+
+    fn supports_hosted_tool_search(&self) -> bool {
+        self.inner.supports_hosted_tool_search()
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        self.inner.list_models().await
+    }
+
+    async fn refresh_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+        self.inner.refresh_models().await
+    }
+
+    async fn warmup(&self) {
+        self.inner.warmup().await
+    }
+
+    async fn stream_completion(
+        &self,
+        messages: Vec<Message>,
+        tools: &[ToolDefinition],
+        reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let result = self
+            .inner
+            .stream_completion(messages, tools, reasoning, on_chunk)
+            .await;
+        self.reclassify(result)
+    }
+
+    async fn stream_completion_with_namespaces(
+        &self,
+        messages: Vec<Message>,
+        core_tools: &[ToolDefinition],
+        namespaces: &[ToolNamespace],
+        reasoning: ReasoningConfig,
+        on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let result = self
+            .inner
+            .stream_completion_with_namespaces(messages, core_tools, namespaces, reasoning, on_chunk)
+            .await;
+        self.reclassify(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_core::domain::Role;
+    use std::sync::Mutex;
+
+    enum Behavior {
+        Ok,
+        ErrLlm(String),
+        ErrRateLimited,
+    }
+
+    struct StubClient {
+        calls: Mutex<u32>,
+        behavior: Behavior,
+        max_ctx: Option<u64>,
+    }
+
+    impl StubClient {
+        fn new(behavior: Behavior) -> Self {
+            Self {
+                calls: Mutex::new(0),
+                behavior,
+                max_ctx: Some(131_072),
+            }
+        }
+        fn calls(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for StubClient {
+        fn max_context_tokens(&self) -> Option<u64> {
+            self.max_ctx
+        }
+
+        async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn refresh_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
+            Ok(vec![])
+        }
+
+        async fn stream_completion(
+            &self,
+            _messages: Vec<Message>,
+            _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
+            _on_chunk: ChunkCallback,
+        ) -> Result<LlmResponse, CoreError> {
+            *self.calls.lock().unwrap() += 1;
+            match &self.behavior {
+                Behavior::Ok => Ok(LlmResponse {
+                    text: "ok".into(),
+                    tool_calls: vec![],
+                    usage: None,
+                }),
+                Behavior::ErrLlm(s) => Err(CoreError::Llm(s.clone())),
+                Behavior::ErrRateLimited => Err(CoreError::RateLimited {
+                    retry_after: None,
+                    detail: "throttled".into(),
+                }),
+            }
+        }
+
+        fn supports_hosted_tool_search(&self) -> bool {
+            false
+        }
+    }
+
+    fn wrapped(behavior: Behavior) -> ClassifyingLlmClient<StubClient> {
+        ClassifyingLlmClient::new(StubClient::new(behavior), "bedrock")
+    }
+
+    async fn run(c: &ClassifyingLlmClient<StubClient>) -> Result<LlmResponse, CoreError> {
+        c.stream_completion(
+            vec![Message::new(Role::User, "hi")],
+            &[],
+            ReasoningConfig::default(),
+            Box::new(|_| true),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn opaque_overflow_error_is_reclassified() {
+        let c = wrapped(Behavior::ErrLlm(
+            "Input is too long for requested model.".into(),
+        ));
+        let err = run(&c).await.expect_err("must be an error");
+        assert!(
+            matches!(err, CoreError::ContextOverflow { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn opaque_billing_error_maps_to_quota_exceeded() {
+        let c = wrapped(Behavior::ErrLlm(
+            "You exceeded your current quota; check your billing details.".into(),
+        ));
+        let err = run(&c).await.expect_err("must be an error");
+        assert!(matches!(err, CoreError::QuotaExceeded { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn unrecognized_opaque_error_passes_through_unchanged() {
+        let c = wrapped(Behavior::ErrLlm("a wild unfamiliar failure".into()));
+        let err = run(&c).await.expect_err("must be an error");
+        match err {
+            CoreError::Llm(s) => assert_eq!(s, "a wild unfamiliar failure"),
+            other => panic!("expected unchanged Llm error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn already_structured_error_is_not_touched() {
+        let c = wrapped(Behavior::ErrRateLimited);
+        let err = run(&c).await.expect_err("must be an error");
+        assert!(matches!(err, CoreError::RateLimited { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn ok_passes_through() {
+        let c = wrapped(Behavior::Ok);
+        assert!(run(&c).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reclassification_is_single_shot_no_loop() {
+        // The decorator transforms the error once and returns — it must never
+        // re-invoke the inner client (which would risk a loop).
+        let c = wrapped(Behavior::ErrLlm(
+            "Input length (479258) exceeds model's maximum context length (131072).".into(),
+        ));
+        let _ = run(&c).await;
+        assert_eq!(c.inner.calls(), 1, "inner client must be called exactly once");
+    }
+
+    #[test]
+    fn delegates_max_context_tokens_to_inner() {
+        // Critical: the decorator wraps the connector innermost, so it must
+        // not mask the connector's curated context window (issue #176).
+        let c = wrapped(Behavior::Ok);
+        assert_eq!(c.max_context_tokens(), Some(131_072));
+    }
+}

--- a/crates/daemon/src/classifying_llm.rs
+++ b/crates/daemon/src/classifying_llm.rs
@@ -24,6 +24,7 @@
 
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, ToolDefinition, ToolNamespace};
+use desktop_assistant_core::error_classify::{ErrorContext, cause_to_core_error, classify_builtin};
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
 };
@@ -52,10 +53,28 @@ impl<L> ClassifyingLlmClient<L> {
         &self,
         result: Result<LlmResponse, CoreError>,
     ) -> Result<LlmResponse, CoreError> {
-        // Stub (issue #178, slice 5a): real reclassification lands in the
-        // follow-up commit.
-        let _ = &self.connector;
-        result
+        match result {
+            Err(CoreError::Llm(detail)) => {
+                let cause = classify_builtin(&ErrorContext {
+                    connector: &self.connector,
+                    http_status: None,
+                    provider_code: None,
+                    message: &detail,
+                });
+                match cause_to_core_error(cause, detail.clone()) {
+                    Some(mapped) => {
+                        tracing::info!(
+                            connector = %self.connector,
+                            ?cause,
+                            "classified opaque LLM error into a structured cause"
+                        );
+                        Err(mapped)
+                    }
+                    None => Err(CoreError::Llm(detail)),
+                }
+            }
+            other => other,
+        }
     }
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 mod api_surface;
 mod app;
 mod backend_reasoning;
+mod classifying_llm;
 mod config;
 mod connections;
 mod knowledge_service;

--- a/crates/daemon/src/registry.rs
+++ b/crates/daemon/src/registry.rs
@@ -187,7 +187,8 @@ impl Default for ConnectionRegistry {
 /// *before* calling this so misconfigured connections can be marked
 /// unavailable up front.
 pub fn build_llm_client(resolved: ResolvedLlmConfig) -> Arc<dyn LlmClient> {
-    match resolved.connector.as_str() {
+    let connector = resolved.connector.clone();
+    let inner: Arc<dyn LlmClient> = match resolved.connector.as_str() {
         "ollama" => Arc::new(
             desktop_assistant_llm_ollama::OllamaClient::new(resolved.base_url, resolved.model)
                 .with_temperature(resolved.temperature)
@@ -238,7 +239,18 @@ pub fn build_llm_client(resolved: ResolvedLlmConfig) -> Arc<dyn LlmClient> {
             }
             Arc::new(client)
         }
-    }
+    };
+
+    // Classify opaque backend errors (#178): innermost wrap, so it sees the
+    // connector's raw `CoreError::Llm` and remaps it into the structured
+    // variant the recovery ladder / `RetryingLlmClient` act on. Applies to
+    // every stack built through here (interactive, dreaming, backend-tasks,
+    // and the per-connection registry clients). Loop-safe: the remap is pure
+    // and single-shot, and it sits inside `RetryingLlmClient`, which only
+    // retries `RateLimited` — terminal causes are never retried.
+    Arc::new(crate::classifying_llm::ClassifyingLlmClient::new(
+        inner, connector,
+    ))
 }
 
 /// Validate a resolved connection config before building the client.


### PR DESCRIPTION
## What

5a part 2 of the self-learning error classifier (#178): the **`ClassifyingLlmClient` decorator** that consumes the tier-1 matchers from #183 and remaps opaque connector errors into structured `CoreError` variants the recovery machinery already handles.

> **Stacked on #183** (base = `feat/178-error-classifier-core`). It uses `desktop_assistant_core::error_classify`, which lands in #183. Merge #183 first; this re-targets to `main` after.

## How

- `ClassifyingLlmClient<L>` (`crates/daemon/src/classifying_llm.rs`) — same decorator pattern as `FixedReasoningLlmClient`. On a `stream_completion[_with_namespaces]` result it runs `reclassify`: an opaque `CoreError::Llm(detail)` is passed through `classify_builtin`; if a cause is recognized it returns the mapped structured error, otherwise the original error verbatim. `Ok` and already-structured errors are untouched.
- Wired in `registry::build_llm_client` as the **innermost** wrap, so it covers every stack (interactive, dreaming, backend-tasks, per-connection registry clients) and sees the connector's raw error first.
- Every other `LlmClient` method **delegates to inner** — important because the wrap is innermost: masking `max_context_tokens` would have regressed the #176 gpt-oss window, and `estimate_tokens` drives compaction.

## Loop-safety (the #178 acceptance criteria)

This is exactly the "what if the classifier itself loops" concern:
- **Pure, single-shot, non-recursive** — tier 1 has no I/O; `reclassify` transforms an already-returned error once and returns. A test asserts the inner client is called **exactly once**.
- **Placed inside `RetryingLlmClient`**, whose `is_retryable_error` retries **only** `RateLimited` (verified by existing core tests). So billing → `QuotaExceeded` is terminal (never retried), and `ContextOverflow` flows to the bounded recovery ladder. No new loop is introduced.
- The task-local reentrancy guard the contract calls for only becomes relevant when the LLM-backed **tier 3 (5c)** lands — there is no I/O here that could recurse. (Tracked in the #178 loop-safety comment.)

## Tests (TDD — failing tests committed first)

7 tests in `classifying_llm::tests`: overflow remap · billing → `QuotaExceeded` · unrecognized `Llm` passes through · already-structured error untouched · `Ok` untouched · **single-shot / no-loop (inner called once)** · `max_context_tokens` delegates to inner. Full `desktop-assistant-daemon` suite (240) green; fmt + clippy `--all-targets` clean.

## Next in #178
5b — persisted learned-cache tier. 5c — cheap-LLM classification of novel errors (adds the reentrancy guard + secret-scrubbing + bounded rate + timeout).

Part of #178
🤖 Generated with [Claude Code](https://claude.com/claude-code)
