### PR TITLE
feat(dbus): SendPromptWithSystemRefinement — carry per-request refinement over D-Bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
  "zbus",

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -45,6 +45,48 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
     async fn dispatch(&self, cmd: api::Command) -> fdo::Result<api::CommandResult> {
         self.transport.request(cmd).await.map_err(map_transport_err)
     }
+
+    /// Shared body for `SendPrompt` / `SendPromptWithSystemRefinement`:
+    /// builds the `SendMessage` command (with the given
+    /// `system_refinement`; empty = none), dispatches it, and maps the
+    /// immediate result to a correlation id for the caller. Keeping this
+    /// in one place guarantees the two D-Bus methods stay
+    /// byte-identical apart from the refinement.
+    async fn dispatch_send_message(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: String,
+    ) -> fdo::Result<String> {
+        let result = self
+            .dispatch(api::Command::SendMessage {
+                conversation_id: conversation_id.to_string(),
+                content: prompt.to_string(),
+                override_selection: None,
+                system_refinement,
+            })
+            .await
+            .map_err(|e| {
+                // SendMessage returns an immediate Ack on success; if
+                // the daemon refused the request before streaming, we
+                // surface the error directly.
+                to_fdo(e)
+            })?;
+
+        match result {
+            api::CommandResult::Ack => {
+                // Daemon hasn't told us the request id yet — events
+                // will carry it. Use a placeholder so clients have
+                // something to log against; the events flowing through
+                // the forwarder carry the daemon's correlation id.
+                Ok(uuid::Uuid::new_v4().to_string())
+            }
+            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected SendMessage result: {other:?}"
+            ))),
+        }
+    }
 }
 
 #[interface(name = "org.desktopAssistant.Conversations")]
@@ -244,34 +286,30 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
     /// the in-process adapter where the dbus-interface created its
     /// own request id.
     async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> fdo::Result<String> {
-        let result = self
-            .dispatch(api::Command::SendMessage {
-                conversation_id: conversation_id.to_string(),
-                content: prompt.to_string(),
-                override_selection: None,
-                system_refinement: String::new(),
-            })
+        self.dispatch_send_message(conversation_id, prompt, String::new())
             .await
-            .map_err(|e| {
-                // SendMessage returns an immediate Ack on success; if
-                // the daemon refused the request before streaming, we
-                // surface the error directly.
-                to_fdo(e)
-            })?;
+    }
 
-        match result {
-            api::CommandResult::Ack => {
-                // Daemon hasn't told us the request id yet — events
-                // will carry it. Use a placeholder so clients have
-                // something to log against; the events flowing through
-                // the forwarder carry the daemon's correlation id.
-                Ok(uuid::Uuid::new_v4().to_string())
-            }
-            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
-            other => Err(fdo::Error::Failed(format!(
-                "unexpected SendMessage result: {other:?}"
-            ))),
-        }
+    /// Like [`send_prompt`](Self::send_prompt) but attaches a
+    /// per-request `system_refinement` that the daemon appends to the
+    /// system prompt for THIS turn only. The refinement is never stored
+    /// as a message and never affects later turns (see
+    /// `api::Command::SendMessage`), so the visible transcript records
+    /// only the clean `prompt`. An empty `system_refinement` is
+    /// equivalent to [`send_prompt`](Self::send_prompt).
+    ///
+    /// Added additively (issue #200 follow-up) so the voice daemon can
+    /// dictate "respond briefly, by voice" into an existing chat without
+    /// polluting history. `send_prompt` is intentionally left
+    /// byte-identical for existing chat clients.
+    async fn send_prompt_with_system_refinement(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: &str,
+    ) -> fdo::Result<String> {
+        self.dispatch_send_message(conversation_id, prompt, system_refinement.to_string())
+            .await
     }
 
     /// Signal emitted for each chunk of a streaming response.
@@ -304,4 +342,119 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         request_id: &str,
         error: &str,
     ) -> zbus::Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::Mutex;
+    use tokio::sync::broadcast;
+
+    /// Recording [`BridgeTransport`] that captures every dispatched
+    /// command so a test can assert the exact `api::Command` the adapter
+    /// builds. Returns a fixed `SendMessageAck` so the adapter's
+    /// result-mapping path is exercised end to end.
+    struct RecordingTransport {
+        commands: Mutex<Vec<api::Command>>,
+    }
+
+    impl RecordingTransport {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeTransport for RecordingTransport {
+        async fn request(
+            &self,
+            command: api::Command,
+        ) -> Result<api::CommandResult, BridgeTransportError> {
+            self.commands.lock().await.push(command);
+            Ok(api::CommandResult::SendMessageAck {
+                task_id: "task-1".to_string(),
+            })
+        }
+
+        fn subscribe_events(&self) -> broadcast::Receiver<api::Event> {
+            let (tx, rx) = broadcast::channel(1);
+            // Keep the sender alive for the lifetime of the receiver so
+            // it isn't immediately closed; tests here don't emit events.
+            std::mem::forget(tx);
+            rx
+        }
+    }
+
+    /// A non-empty refinement must produce a `SendMessage` whose
+    /// `system_refinement` carries that text and whose `content` is the
+    /// CLEAN prompt (no blurb prepended). This is the wire half of the
+    /// voice "system-prompt refinement" feature: the daemon appends the
+    /// refinement to the system prompt for this turn only, while the
+    /// visible transcript records just `content`.
+    #[tokio::test]
+    async fn send_prompt_with_system_refinement_sets_refinement_and_clean_content() {
+        let transport = Arc::new(RecordingTransport::new());
+        let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
+
+        let task_id = adapter
+            .send_prompt_with_system_refinement(
+                "conv-1",
+                "what's the weather?",
+                "Respond briefly, by voice.",
+            )
+            .await
+            .expect("send returns the daemon task id");
+        assert_eq!(task_id, "task-1");
+
+        let commands = transport.commands.lock().await;
+        assert_eq!(commands.len(), 1, "exactly one command dispatched");
+        match &commands[0] {
+            api::Command::SendMessage {
+                conversation_id,
+                content,
+                override_selection,
+                system_refinement,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                // The prompt is stored CLEAN — no "You are Adele…" blurb.
+                assert_eq!(content, "what's the weather?");
+                assert_eq!(system_refinement, "Respond briefly, by voice.");
+                assert!(override_selection.is_none());
+            }
+            other => panic!("expected SendMessage, got {other:?}"),
+        }
+    }
+
+    /// `SendPrompt` must stay byte-identical: it builds a `SendMessage`
+    /// with an EMPTY `system_refinement` so existing chat clients are
+    /// unaffected by the additive method.
+    #[tokio::test]
+    async fn send_prompt_leaves_system_refinement_empty() {
+        let transport = Arc::new(RecordingTransport::new());
+        let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
+
+        adapter.send_prompt("conv-2", "hello").await.unwrap();
+
+        let commands = transport.commands.lock().await;
+        assert_eq!(commands.len(), 1);
+        match &commands[0] {
+            api::Command::SendMessage {
+                conversation_id,
+                content,
+                override_selection,
+                system_refinement,
+            } => {
+                assert_eq!(conversation_id, "conv-2");
+                assert_eq!(content, "hello");
+                assert!(
+                    system_refinement.is_empty(),
+                    "send_prompt must not set a refinement"
+                );
+                assert!(override_selection.is_none());
+            }
+            other => panic!("expected SendMessage, got {other:?}"),
+        }
+    }
 }

--- a/crates/dbus-interface/Cargo.toml
+++ b/crates/dbus-interface/Cargo.toml
@@ -10,6 +10,7 @@ desktop-assistant-application = { path = "../application" }
 desktop-assistant-api-model = { path = "../api-model" }
 zbus.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/crates/dbus-interface/src/conversation.rs
+++ b/crates/dbus-interface/src/conversation.rs
@@ -4,6 +4,7 @@ use desktop_assistant_core::domain::ConversationId;
 use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 use desktop_assistant_core::ports::inbound::ConversationService;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
 
@@ -20,6 +21,87 @@ pub struct DbusConversationAdapter<S: ConversationService + 'static> {
 impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
     pub fn new(service: Arc<S>) -> Self {
         Self { service }
+    }
+
+    /// Shared body for `SendPrompt` / `SendPromptWithSystemRefinement`:
+    /// spawn the LLM-call task (carrying `system_refinement`; empty =
+    /// none) under the resolved user_id scope, spawn the signal-emitter
+    /// task, and return the correlation `request_id`. Keeping this in one
+    /// place guarantees the two D-Bus methods stay identical apart from
+    /// the refinement.
+    async fn start_streaming_send(
+        &self,
+        emitter: SignalEmitter<'_>,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: String,
+    ) -> String {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let conv_id = conversation_id.to_string();
+        let prompt = prompt.to_string();
+        let service = Arc::clone(&self.service);
+        let req_id = request_id.clone();
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+
+        // Install the D-Bus user_id scope before spawning the LLM
+        // task so `spawn_send_prompt_llm_task` captures the right id
+        // for the in-spawn `with_user_id` wrap (#156).
+        let llm_conv_id = conv_id.clone();
+        with_user_id(resolve_dbus_user_id(), async {
+            drop(spawn_send_prompt_llm_task(
+                service,
+                llm_conv_id,
+                prompt,
+                system_refinement,
+                tx,
+            ));
+        })
+        .await;
+
+        // Spawn the signal emitter task. Signal emission does not
+        // touch per-user storage, so it doesn't need the scope.
+        let emitter = emitter.to_owned();
+        let signal_conv_id = conv_id.clone();
+        let signal_req_id = req_id.clone();
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                match event {
+                    StreamEvent::Chunk(chunk) => {
+                        if let Err(e) =
+                            Self::response_chunk(&emitter, &signal_conv_id, &signal_req_id, &chunk)
+                                .await
+                        {
+                            tracing::error!("failed to emit ResponseChunk signal: {e}");
+                        }
+                    }
+                    StreamEvent::Complete(full) => {
+                        if let Err(e) = Self::response_complete(
+                            &emitter,
+                            &signal_conv_id,
+                            &signal_req_id,
+                            &full,
+                        )
+                        .await
+                        {
+                            tracing::error!("failed to emit ResponseComplete signal: {e}");
+                        }
+                        break;
+                    }
+                    StreamEvent::Error(err) => {
+                        if let Err(e) =
+                            Self::response_error(&emitter, &signal_conv_id, &signal_req_id, &err)
+                                .await
+                        {
+                            tracing::error!("failed to emit ResponseError signal: {e}");
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+
+        request_id
     }
 }
 
@@ -44,6 +126,7 @@ pub(crate) async fn run_send_prompt_llm_task<S>(
     service: Arc<S>,
     conversation_id: String,
     prompt: String,
+    system_refinement: String,
     tx: mpsc::UnboundedSender<StreamEvent>,
 ) where
     S: ConversationService + 'static,
@@ -54,14 +137,25 @@ pub(crate) async fn run_send_prompt_llm_task<S>(
 
     let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(|_| {});
 
+    // `system_refinement` (empty = none) is a per-request addition to the
+    // system prompt for THIS turn only. We route through
+    // `send_prompt_with_override` with no model override and install the
+    // refinement as a task-local; the core service appends it to the system
+    // message for the LLM call but never stores it, so the visible transcript
+    // records only the clean `prompt`. A fresh `CancellationToken` preserves
+    // pre-existing behaviour (this in-process adapter never cancels).
     match service
-        .send_prompt(
+        .send_prompt_with_override(
             &ConversationId::from(conversation_id.as_str()),
             prompt,
+            None,
+            system_refinement,
             callback,
             on_status,
+            CancellationToken::new(),
         )
         .await
+        .map(|outcome| outcome.response)
     {
         Ok(full_response) => {
             let _ = tx.send(StreamEvent::Complete(full_response));
@@ -90,6 +184,7 @@ pub(crate) fn spawn_send_prompt_llm_task<S>(
     service: Arc<S>,
     conversation_id: String,
     prompt: String,
+    system_refinement: String,
     tx: mpsc::UnboundedSender<StreamEvent>,
 ) -> tokio::task::JoinHandle<()>
 where
@@ -98,7 +193,7 @@ where
     let user_id_for_body = current_user_id();
     tokio::spawn(with_user_id(
         user_id_for_body,
-        run_send_prompt_llm_task(service, conversation_id, prompt, tx),
+        run_send_prompt_llm_task(service, conversation_id, prompt, system_refinement, tx),
     ))
 }
 
@@ -310,66 +405,33 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
         conversation_id: &str,
         prompt: &str,
     ) -> fdo::Result<String> {
-        let request_id = uuid::Uuid::new_v4().to_string();
-        let conv_id = conversation_id.to_string();
-        let prompt = prompt.to_string();
-        let service = Arc::clone(&self.service);
-        let req_id = request_id.clone();
+        Ok(self
+            .start_streaming_send(emitter, conversation_id, prompt, String::new())
+            .await)
+    }
 
-        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
-
-        // Install the D-Bus user_id scope before spawning the LLM
-        // task so `spawn_send_prompt_llm_task` captures the right id
-        // for the in-spawn `with_user_id` wrap (#156).
-        let llm_conv_id = conv_id.clone();
-        with_user_id(resolve_dbus_user_id(), async {
-            drop(spawn_send_prompt_llm_task(service, llm_conv_id, prompt, tx));
-        })
-        .await;
-
-        // Spawn the signal emitter task. Signal emission does not
-        // touch per-user storage, so it doesn't need the scope.
-        let emitter = emitter.to_owned();
-        let signal_conv_id = conv_id.clone();
-        let signal_req_id = req_id.clone();
-        tokio::spawn(async move {
-            while let Some(event) = rx.recv().await {
-                match event {
-                    StreamEvent::Chunk(chunk) => {
-                        if let Err(e) =
-                            Self::response_chunk(&emitter, &signal_conv_id, &signal_req_id, &chunk)
-                                .await
-                        {
-                            tracing::error!("failed to emit ResponseChunk signal: {e}");
-                        }
-                    }
-                    StreamEvent::Complete(full) => {
-                        if let Err(e) = Self::response_complete(
-                            &emitter,
-                            &signal_conv_id,
-                            &signal_req_id,
-                            &full,
-                        )
-                        .await
-                        {
-                            tracing::error!("failed to emit ResponseComplete signal: {e}");
-                        }
-                        break;
-                    }
-                    StreamEvent::Error(err) => {
-                        if let Err(e) =
-                            Self::response_error(&emitter, &signal_conv_id, &signal_req_id, &err)
-                                .await
-                        {
-                            tracing::error!("failed to emit ResponseError signal: {e}");
-                        }
-                        break;
-                    }
-                }
-            }
-        });
-
-        Ok(request_id)
+    /// Like [`send_prompt`](Self::send_prompt) but attaches a
+    /// per-request `system_refinement` that the daemon appends to the
+    /// system prompt for THIS turn only (empty = none). The refinement is
+    /// never stored as a message and never affects later turns, so the
+    /// visible transcript records only the clean `prompt`. Added
+    /// additively (issue #200 follow-up) for the voice daemon; the chat
+    /// clients' `send_prompt` is left byte-identical.
+    async fn send_prompt_with_system_refinement(
+        &self,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: &str,
+    ) -> fdo::Result<String> {
+        Ok(self
+            .start_streaming_send(
+                emitter,
+                conversation_id,
+                prompt,
+                system_refinement.to_string(),
+            )
+            .await)
     }
 
     /// Signal emitted for each chunk of a streaming response.
@@ -593,6 +655,7 @@ mod tests {
                 svc_for_task,
                 "conv-x".to_string(),
                 "hello".to_string(),
+                String::new(),
                 tx,
             )
         })
@@ -613,6 +676,129 @@ mod tests {
             observed,
             vec!["alice-spawn".to_string()],
             "spawned LLM-call body must observe the caller's user_id, not the default sentinel"
+        );
+    }
+
+    /// Service double that records the `prompt` and `system_refinement`
+    /// it was dispatched with via `send_prompt_with_override`, so the
+    /// `SendPromptWithSystemRefinement` plumbing can be asserted without a
+    /// real D-Bus connection.
+    struct RefinementCapturingService {
+        prompt: Mutex<Option<String>>,
+        refinement: Mutex<Option<String>>,
+    }
+
+    impl RefinementCapturingService {
+        fn new() -> Self {
+            Self {
+                prompt: Mutex::new(None),
+                refinement: Mutex::new(None),
+            }
+        }
+    }
+
+    impl ConversationService for RefinementCapturingService {
+        async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new("rec-id", title))
+        }
+        async fn list_conversations(
+            &self,
+            _: Option<u32>,
+            _: bool,
+        ) -> Result<Vec<ConversationSummary>, CoreError> {
+            Ok(vec![])
+        }
+        async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new(id.as_str(), "rec"))
+        }
+        async fn delete_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn rename_conversation(
+            &self,
+            _: &ConversationId,
+            _: String,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn archive_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn unarchive_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn clear_all_history(&self) -> Result<u32, CoreError> {
+            Ok(0)
+        }
+        async fn send_prompt(
+            &self,
+            _: &ConversationId,
+            _: String,
+            _: ChunkCallback,
+            _: StatusCallback,
+        ) -> Result<String, CoreError> {
+            // Should not be hit: the adapter routes through
+            // `send_prompt_with_override` so the refinement is carried.
+            panic!("plain send_prompt must not be called by the streaming send path");
+        }
+        async fn send_prompt_with_override(
+            &self,
+            _conversation_id: &ConversationId,
+            prompt: String,
+            _override_selection: Option<
+                desktop_assistant_core::ports::inbound::PromptSelectionOverride,
+            >,
+            system_refinement: String,
+            mut on_chunk: ChunkCallback,
+            _on_status: StatusCallback,
+            _cancellation: CancellationToken,
+        ) -> Result<desktop_assistant_core::ports::inbound::PromptDispatchOutcome, CoreError>
+        {
+            *self.prompt.lock().unwrap() = Some(prompt);
+            *self.refinement.lock().unwrap() = Some(system_refinement);
+            on_chunk("ok".to_string());
+            Ok(
+                desktop_assistant_core::ports::inbound::PromptDispatchOutcome {
+                    response: "ok".to_string(),
+                    warnings: Vec::new(),
+                },
+            )
+        }
+    }
+
+    /// The `SendPromptWithSystemRefinement` path must pass the CLEAN
+    /// prompt as `content` and the caller-supplied text as
+    /// `system_refinement` through to the core service — mirroring the
+    /// `SendPrompt` handler but with the refinement populated. (The core
+    /// service is what guarantees the refinement is appended to the
+    /// system prompt for this turn only and never stored; see
+    /// `service::tests::system_refinement_is_appended_to_system_prompt_for_the_request`.)
+    #[tokio::test]
+    async fn send_prompt_with_system_refinement_routes_clean_prompt_and_refinement() {
+        let service = Arc::new(RefinementCapturingService::new());
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+
+        run_send_prompt_llm_task(
+            Arc::clone(&service),
+            "conv-x".to_string(),
+            "what's the weather?".to_string(),
+            "Respond briefly, by voice.".to_string(),
+            tx,
+        )
+        .await;
+
+        // Drain so we know the body ran to completion.
+        while rx.recv().await.is_some() {}
+
+        assert_eq!(
+            service.prompt.lock().unwrap().as_deref(),
+            Some("what's the weather?"),
+            "the clean prompt (no blurb) must be sent as content"
+        );
+        assert_eq!(
+            service.refinement.lock().unwrap().as_deref(),
+            Some("Respond briefly, by voice."),
+            "the configured hint must be carried as the per-request system_refinement"
         );
     }
 


### PR DESCRIPTION
## What

#200 added an optional `system_refinement` to the internal `Command::SendMessage` — appended to the LLM system prompt for ONE request, never stored. But the D-Bus `org.desktopAssistant.Conversations` surface was left unchanged, so a D-Bus client (the voice daemon, which reaches the orchestrator over a raw zbus proxy rather than client-common) had no way to deliver it. This closes that gap.

## Change

Adds an **additive** D-Bus method to **both** adapters that publish `org.desktopAssistant.Conversations`:

```
SendPromptWithSystemRefinement(conversation_id: s, prompt: s, system_refinement: s) -> request_id
```

- **`crates/dbus-interface`** (in-process adapter; the surface the daemon serves at `org.desktopAssistant`, which the voice daemon connects to today): routes through `ConversationService::send_prompt_with_override` with no model override and the refinement installed, instead of the plain `send_prompt`. A shared `start_streaming_send` helper backs both `SendPrompt` and the new method so they stay identical apart from the refinement, preserving the #156 per-user-id scope around the spawned LLM task.
- **`crates/dbus-bridge`** (standalone UDS-bridge binary, the forward-looking `org.desktopAssistant` owner): builds the same `Command::SendMessage` with `system_refinement` populated, via a shared `dispatch_send_message` helper.

Both adapters are documented as method-for-method mirrors, so both gained the method.

## Invariants

- Empty `system_refinement` == none.
- `SendPrompt` is left **byte-identical** in both adapters — existing chat clients (TUI/GTK/KDE) are unaffected.
- The **visible transcript records only the clean `prompt`**: the core service stores the clean user message and appends the refinement to the system prompt for the turn only, never persisting it (proven by the pre-existing `service::tests::system_refinement_is_appended_to_system_prompt_for_the_request`).

## Tests

- **dbus-bridge**: a non-empty refinement yields a `SendMessage` whose `system_refinement` is set and whose `content` is the clean prompt; `send_prompt` leaves the refinement empty.
- **dbus-interface**: the refinement path dispatches the clean prompt as `content` and the supplied text as `system_refinement` to the service (capturing-service double); `send_prompt` continues to propagate the user-id scope.

`just check` green.

## Companion

The voice side (adelie-ai/voice) calls this new method with the clean transcript as `prompt` and the configured spoken-response hint as `system_refinement`, with a graceful fallback to the old prepend-and-`send_prompt` behavior on an un-upgraded orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)