### PR TITLE
client-common: unified Connector + clap TransportArgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap",
  "desktop-assistant-api-model",
  "desktop-assistant-application",
  "desktop-assistant-auth-jwt",

--- a/crates/client-common/Cargo.toml
+++ b/crates/client-common/Cargo.toml
@@ -7,10 +7,13 @@ license = "AGPL-3.0-or-later"
 [features]
 default = ["dbus"]
 dbus = ["dep:zbus"]
+# Opt-in `TransportArgs` clap argument group for CLI clients.
+clap = ["dep:clap"]
 
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+clap = { version = "4", features = ["derive"], optional = true }
 desktop-assistant-api-model = { path = "../api-model" }
 futures = "0.3"
 reqwest = { version = "0.13", features = ["json"] }

--- a/crates/client-common/src/cli.rs
+++ b/crates/client-common/src/cli.rs
@@ -1,0 +1,170 @@
+//! Optional `clap` integration (behind the `clap` feature).
+//!
+//! [`TransportArgs`] is a flattenable argument group giving every CLI client the
+//! same transport flags (`--transport`, `--service`, `--socket-path`, the WS
+//! auth options) and a one-call path to a [`Connector`]. It defaults to the
+//! local Unix socket, so a tool run with no flags talks to the local daemon.
+//!
+//! ```ignore
+//! #[derive(clap::Parser)]
+//! struct Cli {
+//!     #[command(flatten)]
+//!     transport: desktop_assistant_client_common::TransportArgs,
+//! }
+//! let cli = Cli::parse();
+//! let connector = cli.transport.connect().await?;
+//! ```
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+use crate::config::{ConnectionConfig, TransportMode};
+use crate::connector::Connector;
+
+/// Standard transport flags for a CLI assistant client.
+#[derive(Args, Debug, Clone, Default)]
+pub struct TransportArgs {
+    /// Transport to reach the assistant daemon: `dbus`, `uds` (local socket),
+    /// or `ws`. Inferred from `--service` / `--socket-path`; defaults to `uds`.
+    #[arg(long, value_name = "dbus|uds|ws")]
+    pub transport: Option<String>,
+
+    /// WebSocket URL of a (possibly remote) daemon, e.g. `wss://host:11339/ws`.
+    /// Implies `--transport ws`.
+    #[arg(long, value_name = "URL")]
+    pub service: Option<String>,
+
+    /// Path to the daemon's local Unix socket. Implies `--transport uds`.
+    #[arg(long, value_name = "PATH")]
+    pub socket_path: Option<PathBuf>,
+
+    /// Bearer JWT for the WebSocket/UDS transport (skips token minting).
+    #[arg(long, value_name = "JWT")]
+    pub ws_jwt: Option<String>,
+
+    /// Username for the `/login` token fallback (WebSocket).
+    #[arg(long, value_name = "USER")]
+    pub ws_login_username: Option<String>,
+
+    /// Password for the `/login` token fallback (WebSocket).
+    #[arg(long, value_name = "PASS")]
+    pub ws_login_password: Option<String>,
+
+    /// PEM CA certificate to trust for `wss://` (defaults to the daemon's CA).
+    #[arg(long, value_name = "PATH")]
+    pub tls_ca_cert: Option<PathBuf>,
+}
+
+impl TransportArgs {
+    /// Resolve these flags into a [`ConnectionConfig`]. Precedence: an explicit
+    /// `--transport` wins; otherwise `--service` selects WS and `--socket-path`
+    /// selects UDS; with nothing given it defaults to **local UDS**. Unset
+    /// fields fall back to [`ConnectionConfig`]'s defaults.
+    pub fn connection_config(&self) -> Result<ConnectionConfig> {
+        let mode = match self.transport.as_deref() {
+            Some(raw) => match raw.to_ascii_lowercase().as_str() {
+                "dbus" => TransportMode::Dbus,
+                "uds" | "local" => TransportMode::Uds,
+                "ws" | "websocket" => TransportMode::Ws,
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "unknown --transport '{other}' (expected dbus, uds, or ws)"
+                    ));
+                }
+            },
+            None if self.service.is_some() => TransportMode::Ws,
+            None if self.socket_path.is_some() => TransportMode::Uds,
+            None => TransportMode::Uds, // local-first default
+        };
+
+        let mut config = ConnectionConfig {
+            transport_mode: mode,
+            ..ConnectionConfig::default()
+        };
+        if let Some(url) = &self.service {
+            config.ws_url = url.clone();
+        }
+        if self.socket_path.is_some() {
+            config.socket_path = self.socket_path.clone();
+        }
+        if self.ws_jwt.is_some() {
+            config.ws_jwt = self.ws_jwt.clone();
+        }
+        if self.ws_login_username.is_some() {
+            config.ws_login_username = self.ws_login_username.clone();
+        }
+        if self.ws_login_password.is_some() {
+            config.ws_login_password = self.ws_login_password.clone();
+        }
+        if self.tls_ca_cert.is_some() {
+            config.tls_ca_cert = self.tls_ca_cert.clone();
+        }
+        Ok(config)
+    }
+
+    /// Resolve the config and [`Connector::connect`] in one call.
+    pub async fn connect(&self) -> Result<Connector> {
+        Connector::connect(&self.connection_config()?).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_local_uds() {
+        let config = TransportArgs::default().connection_config().unwrap();
+        assert_eq!(config.transport_mode, TransportMode::Uds);
+    }
+
+    #[test]
+    fn service_url_implies_ws() {
+        let args = TransportArgs {
+            service: Some("wss://host:11339/ws".into()),
+            ..Default::default()
+        };
+        let config = args.connection_config().unwrap();
+        assert_eq!(config.transport_mode, TransportMode::Ws);
+        assert_eq!(config.ws_url, "wss://host:11339/ws");
+    }
+
+    #[test]
+    fn socket_path_implies_uds() {
+        let args = TransportArgs {
+            socket_path: Some("/run/user/1000/adelie/sock".into()),
+            ..Default::default()
+        };
+        let config = args.connection_config().unwrap();
+        assert_eq!(config.transport_mode, TransportMode::Uds);
+        assert_eq!(
+            config.socket_path.as_deref(),
+            Some(std::path::Path::new("/run/user/1000/adelie/sock"))
+        );
+    }
+
+    #[test]
+    fn explicit_transport_overrides_inference() {
+        // --transport wins even when a --service URL is also present.
+        let args = TransportArgs {
+            transport: Some("dbus".into()),
+            service: Some("wss://host/ws".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            args.connection_config().unwrap().transport_mode,
+            TransportMode::Dbus
+        );
+    }
+
+    #[test]
+    fn unknown_transport_is_an_error() {
+        let args = TransportArgs {
+            transport: Some("carrier-pigeon".into()),
+            ..Default::default()
+        };
+        assert!(args.connection_config().is_err());
+    }
+}

--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -1,0 +1,180 @@
+//! A single high-level handle over any transport.
+//!
+//! [`Connector`] wraps [`connect_transport`](crate::transport::connect_transport):
+//! it owns the chosen [`TransportClient`] *and* the daemon's signal stream,
+//! fanning every [`SignalEvent`] out to any number of
+//! [`subscribe`](Connector::subscribe)rs. A client issues commands and reads
+//! events through one object instead of juggling a `(client, receiver)` pair and
+//! per-transport channel wiring — the transport choice (D-Bus / local UDS /
+//! WebSocket) lives entirely in the [`ConnectionConfig`].
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+
+use crate::config::ConnectionConfig;
+use crate::signal::SignalEvent;
+use crate::transport::{AssistantClient, TransportClient, connect_transport, transport_label};
+
+type Subscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<SignalEvent>>>>;
+
+/// Pump a transport's signal stream out to all registered subscribers until it
+/// closes, then notify them with a final [`SignalEvent::Disconnected`].
+fn spawn_fanout(mut signal_rx: mpsc::UnboundedReceiver<SignalEvent>) -> Subscribers {
+    let subscribers: Subscribers = Arc::new(Mutex::new(Vec::new()));
+    let pump = Arc::clone(&subscribers);
+    tokio::spawn(async move {
+        while let Some(event) = signal_rx.recv().await {
+            // Deliver to every live subscriber; drop those whose receiver is gone.
+            pump.lock()
+                .unwrap()
+                .retain(|tx| tx.send(event.clone()).is_ok());
+        }
+        // The transport closed — give subscribers a terminal event to react to.
+        for tx in pump.lock().unwrap().drain(..) {
+            let _ = tx.send(SignalEvent::Disconnected {
+                reason: "signal stream closed".to_string(),
+            });
+        }
+    });
+    subscribers
+}
+
+fn register(subscribers: &Subscribers) -> mpsc::UnboundedReceiver<SignalEvent> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    subscribers.lock().unwrap().push(tx);
+    rx
+}
+
+/// A connected assistant client plus its automatically-managed event stream.
+pub struct Connector {
+    client: TransportClient,
+    subscribers: Subscribers,
+    label: String,
+}
+
+impl Connector {
+    /// Connect over the transport named by `config` and start pumping the
+    /// daemon's signal stream to subscribers.
+    pub async fn connect(config: &ConnectionConfig) -> Result<Self> {
+        let (client, signal_rx) = connect_transport(config).await?;
+        Ok(Self {
+            client,
+            subscribers: spawn_fanout(signal_rx),
+            label: transport_label(config),
+        })
+    }
+
+    /// A fresh receiver for the daemon's signal stream. Every subscriber sees
+    /// every event from the moment it subscribes; drop the receiver to
+    /// unsubscribe. Subscribe before sending a prompt so no early chunk is lost.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<SignalEvent> {
+        register(&self.subscribers)
+    }
+
+    /// The underlying transport client — the full [`AssistantClient`] surface
+    /// plus [`as_commands`](TransportClient::as_commands) for socket-only
+    /// commands not modelled on the convenience methods below.
+    pub fn client(&self) -> &TransportClient {
+        &self.client
+    }
+
+    /// Human-readable description of the active connection (e.g. "Connected via
+    /// local socket …").
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Create a conversation (works over every transport).
+    pub async fn create_conversation(&self, title: &str) -> Result<String> {
+        self.client.create_conversation(title).await
+    }
+
+    /// Send a prompt (works over every transport).
+    pub async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String> {
+        self.client.send_prompt(conversation_id, prompt).await
+    }
+
+    /// Send a prompt carrying a per-request system-prompt refinement. Socket
+    /// transports (UDS / WS) pass it as a dedicated field; the D-Bus transport —
+    /// whose high-level client has no refinement field — folds it into the
+    /// prompt (the historical fallback), so the call works everywhere.
+    pub async fn send_prompt_with_system_refinement(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: &str,
+    ) -> Result<String> {
+        if let Some(commands) = self.client.as_commands() {
+            commands
+                .send_prompt_with_system_refinement(conversation_id, prompt, system_refinement)
+                .await
+        } else {
+            let composed = if system_refinement.trim().is_empty() {
+                prompt.to_string()
+            } else {
+                format!("{system_refinement}\n\n{prompt}")
+            };
+            self.client.send_prompt(conversation_id, &composed).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fanout_delivers_to_every_subscriber() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let subs = spawn_fanout(rx);
+        let mut a = register(&subs);
+        let mut b = register(&subs);
+
+        tx.send(SignalEvent::Chunk {
+            request_id: "r".into(),
+            chunk: "hi".into(),
+        })
+        .unwrap();
+
+        assert!(matches!(a.recv().await, Some(SignalEvent::Chunk { .. })));
+        assert!(matches!(b.recv().await, Some(SignalEvent::Chunk { .. })));
+    }
+
+    #[tokio::test]
+    async fn fanout_drops_a_gone_subscriber_and_keeps_serving_others() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let subs = spawn_fanout(rx);
+        let gone = register(&subs);
+        let mut live = register(&subs);
+        drop(gone); // its receiver is dropped — must not break delivery to `live`
+
+        tx.send(SignalEvent::Chunk {
+            request_id: "r".into(),
+            chunk: "one".into(),
+        })
+        .unwrap();
+        assert!(matches!(live.recv().await, Some(SignalEvent::Chunk { .. })));
+        // After the dead subscriber is retained-out, only `live` remains.
+        tx.send(SignalEvent::Chunk {
+            request_id: "r".into(),
+            chunk: "two".into(),
+        })
+        .unwrap();
+        assert!(matches!(live.recv().await, Some(SignalEvent::Chunk { .. })));
+    }
+
+    #[tokio::test]
+    async fn fanout_emits_disconnected_when_the_stream_closes() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let subs = spawn_fanout(rx);
+        let mut a = register(&subs);
+        drop(tx); // close the upstream signal stream
+
+        assert!(matches!(
+            a.recv().await,
+            Some(SignalEvent::Disconnected { .. })
+        ));
+    }
+}

--- a/crates/client-common/src/lib.rs
+++ b/crates/client-common/src/lib.rs
@@ -1,8 +1,11 @@
 //! Shared client-side transport, config, and command types for the assistant frontends.
 
 pub mod auth;
+#[cfg(feature = "clap")]
+pub mod cli;
 pub mod commands;
 pub mod config;
+pub mod connector;
 #[cfg(feature = "dbus")]
 pub mod dbus_client;
 pub mod signal;
@@ -11,8 +14,11 @@ pub mod types;
 pub mod uds_client;
 pub mod ws_client;
 
+#[cfg(feature = "clap")]
+pub use cli::TransportArgs;
 pub use commands::AssistantCommands;
 pub use config::{ConnectionConfig, TransportMode, default_desktop_socket_path};
+pub use connector::Connector;
 pub use signal::SignalEvent;
 pub use transport::{AssistantClient, TransportClient, connect_transport};
 pub use types::{ChatMessage, ConversationDetail, ConversationSummary};

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -1,6 +1,7 @@
 use desktop_assistant_api_model as api;
 
-#[derive(Debug)]
+// `Clone` lets the `Connector` fan one signal stream out to many subscribers.
+#[derive(Debug, Clone)]
 pub enum SignalEvent {
     Chunk {
         request_id: String,


### PR DESCRIPTION
A single high-level entry point so clients stop hand-wiring transports and signal channels.

## What
- **`Connector::connect(&config)`** owns the chosen transport (D-Bus / local UDS / WebSocket) **and** the daemon's signal stream, fanning every `SignalEvent` out to any number of `subscribe()`rs (a fresh `mpsc` receiver per call). Convenience `create_conversation` / `send_prompt` / `send_prompt_with_system_refinement` + `client()` for the full `AssistantClient` / `as_commands` surface.
- **`TransportArgs`** (new opt-in `clap` feature): `--transport` / `--service` / `--socket-path` / WS-auth flags → `ConnectionConfig` (defaulting to **local UDS**), with `.connect()`.
- `SignalEvent` derives `Clone` (enables the fan-out).

## Designed around real usage
Verified against the two existing consumers so migration is a clean drop-in (not done here):
- **adele-tui** holds `(client, signal_rx)` and reads `signal_rx.recv()` in a `select!` loop → `connector.subscribe()` + `connector.client()`.
- **adele-gtk** wraps `Arc<TransportClient>` and reads `signal_rx` in its bridge → `Arc<Connector>` + `connector.subscribe()`.

## Safety
Additive and non-breaking: `connect_transport` and the transport clients are untouched; the `clap` feature is off by default. client-common `fmt` / `clippy -D warnings` / `test` green (new connector fan-out + `TransportArgs` inference tests); the default (no-`clap`) build is also verified.

First consumer: the voice service (adelie-ai/voice#31). adele-tui / adele-gtk migrate later.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)