### PR TITLE
fix(#205): 16MB tokio worker stack — the send-prompt future overflows the default 2MB

### DIFF
--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -560,8 +560,23 @@ impl api_surface::ConversationSelectionStore for AnyConversationStore {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // The interactive send-prompt task spawns a very large future: the deeply
+    // nested generic ConversationHandler / LLM-client stack
+    // (RoutingConversationHandler<ConversationHandler<MaybeProfiled<Retrying<
+    // FixedReasoning<RoutingLlmClient>>>, McpToolExecutor>>) monomorphizes into
+    // a multi-MB async state machine, and constructing it on the default 2 MB
+    // tokio worker stack overflowed the guard page (#205). Give workers a
+    // larger stack. (Proper follow-up: shrink the future via `Arc<dyn …>`
+    // dynamic dispatch so it isn't multi-MB in the first place.)
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(16 * 1024 * 1024)
+        .build()?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();


### PR DESCRIPTION
## Root cause (from a symbolized core dump)
The orchestrator's intermittent `tokio-rt-worker has overflowed its stack` aborts are **not infinite recursion** — they're a **single oversized stack frame**. The interactive send-prompt task spawns a future whose type is gigantic:

```
tokio::task::spawn::spawn<… run_send_prompt_llm_task<
  RoutingConversationHandler<ConversationHandler<MaybeProfiled<
    RetryingLlmClient<FixedReasoningLlmClient<RoutingLlmClient>>>,
    McpToolExecutor>>> …>
```

That deeply-nested generic handler/client stack monomorphizes into a **multi-MB async state machine**, and constructing/moving it on the default **2 MB** tokio worker stack blows the guard page (`conversation.rs:194`, the `tokio::spawn`). Release sits right on the edge (intermittent); a debug build's bigger frames overflow **every** turn. Dreaming (no tools/handler → tiny future) never crashed.

## Fix
Replace `#[tokio::main]` with a multi-thread runtime that sets `thread_stack_size(16 * 1024 * 1024)`.

## Verification
Reproduced the exact crash ("What's the forecast for today?") on a **debug** build (the worst case):
- **before:** `SendPrompt` → `Call failed: Remote peer disconnected` (overflow → abort → systemd restart)
- **after:** `SendPrompt` → `s "2b1bc1a0-…"` (request id); daemon stays `active`, no overflow.

## Follow-up (separate)
This is the right *practical* fix, but the multi-MB future is a smell. A proper follow-up is to shrink it via `Arc<dyn …>` dynamic dispatch for the handler/LLM-client stack so the per-turn future isn't multi-MB. Worth its own issue.

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)