### PR TITLE
feat(#204): in-flight re-attach (phase 2) + client-common idempotency threading

### DIFF
--- a/crates/application/src/inflight.rs
+++ b/crates/application/src/inflight.rs
@@ -1,0 +1,302 @@
+//! In-flight `SendMessage` re-attach (#204 phase 2).
+//!
+//! Phase 1 (completed-dedup) replays a *finished* turn's reply. This is the
+//! other half: a duplicate `SendMessage` carrying an `idempotency_key` whose
+//! original is *still running in this process* (a transient connection blip,
+//! no daemon restart) re-attaches to the live turn — replaying the chunks
+//! emitted so far, then forwarding the rest live — instead of running a second
+//! turn and double-processing an action.
+//!
+//! A live keyed turn emits through a [`TeeSink`]: events go to the original
+//! caller's sink unchanged *and* into an [`InFlightTurn`], which buffers every
+//! event for late re-attachers and broadcasts it to those already attached.
+//! The [`InFlightRegistry`] indexes live turns by `(user_id,
+//! conversation_id, idempotency_key)`; a turn registers when it starts and
+//! removes itself when it ends.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use desktop_assistant_api_model as api;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::broadcast;
+
+use crate::EventSink;
+
+/// Broadcast capacity for live re-attach delivery. A re-attacher that falls
+/// more than this many events behind drops the overflow (logged by tokio as a
+/// lag), but the terminal `AssistantCompleted` carries the full reply text, so
+/// even a lagging re-attacher ends with the complete answer.
+const INFLIGHT_BROADCAST_CAP: usize = 256;
+
+/// A single live turn's fan-out hub: an append-only event buffer plus a live
+/// broadcast. Buffer-append and broadcast happen under one lock so a
+/// re-attacher can snapshot the buffer and subscribe atomically — no event is
+/// duplicated or dropped at the snapshot/subscribe boundary.
+pub(crate) struct InFlightTurn {
+    buffer: AsyncMutex<Vec<api::Event>>,
+    tx: broadcast::Sender<api::Event>,
+}
+
+impl InFlightTurn {
+    fn new() -> Arc<Self> {
+        let (tx, _rx) = broadcast::channel(INFLIGHT_BROADCAST_CAP);
+        Arc::new(Self {
+            buffer: AsyncMutex::new(Vec::new()),
+            tx,
+        })
+    }
+
+    /// Record + fan out one event. `Err` from `send` just means there are no
+    /// live subscribers right now; the buffer still keeps the event for a
+    /// future re-attacher.
+    async fn emit_event(&self, event: api::Event) {
+        let mut buffer = self.buffer.lock().await;
+        buffer.push(event.clone());
+        let _ = self.tx.send(event);
+    }
+
+    /// Atomically snapshot the events emitted so far and subscribe to the
+    /// rest. Holding the buffer lock across the `subscribe()` call makes this
+    /// mutually exclusive with [`Self::emit_event`], so the snapshot and the
+    /// live subscription partition the event stream exactly.
+    pub(crate) async fn snapshot_and_subscribe(
+        &self,
+    ) -> (Vec<api::Event>, broadcast::Receiver<api::Event>) {
+        let buffer = self.buffer.lock().await;
+        let rx = self.tx.subscribe();
+        (buffer.clone(), rx)
+    }
+}
+
+/// `EventSink` that mirrors a turn's events to the original caller's sink
+/// (unchanged behaviour) *and* into the fan-out hub for re-attachers.
+pub(crate) struct TeeSink {
+    primary: Arc<dyn EventSink>,
+    hub: Arc<InFlightTurn>,
+}
+
+impl TeeSink {
+    pub(crate) fn new(primary: Arc<dyn EventSink>, hub: Arc<InFlightTurn>) -> Self {
+        Self { primary, hub }
+    }
+}
+
+#[async_trait]
+impl EventSink for TeeSink {
+    async fn emit(&self, event: api::Event) -> bool {
+        // Feed the hub first so a re-attacher that joins right after can't miss
+        // an event the primary already received.
+        self.hub.emit_event(event.clone()).await;
+        self.primary.emit(event).await
+    }
+}
+
+/// Re-attach a sink to a live turn: replay the buffered events, then forward
+/// live events until the turn ends (the hub's sender drops) or the sink
+/// disconnects. Holds only a [`broadcast::Receiver`], never a strong reference
+/// to the [`InFlightTurn`], so it never keeps the hub (and thus the broadcast
+/// channel) alive past the turn it's following.
+pub(crate) async fn forward_inflight(
+    replay: Vec<api::Event>,
+    mut rx: broadcast::Receiver<api::Event>,
+    sink: Arc<dyn EventSink>,
+) {
+    for event in replay {
+        if !sink.emit(event).await {
+            return;
+        }
+    }
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                if !sink.emit(event).await {
+                    return;
+                }
+            }
+            Err(broadcast::error::RecvError::Closed) => return,
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                // Slow re-attacher; skip the dropped deltas and keep going. The
+                // terminal AssistantCompleted still carries the full reply.
+            }
+        }
+    }
+}
+
+/// In-memory index of live keyed turns, by `(user_id, conversation_id,
+/// idempotency_key)`. A duplicate keyed `SendMessage` that finds a live entry
+/// re-attaches instead of running again.
+#[derive(Default)]
+pub(crate) struct InFlightRegistry {
+    map: Mutex<HashMap<(String, String, String), Arc<InFlightTurn>>>,
+}
+
+impl InFlightRegistry {
+    fn key(
+        user_id: &str,
+        conversation_id: &str,
+        idempotency_key: &str,
+    ) -> (String, String, String) {
+        (
+            user_id.to_string(),
+            conversation_id.to_string(),
+            idempotency_key.to_string(),
+        )
+    }
+
+    /// Atomically claim a fresh live slot, returning its hub. Returns `None`
+    /// when a live turn for this key already exists — the caller should
+    /// re-attach via [`Self::get`] instead. The check-and-insert under one lock
+    /// closes the concurrent same-key race.
+    pub(crate) fn register(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        idempotency_key: &str,
+    ) -> Option<Arc<InFlightTurn>> {
+        let mut map = self.map.lock().unwrap();
+        let k = Self::key(user_id, conversation_id, idempotency_key);
+        if map.contains_key(&k) {
+            return None;
+        }
+        let turn = InFlightTurn::new();
+        map.insert(k, Arc::clone(&turn));
+        Some(turn)
+    }
+
+    /// The live turn for this key, if one is currently running.
+    pub(crate) fn get(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        idempotency_key: &str,
+    ) -> Option<Arc<InFlightTurn>> {
+        let map = self.map.lock().unwrap();
+        map.get(&Self::key(user_id, conversation_id, idempotency_key))
+            .map(Arc::clone)
+    }
+
+    /// Remove the live entry once the turn ends, so later same-key requests
+    /// fall through to completed-dedup (or run fresh).
+    pub(crate) fn remove(&self, user_id: &str, conversation_id: &str, idempotency_key: &str) {
+        let mut map = self.map.lock().unwrap();
+        map.remove(&Self::key(user_id, conversation_id, idempotency_key));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// Recording sink: collects emitted events, optionally a fixed number then
+    /// reports disconnect.
+    struct RecordingSink {
+        events: StdMutex<Vec<api::Event>>,
+    }
+    impl RecordingSink {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                events: StdMutex::new(Vec::new()),
+            })
+        }
+        fn delta_chunks(&self) -> Vec<String> {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|e| match e {
+                    api::Event::AssistantDelta { chunk, .. } => Some(chunk.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+    #[async_trait]
+    impl EventSink for RecordingSink {
+        async fn emit(&self, event: api::Event) -> bool {
+            self.events.lock().unwrap().push(event);
+            true
+        }
+    }
+
+    fn delta(chunk: &str) -> api::Event {
+        api::Event::AssistantDelta {
+            conversation_id: "c1".into(),
+            request_id: "r".into(),
+            chunk: chunk.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reattacher_gets_buffered_then_live_events() {
+        let turn = InFlightTurn::new();
+        // Two chunks emitted before anyone re-attaches.
+        turn.emit_event(delta("a")).await;
+        turn.emit_event(delta("b")).await;
+
+        // A re-attacher snapshots (gets a, b) and subscribes.
+        let (replay, rx) = turn.snapshot_and_subscribe().await;
+        let sink = RecordingSink::new();
+        let sink_dyn: Arc<dyn EventSink> = sink.clone();
+        let forward = tokio::spawn(forward_inflight(replay, rx, sink_dyn));
+
+        // More chunks emitted after re-attach arrive live.
+        turn.emit_event(delta("c")).await;
+        turn.emit_event(delta("d")).await;
+
+        // Dropping the turn closes the channel so the forward task finishes.
+        drop(turn);
+        forward.await.unwrap();
+
+        assert_eq!(sink.delta_chunks(), vec!["a", "b", "c", "d"]);
+    }
+
+    #[tokio::test]
+    async fn snapshot_and_subscribe_partitions_the_stream() {
+        // No event is duplicated across the buffer snapshot and the live
+        // subscription, nor dropped at the boundary.
+        let turn = InFlightTurn::new();
+        turn.emit_event(delta("x")).await;
+        let (replay, rx) = turn.snapshot_and_subscribe().await;
+        turn.emit_event(delta("y")).await;
+
+        let sink = RecordingSink::new();
+        let sink_dyn: Arc<dyn EventSink> = sink.clone();
+        let forward = tokio::spawn(forward_inflight(replay, rx, sink_dyn));
+        drop(turn);
+        forward.await.unwrap();
+
+        assert_eq!(
+            sink.delta_chunks(),
+            vec!["x", "y"],
+            "x via replay, y via live — exactly once each"
+        );
+    }
+
+    #[test]
+    fn register_is_an_atomic_claim() {
+        let reg = InFlightRegistry::default();
+        assert!(
+            reg.register("u", "c", "k").is_some(),
+            "first claim wins the slot"
+        );
+        assert!(
+            reg.register("u", "c", "k").is_none(),
+            "a second claim for a live key loses"
+        );
+        assert!(reg.get("u", "c", "k").is_some(), "the live turn is visible");
+
+        // A different (user, conv, key) tuple is independent.
+        assert!(reg.register("u", "c", "other").is_some());
+        assert!(reg.register("other", "c", "k").is_some());
+
+        reg.remove("u", "c", "k");
+        assert!(reg.get("u", "c", "k").is_none(), "removed entries are gone");
+        assert!(
+            reg.register("u", "c", "k").is_some(),
+            "a freed key can be claimed again"
+        );
+    }
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod background_tasks;
 pub mod client_tools;
+mod inflight;
 pub mod subagent_tools;
 
 use std::sync::Arc;
@@ -27,6 +28,7 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::background_tasks::{BackgroundTaskRegistry, TaskError};
+use crate::inflight::{InFlightRegistry, InFlightTurn, TeeSink, forward_inflight};
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -331,6 +333,12 @@ where
     /// completed-dedup). `None` (no DB, tests) makes the key a no-op so
     /// `SendMessage` behaves exactly as before.
     idempotency: Option<Arc<dyn IdempotencyKeyStore>>,
+    /// In-memory index of live keyed turns (#204 phase 2). A `SendMessage`
+    /// carrying an `idempotency_key` whose original is still running in this
+    /// process re-attaches to that live turn (replay buffered chunks + forward
+    /// live) instead of running a second turn. Always present (no DB needed);
+    /// only consulted when a request carries a key.
+    inflight: Arc<InFlightRegistry>,
 }
 
 impl<A, C, S, N, K> DefaultAssistantApiHandler<A, C, S, N, K>
@@ -361,6 +369,7 @@ where
             scratchpad_delete_many: None,
             scratchpad_clear: None,
             idempotency: None,
+            inflight: Arc::new(InFlightRegistry::default()),
         }
     }
 
@@ -435,6 +444,49 @@ where
         };
         replay_completed_response(sink, conversation_id, request_id, response).await;
         Ok(true)
+    }
+
+    /// Spawn a registry task that re-attaches `sink` to a live in-flight turn:
+    /// replay its buffered events, then forward live events until it ends
+    /// (#204 phase 2).
+    async fn spawn_reattach(
+        registry: &BackgroundTaskRegistry,
+        user_id: UserId,
+        conversation_id: &str,
+        sink: Arc<dyn EventSink>,
+        turn: Arc<InFlightTurn>,
+    ) -> api::TaskId {
+        let (replay, rx) = turn.snapshot_and_subscribe().await;
+        let kind = api::TaskKind::Conversation {
+            conversation_id: conversation_id.to_string(),
+        };
+        let title = format!("Conversation: {conversation_id}");
+        registry.spawn(user_id, kind, title, move |_ctx| async move {
+            forward_inflight(replay, rx, sink).await;
+            Ok(())
+        })
+    }
+
+    /// Spawn a registry task that replays a completed turn's stored reply to
+    /// `sink` (#204 phase 1), keyed by the retry's own `request_id`.
+    fn spawn_completed_replay(
+        registry: &BackgroundTaskRegistry,
+        user_id: UserId,
+        conversation_id: &str,
+        request_id: &str,
+        sink: Arc<dyn EventSink>,
+        response: String,
+    ) -> api::TaskId {
+        let kind = api::TaskKind::Conversation {
+            conversation_id: conversation_id.to_string(),
+        };
+        let title = format!("Conversation: {conversation_id}");
+        let conv = conversation_id.to_string();
+        let req = request_id.to_string();
+        registry.spawn(user_id, kind, title, move |_ctx| async move {
+            replay_completed_response(&sink, &conv, &req, response).await;
+            Ok(())
+        })
     }
 
     fn map_core_err<E: ToString>(e: E) -> ApiError {
@@ -1531,37 +1583,72 @@ where
         };
         let user_id = desktop_assistant_core::ports::auth::current_user_id();
 
-        // Completed-dedup (#204): when this key already has a committed
-        // reply, register a tiny replay task so the dispatcher's
-        // `SendMessageAck { task_id }` arrives before the stream — exactly
-        // as for a normal turn — then replay the stored reply instead of
-        // re-running the LLM/tools.
-        if let (Some(key), Some(store)) = (idempotency_key.as_deref(), self.idempotency.as_ref()) {
-            let completed = store
-                .lookup_completed(&conversation_id, key)
-                .await
-                .map_err(Self::map_core_err)?;
-            if let Some(response) = completed {
-                let kind = api::TaskKind::Conversation {
-                    conversation_id: conversation_id.clone(),
-                };
-                let title = format!("Conversation: {conversation_id}");
-                let sink_for_replay = Arc::clone(&sink);
-                let conv_for_replay = conversation_id.clone();
-                let req_for_replay = request_id.clone();
-                let task_id = registry.spawn(user_id, kind, title, move |_ctx| async move {
-                    replay_completed_response(
-                        &sink_for_replay,
-                        &conv_for_replay,
-                        &req_for_replay,
-                        response,
-                    )
-                    .await;
-                    Ok(())
-                });
+        // Idempotency shortcuts for a keyed SendMessage (#204), tried before
+        // dispatching a fresh turn.
+        if let Some(key) = idempotency_key.as_deref() {
+            // (1) In-flight re-attach (phase 2): the original is still running
+            // in this process — re-attach to its live stream (replay buffered
+            // chunks, then forward live) instead of running a second turn.
+            if let Some(turn) = self.inflight.get(user_id.as_str(), &conversation_id, key) {
+                let task_id = Self::spawn_reattach(
+                    &registry,
+                    user_id,
+                    &conversation_id,
+                    Arc::clone(&sink),
+                    turn,
+                )
+                .await;
                 return Ok(Some(task_id));
             }
+            // (2) Completed-dedup (phase 1): the original finished — replay its
+            // committed reply. A registry replay-task keeps the dispatcher's
+            // `SendMessageAck { task_id }`-then-stream ordering identical to a
+            // normal turn.
+            if let Some(store) = self.idempotency.as_ref() {
+                let completed = store
+                    .lookup_completed(&conversation_id, key)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                if let Some(response) = completed {
+                    let task_id = Self::spawn_completed_replay(
+                        &registry,
+                        user_id,
+                        &conversation_id,
+                        &request_id,
+                        Arc::clone(&sink),
+                        response,
+                    );
+                    return Ok(Some(task_id));
+                }
+            }
         }
+
+        // Fresh turn. For a keyed turn, claim an in-flight slot so a concurrent
+        // duplicate can re-attach; if we lose that claim to a racing same-key
+        // turn, re-attach to the winner rather than running twice.
+        let inflight_slot = match idempotency_key.as_deref() {
+            Some(key) => match self
+                .inflight
+                .register(user_id.as_str(), &conversation_id, key)
+            {
+                Some(turn) => Some((key.to_string(), turn)),
+                None => {
+                    if let Some(turn) = self.inflight.get(user_id.as_str(), &conversation_id, key) {
+                        let task_id = Self::spawn_reattach(
+                            &registry,
+                            user_id,
+                            &conversation_id,
+                            Arc::clone(&sink),
+                            turn,
+                        )
+                        .await;
+                        return Ok(Some(task_id));
+                    }
+                    None
+                }
+            },
+            None => None,
+        };
 
         let conversations = Arc::clone(&self.conversations);
         // Pair the store with the key (both-or-neither) so the turn body
@@ -1572,20 +1659,25 @@ where
         };
         let title = format!("Conversation: {conversation_id}");
 
-        let conv_id_for_body = conversation_id.clone();
-        let request_id_for_body = request_id.clone();
-        let sink_for_body = Arc::clone(&sink);
-        let user_id_for_body = user_id.clone();
+        // A keyed turn emits through a `TeeSink` so its events both reach the
+        // caller and feed the in-flight hub for re-attachers; an unkeyed turn
+        // emits straight to the caller's sink.
+        let turn_sink: Arc<dyn EventSink> = match &inflight_slot {
+            Some((_, turn)) => Arc::new(TeeSink::new(Arc::clone(&sink), Arc::clone(turn))),
+            None => Arc::clone(&sink),
+        };
 
-        // `registry.spawn` is sync; the body runs on its own
-        // `tokio::spawn` so we can return the new task id immediately.
-        // `tokio::spawn` does not propagate task-locals, so the body
-        // must re-install `with_user_id` for storage queries inside
-        // `run_send_turn` to scope to the right user (#154). The
-        // `system_refinement` is moved into the closure as an explicit
-        // value for the same reason — it can't ride a task-local across
-        // the spawn; it is installed as a task-local further down, inside
-        // the per-turn dispatch in the daemon's routing handler.
+        let inflight_index = Arc::clone(&self.inflight);
+        let conv_id_for_body = conversation_id.clone();
+        let conv_id_for_cleanup = conversation_id.clone();
+        let request_id_for_body = request_id.clone();
+        let user_id_for_body = user_id.clone();
+        let user_id_for_cleanup = user_id.clone();
+
+        // `registry.spawn` is sync; the body runs on its own `tokio::spawn` so
+        // we can return the new task id immediately. `tokio::spawn` doesn't
+        // propagate task-locals, so the body re-installs `with_user_id` for
+        // storage queries inside `run_send_turn` (#154).
         let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
             ctx.logs.append(
                 api::LogLevel::Info,
@@ -1604,11 +1696,19 @@ where
                     system_refinement,
                     request_id_for_body,
                     idempotency,
-                    sink_for_body,
+                    turn_sink,
                     ctx.token.clone(),
                 ),
             )
             .await;
+
+            // Free the in-flight slot now the turn is done. `run_send_turn` has
+            // returned, so its `TeeSink` (the other hub owner) is dropped here
+            // too — once the slot is removed the broadcast closes and any
+            // re-attach streams finish.
+            if let Some((key, _turn)) = inflight_slot {
+                inflight_index.remove(user_id_for_cleanup.as_str(), &conv_id_for_cleanup, &key);
+            }
 
             match result {
                 Ok(()) => Ok(()),
@@ -3711,6 +3811,157 @@ mod tests {
             runs.load(Ordering::SeqCst),
             1,
             "a key with no store attached runs the turn as normal"
+        );
+    }
+
+    /// `ConversationService` double that emits one chunk, blocks until
+    /// released, then emits a second chunk and completes — so a second
+    /// same-key request can arrive while the turn is provably in flight.
+    struct GatedConversations {
+        runs: Arc<std::sync::atomic::AtomicUsize>,
+        release: Arc<tokio::sync::Notify>,
+    }
+    #[async_trait::async_trait]
+    impl ConversationService for GatedConversations {
+        async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new("c1", title))
+        }
+        async fn list_conversations(
+            &self,
+            _max_age_days: Option<u32>,
+            _include_archived: bool,
+        ) -> Result<Vec<ConversationSummary>, CoreError> {
+            Ok(vec![])
+        }
+        async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new(id.as_str(), "t"))
+        }
+        async fn delete_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn rename_conversation(
+            &self,
+            _id: &ConversationId,
+            _title: String,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn archive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn unarchive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn clear_all_history(&self) -> Result<u32, CoreError> {
+            Ok(0)
+        }
+        async fn send_prompt(
+            &self,
+            _conversation_id: &ConversationId,
+            _prompt: String,
+            mut on_chunk: ChunkCallback,
+            _on_status: StatusCallback,
+        ) -> Result<String, CoreError> {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+            on_chunk("part1 ".to_string());
+            self.release.notified().await;
+            on_chunk("part2".to_string());
+            Ok("part1 part2".to_string())
+        }
+    }
+
+    /// #204 phase 2: a second `SendMessage` with the same key while the first
+    /// is still running in this process re-attaches to the live turn (replay +
+    /// live) instead of running it again. The turn runs exactly once and both
+    /// callers see completion; the re-attacher receives chunks emitted after it
+    /// joined.
+    #[tokio::test]
+    async fn idempotency_inflight_reattach_does_not_rerun() {
+        let runs = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let conv = Arc::new(GatedConversations {
+            runs: Arc::clone(&runs),
+            release: Arc::clone(&release),
+        });
+        let registry = Arc::new(crate::background_tasks::BackgroundTaskRegistry::new());
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            conv,
+            Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        )
+        .with_registry(Arc::clone(&registry));
+
+        let sink1 = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
+        let sink2 = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
+
+        // Request 1 registers the in-flight slot (synchronously) and spawns the
+        // turn, which blocks after its first chunk.
+        let t1 = h
+            .start_send_message(
+                "c1".into(),
+                "hi".into(),
+                None,
+                String::new(),
+                "r1".into(),
+                Some("k1".into()),
+                sink1.clone(),
+            )
+            .await
+            .unwrap()
+            .expect("task 1");
+        // Request 2, same key while #1 is in flight, must re-attach (not rerun).
+        let t2 = h
+            .start_send_message(
+                "c1".into(),
+                "hi".into(),
+                None,
+                String::new(),
+                "r2".into(),
+                Some("k1".into()),
+                sink2.clone(),
+            )
+            .await
+            .unwrap()
+            .expect("task 2");
+
+        release.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(5), registry.wait(&t1))
+            .await
+            .expect("turn finishes");
+        tokio::time::timeout(std::time::Duration::from_secs(5), registry.wait(&t2))
+            .await
+            .expect("re-attach finishes");
+
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "the turn must run exactly once for two same-key requests"
+        );
+
+        let ev1 = sink1.0.lock().await.clone();
+        let ev2 = sink2.0.lock().await.clone();
+        assert!(
+            ev1.iter()
+                .any(|e| matches!(e, api::Event::AssistantCompleted { .. })),
+            "original caller completes"
+        );
+        assert!(
+            ev2.iter()
+                .any(|e| matches!(e, api::Event::AssistantCompleted { .. })),
+            "re-attached caller completes"
+        );
+        let live2: String = ev2
+            .iter()
+            .filter_map(|e| match e {
+                api::Event::AssistantDelta { chunk, .. } => Some(chunk.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            live2.contains("part2"),
+            "re-attacher receives chunks emitted after it joined: {live2:?}"
         );
     }
 }

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -173,15 +173,40 @@ pub trait AssistantCommands: Send + Sync {
         override_selection: Option<api::SendPromptOverride>,
         system_refinement: String,
     ) -> Result<String> {
+        self.send_prompt_idempotent(
+            conversation_id,
+            prompt,
+            override_selection,
+            system_refinement,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`send_prompt_full`](AssistantCommands::send_prompt_full) but with a
+    /// client-supplied **idempotency key** scoped to the conversation (#204).
+    ///
+    /// A retry carrying the same key after a dropped connection is
+    /// de-duplicated by the daemon — re-attached to the still-running turn, or
+    /// (if it already finished) the committed reply replayed — instead of
+    /// re-running the turn and re-processing an action. `None` is identical to
+    /// [`send_prompt_full`]. Every `send_prompt*` method routes through here so
+    /// the ack-handling and wire shape live in one place.
+    async fn send_prompt_idempotent(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        override_selection: Option<api::SendPromptOverride>,
+        system_refinement: String,
+        idempotency_key: Option<String>,
+    ) -> Result<String> {
         let result = self
             .send_command(api::Command::SendMessage {
                 conversation_id: conversation_id.to_string(),
                 content: prompt.to_string(),
                 override_selection,
                 system_refinement,
-                // No idempotency key from this entry point yet — clients that
-                // want safe retry will pass one via a dedicated method (#204).
-                idempotency_key: None,
+                idempotency_key,
             })
             .await?;
         // Post-#114 the daemon returns `SendMessageAck { task_id }` when its
@@ -454,6 +479,61 @@ mod tests {
                 // The override path carries no system refinement.
                 assert!(system_refinement.is_empty());
             }
+            other => panic!("expected Command::SendMessage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_prompt_idempotent_emits_send_message_with_key() {
+        let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            task_id: "task-1".to_string(),
+        });
+
+        let task_id = client
+            .send_prompt_idempotent(
+                "conv-1",
+                "hello",
+                None,
+                String::new(),
+                Some("turn-key-1".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(task_id, "task-1");
+        match client.last() {
+            api::Command::SendMessage {
+                conversation_id,
+                content,
+                idempotency_key,
+                ..
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(content, "hello");
+                assert_eq!(idempotency_key.as_deref(), Some("turn-key-1"));
+            }
+            other => panic!("expected Command::SendMessage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_prompt_full_stays_idempotency_key_free() {
+        // Non-breaking: the existing entry point must keep emitting a key-less
+        // SendMessage so callers that don't opt into idempotency are unchanged.
+        let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            task_id: "t".to_string(),
+        });
+        client
+            .send_prompt_full("c", "hi", None, String::new())
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::SendMessage {
+                idempotency_key, ..
+            } => assert!(
+                idempotency_key.is_none(),
+                "send_prompt_full must not attach an idempotency key"
+            ),
             other => panic!("expected Command::SendMessage, got {other:?}"),
         }
     }

--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -119,6 +119,42 @@ impl Connector {
             self.client.send_prompt(conversation_id, &composed).await
         }
     }
+
+    /// Send a prompt with a per-request system-prompt refinement AND a
+    /// client-supplied **idempotency key** (#204), so a retry after a dropped
+    /// connection re-attaches to the live turn (or replays a completed reply)
+    /// instead of re-running it. Socket transports (UDS / WS) carry both as
+    /// dedicated fields; the D-Bus transport has neither, so it folds the
+    /// refinement into the prompt and drops the key — a dropped D-Bus call
+    /// isn't recoverable this way, so use a socket transport for idempotent
+    /// retry. `idempotency_key = None` behaves like
+    /// [`send_prompt_with_system_refinement`](Self::send_prompt_with_system_refinement).
+    pub async fn send_prompt_with_system_refinement_idempotent(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        system_refinement: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<String> {
+        if let Some(commands) = self.client.as_commands() {
+            commands
+                .send_prompt_idempotent(
+                    conversation_id,
+                    prompt,
+                    None,
+                    system_refinement.to_string(),
+                    idempotency_key,
+                )
+                .await
+        } else {
+            let composed = if system_refinement.trim().is_empty() {
+                prompt.to_string()
+            } else {
+                format!("{system_refinement}\n\n{prompt}")
+            };
+            self.client.send_prompt(conversation_id, &composed).await
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Completes **#204**. Phase 1 (completed-dedup, #209) replays a *finished* turn's reply; this adds the other half — **in-flight re-attach** — plus the client-side hooks the voice service consumes.

A duplicate `SendMessage` carrying the same `idempotency_key` while the original is **still running in this process** (a transient connection blip, no daemon restart) now re-attaches to the live turn — replaying the chunks emitted so far, then forwarding the rest live — instead of running a second turn and double-processing an action.

## How

**Orchestrator — `crates/application/src/inflight.rs` (new):**
- `InFlightTurn` — a per-turn fan-out hub: an append-only event buffer + a live `broadcast`, with buffer-append and broadcast under one lock so a re-attacher snapshots the buffer and subscribes **atomically** (no event duplicated or dropped at the boundary).
- `TeeSink` — mirrors a turn's events to the caller's sink (unchanged behaviour) **and** into the hub.
- `forward_inflight` — replay the buffer, then forward live until the turn ends. Holds only a `Receiver`, never the hub, so it can't keep the channel alive past the turn.
- `InFlightRegistry` — live turns indexed by `(user, conversation, key)` with an atomic register-or-lose claim.

**`start_send_message`:** a keyed `SendMessage` tries, in order: (1) in-flight re-attach, (2) completed-dedup replay (#209), else (3) run fresh through a `TeeSink` and free the slot on completion. The register claim + a lost-race re-attach close the concurrent same-key window.

**client-common (non-breaking — tui/gtk unaffected):**
- `AssistantCommands::send_prompt_idempotent` (full + key); `send_prompt_full` now delegates to it with `None`, so existing callers emit a byte-identical `SendMessage`.
- `Connector::send_prompt_with_system_refinement_idempotent` — the refinement+key convenience the voice service uses.

## Tests

- `inflight` unit tests: buffered-then-live replay, snapshot/subscribe partitioning (exactly-once across the boundary), atomic register-or-lose.
- Handler integration test: two same-key requests run the turn **exactly once** and **both callers complete**; the re-attacher receives chunks emitted after it joined.
- client-common: key-carrying vs key-free sends (and that `send_prompt_full` stays key-free).
- Full `just check` green on the pinned 1.96.0 toolchain.

## Follow-up (separate repo)

Voice consumption (per-turn key + reconnect-and-retry) — adelie-ai/voice#39.

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)