### PR TITLE
fix(#204): restamp request_id on re-attached events so retrying clients correlate

### DIFF
--- a/crates/application/src/inflight.rs
+++ b/crates/application/src/inflight.rs
@@ -93,25 +93,50 @@ impl EventSink for TeeSink {
     }
 }
 
+/// Restamp a forwarded event with the re-attacher's `request_id`.
+///
+/// The live turn emitted its events under the *original* request's id, but the
+/// re-attaching client (a retry) correlates the stream against the id of *its
+/// own* request — exactly as it would for a normal turn (and as completed-dedup
+/// replay already does). Without this, a retrying client like the voice service
+/// (which matches `event.request_id == its_request_id`) would silently ignore
+/// every re-attached event. Only the request-scoped events carry a
+/// `request_id`; conversation-scoped ones pass through untouched.
+fn restamp_request_id(mut event: api::Event, request_id: &str) -> api::Event {
+    match &mut event {
+        api::Event::AssistantDelta { request_id: r, .. }
+        | api::Event::AssistantStatus { request_id: r, .. }
+        | api::Event::AssistantCompleted { request_id: r, .. }
+        | api::Event::AssistantError { request_id: r, .. } => {
+            *r = request_id.to_string();
+        }
+        _ => {}
+    }
+    event
+}
+
 /// Re-attach a sink to a live turn: replay the buffered events, then forward
 /// live events until the turn ends (the hub's sender drops) or the sink
-/// disconnects. Holds only a [`broadcast::Receiver`], never a strong reference
-/// to the [`InFlightTurn`], so it never keeps the hub (and thus the broadcast
-/// channel) alive past the turn it's following.
+/// disconnects. Each forwarded event is restamped with `request_id` (the
+/// re-attacher's request id) so the retrying client correlates the stream the
+/// same way it would a normal turn. Holds only a [`broadcast::Receiver`], never
+/// a strong reference to the [`InFlightTurn`], so it never keeps the hub (and
+/// thus the broadcast channel) alive past the turn it's following.
 pub(crate) async fn forward_inflight(
     replay: Vec<api::Event>,
     mut rx: broadcast::Receiver<api::Event>,
+    request_id: String,
     sink: Arc<dyn EventSink>,
 ) {
     for event in replay {
-        if !sink.emit(event).await {
+        if !sink.emit(restamp_request_id(event, &request_id)).await {
             return;
         }
     }
     loop {
         match rx.recv().await {
             Ok(event) => {
-                if !sink.emit(event).await {
+                if !sink.emit(restamp_request_id(event, &request_id)).await {
                     return;
                 }
             }
@@ -212,6 +237,17 @@ mod tests {
                 })
                 .collect()
         }
+        fn request_ids(&self) -> Vec<String> {
+            self.events
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|e| match e {
+                    api::Event::AssistantDelta { request_id, .. } => Some(request_id.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
     }
     #[async_trait]
     impl EventSink for RecordingSink {
@@ -240,7 +276,12 @@ mod tests {
         let (replay, rx) = turn.snapshot_and_subscribe().await;
         let sink = RecordingSink::new();
         let sink_dyn: Arc<dyn EventSink> = sink.clone();
-        let forward = tokio::spawn(forward_inflight(replay, rx, sink_dyn));
+        let forward = tokio::spawn(forward_inflight(
+            replay,
+            rx,
+            "reattacher-rid".to_string(),
+            sink_dyn,
+        ));
 
         // More chunks emitted after re-attach arrive live.
         turn.emit_event(delta("c")).await;
@@ -251,6 +292,10 @@ mod tests {
         forward.await.unwrap();
 
         assert_eq!(sink.delta_chunks(), vec!["a", "b", "c", "d"]);
+        assert!(
+            sink.request_ids().iter().all(|r| r == "reattacher-rid"),
+            "every re-attached event is restamped with the re-attacher's request id"
+        );
     }
 
     #[tokio::test]
@@ -264,7 +309,7 @@ mod tests {
 
         let sink = RecordingSink::new();
         let sink_dyn: Arc<dyn EventSink> = sink.clone();
-        let forward = tokio::spawn(forward_inflight(replay, rx, sink_dyn));
+        let forward = tokio::spawn(forward_inflight(replay, rx, "rid".to_string(), sink_dyn));
         drop(turn);
         forward.await.unwrap();
 

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -453,6 +453,7 @@ where
         registry: &BackgroundTaskRegistry,
         user_id: UserId,
         conversation_id: &str,
+        request_id: &str,
         sink: Arc<dyn EventSink>,
         turn: Arc<InFlightTurn>,
     ) -> api::TaskId {
@@ -461,8 +462,11 @@ where
             conversation_id: conversation_id.to_string(),
         };
         let title = format!("Conversation: {conversation_id}");
+        // Restamp forwarded events with this (the re-attacher's) request id so
+        // the retrying client correlates the stream like a normal turn.
+        let request_id = request_id.to_string();
         registry.spawn(user_id, kind, title, move |_ctx| async move {
-            forward_inflight(replay, rx, sink).await;
+            forward_inflight(replay, rx, request_id, sink).await;
             Ok(())
         })
     }
@@ -1594,6 +1598,7 @@ where
                     &registry,
                     user_id,
                     &conversation_id,
+                    &request_id,
                     Arc::clone(&sink),
                     turn,
                 )
@@ -1638,6 +1643,7 @@ where
                             &registry,
                             user_id,
                             &conversation_id,
+                            &request_id,
                             Arc::clone(&sink),
                             turn,
                         )
@@ -3948,9 +3954,12 @@ mod tests {
             "original caller completes"
         );
         assert!(
-            ev2.iter()
-                .any(|e| matches!(e, api::Event::AssistantCompleted { .. })),
-            "re-attached caller completes"
+            ev2.iter().any(|e| matches!(
+                e,
+                api::Event::AssistantCompleted { request_id, .. } if request_id == "r2"
+            )),
+            "re-attached caller completes, with events restamped to ITS request id (r2), \
+             not the original turn's (r1) — so a request_id-correlating client matches them"
         );
         let live2: String = ev2
             .iter()


### PR DESCRIPTION
## What

The phase-2 in-flight re-attach path forwarded the **original** turn's `request_id` to a re-attaching client. But streaming clients correlate a response against the `request_id` of **their own** request — the voice service matches `event.request_id == its_request_id` (`pipeline.rs`) — so a re-attacher would silently ignore every forwarded event, defeating re-attach.

Completed-dedup replay already restamps with the retry's `request_id`; this brings re-attach in line.

## How

- `forward_inflight` restamps each forwarded request-scoped event (`AssistantDelta` / `AssistantStatus` / `AssistantCompleted` / `AssistantError`) with the re-attacher's `request_id`; conversation-scoped events pass through untouched.
- `spawn_reattach` threads the re-attacher's `request_id` through.

This preserves the same `(events ↔ ack)` correlation relationship a normal turn has, so a request_id-correlating client matches the re-attached stream exactly as it would a fresh turn.

## Why now

Latent until a client actually sends idempotency keys (so re-attach is currently unreachable in production), but it's a prerequisite for the voice service's idempotent retry (adelie-ai/voice#39).

## Tests

- The re-attach integration test now asserts the re-attacher's events carry **its** request id (`r2`), not the original turn's (`r1`).
- A unit test asserts forwarded events are restamped.
- Full `just check` green.

Relates to #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)