### PR TITLE
Use the scratchpad selectively, not on every turn (#216)

### DIFF
--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -34,6 +34,10 @@ Writing:
 == Scratchpad ==
 The scratchpad (builtin_scratchpad_write/search/delete) is an ephemeral, per-conversation notepad. Use it to keep working facts high in context for THIS conversation only: an evolving plan, open questions, a working set of facts or IDs, intermediate results. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base. Notes are keyed; writing the same key replaces it. Batch several at once with notes: [{key, content}].
 
+When to use it — be selective:
+- Use it ONLY when you genuinely need to carry information forward across a large or multi-step task: a multi-step plan you're working through, findings/notes from an investigation you'll reference later, intermediate results you must hold across many turns or tool calls.
+- For small, one-shot tasks — a single question, a quick lookup, a one-line action — do NOT touch the scratchpad. Just answer or act. Writing notes you'll never reread is noise.
+
 Current goal:
 - Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
 - Evolve it as the objective shifts; clear it when the task is done.

--- a/crates/core/src/prompts/sections/scratchpad.txt
+++ b/crates/core/src/prompts/sections/scratchpad.txt
@@ -1,6 +1,10 @@
 == Scratchpad ==
 The scratchpad (builtin_scratchpad_write/search/delete) is an ephemeral, per-conversation notepad. Use it to keep working facts high in context for THIS conversation only: an evolving plan, open questions, a working set of facts or IDs, intermediate results. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base. Notes are keyed; writing the same key replaces it. Batch several at once with notes: [{key, content}].
 
+When to use it — be selective:
+- Use it ONLY when you genuinely need to carry information forward across a large or multi-step task: a multi-step plan you're working through, findings/notes from an investigation you'll reference later, intermediate results you must hold across many turns or tool calls.
+- For small, one-shot tasks — a single question, a quick lookup, a one-line action — do NOT touch the scratchpad. Just answer or act. Writing notes you'll never reread is noise.
+
 Current goal:
 - Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
 - Evolve it as the objective shifts; clear it when the task is done.

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -391,7 +391,12 @@ impl BuiltinToolService {
                 TOOL_SCRATCHPAD_WRITE,
                 "Add or update notes in this conversation's scratchpad — an ephemeral, \
                  per-conversation working store for facts you want to keep high in context \
-                 right now (an evolving plan, open questions, a working set of IDs). Notes are \
+                 right now (an evolving plan, open questions, a working set of IDs). Use it \
+                 SELECTIVELY: only when you need to carry information forward across a large or \
+                 multi-step task (a multi-step plan, investigation notes you'll reference later, \
+                 intermediate results held across many turns). For small one-shot tasks — a \
+                 single question, quick lookup, or one-line action — don't write here; just \
+                 answer or act. Notes are \
                  keyed; writing the same key again replaces it. Pass `notes` to upsert several \
                  at once. Use the reserved key 'goal' for the current objective: it is \
                  auto-surfaced as your task anchor every turn (so it survives compaction), and \


### PR DESCRIPTION
## What

Guidance/prompt change so the assistant stops journaling to its conversation scratchpad on every turn. It should reach for the scratchpad **only** when it genuinely needs to carry information forward across a **large / multi-step** task; for small one-shot tasks it should just answer/act.

This is a prompt/guidance change only — scratchpad storage, schema, commands, and events (#184/#185/#189/#193) are untouched.

## Changes

- `crates/core/src/prompts/sections/scratchpad.txt` and `crates/core/src/prompts/runtime_system_instruction.txt`: added a concise **"When to use it — be selective"** block with the large-vs-small distinction and brief examples (multi-step plan / investigation notes / carried-forward results vs. single question / quick lookup / one-line action). The two files are kept byte-identical so the existing `assembled_static_sections_match_original` test still holds.
- `crates/mcp-client/src/builtin.rs`: softened the `builtin_scratchpad_write` tool description so the tool itself nudges toward selective use ("use SELECTIVELY ... for small one-shot tasks, don't write here; just answer or act") instead of "facts you want to keep high in context right now."

## Validation

`just check` (fmt + clippy `--workspace --all-targets -D warnings` + build + test) — GREEN, 0 warnings, all tests pass including the prompt-assembly equality test.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)