### PR TITLE
fix(voice#49): carry turn request_id in SendMessageAck so socket clients correlate streamed responses

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -401,10 +401,23 @@ pub enum CommandResult {
     BackgroundTaskSpawned {
         id: String,
     },
-    /// Ack for `SendMessage`, carrying the registered task id so callers can
-    /// correlate the streamed `Task*` events back to the request. Introduced
-    /// alongside the background-task registry so we don't overload `Ack`.
+    /// Ack for `SendMessage`, carrying both correlation ids the streamed
+    /// events use:
+    ///
+    /// - `request_id` — stamped on every `AssistantDelta` / `AssistantCompleted`
+    ///   / `AssistantError` event for THIS turn. Socket clients (UDS / WS) match
+    ///   streamed response events to their send by this id, exactly as the
+    ///   D-Bus `SendPrompt` reply does. This is the field a streaming client
+    ///   wants (voice#49).
+    /// - `task_id` — the registered background-task id, used to correlate the
+    ///   `Task*` lifecycle events and to drive the process-manager UI / Cancel.
+    ///
+    /// Introduced alongside the background-task registry so we don't overload
+    /// `Ack`; `request_id` was added in voice#49 so socket clients can correlate
+    /// streamed responses (the dispatcher generates a turn `request_id` distinct
+    /// from the `task_id`, and the events carry the former).
     SendMessageAck {
+        request_id: String,
         task_id: String,
     },
 
@@ -1670,15 +1683,20 @@ mod tests {
     }
 
     #[test]
-    fn send_message_ack_carries_task_id() {
-        // Golden-file test for the new SendMessageAck shape: callers must be
-        // able to correlate the ack to the registered background task.
+    fn send_message_ack_carries_request_and_task_ids() {
+        // Golden-file test for the SendMessageAck shape: callers must be able
+        // to correlate the ack to BOTH the streamed response events
+        // (`request_id`, voice#49) and the registered background task
+        // (`task_id`).
         let res = CommandResult::SendMessageAck {
+            request_id: "req-xyz".into(),
             task_id: "task-abc".into(),
         };
         let v: serde_json::Value = serde_json::to_value(&res).unwrap();
-        let expected: serde_json::Value =
-            serde_json::from_str(r#"{"send_message_ack":{"task_id":"task-abc"}}"#).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"send_message_ack":{"request_id":"req-xyz","task_id":"task-abc"}}"#,
+        )
+        .unwrap();
         assert_eq!(v, expected);
         let back: CommandResult = serde_json::from_value(v).unwrap();
         assert_eq!(res, back);

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -209,13 +209,19 @@ pub trait AssistantCommands: Send + Sync {
                 idempotency_key,
             })
             .await?;
-        // Post-#114 the daemon returns `SendMessageAck { task_id }` when its
-        // handler is wired with a `BackgroundTaskRegistry`; older / test
-        // daemons may still return the legacy bare `Ack`. Both are valid
-        // wire-level acks for this call site — the task id is surfaced via
-        // streaming events, not the ack.
+        // The daemon replies with `SendMessageAck { request_id, task_id }`. We
+        // return the `request_id` — the id every streamed `AssistantDelta` /
+        // `AssistantCompleted` / `AssistantError` event for this turn is
+        // stamped with — so a streaming client can correlate the response back
+        // to its send (voice#49). The `task_id` (background-task id, used to
+        // correlate `Task*` events / drive Cancel) is not what a response
+        // stream is keyed on, so it is intentionally not the return value here.
+        //
+        // A legacy / pre-#114 daemon that still replies with a bare `Ack`
+        // carries no correlation id; we surface an empty string as before
+        // (such a client falls back to matching events loosely).
         match result {
-            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
+            api::CommandResult::SendMessageAck { request_id, .. } => Ok(request_id),
             api::CommandResult::Ack => Ok(String::new()),
             other => Err(anyhow!("unexpected response for send_prompt: {other:?}")),
         }
@@ -450,6 +456,7 @@ mod tests {
     #[tokio::test]
     async fn send_prompt_with_override_emits_send_message_with_override() {
         let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            request_id: "req-1".to_string(),
             task_id: "task-1".to_string(),
         });
         let override_selection = Some(api::SendPromptOverride {
@@ -458,12 +465,14 @@ mod tests {
             effort: None,
         });
 
-        let task_id = client
+        let returned = client
             .send_prompt_with_override("conv-1", "hello", override_selection.clone())
             .await
             .unwrap();
 
-        assert_eq!(task_id, "task-1");
+        // The send returns the turn `request_id` (what streamed events carry),
+        // not the `task_id` (voice#49).
+        assert_eq!(returned, "req-1");
         match client.last() {
             api::Command::SendMessage {
                 conversation_id,
@@ -486,10 +495,11 @@ mod tests {
     #[tokio::test]
     async fn send_prompt_idempotent_emits_send_message_with_key() {
         let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            request_id: "req-1".to_string(),
             task_id: "task-1".to_string(),
         });
 
-        let task_id = client
+        let returned = client
             .send_prompt_idempotent(
                 "conv-1",
                 "hello",
@@ -500,7 +510,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(task_id, "task-1");
+        // Returns the correlation `request_id`, not the `task_id` (voice#49).
+        assert_eq!(returned, "req-1");
         match client.last() {
             api::Command::SendMessage {
                 conversation_id,
@@ -521,6 +532,7 @@ mod tests {
         // Non-breaking: the existing entry point must keep emitting a key-less
         // SendMessage so callers that don't opt into idempotency are unchanged.
         let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            request_id: "r".to_string(),
             task_id: "t".to_string(),
         });
         client
@@ -541,10 +553,11 @@ mod tests {
     #[tokio::test]
     async fn send_prompt_with_system_refinement_emits_send_message_with_refinement() {
         let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            request_id: "req-3".to_string(),
             task_id: "task-3".to_string(),
         });
 
-        let task_id = client
+        let returned = client
             .send_prompt_with_system_refinement(
                 "conv-1",
                 "what's the weather?",
@@ -553,7 +566,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(task_id, "task-3");
+        // Returns the correlation `request_id`, not the `task_id` (voice#49).
+        assert_eq!(returned, "req-3");
         match client.last() {
             api::Command::SendMessage {
                 conversation_id,
@@ -616,11 +630,12 @@ mod tests {
         // reached as via `TransportClient::as_commands`), not only on a
         // concrete `WsClient`.
         let client = RecordingClient::new(api::CommandResult::SendMessageAck {
+            request_id: "req-2".to_string(),
             task_id: "task-2".to_string(),
         });
         let commands: &dyn AssistantCommands = &client;
 
-        let task_id = commands
+        let returned = commands
             .send_prompt_with_override(
                 "conv-2",
                 "hi",
@@ -632,7 +647,8 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(task_id, "task-2");
+        // Returns the correlation `request_id`, not the `task_id` (voice#49).
+        assert_eq!(returned, "req-2");
         assert!(matches!(
             client.last(),
             api::Command::SendMessage {

--- a/crates/client-common/tests/uds_streaming.rs
+++ b/crates/client-common/tests/uds_streaming.rs
@@ -1,0 +1,279 @@
+//! Regression test for voice#49: streamed response events must reach a UDS
+//! client AND be correlatable to the send.
+//!
+//! The bug: over the socket transports (UDS / WS) the dispatcher generates a
+//! turn `request_id` (which every streamed `AssistantDelta` / `AssistantCompleted`
+//! event is stamped with) that was *different* from the id the `SendMessage`
+//! ack returned (the registry `task_id`). A streaming client (voice) filters
+//! response events by the id its `send_prompt` returned, so with mismatched ids
+//! every event was dropped and the turn hung in `Processing`. The D-Bus path
+//! worked because its `SendPrompt` reply returns the same id its signals carry.
+//!
+//! The fix makes `SendMessageAck` carry the turn `request_id`, and the client's
+//! `send_prompt*` returns it — so `returned_id == streamed_event.request_id`.
+//!
+//! These tests spin up the real `desktop-assistant-uds` server in-process with
+//! a handler that mimics the production registry path (returns `Some(task_id)`,
+//! streams events from a background task through the per-connection sink), then
+//! connect through `client-common`'s public `connect_transport`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::{ApiResult, AssistantApiHandler, EventSink};
+use desktop_assistant_auth_jwt as jwt;
+use desktop_assistant_client_common::{
+    AssistantClient, ConnectionConfig, Connector, SignalEvent, TransportMode, connect_transport,
+};
+use desktop_assistant_uds::{UdsAuthValidator, UdsServer, UdsServerConfig};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::time::{Duration, timeout};
+
+const ISS: &str = "test-uds-iss";
+const AUD: &str = "test-uds-aud";
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn mint_test_jwt(signing_key: &str, subject: &str) -> String {
+    let now = unix_now();
+    let claims = jwt::Claims {
+        iss: ISS.into(),
+        sub: subject.into(),
+        aud: AUD.into(),
+        exp: now + 600,
+        iat: now,
+        nbf: now.saturating_sub(1),
+        jti: uuid::Uuid::new_v4().to_string(),
+    };
+    jwt::encode(&claims, signing_key).expect("encode jwt")
+}
+
+/// Mimics the production registry path: returns `Some(task_id)` so the
+/// dispatcher replies with `SendMessageAck`, then streams events from a
+/// background task through the per-connection sink — stamping each event with
+/// the dispatcher-supplied `request_id` (NOT the task_id), exactly as the real
+/// `run_send_turn` does.
+struct RegistryStreamingHandler;
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for RegistryStreamingHandler {
+    async fn handle_command(&self, _cmd: api::Command) -> ApiResult<api::CommandResult> {
+        Ok(api::CommandResult::Ack)
+    }
+
+    async fn handle_send_message(
+        &self,
+        _conversation_id: String,
+        _content: String,
+        _request_id: String,
+        _sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+
+    async fn start_send_message(
+        &self,
+        conversation_id: String,
+        _content: String,
+        _override_selection: Option<api::SendPromptOverride>,
+        _system_refinement: String,
+        request_id: String,
+        _idempotency_key: Option<String>,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<Option<api::TaskId>> {
+        // The task_id is deliberately DIFFERENT from the request_id, just like
+        // production — this is what regresses voice#49 if the ack returned the
+        // task_id instead of the request_id.
+        let task_id = api::TaskId(uuid::Uuid::new_v4().to_string());
+        tokio::spawn(async move {
+            sink.emit(api::Event::AssistantDelta {
+                conversation_id: conversation_id.clone(),
+                request_id: request_id.clone(),
+                chunk: "hel".into(),
+            })
+            .await;
+            sink.emit(api::Event::AssistantDelta {
+                conversation_id: conversation_id.clone(),
+                request_id: request_id.clone(),
+                chunk: "lo".into(),
+            })
+            .await;
+            sink.emit(api::Event::AssistantCompleted {
+                conversation_id,
+                request_id,
+                full_response: "hello".into(),
+            })
+            .await;
+        });
+        Ok(Some(task_id))
+    }
+}
+
+struct StaticJwtAuth {
+    signing_key: String,
+}
+
+#[async_trait::async_trait]
+impl UdsAuthValidator for StaticJwtAuth {
+    async fn validate_bearer_token(&self, token: &str) -> bool {
+        jwt::decode(token, &self.signing_key, ISS, AUD).is_ok()
+    }
+}
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if path.exists() && UnixStream::connect(path).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("uds socket {path:?} did not appear");
+}
+
+fn uds_config(socket_path: PathBuf, jwt: String) -> ConnectionConfig {
+    ConnectionConfig {
+        transport_mode: TransportMode::Uds,
+        socket_path: Some(socket_path),
+        ws_jwt: Some(jwt),
+        ..ConnectionConfig::default()
+    }
+}
+
+fn start_server(socket_path: PathBuf, signing_key: String) -> tokio::sync::oneshot::Sender<()> {
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(RegistryStreamingHandler);
+    let auth: Arc<dyn UdsAuthValidator> = Arc::new(StaticJwtAuth { signing_key });
+    let config = UdsServerConfig::new(socket_path);
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server = UdsServer::new(handler, auth, config);
+    tokio::spawn(async move {
+        let _ = server
+            .serve_with_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    tx
+}
+
+/// The core voice#49 assertion at the raw-transport level: streamed response
+/// events reach a UDS client, AND the id `send_prompt` returns is the SAME id
+/// those events carry (so a client filtering by that id sees its response).
+#[tokio::test]
+async fn uds_streamed_response_is_correlatable_to_the_send() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let shutdown = start_server(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    let (client, mut signals) = connect_transport(&cfg).await.expect("connect over uds");
+
+    let returned_id = timeout(Duration::from_secs(2), client.send_prompt("conv-1", "hi"))
+        .await
+        .expect("send_prompt should ack")
+        .expect("ack ok");
+    assert!(
+        !returned_id.is_empty(),
+        "send_prompt must return the turn request_id, not an empty string"
+    );
+
+    // Read events; every response event's request_id MUST equal the id the
+    // send returned — otherwise a client filtering by it (voice) drops them.
+    let mut chunks = String::new();
+    let mut got_complete = false;
+    for _ in 0..10 {
+        match timeout(Duration::from_secs(2), signals.recv()).await {
+            Ok(Some(SignalEvent::Chunk { request_id, chunk })) => {
+                assert_eq!(
+                    request_id, returned_id,
+                    "chunk request_id must match the id send_prompt returned (voice#49)"
+                );
+                chunks.push_str(&chunk);
+            }
+            Ok(Some(SignalEvent::Complete {
+                request_id,
+                full_response,
+            })) => {
+                assert_eq!(
+                    request_id, returned_id,
+                    "complete request_id must match the id send_prompt returned (voice#49)"
+                );
+                assert_eq!(full_response, "hello");
+                got_complete = true;
+                break;
+            }
+            Ok(Some(_other)) => {}
+            Ok(None) => panic!("signal stream closed before completion"),
+            Err(_) => panic!("timed out waiting for a response event (chunks so far: {chunks:?})"),
+        }
+    }
+    assert_eq!(chunks, "hello", "expected streamed chunks");
+    assert!(got_complete, "expected the Complete event");
+
+    let _ = shutdown.send(());
+}
+
+/// Same assertion exercised through the high-level [`Connector`] — the exact
+/// path the voice service uses (subscribe before send, then read the fanned-out
+/// signal stream and filter by the returned id).
+#[tokio::test]
+async fn connector_over_uds_delivers_correlated_response() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let shutdown = start_server(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    let connector = Connector::connect(&cfg).await.expect("connector over uds");
+
+    // Subscribe BEFORE sending (the voice pipeline's ordering) so no early
+    // chunk is lost.
+    let mut events = connector.subscribe();
+
+    let returned_id = timeout(
+        Duration::from_secs(2),
+        connector.send_prompt("conv-1", "hi"),
+    )
+    .await
+    .expect("send_prompt should ack")
+    .expect("ack ok");
+
+    let mut chunks = String::new();
+    let mut got_complete = false;
+    for _ in 0..10 {
+        match timeout(Duration::from_secs(2), events.recv()).await {
+            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
+                chunks.push_str(&chunk)
+            }
+            Ok(Some(SignalEvent::Complete {
+                request_id,
+                full_response,
+            })) if request_id == returned_id => {
+                assert_eq!(full_response, "hello");
+                got_complete = true;
+                break;
+            }
+            // Events for a different request id would be dropped by a real
+            // client's filter — the regression we're guarding against.
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("connector signal stream closed before completion"),
+            Err(_) => panic!("timed out waiting for a correlated response event"),
+        }
+    }
+    assert_eq!(
+        chunks, "hello",
+        "connector must deliver the streamed chunks"
+    );
+    assert!(got_complete, "connector must deliver the Complete event");
+
+    let _ = shutdown.send(());
+}

--- a/crates/client-common/tests/uds_transport.rs
+++ b/crates/client-common/tests/uds_transport.rs
@@ -171,21 +171,27 @@ async fn uds_transport_exposes_command_channel_via_as_commands() {
         .expect("as_commands must be Some for a UDS transport");
 
     // Per-conversation model override over UDS. The TestHandler uses the
-    // legacy `Ack` send path, so the returned task id is empty — the point is
-    // that the command reaches the daemon over the local socket at all.
+    // legacy (no-registry) send path, which the dispatcher now acks with a
+    // `SendMessageAck` carrying the turn `request_id` (and an empty task_id) so
+    // the response stream is correlatable even here (voice#49). The point of
+    // this test is that the command reaches the daemon over the local socket at
+    // all, so we just assert a correlation id came back.
     let override_selection = Some(api::SendPromptOverride {
         connection_id: "conn-1".to_string(),
         model_id: "model-1".to_string(),
         effort: None,
     });
-    let task_id = timeout(
+    let request_id = timeout(
         Duration::from_secs(2),
         commands.send_prompt_with_override("conv-1", "hi", override_selection),
     )
     .await
     .expect("no response within 2s")
     .expect("send_prompt_with_override over uds");
-    assert_eq!(task_id, String::new());
+    assert!(
+        !request_id.is_empty(),
+        "the legacy send path must still return a turn request_id (voice#49)"
+    );
 
     // Model listing over UDS.
     let models = timeout(

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -77,13 +77,18 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
 
         match result {
             api::CommandResult::Ack => {
-                // Daemon hasn't told us the request id yet — events
-                // will carry it. Use a placeholder so clients have
-                // something to log against; the events flowing through
-                // the forwarder carry the daemon's correlation id.
+                // Legacy bare `Ack`: the daemon told us no correlation id, so
+                // use a placeholder for the caller to log against. (The events
+                // flowing through the forwarder carry the daemon's own
+                // correlation id, which a bare-Ack daemon never surfaced here.)
                 Ok(uuid::Uuid::new_v4().to_string())
             }
-            api::CommandResult::SendMessageAck { task_id } => Ok(task_id),
+            // Return the turn `request_id` — the id every streamed `Assistant*`
+            // event carries — so the D-Bus caller can correlate the response
+            // events the bridge forwards (voice#49). The `task_id` keys `Task*`
+            // events, not the response stream, so it is not the value to hand
+            // back here.
+            api::CommandResult::SendMessageAck { request_id, .. } => Ok(request_id),
             other => Err(fdo::Error::Failed(format!(
                 "unexpected SendMessage result: {other:?}"
             ))),
@@ -376,6 +381,7 @@ mod tests {
         ) -> Result<api::CommandResult, BridgeTransportError> {
             self.commands.lock().await.push(command);
             Ok(api::CommandResult::SendMessageAck {
+                request_id: "req-1".to_string(),
                 task_id: "task-1".to_string(),
             })
         }
@@ -400,15 +406,18 @@ mod tests {
         let transport = Arc::new(RecordingTransport::new());
         let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
 
-        let task_id = adapter
+        let request_id = adapter
             .send_prompt_with_system_refinement(
                 "conv-1",
                 "what's the weather?",
                 "Respond briefly, by voice.",
             )
             .await
-            .expect("send returns the daemon task id");
-        assert_eq!(task_id, "task-1");
+            .expect("send returns the daemon correlation id");
+        // The adapter returns the turn `request_id` (what streamed events carry,
+        // so the D-Bus caller can correlate the response), not the `task_id`
+        // (voice#49).
+        assert_eq!(request_id, "req-1");
 
         let commands = transport.commands.lock().await;
         assert_eq!(commands.len(), 1, "exactly one command dispatched");

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -87,9 +87,13 @@ impl EventSink for ChannelEventSink {
 /// Behavior preserved from the old WS `handle_socket`:
 ///
 /// - Each [`WsRequest::command`] is dispatched through `handler`.
-/// - `SendMessage` is streamed: an immediate `Ack` result frame, then
-///   `AssistantDelta` / `AssistantCompleted` / `AssistantError` events,
-///   forwarded through a [`ChannelEventSink`] into the outbound channel.
+/// - `SendMessage` is streamed: an immediate `SendMessageAck` result frame
+///   carrying the turn `request_id` (and, when a registry is attached, the
+///   `task_id`), then `AssistantDelta` / `AssistantCompleted` /
+///   `AssistantError` events stamped with that same `request_id`, forwarded
+///   through a [`ChannelEventSink`] into the outbound channel. The ack's
+///   `request_id` is what a socket client correlates its response stream by,
+///   mirroring the D-Bus `SendPrompt` reply (voice#49).
 /// - `SetConfig` emits both a `Result` and a `ConfigChanged` event on
 ///   success.
 /// - Other commands round-trip through `handler.handle_command` and
@@ -166,8 +170,12 @@ pub async fn dispatch_loop<R, W>(
                 // path so the ack can carry the registered task id
                 // (#114). When the handler opts out (no registry
                 // attached — single-tenant tests and the like) we
-                // fall back to the legacy bare-`Ack` + inline
-                // streaming path that pre-#114 transports used.
+                // fall back to the inline-streaming path that pre-#114
+                // transports used. Either way the ack is a
+                // `SendMessageAck` carrying the turn `request_id` that
+                // streamed events are stamped with, so a socket client
+                // can correlate the response (voice#49); the legacy path
+                // simply leaves `task_id` empty.
                 let task_id = with_user_id(
                     user_id.clone(),
                     handler.start_send_message(
@@ -187,11 +195,20 @@ pub async fn dispatch_loop<R, W>(
                         // Handler registered the turn via the registry
                         // and the body is already running in the
                         // background — emit the new typed ack and
-                        // continue the loop.
+                        // continue the loop. The ack carries BOTH the
+                        // turn `request_id` (which every streamed
+                        // `Assistant*` event is stamped with) and the
+                        // registry `task_id` (which the `Task*` events
+                        // carry), so a socket client can correlate the
+                        // streamed RESPONSE back to its send the same way
+                        // the D-Bus `SendPrompt` reply does (voice#49).
                         if out_tx
                             .send(WsFrame::Result {
                                 id: req.id.clone(),
-                                result: api::CommandResult::SendMessageAck { task_id: id.0 },
+                                result: api::CommandResult::SendMessageAck {
+                                    request_id: request_id.clone(),
+                                    task_id: id.0,
+                                },
                             })
                             .await
                             .is_err()
@@ -200,13 +217,20 @@ pub async fn dispatch_loop<R, W>(
                         }
                     }
                     Ok(None) => {
-                        // Legacy path: ack first, then drive the
-                        // streaming send on a spawned task so the
-                        // dispatcher remains responsive.
+                        // Legacy path (no registry attached — single-tenant
+                        // tests and the like): ack first, then drive the
+                        // streaming send on a spawned task so the dispatcher
+                        // remains responsive. The ack still carries the turn
+                        // `request_id` (with an empty `task_id`, since no task
+                        // was registered) so a socket client can correlate the
+                        // streamed response even on this path (voice#49).
                         if out_tx
                             .send(WsFrame::Result {
                                 id: req.id.clone(),
-                                result: api::CommandResult::Ack,
+                                result: api::CommandResult::SendMessageAck {
+                                    request_id: request_id.clone(),
+                                    task_id: String::new(),
+                                },
                             })
                             .await
                             .is_err()

--- a/crates/transport-dispatch/tests/background_task_wiring.rs
+++ b/crates/transport-dispatch/tests/background_task_wiring.rs
@@ -9,9 +9,11 @@
 //! - Subscribe is idempotent at the per-connection level — a second
 //!   Subscribe on a connection that already has a live forwarder Acks
 //!   without leaking a second receiver.
-//! - SendMessage's response carries `SendMessageAck { task_id }` when
-//!   the handler registered the turn with the registry; the legacy bare
-//!   `Ack` is preserved for handlers that don't opt into registration.
+//! - SendMessage's response carries `SendMessageAck { request_id, task_id }`:
+//!   the `task_id` when the handler registered the turn with the registry, and
+//!   the turn `request_id` (which streamed events are stamped with) on both the
+//!   registry and the legacy paths so a socket client can correlate the
+//!   response stream (voice#49).
 //! - When the handler exposes no broadcast hook (no registry attached)
 //!   Subscribe surfaces a clean error frame rather than spawning a dead
 //!   forwarder.
@@ -402,8 +404,10 @@ async fn connection_drop_cancels_event_subscription_cleanly() {
 }
 
 /// SendMessage with a handler that registers via `start_send_message`
-/// produces `SendMessageAck { task_id }` — and the id matches a row in
-/// the registry.
+/// produces `SendMessageAck { request_id, task_id }` — the `task_id`
+/// matches a row in the registry, and the `request_id` (the id streamed
+/// `Assistant*` events are stamped with) is present so a socket client can
+/// correlate the response stream (voice#49).
 #[tokio::test]
 async fn send_message_ack_carries_a_real_task_id() {
     let registry = Arc::new(BackgroundTaskRegistry::new());
@@ -429,9 +433,20 @@ async fn send_message_ack_carries_a_real_task_id() {
     let task_id = match frame {
         WsFrame::Result {
             id,
-            result: api::CommandResult::SendMessageAck { task_id },
+            result:
+                api::CommandResult::SendMessageAck {
+                    request_id,
+                    task_id,
+                },
         } => {
             assert_eq!(id, "send-1");
+            // The ack must carry a non-empty turn correlation id (voice#49):
+            // it is what every streamed `Assistant*` event is keyed on, so a
+            // socket client matches its response stream by this id.
+            assert!(
+                !request_id.is_empty(),
+                "registry-path ack must carry the turn request_id"
+            );
             api::TaskId(task_id)
         }
         other => panic!("expected SendMessageAck, got {other:?}"),
@@ -444,13 +459,17 @@ async fn send_message_ack_carries_a_real_task_id() {
 }
 
 /// When the handler does NOT opt into `start_send_message` (default impl
-/// returns `None`), the dispatcher falls back to the legacy bare-Ack
-/// flow so existing transports keep working.
+/// returns `None`), the dispatcher falls back to the legacy inline-streaming
+/// flow so existing transports keep working. The ack still carries the turn
+/// `request_id` (with an empty `task_id`, since no task was registered) so a
+/// socket client can correlate the streamed response on this path too
+/// (voice#49).
 #[tokio::test]
 async fn send_message_falls_back_to_legacy_ack_when_handler_opts_out() {
     /// Stub that only implements `handle_send_message` (no
     /// `start_send_message` override) — the dispatcher should not panic
-    /// and should send `CommandResult::Ack` back.
+    /// and should send a `SendMessageAck` carrying the turn request_id and
+    /// an empty task_id.
     struct LegacyHandler;
     #[async_trait::async_trait]
     impl AssistantApiHandler for LegacyHandler {
@@ -487,9 +506,25 @@ async fn send_message_falls_back_to_legacy_ack_when_handler_opts_out() {
     match frame {
         WsFrame::Result {
             id,
-            result: api::CommandResult::Ack,
-        } => assert_eq!(id, "send-2"),
-        other => panic!("expected legacy Ack, got {other:?}"),
+            result:
+                api::CommandResult::SendMessageAck {
+                    request_id,
+                    task_id,
+                },
+        } => {
+            assert_eq!(id, "send-2");
+            // Legacy path: a turn request_id is present (so the response stream
+            // can be correlated) but no background task was registered.
+            assert!(
+                !request_id.is_empty(),
+                "legacy-path ack must still carry the turn request_id"
+            );
+            assert!(
+                task_id.is_empty(),
+                "legacy path registers no task, so task_id is empty"
+            );
+        }
+        other => panic!("expected SendMessageAck on the legacy path, got {other:?}"),
     }
 
     let _ = handle.await;
@@ -587,4 +622,119 @@ async fn subscribe_is_idempotent_per_connection() {
 
     drop(in_tx);
     let _ = dispatch.await;
+}
+
+/// voice#49 regression at the dispatcher level: the `request_id` in the
+/// `SendMessageAck` MUST equal the `request_id` stamped on the streamed
+/// `AssistantDelta` / `AssistantCompleted` events. A socket client correlates
+/// its response stream by the ack's id, so if these diverge (as they did when
+/// the ack returned the registry `task_id` instead) every event is dropped and
+/// the turn hangs.
+#[tokio::test]
+async fn send_message_ack_request_id_matches_streamed_event_request_id() {
+    /// Streams two deltas + a completed event, each stamped with the
+    /// dispatcher-supplied `request_id`, from a background task — mirroring
+    /// the production registry path.
+    struct StreamingHandler;
+    #[async_trait::async_trait]
+    impl AssistantApiHandler for StreamingHandler {
+        async fn handle_command(&self, _cmd: api::Command) -> ApiResult<api::CommandResult> {
+            Err(ApiError::Unsupported)
+        }
+        async fn handle_send_message(
+            &self,
+            _c: String,
+            _t: String,
+            _r: String,
+            _s: Arc<dyn EventSink>,
+        ) -> ApiResult<()> {
+            Ok(())
+        }
+        async fn start_send_message(
+            &self,
+            conversation_id: String,
+            _content: String,
+            _override_selection: Option<api::SendPromptOverride>,
+            _system_refinement: String,
+            request_id: String,
+            _idempotency_key: Option<String>,
+            sink: Arc<dyn EventSink>,
+        ) -> ApiResult<Option<api::TaskId>> {
+            // task_id is deliberately a different uuid than request_id.
+            let task_id = api::TaskId(uuid::Uuid::new_v4().to_string());
+            tokio::spawn(async move {
+                sink.emit(api::Event::AssistantDelta {
+                    conversation_id: conversation_id.clone(),
+                    request_id: request_id.clone(),
+                    chunk: "hi".into(),
+                })
+                .await;
+                sink.emit(api::Event::AssistantCompleted {
+                    conversation_id,
+                    request_id,
+                    full_response: "hi".into(),
+                })
+                .await;
+            });
+            Ok(Some(task_id))
+        }
+    }
+
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(StreamingHandler);
+    let (mut out_rx, handle) = drive(
+        handler,
+        user("alice"),
+        vec![WsRequest {
+            id: "send-corr".into(),
+            command: api::Command::SendMessage {
+                conversation_id: "conv-1".into(),
+                content: "hello".into(),
+                override_selection: None,
+                system_refinement: String::new(),
+                idempotency_key: None,
+            },
+        }],
+    );
+
+    // First frame: the ack carrying the correlation request_id.
+    let ack_request_id = match next_frame(&mut out_rx).await {
+        WsFrame::Result {
+            id,
+            result: api::CommandResult::SendMessageAck { request_id, .. },
+        } => {
+            assert_eq!(id, "send-corr");
+            request_id
+        }
+        other => panic!("expected SendMessageAck, got {other:?}"),
+    };
+    assert!(!ack_request_id.is_empty(), "ack must carry a request_id");
+
+    // Every streamed response event must carry that same request_id.
+    let mut saw_delta = false;
+    let mut saw_completed = false;
+    for _ in 0..5 {
+        match next_frame(&mut out_rx).await {
+            WsFrame::Event {
+                event: api::Event::AssistantDelta { request_id, .. },
+            } => {
+                assert_eq!(request_id, ack_request_id, "delta must match the ack id");
+                saw_delta = true;
+            }
+            WsFrame::Event {
+                event: api::Event::AssistantCompleted { request_id, .. },
+            } => {
+                assert_eq!(
+                    request_id, ack_request_id,
+                    "completed must match the ack id"
+                );
+                saw_completed = true;
+                break;
+            }
+            other => panic!("unexpected frame while streaming: {other:?}"),
+        }
+    }
+    assert!(saw_delta, "expected an AssistantDelta event");
+    assert!(saw_completed, "expected an AssistantCompleted event");
+
+    let _ = handle.await;
 }

--- a/crates/transport-dispatch/tests/dispatcher.rs
+++ b/crates/transport-dispatch/tests/dispatcher.rs
@@ -115,39 +115,47 @@ async fn dispatcher_streams_send_message_ack_then_events() {
 
     use futures::StreamExt;
 
+    // The send is acked with `SendMessageAck` carrying the turn request_id
+    // (voice#49); the streamed events are stamped with that same id.
     let f1 = tokio::time::timeout(std::time::Duration::from_secs(2), out_rx.next())
         .await
         .unwrap()
         .unwrap();
-    assert!(matches!(
-        f1,
+    let ack_request_id = match f1 {
         WsFrame::Result {
-            result: api::CommandResult::Ack,
+            result: api::CommandResult::SendMessageAck { request_id, .. },
             ..
+        } => {
+            assert!(!request_id.is_empty(), "ack must carry the turn request_id");
+            request_id
         }
-    ));
+        other => panic!("expected SendMessageAck, got {other:?}"),
+    };
 
     let f2 = tokio::time::timeout(std::time::Duration::from_secs(2), out_rx.next())
         .await
         .unwrap()
         .unwrap();
-    assert!(matches!(
-        f2,
+    match f2 {
         WsFrame::Event {
-            event: api::Event::AssistantDelta { .. }
-        }
-    ));
+            event: api::Event::AssistantDelta { request_id, .. },
+        } => assert_eq!(request_id, ack_request_id, "delta must match the ack id"),
+        other => panic!("expected AssistantDelta, got {other:?}"),
+    }
 
     let f3 = tokio::time::timeout(std::time::Duration::from_secs(2), out_rx.next())
         .await
         .unwrap()
         .unwrap();
-    assert!(matches!(
-        f3,
+    match f3 {
         WsFrame::Event {
-            event: api::Event::AssistantCompleted { .. }
-        }
-    ));
+            event: api::Event::AssistantCompleted { request_id, .. },
+        } => assert_eq!(
+            request_id, ack_request_id,
+            "completed must match the ack id"
+        ),
+        other => panic!("expected AssistantCompleted, got {other:?}"),
+    }
 
     dispatch.abort();
 }

--- a/crates/ws-interface/tests/ping.rs
+++ b/crates/ws-interface/tests/ping.rs
@@ -1050,16 +1050,28 @@ async fn ws_send_message_ack_then_streaming_events() {
     .await
     .unwrap();
 
+    // The send is acked with a `SendMessageAck` carrying the turn `request_id`
+    // (and an empty task_id on this no-registry path) so a socket client can
+    // correlate the streamed response (voice#49).
     let first =
         serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
             .unwrap();
-    assert_eq!(
-        first,
+    let ack_request_id = match first {
         WsFrame::Result {
-            id: "3".into(),
-            result: desktop_assistant_api_model::CommandResult::Ack
+            id,
+            result:
+                desktop_assistant_api_model::CommandResult::SendMessageAck {
+                    request_id,
+                    task_id,
+                },
+        } => {
+            assert_eq!(id, "3");
+            assert!(!request_id.is_empty(), "ack must carry the turn request_id");
+            assert!(task_id.is_empty(), "no-registry path registers no task");
+            request_id
         }
-    );
+        other => panic!("expected SendMessageAck, got {other:?}"),
+    };
 
     let second =
         serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
@@ -1079,6 +1091,12 @@ async fn ws_send_message_ack_then_streaming_events() {
         }
         other => panic!("unexpected frame: {other:?}"),
     };
+    // voice#49: the streamed events MUST carry the same request_id the ack
+    // returned, so a client filtering by the ack id sees its response.
+    assert_eq!(
+        request_id, ack_request_id,
+        "streamed event request_id must match the SendMessageAck request_id"
+    );
 
     let third =
         serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
@@ -1166,13 +1184,16 @@ async fn ws_send_message_cancels_when_client_disconnects() {
     let ack =
         serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
             .unwrap();
-    assert_eq!(
-        ack,
+    match ack {
         WsFrame::Result {
-            id: "4".into(),
-            result: desktop_assistant_api_model::CommandResult::Ack
+            id,
+            result: desktop_assistant_api_model::CommandResult::SendMessageAck { request_id, .. },
+        } => {
+            assert_eq!(id, "4");
+            assert!(!request_id.is_empty(), "ack must carry the turn request_id");
         }
-    );
+        other => panic!("expected SendMessageAck, got {other:?}"),
+    }
 
     ws.close(None).await.unwrap();
     drop(ws);


### PR DESCRIPTION
Fixes adelie-ai/voice#49

## Problem
With `[assistant] transport = "uds"` (the Connector default since voice#37), a voice turn **sends** fine and the orchestrator **completes** it (reply saved, shown in the KDE plasmoid which uses D-Bus), but the client **never receives the streamed response events** — it hangs in `Processing`, or logs `assistant signal stream closed before completion`. The same turn over `transport = "dbus"` works.

## Root cause (correlation, not framing or fan-out)
The UDS framing, the `Connector` fan-out, and the server-side event emission are all fine — proven by integration probes. The actual bug is a **request-id mismatch**:

- The shared `dispatch_loop` generates a turn `request_id` (UUID) and stamps it on every streamed `AssistantDelta` / `AssistantCompleted` / `AssistantError` event.
- But the `SendMessage` ack returned the **registry `task_id`** (a *different* UUID). The client's `send_prompt*` returned that `task_id`.
- Streaming clients (voice's pipeline) filter response events by `rid == <id send_prompt returned>`. Since `task_id != request_id`, **every event was dropped** → hang.

D-Bus worked because its `SendPrompt` reply returns the same id its signals carry (`crates/dbus-interface/src/conversation.rs`). This latent bug also affected the dbus-bridge and the tui/gtk Connector migration (any socket client filtering by the returned id).

## Fix
- `api-model`: `SendMessageAck` now carries `request_id` alongside `task_id`. `request_id` correlates the streamed RESPONSE; `task_id` still correlates `Task*` lifecycle events.
- `transport-dispatch`: the dispatcher populates `request_id` in the ack on **both** the registry-backed and legacy paths (the legacy path now also acks with `SendMessageAck`, `task_id` empty, instead of a bare `Ack`).
- `client-common`: `send_prompt_idempotent` (and thus every `send_prompt*`) returns the `request_id` — so `returned_id == streamed_event.request_id`, parity with D-Bus.
- `dbus-bridge`: the adapter returns `request_id` (its forwarded events carry it).

No voice / adele-kde changes — voice picks this up via its client-common path-dep with no code change.

## Tests
- `transport-dispatch`: new test asserts the ack `request_id` equals the streamed events' `request_id` (registry + legacy paths); existing ack-shape tests updated.
- `client-common`: new `uds_streaming` integration test stands up the **real UDS server** with a registry-style streaming handler and asserts — both at the raw transport and through the `Connector` (subscribe-before-send, the voice ordering) — that the id `send_prompt` returns matches every streamed event's `request_id`.
- `ws-interface` / dispatcher tests updated for the new ack shape + correlation.

## Validation
`just check` is green (fmt + clippy `--workspace --all-targets -D warnings` + build + full workspace test). No warnings.

## Live verification still PENDING
A full end-to-end check needs the running voice daemon + orchestrator over `transport = "uds"`, which can't be driven here. This is proven at the unit/integration level only — **not** live-verified. Please run a real "Hey Adele" turn with voice's `transport = "uds"` to confirm before reverting voice's interim `dbus` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)