### PR TITLE
Emit turn progress status (turn-start + per tool call) for client heartbeat + voice narration (#223)

### DIFF
--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -50,6 +50,11 @@ fn cancellation_token_or_default() -> CancellationToken {
 /// Maximum number of tool-calling rounds before giving up.
 const MAX_TOOL_ROUNDS: usize = 200;
 
+/// Turn-start liveness status (issue #223), emitted via `on_status` before the
+/// first LLM token so clients (voice) get an immediate heartbeat. Terse and
+/// speakable; the voice client decides whether/how to narrate it.
+const TURN_START_STATUS: &str = "Working on it";
+
 fn now_timestamp() -> String {
     Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
 }
@@ -423,6 +428,13 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             std::collections::HashMap::new();
         // Track whether hosted search has been demoted to local fallback.
         let mut hosted_search_demoted = false;
+
+        // Turn-start liveness status (issue #223): emit a brief "working on it"
+        // as soon as the turn is set up, before the first LLM token. This gives
+        // clients (voice) an immediate heartbeat — without it a multi-round tool
+        // turn is silent until the final answer streams. Per-tool-round statuses
+        // follow from the dispatch loop below.
+        on_status(TURN_START_STATUS.to_string());
 
         for round in 0..MAX_TOOL_ROUNDS {
             // Between-turns cancellation checkpoint (issue #109): if the
@@ -1005,6 +1017,15 @@ mod tests {
         Box::new(|_| {})
     }
 
+    /// A [`StatusCallback`] that records every emitted status message into the
+    /// returned shared buffer, so a test can assert what the turn emitted.
+    fn recording_status() -> (StatusCallback, Arc<std::sync::Mutex<Vec<String>>>) {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log_for_cb = Arc::clone(&log);
+        let cb: StatusCallback = Box::new(move |msg| log_for_cb.lock().unwrap().push(msg));
+        (cb, log)
+    }
+
     struct ListOnlyStore {
         conversations: Vec<Conversation>,
     }
@@ -1404,6 +1425,74 @@ mod tests {
             updated.messages[3].content,
             "The file contains: hello world"
         );
+    }
+
+    #[tokio::test]
+    async fn turn_emits_turn_start_then_per_tool_status() {
+        // Issue #223: a turn must emit a turn-start liveness status before the
+        // first LLM token, and one status per tool call from the dispatch loop,
+        // so clients get a heartbeat + narratable progress between rounds.
+        let tools = vec![
+            ToolDefinition::new("calendar_list", "List calendar", serde_json::json!({})),
+            ToolDefinition::new("notes_search", "Search notes", serde_json::json!({})),
+        ];
+        let responses = vec![
+            LlmResponse::with_tool_calls(
+                "",
+                vec![
+                    ToolCall::new("c1", "calendar_list", "{}"),
+                    ToolCall::new("c2", "notes_search", "{}"),
+                ],
+            ),
+            LlmResponse::text("All set"),
+        ];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("calendar_list".to_string(), "ok".to_string());
+        tool_results.insert("notes_search".to_string(), "ok".to_string());
+
+        let handler = make_tool_handler(responses, tools, tool_results);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let (status_cb, status_log) = recording_status();
+        let result = handler
+            .send_prompt(&conv.id, "Do it".into(), noop_callback(), status_cb)
+            .await
+            .unwrap();
+        assert_eq!(result, "All set");
+
+        let statuses = status_log.lock().unwrap().clone();
+        // First status is the turn-start heartbeat, before any tool round.
+        assert_eq!(
+            statuses.first().map(String::as_str),
+            Some(TURN_START_STATUS),
+            "expected turn-start status first; got {statuses:?}"
+        );
+        // Each tool call emits a human-labelled status.
+        assert!(
+            statuses.contains(&"Checking your calendar".to_string()),
+            "expected a calendar status; got {statuses:?}"
+        );
+        assert!(
+            statuses.contains(&"Searching your notes".to_string()),
+            "expected a notes status; got {statuses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_with_no_tools_still_emits_turn_start_status() {
+        // Even a plain text turn (no tool rounds) must emit the turn-start
+        // heartbeat so the client knows the assistant is working.
+        let handler = make_handler(vec!["Hello there"]);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let (status_cb, status_log) = recording_status();
+        handler
+            .send_prompt(&conv.id, "Hi".into(), noop_callback(), status_cb)
+            .await
+            .unwrap();
+
+        let statuses = status_log.lock().unwrap().clone();
+        assert_eq!(statuses, vec![TURN_START_STATUS.to_string()]);
     }
 
     #[tokio::test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -52,12 +52,68 @@ pub(crate) fn tool_status_message(tool_name: &str, arguments: &serde_json::Value
             }
         }
         "builtin_mcp_control" => "Managing tool servers".into(),
-        name => {
-            // For MCP/dynamic tools, humanize the snake_case name.
-            let friendly = name.replace('_', " ");
-            format!("Running {friendly}")
-        }
+        name => humanize_mcp_tool_status(name),
     }
+}
+
+/// Render a friendly, speakable status for a dynamic/MCP tool from its name
+/// alone (issue #223). MCP tool names are not known at compile time, so we map
+/// by their leading action verb to a natural phrase and append the remaining
+/// words as the resource (e.g. `calendar_list_events` → "Checking your calendar
+/// events", `notes_search` → "Searching your notes"). Names use `_` or `.`
+/// separators (`calendar.list` ≡ `calendar_list`). Falls back to
+/// "Running <words>" when no verb is recognized.
+fn humanize_mcp_tool_status(name: &str) -> String {
+    // Normalize separators so `a.b.c` and `a_b_c` both split into words.
+    let words: Vec<&str> = name.split(['_', '.']).filter(|w| !w.is_empty()).collect();
+    if words.is_empty() {
+        return "Working on it".into();
+    }
+
+    // The action verb may appear first (verb_resource, e.g. `list_events`) or
+    // last (resource_verb, e.g. `calendar_list`). Prefer a first-word match,
+    // then a last-word match, treating the remaining words as the resource.
+    let phrasing = |verb: &str, resource: &[&str]| -> Option<String> {
+        let template = verb_phrase(verb)?;
+        let resource = resource.join(" ");
+        Some(if resource.is_empty() {
+            // No resource words — use a generic object so the phrase reads.
+            template.replace("{}", "that")
+        } else {
+            template.replace("{}", &format!("your {resource}"))
+        })
+    };
+
+    if let Some(msg) = phrasing(words[0], &words[1..]) {
+        return msg;
+    }
+    if words.len() > 1
+        && let Some(msg) = phrasing(words[words.len() - 1], &words[..words.len() - 1])
+    {
+        return msg;
+    }
+
+    // No recognized verb: humanize the whole name.
+    format!("Running {}", words.join(" "))
+}
+
+/// Map a known action verb to a short status template containing a single `{}`
+/// placeholder for the resource (e.g. "your calendar"). Returns `None` for
+/// unrecognized verbs so the caller can fall back. Synonyms collapse onto the
+/// same phrasing so a wide range of MCP naming conventions read naturally.
+fn verb_phrase(verb: &str) -> Option<&'static str> {
+    let phrase = match verb {
+        "list" | "get" | "read" | "fetch" | "show" | "view" | "describe" | "check" => "Checking {}",
+        "search" | "find" | "query" | "lookup" => "Searching {}",
+        "create" | "add" | "new" | "insert" | "schedule" | "book" => "Adding to {}",
+        "update" | "edit" | "modify" | "set" | "change" | "patch" | "correct" => "Updating {}",
+        "delete" | "remove" | "cancel" | "clear" | "drop" => "Removing from {}",
+        "send" | "post" | "reply" | "email" | "message" => "Sending {}",
+        "download" | "export" => "Downloading {}",
+        "upload" | "import" => "Uploading {}",
+        _ => return None,
+    };
+    Some(phrase)
 }
 
 /// Use the LLM to semantically categorize tools into descriptive namespaces.
@@ -283,5 +339,97 @@ impl ToolExecutor for NoopToolExecutor {
         Err(CoreError::ToolExecution(format!(
             "no tool executor configured, cannot execute '{name}'"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn builtin_tools_get_tailored_status() {
+        assert_eq!(
+            tool_status_message("builtin_knowledge_base_write", &json!({})),
+            "Saving to knowledge base"
+        );
+        assert_eq!(
+            tool_status_message("builtin_sys_props", &json!({})),
+            "Checking system properties"
+        );
+        assert_eq!(
+            tool_status_message("builtin_db_query", &json!({})),
+            "Querying database"
+        );
+        assert_eq!(
+            tool_status_message("builtin_mcp_control", &json!({})),
+            "Managing tool servers"
+        );
+    }
+
+    #[test]
+    fn builtin_search_includes_truncated_query() {
+        let msg = tool_status_message(
+            "builtin_knowledge_base_search",
+            &json!({"query": "where did I park"}),
+        );
+        assert_eq!(msg, "Searching knowledge base: where did I park");
+
+        let long = "x".repeat(120);
+        let msg = tool_status_message("builtin_tool_search", &json!({ "query": long }));
+        // 60-char cap on the query portion.
+        assert_eq!(msg, format!("Searching for tools: {}", "x".repeat(60)));
+    }
+
+    #[test]
+    fn mcp_leading_verb_maps_to_human_phrase() {
+        // verb_resource ordering
+        assert_eq!(
+            tool_status_message("list_events", &json!({})),
+            "Checking your events"
+        );
+        assert_eq!(
+            tool_status_message("search_messages", &json!({})),
+            "Searching your messages"
+        );
+        assert_eq!(
+            tool_status_message("create_event", &json!({})),
+            "Adding to your event"
+        );
+        assert_eq!(
+            tool_status_message("delete_file", &json!({})),
+            "Removing from your file"
+        );
+    }
+
+    #[test]
+    fn mcp_trailing_verb_maps_to_human_phrase() {
+        // resource_verb ordering (e.g. calendar.list, notes_search)
+        assert_eq!(
+            tool_status_message("calendar.list", &json!({})),
+            "Checking your calendar"
+        );
+        assert_eq!(
+            tool_status_message("notes_search", &json!({})),
+            "Searching your notes"
+        );
+        assert_eq!(
+            tool_status_message("timeclock_session_query", &json!({})),
+            "Searching your timeclock session"
+        );
+    }
+
+    #[test]
+    fn mcp_unknown_verb_falls_back_to_running() {
+        assert_eq!(
+            tool_status_message("frobnicate_widget", &json!({})),
+            "Running frobnicate widget"
+        );
+    }
+
+    #[test]
+    fn mcp_verb_only_name_reads_naturally() {
+        // A bare verb has no resource words.
+        assert_eq!(tool_status_message("search", &json!({})), "Searching that");
     }
 }


### PR DESCRIPTION
## What

During a multi-round tool turn the orchestrator emitted **nothing between rounds** — clients (voice) got silence until the final answer streamed. This wires up periodic progress so clients have a liveness heartbeat and narratable progress, using the **existing** `Event::AssistantStatus` event and the **existing** `on_status` callback path. No new event type.

## Checkpoints that now emit `AssistantStatus`

1. **Turn start** — a terse `"Working on it"` fires from `send_prompt` *before the first LLM token*, so clients get an immediate heartbeat. This also covers plain text turns that run zero tool rounds.
2. **Each tool call** — the dispatch loop in `crates/core/src/service.rs` already emitted one status per tool call; this PR improves the **human-label mapping** so dynamic/MCP tool names read naturally and speakably.

## Tool → human-label mapping

Builtin tools keep their tailored phrasing (e.g. `builtin_db_query` → "Querying database"). For dynamic/MCP tools (names unknown at compile time), `humanize_mcp_tool_status` matches a leading **or** trailing action verb and treats the remaining words as the resource:

| tool name | status |
|---|---|
| `calendar.list` | Checking your calendar |
| `notes_search` | Searching your notes |
| `list_events` | Checking your events |
| `create_event` | Adding to your event |
| `delete_file` | Removing from your file |
| `timeclock_session_query` | Searching your timeclock session |
| `frobnicate_widget` (unknown verb) | Running frobnicate widget |

Verb synonyms collapse onto one phrase (list/get/read/fetch/show/view → "Checking"; search/find/query/lookup → "Searching"; create/add/schedule/book → "Adding to"; update/edit/set/correct → "Updating"; delete/remove/cancel → "Removing from"; send/post/reply → "Sending"; download/export, upload/import).

## Plumbing (unchanged contract)

`run_send_turn` (application) already bridges `on_status` → `Event::AssistantStatus { conversation_id, request_id, message }` and forwards it on every transport. `send_prompt_with_override` delegates to `send_prompt` passing `on_status` through, so the new emission points reach the production path. Changes are confined to `crates/core` (service.rs + tools.rs).

## Tests

- `tools.rs`: builtin label mapping, MCP label mapping (both verb orderings + synonyms), unknown-verb fallback, verb-only name.
- `service.rs`: a tool turn emits the turn-start status **first** then a per-tool status for each call; a no-tool turn still emits the turn-start heartbeat.

`just check` (fmt + clippy `--workspace --all-targets -D warnings` + build + full test suite) is **green**.

## Note for the voice sibling — `AssistantStatus` contract

The voice client should map `Event::AssistantStatus { conversation_id, request_id, message }`:
- `message` is a short, human, **speakable** string (the voice client decides whether/how to speak it).
- Every status carries `request_id` so it can be correlated to the in-flight turn (and used to reset a stall timeout).
- Cadence: one at turn start, then one per tool call — not per token.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)