### PR TITLE
fix(llm): add connect + per-event stall timeouts to ollama/anthropic/openai (#220)

### DIFF
--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -13,6 +13,49 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
+/// Maximum time to wait for the HTTP connection handshake (response headers)
+/// before failing the turn. Mirrors the Bedrock connector (#214/#220).
+const ANTHROPIC_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Maximum gap allowed between two streamed SSE events. Each received event
+/// resets the clock (the heartbeat), so this only fires when the stream goes
+/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
+const ANTHROPIC_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Outcome of racing a stream's next item against cancellation and a stall
+/// timeout. Extracted so the timeout behaviour is unit-testable with a short
+/// duration instead of the production 60s constant (#220).
+enum StreamStep<T> {
+    /// The stream yielded an item.
+    Item(T),
+    /// The stream ended (no more items).
+    Done,
+    /// The cancellation token tripped.
+    Cancelled,
+    /// No item arrived within the stall timeout.
+    Stalled,
+}
+
+/// Await the next item from `stream`, racing it against `cancellation` and a
+/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
+/// so the stall window resets each time a caller consumes an item.
+async fn next_step<S>(
+    stream: &mut S,
+    cancellation: &tokio_util::sync::CancellationToken,
+    timeout: std::time::Duration,
+) -> StreamStep<S::Item>
+where
+    S: tokio_stream::Stream + Unpin,
+{
+    tokio::select! {
+        _ = cancellation.cancelled() => StreamStep::Cancelled,
+        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
+        next = stream.next() => match next {
+            Some(item) => StreamStep::Item(item),
+            None => StreamStep::Done,
+        },
+    }
+}
+
 /// Return the prompt-token context window for a known Anthropic model id.
 ///
 /// Anthropic's Messages API does not expose context windows in its model
@@ -462,11 +505,19 @@ impl AnthropicClient {
             .json(request_body)
             .send();
 
-        // Race the connection-establishment future against cancellation
-        // so the HTTP connection itself is dropped (no orphaned socket)
-        // when the user cancels mid-handshake.
+        // Race the connection-establishment future against cancellation and a
+        // connect timeout so the HTTP connection itself is dropped (no orphaned
+        // socket) when the user cancels mid-handshake, and so a stalled connect
+        // fails the turn instead of hanging forever (#220).
         let response = tokio::select! {
             _ = cancellation.cancelled() => return Err(CoreError::Cancelled),
+            _ = tokio::time::sleep(ANTHROPIC_CONNECT_TIMEOUT) => {
+                tracing::error!(
+                    timeout_s = ANTHROPIC_CONNECT_TIMEOUT.as_secs(),
+                    "Anthropic request send() timed out (no response headers)"
+                );
+                return Err(CoreError::Llm("Anthropic stream stalled".into()));
+            }
             r = send_fut => r.map_err(|e| CoreError::Llm(format!("HTTP request failed: {e}")))?,
         };
 
@@ -522,19 +573,28 @@ impl AnthropicClient {
             std::collections::HashMap::new();
 
         loop {
-            // Race the next SSE event against cancellation. When the
-            // token trips, drop `events` (and with it the underlying
-            // reqwest body stream) so the HTTP connection is closed
-            // rather than left orphaned in the connection pool.
-            let next = tokio::select! {
-                _ = cancellation.cancelled() => {
+            // Race the next SSE event against cancellation and a stall
+            // timeout. When the token trips, drop `events` (and with it the
+            // underlying reqwest body stream) so the HTTP connection is closed
+            // rather than left orphaned in the connection pool. The stall
+            // window resets on every received event (#220).
+            let event = match next_step(&mut events, &cancellation, ANTHROPIC_EVENT_TIMEOUT).await {
+                StreamStep::Item(ev) => ev,
+                StreamStep::Done => break,
+                StreamStep::Cancelled => {
                     tracing::debug!("Anthropic stream cancelled by token");
                     drop(events);
                     return Err(CoreError::Cancelled);
                 }
-                ev = events.next() => ev,
+                StreamStep::Stalled => {
+                    tracing::error!(
+                        timeout_s = ANTHROPIC_EVENT_TIMEOUT.as_secs(),
+                        "Anthropic stream stalled — no further event"
+                    );
+                    drop(events);
+                    return Err(CoreError::Llm("Anthropic stream stalled".into()));
+                }
             };
-            let Some(event) = next else { break };
             let event = event.map_err(|e| CoreError::Llm(format!("stream read error: {e}")))?;
             let data = event.data.as_str();
             if data == "[DONE]" {
@@ -940,6 +1000,68 @@ fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<std:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Stream that yields `n` items then stays `Pending` forever, simulating a
+    /// mid-stream stall (#220).
+    struct StallingStream {
+        remaining: usize,
+    }
+
+    impl tokio_stream::Stream for StallingStream {
+        type Item = u32;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                std::task::Poll::Ready(Some(0))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
+        match step {
+            StreamStep::Item(_) => "Item",
+            StreamStep::Done => "Done",
+            StreamStep::Cancelled => "Cancelled",
+            StreamStep::Stalled => "Stalled",
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_fires_stall_timeout_after_silence() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut stream = StallingStream { remaining: 1 };
+        let timeout = std::time::Duration::from_millis(50);
+
+        // First item arrives immediately (the heartbeat).
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Item(_) => {}
+            other => panic!("expected first item, got {}", step_name(&other)),
+        }
+
+        // Stream now silent: the per-event timeout must fire rather than hang.
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Stalled => {}
+            other => panic!("expected stall, got {}", step_name(&other)),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_prefers_cancellation_over_stall() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut stream = StallingStream { remaining: 0 };
+        let timeout = std::time::Duration::from_millis(50);
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Cancelled => {}
+            other => panic!("expected cancelled, got {}", step_name(&other)),
+        }
+    }
 
     #[test]
     fn client_builder() {

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -15,6 +15,50 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 use tokio_stream::StreamExt;
 
+/// Maximum time to wait for the HTTP connection handshake (response headers)
+/// before failing the turn. Mirrors the Bedrock connector (#214/#220): a
+/// stalled connect must not hang the turn forever.
+const OLLAMA_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Maximum gap allowed between two streamed NDJSON chunks. Each received chunk
+/// resets the clock (the heartbeat), so this only fires when the stream goes
+/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
+const OLLAMA_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Outcome of racing a stream's next item against cancellation and a stall
+/// timeout. Extracted so the timeout behaviour is unit-testable with a short
+/// duration instead of the production 60s constant (#220).
+enum StreamStep<T> {
+    /// The stream yielded an item.
+    Item(T),
+    /// The stream ended (no more items).
+    Done,
+    /// The cancellation token tripped.
+    Cancelled,
+    /// No item arrived within the stall timeout.
+    Stalled,
+}
+
+/// Await the next item from `stream`, racing it against `cancellation` and a
+/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
+/// so the stall window resets each time a caller consumes an item.
+async fn next_step<S>(
+    stream: &mut S,
+    cancellation: &tokio_util::sync::CancellationToken,
+    timeout: std::time::Duration,
+) -> StreamStep<S::Item>
+where
+    S: tokio_stream::Stream + Unpin,
+{
+    tokio::select! {
+        _ = cancellation.cancelled() => StreamStep::Cancelled,
+        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
+        next = stream.next() => match next {
+            Some(item) => StreamStep::Item(item),
+            None => StreamStep::Done,
+        },
+    }
+}
+
 /// Ollama LLM client that streams completions via the native `/api/chat` endpoint.
 ///
 /// Uses NDJSON streaming (one JSON object per line) and Ollama's native tool
@@ -660,8 +704,17 @@ impl LlmClient for OllamaClient {
             .header("Content-Type", "application/json")
             .json(&request)
             .send();
+        // Bound the connection handshake so a stalled Ollama (model loading,
+        // wedged daemon) fails the turn instead of hanging forever (#220).
         let response = tokio::select! {
             _ = cancellation.cancelled() => return Err(CoreError::Cancelled),
+            _ = tokio::time::sleep(OLLAMA_CONNECT_TIMEOUT) => {
+                tracing::error!(
+                    timeout_s = OLLAMA_CONNECT_TIMEOUT.as_secs(),
+                    "Ollama request send() timed out (no response headers)"
+                );
+                return Err(CoreError::Llm("Ollama stream stalled".into()));
+            }
             r = send_fut => r.map_err(|e| CoreError::Llm(format!("HTTP request failed: {e}")))?,
         };
 
@@ -719,18 +772,27 @@ impl LlmClient for OllamaClient {
         let mut buffer = String::new();
 
         loop {
-            // Race the next NDJSON chunk against cancellation. Dropping
-            // `stream` closes the underlying reqwest body and the
-            // socket — same shape as the SSE adapters.
-            let next = tokio::select! {
-                _ = cancellation.cancelled() => {
+            // Race the next NDJSON chunk against cancellation and a stall
+            // timeout. Dropping `stream` closes the underlying reqwest body
+            // and the socket — same shape as the SSE adapters. The stall
+            // window resets on every received chunk (#220).
+            let chunk = match next_step(&mut stream, &cancellation, OLLAMA_EVENT_TIMEOUT).await {
+                StreamStep::Item(c) => c,
+                StreamStep::Done => break,
+                StreamStep::Cancelled => {
                     tracing::debug!("Ollama stream cancelled by token");
                     drop(stream);
                     return Err(CoreError::Cancelled);
                 }
-                c = stream.next() => c,
+                StreamStep::Stalled => {
+                    tracing::error!(
+                        timeout_s = OLLAMA_EVENT_TIMEOUT.as_secs(),
+                        "Ollama stream stalled — no further chunk"
+                    );
+                    drop(stream);
+                    return Err(CoreError::Llm("Ollama stream stalled".into()));
+                }
             };
-            let Some(chunk) = next else { break };
             let bytes = chunk.map_err(|e| CoreError::Llm(format!("stream read error: {e}")))?;
             buffer.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -919,6 +981,69 @@ mod tests {
     use super::*;
     use httpmock::Method::{GET, POST};
     use httpmock::MockServer;
+
+    /// Stream that yields `n` items then stays `Pending` forever, simulating a
+    /// mid-stream stall (#220).
+    struct StallingStream {
+        remaining: usize,
+    }
+
+    impl tokio_stream::Stream for StallingStream {
+        type Item = u32;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                std::task::Poll::Ready(Some(0))
+            } else {
+                // Go silent: never wake, never end.
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_fires_stall_timeout_after_silence() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut stream = StallingStream { remaining: 1 };
+        let timeout = std::time::Duration::from_millis(50);
+
+        // First item arrives immediately (the heartbeat).
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Item(_) => {}
+            other => panic!("expected first item, got {}", step_name(&other)),
+        }
+
+        // Stream now silent: the per-event timeout must fire rather than hang.
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Stalled => {}
+            other => panic!("expected stall, got {}", step_name(&other)),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_prefers_cancellation_over_stall() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut stream = StallingStream { remaining: 0 };
+        let timeout = std::time::Duration::from_millis(50);
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Cancelled => {}
+            other => panic!("expected cancelled, got {}", step_name(&other)),
+        }
+    }
+
+    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
+        match step {
+            StreamStep::Item(_) => "Item",
+            StreamStep::Done => "Done",
+            StreamStep::Cancelled => "Cancelled",
+            StreamStep::Stalled => "Stalled",
+        }
+    }
 
     #[test]
     fn chat_message_from_user() {

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -13,6 +13,49 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
+/// Maximum time to wait for the HTTP connection handshake (response headers)
+/// before failing the turn. Mirrors the Bedrock connector (#214/#220).
+const OPENAI_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+/// Maximum gap allowed between two streamed SSE events. Each received event
+/// resets the clock (the heartbeat), so this only fires when the stream goes
+/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
+const OPENAI_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Outcome of racing a stream's next item against cancellation and a stall
+/// timeout. Extracted so the timeout behaviour is unit-testable with a short
+/// duration instead of the production 60s constant (#220).
+enum StreamStep<T> {
+    /// The stream yielded an item.
+    Item(T),
+    /// The stream ended (no more items).
+    Done,
+    /// The cancellation token tripped.
+    Cancelled,
+    /// No item arrived within the stall timeout.
+    Stalled,
+}
+
+/// Await the next item from `stream`, racing it against `cancellation` and a
+/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
+/// so the stall window resets each time a caller consumes an item.
+async fn next_step<S>(
+    stream: &mut S,
+    cancellation: &tokio_util::sync::CancellationToken,
+    timeout: std::time::Duration,
+) -> StreamStep<S::Item>
+where
+    S: tokio_stream::Stream + Unpin,
+{
+    tokio::select! {
+        _ = cancellation.cancelled() => StreamStep::Cancelled,
+        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
+        next = stream.next() => match next {
+            Some(item) => StreamStep::Item(item),
+            None => StreamStep::Done,
+        },
+    }
+}
+
 /// Return the prompt-token context window for a known OpenAI model id.
 ///
 /// OpenAI exposes context windows through `/v1/models` only inconsistently,
@@ -481,8 +524,17 @@ impl OpenAiClient {
             .header("Content-Type", "application/json")
             .json(request_body)
             .send();
+        // Bound the connection handshake so a stalled connect fails the turn
+        // instead of hanging forever (#220).
         let response = tokio::select! {
             _ = cancellation.cancelled() => return Err(CoreError::Cancelled),
+            _ = tokio::time::sleep(OPENAI_CONNECT_TIMEOUT) => {
+                tracing::error!(
+                    timeout_s = OPENAI_CONNECT_TIMEOUT.as_secs(),
+                    "OpenAI request send() timed out (no response headers)"
+                );
+                return Err(CoreError::Llm("OpenAI stream stalled".into()));
+            }
             r = send_fut => r.map_err(|e| CoreError::Llm(format!("HTTP request failed: {e}")))?,
         };
 
@@ -547,17 +599,27 @@ impl OpenAiClient {
         let mut token_usage: Option<TokenUsage> = None;
 
         loop {
-            // Race the next SSE event against cancellation. See the
-            // Anthropic adapter for the rationale; same pattern here.
-            let next = tokio::select! {
-                _ = cancellation.cancelled() => {
+            // Race the next SSE event against cancellation and a stall
+            // timeout. See the Anthropic adapter for the rationale; same
+            // pattern here. The stall window resets on every received
+            // event (#220).
+            let event = match next_step(&mut events, &cancellation, OPENAI_EVENT_TIMEOUT).await {
+                StreamStep::Item(ev) => ev,
+                StreamStep::Done => break,
+                StreamStep::Cancelled => {
                     tracing::debug!("OpenAI stream cancelled by token");
                     drop(events);
                     return Err(CoreError::Cancelled);
                 }
-                ev = events.next() => ev,
+                StreamStep::Stalled => {
+                    tracing::error!(
+                        timeout_s = OPENAI_EVENT_TIMEOUT.as_secs(),
+                        "OpenAI stream stalled — no further event"
+                    );
+                    drop(events);
+                    return Err(CoreError::Llm("OpenAI stream stalled".into()));
+                }
             };
-            let Some(event) = next else { break };
             let event = event.map_err(|e| CoreError::Llm(format!("stream read error: {e}")))?;
             let data = event.data.as_str();
             match event.event.as_str() {
@@ -1008,6 +1070,68 @@ impl desktop_assistant_core::ports::embedding::EmbeddingClient for OpenAiClient 
 mod tests {
     use super::*;
     use desktop_assistant_core::ports::llm::ReasoningLevel;
+
+    /// Stream that yields `n` items then stays `Pending` forever, simulating a
+    /// mid-stream stall (#220).
+    struct StallingStream {
+        remaining: usize,
+    }
+
+    impl tokio_stream::Stream for StallingStream {
+        type Item = u32;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                std::task::Poll::Ready(Some(0))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
+        match step {
+            StreamStep::Item(_) => "Item",
+            StreamStep::Done => "Done",
+            StreamStep::Cancelled => "Cancelled",
+            StreamStep::Stalled => "Stalled",
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_fires_stall_timeout_after_silence() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut stream = StallingStream { remaining: 1 };
+        let timeout = std::time::Duration::from_millis(50);
+
+        // First item arrives immediately (the heartbeat).
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Item(_) => {}
+            other => panic!("expected first item, got {}", step_name(&other)),
+        }
+
+        // Stream now silent: the per-event timeout must fire rather than hang.
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Stalled => {}
+            other => panic!("expected stall, got {}", step_name(&other)),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_prefers_cancellation_over_stall() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut stream = StallingStream { remaining: 0 };
+        let timeout = std::time::Duration::from_millis(50);
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Cancelled => {}
+            other => panic!("expected cancelled, got {}", step_name(&other)),
+        }
+    }
 
     // --- convert_messages tests ---
 


### PR DESCRIPTION
## Summary

Only the Bedrock connector bounded its streaming dispatch. The ollama, anthropic, and openai adapters raced each `stream.next()` against the cancellation token **only**, so a mid-stream stall (silent socket, wedged/loading model) hung the turn forever.

This ports the Bedrock pattern (`crates/llm-bedrock/src/lib.rs` ~line 1271) to all three connectors:

- **Connect timeout (30s):** the existing `send()` `tokio::select!` gains a `tokio::time::sleep(*_CONNECT_TIMEOUT)` branch that returns `CoreError::Llm("<provider> stream stalled")` if response headers never arrive.
- **Per-event stall timeout (60s):** a small `next_step` helper races the stream's next item against cancellation **and** a fresh `tokio::time::sleep(*_EVENT_TIMEOUT)`. The sleep is recreated every loop iteration, so each received token resets the stall window (the heartbeat). On expiry it drops the stream (closing the HTTP body, same as the cancellation path) and returns `CoreError::Llm("<provider> stream stalled")`.

Constants match Bedrock exactly (30s connect / 60s event) and are **module-local on purpose** — threading them through the central config is a deferred follow-up, keeping this change isolated to the three connectors.

## Per-provider

| Crate | Connect | Per-event |
|---|---|---|
| `llm-ollama` | `OLLAMA_CONNECT_TIMEOUT` on the `/api/chat` send | `OLLAMA_EVENT_TIMEOUT` on the NDJSON `bytes_stream()` loop |
| `llm-anthropic` | `ANTHROPIC_CONNECT_TIMEOUT` on the `/v1/messages` send | `ANTHROPIC_EVENT_TIMEOUT` on the SSE `eventsource()` loop |
| `llm-openai` | `OPENAI_CONNECT_TIMEOUT` on the `/responses` send | `OPENAI_EVENT_TIMEOUT` on the SSE `eventsource()` loop |

## Tests

Each crate gains two fast unit tests over the `next_step` helper (`#[tokio::test(start_paused = true)]`, 50ms timeout so they don't sleep for real):
- `next_step_fires_stall_timeout_after_silence` — stream yields one item (heartbeat) then goes `Pending` forever → asserts `StreamStep::Stalled`.
- `next_step_prefers_cancellation_over_stall` — pre-cancelled token → asserts `StreamStep::Cancelled`.

## Validation

`just check` (fmt-check + clippy `--workspace --all-targets -D warnings` + build + `cargo test --workspace`) is **GREEN** — exit 0, no warnings, no failures. The pre-push hook (same `just check`) also passed.

## Scope

Touches only `llm-ollama`, `llm-anthropic`, `llm-openai` (+ their tests). `llm-bedrock` (already done), client-common, daemon, application, core, and api-model are untouched.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)