### PR TITLE
feat(daemon): state-preserving config hot-reload (#222)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "jsonwebtoken",
  "keyring-core",
  "libc",
+ "notify",
  "rcgen",
  "reqwest",
  "rustls 0.23.40",
@@ -1782,6 +1783,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -2473,6 +2483,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,6 +2634,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2735,6 +2786,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
 ]
 
 [workspace.dependencies]
+notify = "8"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 zbus = { version = "5", default-features = false, features = ["tokio"] }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -18,6 +18,7 @@ desktop-assistant-mcp-client.workspace = true
 desktop-assistant-storage.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+notify.workspace = true
 zbus.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -196,6 +196,11 @@ impl RegistryHandle {
 
     /// Reload the registry (and re-read the config from disk). Used when
     /// external tools mutate the config file.
+    ///
+    /// Prefer [`RegistryHandle::apply_reload`] for the live hot-reload path:
+    /// it validates the new config and classifies what changed before
+    /// swapping. This method is the unconditional swap retained for callers
+    /// that already hold a known-good config.
     #[allow(dead_code)]
     pub fn reload(&self) -> anyhow::Result<()> {
         let config = load_daemon_config(&self.config_path)?.unwrap_or_default();
@@ -204,6 +209,95 @@ impl RegistryHandle {
         state.config = config;
         state.registry = registry;
         Ok(())
+    }
+
+    /// Validate the on-disk config and, if it parses and the registry
+    /// rebuilds, swap it in under the lock — a state-preserving hot reload
+    /// (#222).
+    ///
+    /// Non-breaking swap: the registry stores clients as `Arc<dyn LlmClient>`,
+    /// and dispatch clones the `Arc` it needs *before* awaiting (see
+    /// `client_for` / `send_prompt_with_override`). Replacing `state.registry`
+    /// here only drops the registry's own references; any in-flight turn that
+    /// already cloned its client keeps that client alive by refcount until the
+    /// turn finishes, while new turns resolve through the freshly built
+    /// registry. Active connections and turns are never torn down.
+    ///
+    /// Validate-before-apply: a config that fails to parse/validate is
+    /// refused — the method logs a clear error and returns `Err` while the
+    /// last-good config and registry keep running untouched. A reload never
+    /// panics or exits the daemon on a bad config. Subsystems wired once at
+    /// startup (database, embeddings, TLS, …) are reported as
+    /// "restart required" rather than silently dropped.
+    ///
+    /// Returns the [`ReloadPlan`] describing what was applied (and what still
+    /// needs a restart) on success.
+    pub fn apply_reload(&self) -> anyhow::Result<crate::config::ReloadPlan> {
+        // 1. Parse + validate the candidate from disk. `load_daemon_config`
+        //    surfaces TOML and [connections]/[purposes] validation errors. A
+        //    failure here returns Err and leaves the running state untouched.
+        let new_config = match load_daemon_config(&self.config_path) {
+            Ok(Some(cfg)) => cfg,
+            Ok(None) => {
+                tracing::warn!(
+                    "config reload: {} is missing or empty; keeping the running config",
+                    self.config_path.display()
+                );
+                anyhow::bail!("config file is missing or empty");
+            }
+            Err(e) => {
+                tracing::error!(
+                    "config reload refused: {} failed to parse/validate: {e:#}; \
+                     keeping the last-good running config",
+                    self.config_path.display()
+                );
+                return Err(e);
+            }
+        };
+
+        // 2. Build the candidate registry off the lock. `build_registry` is
+        //    infallible (bad connections become `Unavailable` rows rather than
+        //    aborting), but we refuse a config that yields *zero* usable
+        //    connections when the running one had at least one — that would
+        //    silently break every new turn. The running registry stays put.
+        let new_registry = build_registry(&new_config);
+        {
+            let state = self.state.read().expect("registry state poisoned");
+            let plan = crate::config::plan_reload(&state.config, &new_config);
+            if plan.is_empty() {
+                tracing::info!("config reload: no effective changes; nothing to apply");
+                return Ok(plan);
+            }
+            if state.registry.live_count() > 0 && new_registry.live_count() == 0 {
+                tracing::error!(
+                    "config reload refused: the new config has no usable LLM connection \
+                     (every connection failed to build); keeping the last-good running config"
+                );
+                anyhow::bail!("new config has no usable LLM connection");
+            }
+        }
+
+        // 3. Re-diff and swap under the write lock. Re-reading `state.config`
+        //    here (rather than trusting the read-lock snapshot above) keeps the
+        //    plan consistent if a concurrent `mutate_config` slipped in.
+        let mut state = self.state.write().expect("registry state poisoned");
+        let plan = crate::config::plan_reload(&state.config, &new_config);
+        state.config = new_config;
+        // Swapping the registry drops only its own Arc handles; in-flight turns
+        // that already cloned their client keep it alive (see method docs).
+        state.registry = new_registry;
+        drop(state);
+
+        if plan.rebuild_registry {
+            tracing::info!("config reload applied: connection registry rebuilt for new turns");
+        }
+        if plan.needs_restart() {
+            tracing::warn!(
+                "config reload: these changes need a daemon restart to take effect: {}",
+                plan.restart_required.join(", ")
+            );
+        }
+        Ok(plan)
     }
 }
 
@@ -1427,6 +1521,201 @@ mod tests {
         // Either the network fails (empty list) or succeeds — both are OK
         // since we're just checking we don't hard-error when aggregating.
         let _ = svc.list_available_models(None, false).await;
+    }
+
+    // ----- Hot-reload (apply_reload) tests (#222) ----------------------
+    //
+    // These cover the state-preserving swap:
+    // - an in-flight turn's cloned `Arc<dyn LlmClient>` stays alive across a
+    //   reload (registry swap drops only the registry's own handles)
+    // - a malformed config is refused without disturbing the running state
+    // - a valid edit swaps the config + registry in place
+
+    mod hot_reload {
+        use super::*;
+
+        /// Write `toml` to a fresh temp path and return a handle whose
+        /// `config_path` points at it, so `apply_reload` reads our file.
+        fn handle_for_toml(toml: &str) -> (Arc<RegistryHandle>, std::path::PathBuf) {
+            let path = tmp_config_path();
+            std::fs::write(&path, toml).expect("write initial config");
+            let cfg = crate::config::load_daemon_config(&path)
+                .expect("initial config parses")
+                .expect("initial config present");
+            let registry = build_registry(&cfg);
+            let handle =
+                Arc::new(RegistryHandle::new(cfg, registry).with_config_path(path.clone()));
+            (handle, path)
+        }
+
+        const OLLAMA_A: &str = r#"
+[connections.local]
+type = "ollama"
+base_url = "http://localhost:11434"
+"#;
+
+        #[test]
+        fn in_flight_turn_client_survives_reload() {
+            // Simulate an in-flight turn: dispatch clones the `Arc<dyn
+            // LlmClient>` before awaiting. Hold that clone across a reload and
+            // assert the underlying client is NOT dropped — the registry swap
+            // must rely on refcounts, not forcibly tear clients down.
+            let (handle, path) = handle_for_toml(OLLAMA_A);
+            let id = ConnectionId::new("local").unwrap();
+
+            // The "in-flight turn" grabs its client up front.
+            let in_flight = handle.client_for(&id).expect("client present");
+            let weak = Arc::downgrade(&in_flight);
+            assert!(weak.upgrade().is_some());
+
+            // Edit the connection's base_url and reload. This rebuilds the
+            // registry — the swap drops the registry's own Arc but our
+            // in-flight clone must keep the old client alive.
+            std::fs::write(
+                &path,
+                r#"
+[connections.local]
+type = "ollama"
+base_url = "http://localhost:9999"
+"#,
+            )
+            .unwrap();
+            let plan = handle.apply_reload().expect("valid reload applies");
+            assert!(plan.rebuild_registry, "a connection edit rebuilds");
+            assert!(!plan.needs_restart());
+
+            // The in-flight turn's client is still alive (refcount held by our
+            // clone), even though the registry now serves a different client.
+            assert!(
+                weak.upgrade().is_some(),
+                "the registry swap must not drop a client an in-flight turn still holds"
+            );
+            // New turns resolve through the freshly built registry.
+            assert!(handle.client_for(&id).is_some());
+
+            // Drop the in-flight clone; now the old client can be reclaimed.
+            drop(in_flight);
+            assert!(
+                weak.upgrade().is_none(),
+                "once the in-flight turn finishes, the old client is reclaimed"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+
+        #[test]
+        fn malformed_config_is_refused_without_disturbing_running_state() {
+            let (handle, path) = handle_for_toml(OLLAMA_A);
+            let id = ConnectionId::new("local").unwrap();
+            let before = handle.snapshot_config();
+            let live_before = handle.client_for(&id).is_some();
+            assert!(live_before, "the good config has a live client");
+
+            // Garbage TOML on disk.
+            std::fs::write(&path, "this is not = valid toml [[[").unwrap();
+            let err = handle
+                .apply_reload()
+                .expect_err("a malformed config must be refused");
+            assert!(!format!("{err:#}").is_empty());
+
+            // Running state is untouched: same config, same live client.
+            let after = handle.snapshot_config();
+            assert_eq!(
+                toml::to_string(&before).unwrap(),
+                toml::to_string(&after).unwrap(),
+                "a refused reload must leave the last-good config in place"
+            );
+            assert!(
+                handle.client_for(&id).is_some(),
+                "a refused reload must not drop the running registry's clients"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+
+        #[test]
+        fn reload_with_no_changes_is_a_noop() {
+            let (handle, path) = handle_for_toml(OLLAMA_A);
+            // Rewrite identical content (an editor save with no edits).
+            std::fs::write(&path, OLLAMA_A).unwrap();
+            let plan = handle.apply_reload().expect("identical config applies");
+            assert!(plan.is_empty(), "an unchanged config is a no-op reload");
+            let _ = std::fs::remove_file(&path);
+        }
+
+        #[test]
+        fn valid_edit_swaps_config_and_registry() {
+            let (handle, path) = handle_for_toml(OLLAMA_A);
+            assert!(
+                handle
+                    .client_for(&ConnectionId::new("local").unwrap())
+                    .is_some()
+            );
+
+            // Add a second connection.
+            std::fs::write(
+                &path,
+                r#"
+[connections.local]
+type = "ollama"
+base_url = "http://localhost:11434"
+
+[connections.other]
+type = "ollama"
+base_url = "http://localhost:11435"
+"#,
+            )
+            .unwrap();
+            let plan = handle.apply_reload().expect("valid reload applies");
+            assert!(plan.rebuild_registry);
+            // The new connection is now routable.
+            assert!(
+                handle
+                    .client_for(&ConnectionId::new("other").unwrap())
+                    .is_some(),
+                "a reload that adds a connection makes it routable for new turns"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+
+        #[test]
+        fn reload_refused_when_new_config_has_no_usable_connection() {
+            // Start good (ollama is healthy), then edit to an openai
+            // connection with no api key — every connection fails to build.
+            // The reload must be refused so new turns don't all break.
+            let unused = format!("DA_TEST_RELOAD_KEY_{}", uuid::Uuid::new_v4().simple());
+            // SAFETY: unique name, single-threaded test.
+            unsafe {
+                std::env::remove_var(&unused);
+            }
+            let (handle, path) = handle_for_toml(OLLAMA_A);
+            let id = ConnectionId::new("local").unwrap();
+            assert!(handle.client_for(&id).is_some());
+
+            std::fs::write(
+                &path,
+                format!(
+                    r#"
+[connections.cloud]
+type = "openai"
+base_url = "https://api.openai.com/v1"
+api_key_env = "{unused}"
+"#
+                ),
+            )
+            .unwrap();
+            let err = handle
+                .apply_reload()
+                .expect_err("a config with no usable connection must be refused");
+            assert!(
+                format!("{err:#}").contains("no usable LLM connection"),
+                "refusal should explain the cause: {err:#}"
+            );
+            // The original healthy connection is still live.
+            assert!(
+                handle.client_for(&id).is_some(),
+                "a refused reload keeps the last-good registry"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
     }
 
     // ----- RoutingConversationHandler dispatch-routing tests -----------

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -4,9 +4,15 @@ mod migration;
 mod oidc;
 #[cfg(target_os = "linux")]
 mod pam_auth;
+mod reload;
 mod resolution;
 mod secrets;
 mod views;
+
+// Hot-reload classification (#222): pure old/new config diff into a
+// `ReloadPlan`. Re-exported at `config::` so `api_surface` and `main` address
+// them without the submodule path.
+pub use reload::{ReloadPlan, plan_reload};
 
 // Re-export the settings views public API at `config::` so existing
 // callers (the inbound API handler, the dbus settings adapter) keep

--- a/crates/daemon/src/config/reload.rs
+++ b/crates/daemon/src/config/reload.rs
@@ -1,0 +1,201 @@
+//! Pure classification of what a config reload implies (#222).
+//!
+//! Mirrors the voice daemon's `plan_reload` (voice config#52): a
+//! side-effect-free diff of the old vs. new [`DaemonConfig`] into a
+//! [`ReloadPlan`] so the apply decision is unit-tested without touching
+//! disk, the registry, or any live connection.
+//!
+//! Three classes of knob:
+//!
+//! - **Hot-apply** — picked up by rebuilding the in-memory connection
+//!   registry under its `RwLock`. New turns route through the new clients;
+//!   in-flight turns keep the `Arc<dyn LlmClient>` they already cloned alive
+//!   by refcount (see [`crate::api_surface::RegistryHandle::apply_reload`]).
+//!   This covers `[connections]`, `[purposes]`, and the legacy `[llm]` block.
+//!
+//! - **Rebuild** — same mechanism as hot-apply today (a full registry
+//!   rebuild), called out separately so the log explains what changed.
+//!
+//! - **Restart-required** — wired once at process start and not swappable
+//!   live: the database pool/url, embeddings backend, persistence, WS auth,
+//!   TLS, and profiling. A reload still applies every hot knob in the same
+//!   edit; these are flagged in the plan so the daemon logs that a restart is
+//!   needed for them to take effect, rather than silently ignoring them.
+
+use super::DaemonConfig;
+
+/// The work a reload implies, derived purely from the old/new
+/// [`DaemonConfig`]. Pure and side-effect-free.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReloadPlan {
+    /// Rebuild the connection registry: `[connections]`, `[purposes]`, or the
+    /// legacy `[llm]` block changed. New turns route through the new clients.
+    pub rebuild_registry: bool,
+    /// Knobs that only take effect on a full process restart (database,
+    /// embeddings, persistence, ws-auth, TLS, profiling). Human-readable
+    /// labels for the log; applying a reload does not act on them.
+    pub restart_required: Vec<String>,
+}
+
+impl ReloadPlan {
+    /// True when nothing changed — the watcher/`Reload` can skip a no-op.
+    pub fn is_empty(&self) -> bool {
+        !self.rebuild_registry && self.restart_required.is_empty()
+    }
+
+    /// True when at least one knob requires a restart to take effect.
+    pub fn needs_restart(&self) -> bool {
+        !self.restart_required.is_empty()
+    }
+}
+
+/// Diff two [`DaemonConfig`] snapshots into the concrete work a reload implies.
+///
+/// - `[connections]` / `[purposes]` / `[llm]` changes set `rebuild_registry`
+///   (hot-applied by swapping the registry under its lock).
+/// - `[database]` / `[embeddings]` / `[persistence]` / `[ws_auth]` / `[tls]` /
+///   `[profiling]` changes are flagged in `restart_required` because those
+///   subsystems are constructed once at daemon startup.
+pub fn plan_reload(old: &DaemonConfig, new: &DaemonConfig) -> ReloadPlan {
+    let mut plan = ReloadPlan::default();
+
+    // Hot-applicable: anything the registry rebuild observes. `ConnectionConfig`
+    // / `Purposes` / `LlmConfig` aren't `PartialEq`, so compare via their
+    // serialized form — cheap, allocation-light at reload cadence, and exact.
+    if !areas_eq(&old.connections, &new.connections)
+        || !areas_eq(&old.purposes, &new.purposes)
+        || !areas_eq(&old.llm, &new.llm)
+        || !areas_eq(&old.backend_tasks, &new.backend_tasks)
+    {
+        plan.rebuild_registry = true;
+    }
+
+    // Restart-required: subsystems wired once at startup.
+    if !areas_eq(&old.database, &new.database) {
+        plan.restart_required.push("database".to_string());
+    }
+    if !areas_eq(&old.embeddings, &new.embeddings) {
+        plan.restart_required.push("embeddings".to_string());
+    }
+    if !areas_eq(&old.persistence, &new.persistence) {
+        plan.restart_required.push("persistence (git)".to_string());
+    }
+    if !areas_eq(&old.ws_auth, &new.ws_auth) {
+        plan.restart_required.push("ws_auth".to_string());
+    }
+    if !areas_eq(&old.tls, &new.tls) {
+        plan.restart_required.push("tls".to_string());
+    }
+    if !areas_eq(&old.profiling, &new.profiling) {
+        plan.restart_required.push("profiling".to_string());
+    }
+
+    plan
+}
+
+/// Structural equality of two config sub-areas via their TOML form. The config
+/// value types don't all implement `PartialEq`, and `serde` round-trips are the
+/// project's existing equality proxy for these. Serialization failures (which
+/// don't happen for valid in-memory config) conservatively report "changed".
+fn areas_eq<T: serde::Serialize>(a: &T, b: &T) -> bool {
+    match (toml::to_string(a), toml::to_string(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connections::{ConnectionConfig, OllamaConnection};
+
+    fn cfg_with_ollama(id: &str, base: &str) -> DaemonConfig {
+        let mut cfg = DaemonConfig::default();
+        cfg.connections.insert(
+            id.to_string(),
+            ConnectionConfig::Ollama(OllamaConnection {
+                base_url: Some(base.to_string()),
+            }),
+        );
+        cfg
+    }
+
+    #[test]
+    fn no_change_is_an_empty_plan() {
+        let cfg = cfg_with_ollama("local", "http://localhost:11434");
+        let plan = plan_reload(&cfg, &cfg);
+        assert!(
+            plan.is_empty(),
+            "an unchanged config must be a no-op reload"
+        );
+        assert!(!plan.needs_restart());
+    }
+
+    #[test]
+    fn connection_change_rebuilds_registry_without_restart() {
+        let old = cfg_with_ollama("local", "http://localhost:11434");
+        let new = cfg_with_ollama("local", "http://localhost:9999");
+        let plan = plan_reload(&old, &new);
+        assert!(plan.rebuild_registry, "a [connections] edit hot-applies");
+        assert!(
+            !plan.needs_restart(),
+            "a connection change never forces a restart"
+        );
+        assert!(!plan.is_empty());
+    }
+
+    #[test]
+    fn adding_a_connection_rebuilds_registry() {
+        let old = cfg_with_ollama("a", "http://localhost:11434");
+        let mut new = old.clone();
+        new.connections.insert(
+            "b".to_string(),
+            ConnectionConfig::Ollama(OllamaConnection {
+                base_url: Some("http://localhost:11435".to_string()),
+            }),
+        );
+        let plan = plan_reload(&old, &new);
+        assert!(plan.rebuild_registry);
+        assert!(!plan.needs_restart());
+    }
+
+    #[test]
+    fn database_change_flags_restart_required() {
+        let old = DaemonConfig::default();
+        let mut new = old.clone();
+        new.database.url = Some("postgres://localhost/da".to_string());
+        let plan = plan_reload(&old, &new);
+        assert!(plan.needs_restart());
+        assert!(
+            plan.restart_required.iter().any(|s| s == "database"),
+            "database edits must be flagged restart-required: {:?}",
+            plan.restart_required
+        );
+        // A pure database edit does not by itself rebuild the registry.
+        assert!(!plan.rebuild_registry);
+    }
+
+    #[test]
+    fn mixed_edit_hot_applies_connection_and_flags_database_restart() {
+        let old = cfg_with_ollama("local", "http://localhost:11434");
+        let mut new = cfg_with_ollama("local", "http://localhost:9999");
+        new.database.url = Some("postgres://localhost/da".to_string());
+        let plan = plan_reload(&old, &new);
+        // The hot knob in the same edit still applies …
+        assert!(plan.rebuild_registry);
+        // … while the restart-only knob is flagged.
+        assert!(plan.restart_required.iter().any(|s| s == "database"));
+    }
+
+    #[test]
+    fn embeddings_and_tls_changes_are_restart_required() {
+        let old = DaemonConfig::default();
+        let mut new = old.clone();
+        new.embeddings.connector = Some("ollama".to_string());
+        new.tls.enabled = !old.tls.enabled;
+        let plan = plan_reload(&old, &new);
+        assert!(plan.restart_required.iter().any(|s| s == "embeddings"));
+        assert!(plan.restart_required.iter().any(|s| s == "tls"));
+        assert!(!plan.rebuild_registry);
+    }
+}

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -32,6 +32,7 @@ use crate::registry::{ConnectionHealth, build_llm_client, build_registry};
 use desktop_assistant_application::DefaultAssistantApiHandler;
 use desktop_assistant_core::service::ConversationHandler;
 use desktop_assistant_dbus::conversation::DbusConversationAdapter;
+use desktop_assistant_dbus::reload::DbusReloadAdapter;
 use desktop_assistant_dbus::settings::DbusSettingsAdapter;
 use desktop_assistant_mcp_client::config as mcp_config;
 use desktop_assistant_mcp_client::executor::{BuiltinToolService, McpToolExecutor};
@@ -323,6 +324,120 @@ async fn shutdown_signal() {
         _ = ctrl_c => {}
         _ = terminate => {}
     }
+}
+
+/// Consume reload pings (from the D-Bus `Reload` method and the config-file
+/// watcher) and apply the new config to the running daemon (#222).
+///
+/// Coalesces a burst: it drains any pings that arrived while the last apply ran
+/// so an editor's write/rename/chmod storm collapses into one
+/// validate-classify-swap. `apply_reload` is state-preserving — it swaps the
+/// connection registry under its lock so new turns pick up the new clients
+/// while in-flight turns keep theirs alive by refcount — and never panics on a
+/// bad config: it refuses the apply, logs the cause, and keeps the last-good
+/// config running.
+fn spawn_reload_consumer(
+    registry: Arc<api_surface::RegistryHandle>,
+    mut reload_rx: tokio::sync::mpsc::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        while reload_rx.recv().await.is_some() {
+            // Drain any pings queued behind this one — a single apply observes
+            // the latest on-disk config, so coalescing is correct.
+            while reload_rx.try_recv().is_ok() {}
+            tracing::info!("config reload requested; re-reading daemon.toml");
+            match registry.apply_reload() {
+                Ok(plan) if plan.is_empty() => {}
+                Ok(_) => tracing::info!("config reload applied"),
+                Err(e) => {
+                    tracing::error!("config reload refused; keeping the last-good config: {e:#}")
+                }
+            }
+        }
+        tracing::debug!("config reload consumer exiting (channel closed)");
+    });
+}
+
+/// Watch `daemon.toml` for edits and ping the reload consumer (#222),
+/// debounced so an editor's write/rename/chmod burst collapses into one reload.
+///
+/// Mirrors the voice daemon's `spawn_config_watcher`: watch the *parent
+/// directory* (many editors replace the file via a temp-file rename, which
+/// breaks a watch bound to the original inode), bridge `notify`'s callback
+/// thread to a std channel, then debounce on a dedicated blocking thread that
+/// forwards a single async ping per quiet window. The KCM gets instant reload
+/// via the D-Bus `Reload` method; this covers hand-edits and other tools.
+fn spawn_config_watcher(config_path: std::path::PathBuf, reload_tx: tokio::sync::mpsc::Sender<()>) {
+    use notify::{RecursiveMode, Watcher};
+
+    let dir = match config_path.parent() {
+        Some(d) => d.to_path_buf(),
+        None => {
+            tracing::warn!("config watcher: config path has no parent dir, not watching");
+            return;
+        }
+    };
+    let file_name = config_path.file_name().map(std::ffi::OsString::from);
+
+    // notify's callback runs on its own (non-async) thread; bridge to a std
+    // mpsc, then debounce on a dedicated blocking thread that forwards into the
+    // async reload channel. A blocking thread (not a Tokio task) is used because
+    // the std `recv()` would otherwise park a runtime worker.
+    let (raw_tx, raw_rx) = std::sync::mpsc::channel::<()>();
+    let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(event) = res {
+            // Only react to events touching our config file (the dir may hold
+            // other files). Match by file name; rename targets count too.
+            let touches_config = file_name.as_ref().is_none_or(|name| {
+                event
+                    .paths
+                    .iter()
+                    .any(|p| p.file_name() == Some(name.as_os_str()))
+            });
+            let relevant = matches!(
+                event.kind,
+                notify::EventKind::Modify(_)
+                    | notify::EventKind::Create(_)
+                    | notify::EventKind::Remove(_)
+            );
+            if touches_config && relevant {
+                let _ = raw_tx.send(());
+            }
+        }
+    });
+    let mut watcher = match watcher {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(
+                "config watcher: failed to create watcher, live reload on file edits disabled: {e}"
+            );
+            return;
+        }
+    };
+    if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+        tracing::warn!(
+            dir = %dir.display(),
+            "config watcher: failed to watch dir, live reload on file edits disabled: {e}"
+        );
+        return;
+    }
+
+    std::thread::spawn(move || {
+        // Keep the watcher alive for the life of the thread (dropping it stops
+        // watching).
+        let _watcher = watcher;
+        // Block until the first raw event, then wait out a short quiet window
+        // and drain any burst — collapsing an editor's write/rename/chmod storm
+        // into one reload.
+        while raw_rx.recv().is_ok() {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            while raw_rx.try_recv().is_ok() {}
+            tracing::info!("daemon.toml changed on disk; requesting reload");
+            if reload_tx.blocking_send(()).is_err() {
+                break; // consumer gone
+            }
+        }
+    });
 }
 
 /// Enum wrapper to dispatch between conversation store backends at runtime.
@@ -1467,6 +1582,18 @@ async fn main() -> Result<()> {
         .with_config_path(config_path.clone()),
     );
 
+    // State-preserving config hot-reload (#222). The D-Bus `Reload` method and
+    // the config-file watcher both ping this bounded channel; one consumer task
+    // coalesces a burst and calls `RegistryHandle::apply_reload`, which
+    // validates the new config and swaps the registry under its lock — new turns
+    // get the new clients while in-flight turns keep theirs alive by refcount. A
+    // bad config is refused and the last-good config keeps running. The channel
+    // is bounded (depth 4) so a flood of edits can't grow it without limit; the
+    // consumer drains the queue before each apply.
+    let (reload_tx, reload_rx) = tokio::sync::mpsc::channel::<()>(4);
+    spawn_reload_consumer(Arc::clone(&registry_handle), reload_rx);
+    spawn_config_watcher(config_path.clone(), reload_tx.clone());
+
     // Wire the learned (tier 2) and LLM (tier 3) tiers of the backend-error
     // classifier (#178). The deterministic tier-1 matchers already run inside
     // every `ClassifyingLlmClient` built by `build_llm_client`; here we install
@@ -1678,6 +1805,14 @@ async fn main() -> Result<()> {
                     desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(Arc::clone(
                         &api_handler,
                     )),
+                )
+            })
+            .and_then(|b| {
+                // Hot-reload trigger (#222): the KCM calls `Reload` after
+                // writing daemon.toml so changes apply without a restart.
+                b.serve_at(
+                    "/org/desktopAssistant/Reload",
+                    DbusReloadAdapter::new(reload_tx.clone()),
                 )
             }) {
             Ok(builder) => match builder.build().await {

--- a/crates/dbus-bridge/src/adapter.rs
+++ b/crates/dbus-bridge/src/adapter.rs
@@ -27,12 +27,14 @@ pub mod connections;
 pub mod conversations;
 pub mod event_forwarder;
 pub mod knowledge;
+pub mod reload;
 pub mod settings;
 
 pub use background_tasks::DbusBackgroundTasksAdapter;
 pub use connections::DbusConnectionsAdapter;
 pub use conversations::DbusConversationsAdapter;
 pub use knowledge::DbusKnowledgeAdapter;
+pub use reload::DbusReloadAdapter;
 pub use settings::DbusSettingsAdapter;
 
 /// Well-known D-Bus bus name. Same as the in-process daemon's name —
@@ -50,4 +52,5 @@ pub mod paths {
     pub const CONNECTIONS: &str = "/org/desktopAssistant/Connections";
     pub const KNOWLEDGE: &str = "/org/desktopAssistant/Knowledge";
     pub const BACKGROUND_TASKS: &str = "/org/desktopAssistant/BackgroundTasks";
+    pub const RELOAD: &str = "/org/desktopAssistant/Reload";
 }

--- a/crates/dbus-bridge/src/adapter/reload.rs
+++ b/crates/dbus-bridge/src/adapter/reload.rs
@@ -1,0 +1,127 @@
+//! D-Bus adapter for `/org/desktopAssistant/Reload` (#222).
+//!
+//! Mirrors the in-process `org.desktopAssistant.Reload` interface
+//! (`crates/dbus-interface/src/reload.rs`) method-for-method so a client (the
+//! KCM) gets a working `Reload` regardless of which D-Bus surface — the
+//! in-process daemon adapter or this standalone bridge — owns
+//! `org.desktopAssistant`.
+//!
+//! Reload is a daemon-*local* operation (re-read `daemon.toml`, validate, swap
+//! the connection registry under its lock). It is deliberately NOT modeled as
+//! an `api::Command` on the UDS/WS wire — the daemon already watches its config
+//! file. So the bridge implements `Reload` by bumping the mtime of
+//! `daemon.toml`, which trips the daemon's file watcher and drives the same
+//! validate-classify-swap path the in-process `Reload` method does. This keeps
+//! the bridge free of any new wire command while still giving the KCM a single
+//! `Reload` call to make after it writes the config.
+
+use std::path::PathBuf;
+
+use zbus::{fdo, interface};
+
+/// Resolve `daemon.toml` the same way the daemon does: `$XDG_CONFIG_HOME`
+/// (falling back to `$HOME/.config`) + `desktop-assistant/daemon.toml`. Kept in
+/// sync with `desktop_assistant_daemon::config::default_daemon_config_path` (the
+/// bridge does not link the daemon crate, by design).
+fn default_daemon_config_path() -> PathBuf {
+    let config_home = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".to_string())).join(".config")
+        });
+    config_home.join("desktop-assistant").join("daemon.toml")
+}
+
+/// D-Bus adapter exposing `Reload` on `org.desktopAssistant.Reload`.
+pub struct DbusReloadAdapter {
+    config_path: PathBuf,
+}
+
+impl Default for DbusReloadAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbusReloadAdapter {
+    pub fn new() -> Self {
+        Self {
+            config_path: default_daemon_config_path(),
+        }
+    }
+
+    /// Override the config path (used in tests).
+    pub fn with_config_path(mut self, path: PathBuf) -> Self {
+        self.config_path = path;
+        self
+    }
+
+    /// Touch the config file's mtime so the daemon's file watcher fires and
+    /// applies the (already-written) config. Returns an error if the file does
+    /// not exist — there is nothing for the daemon to reload.
+    fn touch_config(&self) -> std::io::Result<()> {
+        let now = std::time::SystemTime::now();
+        let file = std::fs::File::open(&self.config_path)?;
+        file.set_modified(now)
+    }
+}
+
+#[interface(name = "org.desktopAssistant.Reload")]
+impl DbusReloadAdapter {
+    /// Ask the daemon to re-read `daemon.toml` and apply any changed config
+    /// without a restart (#222).
+    ///
+    /// The KCM calls this after writing the config. The bridge bumps the
+    /// config file's mtime to trip the daemon's file watcher, which runs the
+    /// state-preserving validate-classify-swap (in-flight turns keep their
+    /// clients; a bad config is refused and the last-good config keeps
+    /// running).
+    async fn reload(&self) -> fdo::Result<()> {
+        self.touch_config().map_err(|e| {
+            fdo::Error::Failed(format!(
+                "failed to signal reload via {}: {e}",
+                self.config_path.display()
+            ))
+        })?;
+        tracing::info!("config reload requested over D-Bus (bridge); nudged the daemon watcher");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reload_bumps_config_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.toml");
+        std::fs::write(&path, "[llm]\nconnector = \"ollama\"\n").unwrap();
+
+        // Backdate the mtime so the touch is observable.
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        std::fs::File::open(&path)
+            .unwrap()
+            .set_modified(old)
+            .unwrap();
+        let before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        let adapter = DbusReloadAdapter::new().with_config_path(path.clone());
+        adapter.reload().await.expect("reload touches the config");
+
+        let after = std::fs::metadata(&path).unwrap().modified().unwrap();
+        assert!(after > before, "Reload must bump the config file mtime");
+    }
+
+    #[tokio::test]
+    async fn reload_errors_when_config_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.toml");
+        let adapter = DbusReloadAdapter::new().with_config_path(path);
+        let err = adapter
+            .reload()
+            .await
+            .expect_err("a missing config must surface a clean D-Bus error");
+        assert!(format!("{err}").contains("failed to signal reload"));
+    }
+}

--- a/crates/dbus-bridge/src/main.rs
+++ b/crates/dbus-bridge/src/main.rs
@@ -26,7 +26,8 @@ use clap::Parser;
 use desktop_assistant_api_model as api;
 use desktop_assistant_dbus_bridge::adapter::{
     DBUS_SERVICE_NAME, DbusBackgroundTasksAdapter, DbusConnectionsAdapter,
-    DbusConversationsAdapter, DbusKnowledgeAdapter, DbusSettingsAdapter, event_forwarder, paths,
+    DbusConversationsAdapter, DbusKnowledgeAdapter, DbusReloadAdapter, DbusSettingsAdapter,
+    event_forwarder, paths,
 };
 use desktop_assistant_dbus_bridge::minter::{MintRequest, default_minter_socket_path, fetch_jwt};
 use desktop_assistant_dbus_bridge::transport::{
@@ -139,6 +140,9 @@ async fn main() -> anyhow::Result<()> {
     let connections = DbusConnectionsAdapter::new(Arc::clone(&transport));
     let knowledge = DbusKnowledgeAdapter::new(Arc::clone(&transport));
     let background_tasks = DbusBackgroundTasksAdapter::new(Arc::clone(&transport));
+    // Config hot-reload (#222): nudges the daemon's file watcher so the KCM can
+    // apply config changes without a daemon restart.
+    let reload = DbusReloadAdapter::new();
 
     let connection = zbus::connection::Builder::session()
         .context("failed to connect to D-Bus session bus")?
@@ -148,6 +152,7 @@ async fn main() -> anyhow::Result<()> {
         .serve_at(paths::CONNECTIONS, connections)?
         .serve_at(paths::KNOWLEDGE, knowledge)?
         .serve_at(paths::BACKGROUND_TASKS, background_tasks)?
+        .serve_at(paths::RELOAD, reload)?
         .build()
         .await
         .context("failed to build D-Bus connection")?;

--- a/crates/dbus-bridge/tests/bridge.rs
+++ b/crates/dbus-bridge/tests/bridge.rs
@@ -487,6 +487,7 @@ fn dbus_surface_object_paths_match_legacy() {
     assert_eq!(paths::SETTINGS, "/org/desktopAssistant/Settings");
     assert_eq!(paths::CONNECTIONS, "/org/desktopAssistant/Connections");
     assert_eq!(paths::KNOWLEDGE, "/org/desktopAssistant/Knowledge");
+    assert_eq!(paths::RELOAD, "/org/desktopAssistant/Reload");
 }
 
 #[test]

--- a/crates/dbus-interface/src/lib.rs
+++ b/crates/dbus-interface/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod connections;
 pub mod conversation;
 pub mod knowledge;
+pub mod reload;
 pub mod settings;
 
 use desktop_assistant_core::ports::auth::UserId;

--- a/crates/dbus-interface/src/reload.rs
+++ b/crates/dbus-interface/src/reload.rs
@@ -1,0 +1,76 @@
+//! D-Bus `Reload` method for state-preserving config hot-reload (#222).
+//!
+//! Mirrors the voice daemon's `org.desktopAssistant.Voice.Reload`: the KCM
+//! writes `daemon.toml` via the settings setters, then calls `Reload` so the
+//! orchestrator re-reads the file and applies the changed knobs without a
+//! restart (which would sever every client and kill in-flight turns).
+//!
+//! The adapter only *pings* a channel; the daemon's reload-consumer task does
+//! the validate-classify-swap (see `crates/daemon/src/api_surface.rs`
+//! `RegistryHandle::apply_reload`). A bounded channel keeps a flurry of calls
+//! from unbounded buffering — the consumer coalesces them.
+
+use tokio::sync::mpsc;
+use zbus::{fdo, interface};
+
+/// D-Bus adapter exposing `Reload` on `org.desktopAssistant.Reload`.
+pub struct DbusReloadAdapter {
+    /// Pings the daemon's reload-consumer task to re-read and apply the config.
+    reload_tx: mpsc::Sender<()>,
+}
+
+impl DbusReloadAdapter {
+    pub fn new(reload_tx: mpsc::Sender<()>) -> Self {
+        Self { reload_tx }
+    }
+}
+
+#[interface(name = "org.desktopAssistant.Reload")]
+impl DbusReloadAdapter {
+    /// Re-read `daemon.toml` and apply any changed config to the running
+    /// daemon without a restart (#222).
+    ///
+    /// Hot-applies `[connections]` / `[purposes]` / `[llm]` by rebuilding the
+    /// connection registry — new turns route through the new clients while
+    /// in-flight turns keep the client they already hold alive until they
+    /// finish. Subsystems wired once at startup (database, embeddings, TLS,
+    /// ws-auth, persistence, profiling) are logged as needing a restart. A
+    /// config that fails to parse/validate is refused and the last-good config
+    /// keeps running.
+    ///
+    /// Returns immediately after queuing the request; the apply happens
+    /// asynchronously. A file watcher also picks up edits made any other way.
+    async fn reload(&self) -> fdo::Result<()> {
+        self.reload_tx
+            .send(())
+            .await
+            .map_err(|e| fdo::Error::Failed(format!("failed to trigger reload: {e}")))?;
+        tracing::info!("config reload requested over D-Bus");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reload_pings_the_channel() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let adapter = DbusReloadAdapter::new(tx);
+        adapter.reload().await.expect("reload queues a ping");
+        assert!(rx.try_recv().is_ok(), "Reload must enqueue a reload ping");
+    }
+
+    #[tokio::test]
+    async fn reload_errors_when_consumer_is_gone() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx); // consumer task gone
+        let adapter = DbusReloadAdapter::new(tx);
+        let err = adapter
+            .reload()
+            .await
+            .expect_err("a dropped consumer must surface a clean D-Bus error");
+        assert!(format!("{err}").contains("failed to trigger reload"));
+    }
+}


### PR DESCRIPTION
## What

Wire the half-built reload machinery into a non-breaking config hot-reload so the orchestrator picks up `daemon.toml` changes without a restart (which severs every client and kills in-flight turns).

## Changes

- **File watcher** (`notify`, debounced) on `daemon.toml` in `main.rs` → a bounded reload channel, mirroring voice's `spawn_config_watcher` (watches the parent dir so editor temp-file renames still fire).
- **D-Bus `Reload`** — a new `org.desktopAssistant.Reload` object in both the in-process `dbus-interface` adapter and the `dbus-bridge` adapter, so the KCM can trigger a reload after writing config instead of restarting. The bridge nudges the daemon's file watcher (Reload is a daemon-local op, not a wire `Command`).
- **Pure knob classification** — `config::plan_reload(old, new) -> ReloadPlan` splits changes into **hot-apply** (rebuild the connection registry: `[connections]`/`[purposes]`/`[llm]`/`[backend_tasks]`) vs. **restart-required** (`[database]`/`[embeddings]`/`[persistence]`/`[ws_auth]`/`[tls]`/`[profiling]`). Unit-tested with no disk/registry side effects, like voice's `plan_reload`.
- **Non-breaking registry swap** — `RegistryHandle::apply_reload` validates the new config, builds the candidate registry off-lock, then swaps it under the `RwLock`. Dispatch clones its `Arc<dyn LlmClient>` *before* awaiting, so the swap (which drops only the registry's own handles) leaves an in-flight turn's client alive by refcount until the turn finishes; new turns route through the new registry. Active turns/connections are never torn down.
- **Validate-before-apply** — a config that fails to parse/validate, or that yields zero usable connections when the running one had some, is refused with a clear logged error; the last-good config keeps running and the daemon never panics/exits on a bad reload.

## What hot-reloads vs. needs a restart

| Hot-applied (new turns, no restart) | Restart-required (logged) |
| --- | --- |
| `[connections]`, `[purposes]`, `[llm]`, `[backend_tasks]` | `[database]`, `[embeddings]`, `[persistence]`, `[ws_auth]`, `[tls]`, `[profiling]` |

A mixed edit applies the hot knobs and logs the restart-only ones — it never silently drops them.

## Tests

- `config::reload` — `plan_reload` classification (no-op, connection edit, add connection, database/embeddings/tls restart flags, mixed edit).
- `api_surface::hot_reload` — an in-flight turn's cloned client survives a reload (weak ref still upgradeable, reclaimed once the turn drops it); malformed config refused without disturbing running state; no-usable-connection config refused; valid edit swaps config + registry; no-change is a no-op.
- `reload::tests` (dbus-interface + dbus-bridge) — Reload pings the channel / touches the config mtime; clean errors on a dropped consumer / missing file.

`just check` (fmt + clippy `--workspace --all-targets -D warnings` + build + test) is green; the pre-push hook ran it without hanging.

## Scope

`crates/daemon` (config, main, api_surface) + `crates/dbus-interface` + `crates/dbus-bridge`. Did **not** touch `llm-*`, `client-common`, `application`, or `core` (sibling agents). KCM-side "call Reload after writing" is a separate adele-kde concern.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)