### PR TITLE
feat(client-common): wire the client half of the client-tool protocol (#231)

### DIFF
--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -416,6 +416,55 @@ pub trait AssistantCommands: Send + Sync {
         };
         Ok(())
     }
+
+    // --- Client-side tool execution (issue #107 / #231) -------------------
+
+    /// Advertise the set of client-local MCP tools this connection can run
+    /// (#107). The daemon replaces any previously-registered set on each call —
+    /// send the full list, not deltas — so re-register on every connect.
+    /// Returns the count of tools the daemon accepted (from
+    /// `CommandResult::ClientToolsRegistered`).
+    async fn register_client_tools(
+        &self,
+        tools: Vec<api::ClientToolRegistration>,
+    ) -> Result<usize> {
+        let result = self
+            .send_command(api::Command::RegisterClientTools { tools })
+            .await?;
+        let api::CommandResult::ClientToolsRegistered { count } = result else {
+            return Err(anyhow!("unexpected response for register_client_tools"));
+        };
+        Ok(count as usize)
+    }
+
+    /// Deliver the outcome of a `ClientToolCall` back to the daemon so the
+    /// suspended turn can resume (#107). Pass the `task_id` and `tool_call_id`
+    /// the [`SignalEvent::ClientToolCall`](crate::SignalEvent::ClientToolCall)
+    /// carried, and exactly one of `result` / `error` — the daemon treats both
+    /// `None` as an error.
+    async fn submit_client_tool_result(
+        &self,
+        task_id: &str,
+        tool_call_id: &str,
+        result: Result<String, String>,
+    ) -> Result<()> {
+        let (ok, err) = match result {
+            Ok(value) => (Some(value), None),
+            Err(message) => (None, Some(message)),
+        };
+        let outcome = self
+            .send_command(api::Command::ClientToolResult {
+                task_id: api::TaskId(task_id.to_string()),
+                tool_call_id: tool_call_id.to_string(),
+                result: ok,
+                error: err,
+            })
+            .await?;
+        let api::CommandResult::Ack = outcome else {
+            return Err(anyhow!("unexpected response for submit_client_tool_result"));
+        };
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -734,6 +783,73 @@ mod tests {
                 assert!(!all);
             }
             other => panic!("expected DeleteScratchpadNotes, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_client_tools_emits_command_and_returns_count() {
+        let client = RecordingClient::new(api::CommandResult::ClientToolsRegistered { count: 2 });
+        let tools = vec![
+            api::ClientToolRegistration {
+                name: "weather".into(),
+                description: "look up the weather".into(),
+                input_schema: serde_json::json!({ "type": "object" }),
+            },
+            api::ClientToolRegistration {
+                name: "calendar".into(),
+                description: String::new(),
+                input_schema: serde_json::Value::Null,
+            },
+        ];
+        let count = client.register_client_tools(tools.clone()).await.unwrap();
+        assert_eq!(count, 2);
+        match client.last() {
+            api::Command::RegisterClientTools { tools: emitted } => {
+                assert_eq!(emitted, tools);
+            }
+            other => panic!("expected RegisterClientTools, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_client_tool_result_ok_emits_result_field() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .submit_client_tool_result("task-1", "call-1", Ok("sunny".into()))
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::ClientToolResult {
+                task_id,
+                tool_call_id,
+                result,
+                error,
+            } => {
+                assert_eq!(task_id, api::TaskId("task-1".into()));
+                assert_eq!(tool_call_id, "call-1");
+                assert_eq!(result.as_deref(), Some("sunny"));
+                assert!(error.is_none());
+            }
+            other => panic!("expected ClientToolResult, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn submit_client_tool_result_err_emits_error_field() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .submit_client_tool_result("task-2", "call-2", Err("tool blew up".into()))
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::ClientToolResult { result, error, .. } => {
+                // Exactly one of result/error is populated — an Err maps to the
+                // error field with result left None (the daemon treats both
+                // None as an error).
+                assert!(result.is_none());
+                assert_eq!(error.as_deref(), Some("tool blew up"));
+            }
+            other => panic!("expected ClientToolResult, got {other:?}"),
         }
     }
 }

--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
+use desktop_assistant_api_model as api;
 use tokio::sync::mpsc;
 
 use crate::config::ConnectionConfig;
@@ -195,6 +196,54 @@ impl Connector {
                 format!("{system_refinement}\n\n{prompt}")
             };
             self.client.send_prompt(conversation_id, &composed).await
+        }
+    }
+
+    /// Advertise the set of client-local MCP tools this connection can run
+    /// (#107/#231). The daemon replaces any previously-registered set on each
+    /// call — send the full list, not deltas — so re-register on every connect.
+    /// Returns the count of tools the daemon accepted.
+    ///
+    /// Client tools ride the socket command channel, so this is supported only
+    /// over the UDS/WS transports; the D-Bus transport has no command channel
+    /// for it and returns an error.
+    pub async fn register_client_tools(
+        &self,
+        tools: Vec<api::ClientToolRegistration>,
+    ) -> Result<usize> {
+        match self.client.as_commands() {
+            Some(commands) => commands.register_client_tools(tools).await,
+            None => Err(anyhow::anyhow!(
+                "register_client_tools requires a socket transport (UDS or WS); \
+                 the D-Bus transport does not support client tools"
+            )),
+        }
+    }
+
+    /// Deliver the outcome of a
+    /// [`SignalEvent::ClientToolCall`](crate::SignalEvent::ClientToolCall) back
+    /// to the daemon so the suspended turn can resume (#107/#231). Pass the
+    /// `task_id` and `tool_call_id` from the event and exactly one of
+    /// `result` / `error` (encoded as `Ok` / `Err`).
+    ///
+    /// Supported only over the socket transports (UDS/WS), like
+    /// [`register_client_tools`](Self::register_client_tools).
+    pub async fn submit_client_tool_result(
+        &self,
+        task_id: &str,
+        tool_call_id: &str,
+        result: Result<String, String>,
+    ) -> Result<()> {
+        match self.client.as_commands() {
+            Some(commands) => {
+                commands
+                    .submit_client_tool_result(task_id, tool_call_id, result)
+                    .await
+            }
+            None => Err(anyhow::anyhow!(
+                "submit_client_tool_result requires a socket transport (UDS or WS); \
+                 the D-Bus transport does not support client tools"
+            )),
         }
     }
 }

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -62,6 +62,20 @@ pub enum SignalEvent {
     ScratchpadChanged {
         conversation_id: String,
     },
+    /// The daemon's turn has suspended on a client-local MCP tool call (#107).
+    /// The client is expected to execute `tool_name` with `arguments` against
+    /// its local environment and post the outcome back via
+    /// [`Connector::submit_client_tool_result`](crate::Connector::submit_client_tool_result)
+    /// with the same `task_id` and `tool_call_id`; until then the turn parks.
+    /// `task_id` is the `api::TaskId` unwrapped to its inner `String`, matching
+    /// the rest of this stream's id fields.
+    ClientToolCall {
+        task_id: String,
+        conversation_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+    },
     Disconnected {
         reason: String,
     },

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -300,12 +300,24 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
         api::Event::ScratchpadChanged { conversation_id } => {
             Some(SignalEvent::ScratchpadChanged { conversation_id })
         }
-        // Client-side tool execution (#107): handled by clients that
-        // implement the client-tool protocol directly; the legacy
-        // `SignalEvent` stream is for the GTK desktop UI and does not
-        // surface tool-call requests. Listed explicitly so a future
-        // client that DOES want to react can move it out of this arm.
-        api::Event::ClientToolCall { .. } => None,
+        // Client-side tool execution (#107/#231): surfaced on the signal
+        // stream so a client that advertised client-local tools (voice first)
+        // can execute the requested tool and post the result back via
+        // `Connector::submit_client_tool_result`. The `TaskId` newtype is
+        // unwrapped to its inner `String` to match the rest of this stream.
+        api::Event::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => Some(SignalEvent::ClientToolCall {
+            task_id: task_id.0,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        }),
     }
 }
 
@@ -443,6 +455,37 @@ mod tests {
                 assert_eq!(conversation_id, "c-1");
             }
             other => panic!("expected SignalEvent::ScratchpadChanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_client_tool_call_event() {
+        // #231: a `ClientToolCall` event used to be dropped (`=> None`); it now
+        // surfaces on the signal stream so a client that advertised tools can
+        // run the call and post a result back. The `TaskId` newtype is unwrapped
+        // to its inner string.
+        let signal = map_event_to_signal(api::Event::ClientToolCall {
+            task_id: api::TaskId("task-1".into()),
+            conversation_id: "conv-1".into(),
+            tool_call_id: "call-1".into(),
+            tool_name: "weather".into(),
+            arguments: serde_json::json!({ "city": "Boston" }),
+        });
+        match signal {
+            Some(SignalEvent::ClientToolCall {
+                task_id,
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            }) => {
+                assert_eq!(task_id, "task-1");
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(tool_call_id, "call-1");
+                assert_eq!(tool_name, "weather");
+                assert_eq!(arguments, serde_json::json!({ "city": "Boston" }));
+            }
+            other => panic!("expected SignalEvent::ClientToolCall, got {other:?}"),
         }
     }
 

--- a/crates/client-common/tests/uds_client_tools.rs
+++ b/crates/client-common/tests/uds_client_tools.rs
@@ -1,0 +1,277 @@
+//! #231: the client half of the client-tool protocol must work end-to-end over
+//! the live UDS transport — the same path the voice service uses.
+//!
+//! Three things are exercised against a real in-process `desktop-assistant-uds`
+//! server reached through `client-common`'s public `Connector`:
+//!
+//! 1. `register_client_tools` sends `Command::RegisterClientTools` and returns
+//!    the count the daemon acked (`CommandResult::ClientToolsRegistered`).
+//! 2. A turn emits `Event::ClientToolCall` through the per-connection sink; the
+//!    client receives it on the signal stream as `SignalEvent::ClientToolCall`
+//!    (it used to be silently dropped — `=> None`).
+//! 3. `submit_client_tool_result` sends `Command::ClientToolResult` back; the
+//!    handler records it and acks.
+//!
+//! The handler is a recording double (no real LLM/turn machinery): it stands in
+//! for the "server half" that already exists in the daemon, so this test pins
+//! the wire shapes the client emits/consumes, not the daemon's resumption logic.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::{ApiError, ApiResult, AssistantApiHandler, EventSink};
+use desktop_assistant_auth_jwt as jwt;
+use desktop_assistant_client_common::{ConnectionConfig, Connector, SignalEvent, TransportMode};
+use desktop_assistant_uds::{UdsAuthValidator, UdsServer, UdsServerConfig};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::time::{Duration, timeout};
+
+const ISS: &str = "test-uds-iss";
+const AUD: &str = "test-uds-aud";
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn mint_test_jwt(signing_key: &str, subject: &str) -> String {
+    let now = unix_now();
+    let claims = jwt::Claims {
+        iss: ISS.into(),
+        sub: subject.into(),
+        aud: AUD.into(),
+        exp: now + 600,
+        iat: now,
+        nbf: now.saturating_sub(1),
+        jti: uuid::Uuid::new_v4().to_string(),
+    };
+    jwt::encode(&claims, signing_key).expect("encode jwt")
+}
+
+/// Records the client-tool commands the client sends, and — for a turn — emits a
+/// `ClientToolCall` event through the per-connection sink so the client receives
+/// it on its signal stream.
+#[derive(Default)]
+struct ClientToolHandler {
+    /// Captured `RegisterClientTools` payload(s).
+    registered: Mutex<Vec<api::ClientToolRegistration>>,
+    /// Captured `ClientToolResult` command(s).
+    results: Mutex<Vec<api::Command>>,
+}
+
+#[async_trait::async_trait]
+impl AssistantApiHandler for ClientToolHandler {
+    async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+        match cmd {
+            api::Command::RegisterClientTools { tools } => {
+                let count = tools.len() as u32;
+                *self.registered.lock().unwrap() = tools;
+                Ok(api::CommandResult::ClientToolsRegistered { count })
+            }
+            cmd @ api::Command::ClientToolResult { .. } => {
+                self.results.lock().unwrap().push(cmd);
+                Ok(api::CommandResult::Ack)
+            }
+            _ => Err(ApiError::Unsupported),
+        }
+    }
+
+    async fn handle_send_message(
+        &self,
+        _conversation_id: String,
+        _content: String,
+        _request_id: String,
+        _sink: Arc<dyn EventSink>,
+    ) -> ApiResult<()> {
+        Ok(())
+    }
+
+    /// Use the registry path so the dispatcher hands us the per-connection sink
+    /// (like the real turn body), through which we emit a single
+    /// `ClientToolCall` event for the client to react to.
+    #[allow(clippy::too_many_arguments)]
+    async fn start_send_message(
+        &self,
+        conversation_id: String,
+        _content: String,
+        _override_selection: Option<api::SendPromptOverride>,
+        _system_refinement: String,
+        _request_id: String,
+        _idempotency_key: Option<String>,
+        sink: Arc<dyn EventSink>,
+    ) -> ApiResult<Option<api::TaskId>> {
+        let task_id = api::TaskId(uuid::Uuid::new_v4().to_string());
+        let emitted_task_id = task_id.clone();
+        tokio::spawn(async move {
+            sink.emit(api::Event::ClientToolCall {
+                task_id: emitted_task_id,
+                conversation_id,
+                tool_call_id: "call-1".into(),
+                tool_name: "weather".into(),
+                arguments: serde_json::json!({ "city": "Boston" }),
+            })
+            .await;
+        });
+        Ok(Some(task_id))
+    }
+}
+
+struct StaticJwtAuth {
+    signing_key: String,
+}
+
+#[async_trait::async_trait]
+impl UdsAuthValidator for StaticJwtAuth {
+    async fn validate_bearer_token(&self, token: &str) -> bool {
+        jwt::decode(token, &self.signing_key, ISS, AUD).is_ok()
+    }
+}
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if path.exists() && UnixStream::connect(path).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("uds socket {path:?} did not appear");
+}
+
+fn uds_config(socket_path: PathBuf, jwt: String) -> ConnectionConfig {
+    ConnectionConfig {
+        transport_mode: TransportMode::Uds,
+        socket_path: Some(socket_path),
+        ws_jwt: Some(jwt),
+        ..ConnectionConfig::default()
+    }
+}
+
+fn start_server(
+    socket_path: PathBuf,
+    signing_key: String,
+    handler: Arc<ClientToolHandler>,
+) -> tokio::sync::oneshot::Sender<()> {
+    let handler: Arc<dyn AssistantApiHandler> = handler;
+    let auth: Arc<dyn UdsAuthValidator> = Arc::new(StaticJwtAuth { signing_key });
+    let config = UdsServerConfig::new(socket_path);
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server = UdsServer::new(handler, auth, config);
+    tokio::spawn(async move {
+        let _ = server
+            .serve_with_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    tx
+}
+
+/// Full client-tool round trip over UDS: register, receive the tool-call event,
+/// post the result back.
+#[tokio::test]
+async fn uds_client_tools_round_trip_register_call_result() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let handler = Arc::new(ClientToolHandler::default());
+    let shutdown = start_server(path.clone(), signing_key.clone(), Arc::clone(&handler));
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    let connector = Connector::connect(&cfg).await.expect("connector over uds");
+
+    // Subscribe BEFORE sending so the emitted ClientToolCall isn't lost.
+    let mut events = connector.subscribe();
+
+    // 1. Register two client tools and confirm the daemon-acked count.
+    let tools = vec![
+        api::ClientToolRegistration {
+            name: "weather".into(),
+            description: "look up the weather".into(),
+            input_schema: serde_json::json!({ "type": "object" }),
+        },
+        api::ClientToolRegistration {
+            name: "calendar".into(),
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+        },
+    ];
+    let count = timeout(
+        Duration::from_secs(2),
+        connector.register_client_tools(tools.clone()),
+    )
+    .await
+    .expect("register_client_tools should resolve")
+    .expect("registration ok");
+    assert_eq!(count, 2, "daemon must ack the registered tool count");
+    assert_eq!(
+        *handler.registered.lock().unwrap(),
+        tools,
+        "the handler must receive the full RegisterClientTools payload"
+    );
+
+    // 2. Kick off a turn; the handler emits a ClientToolCall through the sink.
+    let _request_id = timeout(
+        Duration::from_secs(2),
+        connector.send_prompt("conv-1", "hi"),
+    )
+    .await
+    .expect("send_prompt should ack")
+    .expect("ack ok");
+
+    // The client must SEE the tool call on its signal stream (it used to be
+    // dropped). Skip any unrelated events (e.g. a status heartbeat).
+    let (task_id, tool_call_id, tool_name, arguments) = loop {
+        match timeout(Duration::from_secs(2), events.recv()).await {
+            Ok(Some(SignalEvent::ClientToolCall {
+                task_id,
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            })) => {
+                assert_eq!(conversation_id, "conv-1");
+                break (task_id, tool_call_id, tool_name, arguments);
+            }
+            Ok(Some(_other)) => continue,
+            Ok(None) => panic!("signal stream closed before the tool call arrived"),
+            Err(_) => panic!("timed out waiting for SignalEvent::ClientToolCall"),
+        }
+    };
+    assert_eq!(tool_call_id, "call-1");
+    assert_eq!(tool_name, "weather");
+    assert_eq!(arguments, serde_json::json!({ "city": "Boston" }));
+    assert!(!task_id.is_empty(), "task_id must be carried through");
+
+    // 3. Post the tool result back; the handler records the ClientToolResult.
+    timeout(
+        Duration::from_secs(2),
+        connector.submit_client_tool_result(&task_id, &tool_call_id, Ok("sunny, 72F".into())),
+    )
+    .await
+    .expect("submit_client_tool_result should resolve")
+    .expect("result ack ok");
+
+    let results = handler.results.lock().unwrap().clone();
+    assert_eq!(results.len(), 1, "exactly one ClientToolResult expected");
+    match &results[0] {
+        api::Command::ClientToolResult {
+            task_id: got_task,
+            tool_call_id: got_call,
+            result,
+            error,
+        } => {
+            assert_eq!(got_task.0, task_id);
+            assert_eq!(got_call, "call-1");
+            assert_eq!(result.as_deref(), Some("sunny, 72F"));
+            assert!(error.is_none());
+        }
+        other => panic!("expected ClientToolResult, got {other:?}"),
+    }
+
+    let _ = shutdown.send(());
+}


### PR DESCRIPTION
## What

Wires the **client** half of the client-tool protocol in the shared `client-common` so a client (voice first) can advertise tools the LLM calls. The orchestrator/server half already exists (`Command::RegisterClientTools` → suspend turn → `Event::ClientToolCall` → resume on `Command::ClientToolResult`).

### Gaps closed
- `api::Event::ClientToolCall` was **dropped** (`=> None`) in `map_event_to_signal` (shared by the UDS and WS clients) and `SignalEvent` had no variant for it.
- No `Connector` method to send `Command::RegisterClientTools` or `Command::ClientToolResult`.

### Changes (`crates/client-common` only)
- **`signal.rs`** — new `SignalEvent::ClientToolCall { task_id, conversation_id, tool_call_id, tool_name, arguments }`.
- **`ws_client.rs`** — map `api::Event::ClientToolCall` → `SignalEvent::ClientToolCall` (replaces the `=> None` drop), unwrapping the `TaskId` newtype to its inner `String` to match the rest of the stream's id fields. This single mapping serves **both** UDS and WS (UDS reuses `map_event_to_signal`). The D-Bus client subscribes to a fixed set of typed zbus signals with no `ClientToolCall` signal, so there is nothing to map there.
- **`commands.rs`** — two provided methods on `AssistantCommands`, riding the existing oneshot-correlated `send_command` plumbing (incl. the #221 dispatch timeout):
  - `register_client_tools(tools: Vec<ClientToolRegistration>) -> Result<usize>` (returns the count from `ClientToolsRegistered`).
  - `submit_client_tool_result(task_id, tool_call_id, result: Result<String, String>)` (Ok→`result`, Err→`error`; daemon acks).
- **`connector.rs`** — `Connector::register_client_tools` / `Connector::submit_client_tool_result`, dispatched via `as_commands()`. Both require a socket transport (UDS/WS); D-Bus returns a clear error (it has no command channel for this).

## API surface (the voice epic depends on these)
```rust
// SignalEvent (events fanned out by the Connector)
SignalEvent::ClientToolCall {
    task_id: String,
    conversation_id: String,
    tool_call_id: String,
    tool_name: String,
    arguments: serde_json::Value,
}

// Connector methods
async fn register_client_tools(&self, tools: Vec<api::ClientToolRegistration>) -> Result<usize>;
async fn submit_client_tool_result(&self, task_id: &str, tool_call_id: &str, result: Result<String, String>) -> Result<()>;
```

## Tests
- Unit: `api::Event::ClientToolCall` → `SignalEvent::ClientToolCall` mapping; both send methods against `RecordingClient` (Ok and Err result paths).
- Integration (`tests/uds_client_tools.rs`): a full **register → ClientToolCall event → ClientToolResult** round trip over a **loopback UDS server** reached through the public `Connector` (follows the `uds_streaming.rs` harness — handler records the `RegisterClientTools` call, emits a `ClientToolCall` through the per-connection sink during a turn, then records the `ClientToolResult`). This is the exact path the voice service uses (subscribe-before-send, read fanned-out signals).

## Validation
`just check` GREEN: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, build, and the full test suite all pass.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)