### PR TITLE
feat: configurable assistant personality (global) — disposition blurb in the system prompt

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -577,6 +577,11 @@ pub struct Status {
 pub struct Config {
     pub embeddings: EmbeddingsSettingsView,
     pub persistence: PersistenceSettingsView,
+    /// Configurable assistant disposition (issue #226). Carries the 7
+    /// "Expressive 7" trait levels as a typed struct (see
+    /// [`PersonalitySettingsView`]).
+    #[serde(default)]
+    pub personality: PersonalitySettingsView,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -595,6 +600,23 @@ pub struct ConfigChanges {
     pub persistence_remote_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persistence_push_on_update: Option<bool>,
+    // Personality (#226): one optional level per trait. `None` = leave that
+    // trait unchanged on `SetConfig`; a present value overrides just that
+    // trait. Serializes as the lowercase level string (e.g. `"never"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_professionalism: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_warmth: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_directness: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_enthusiasm: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_humor: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_sarcasm: Option<PersonalityLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality_pretentiousness: Option<PersonalityLevel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -820,6 +842,15 @@ pub struct ModelCapabilitiesView {
 // can use either name.
 pub use desktop_assistant_core::ports::inbound::Effort as EffortLevel;
 pub use desktop_assistant_core::ports::inbound::PurposeKind as PurposeKindApi;
+
+// Personality wire types (#226). Re-export the canonical core types so the
+// settings channel, the daemon config, and clients (e.g. the KCM) share one
+// schema rather than maintaining a parallel definition. `PersonalitySettingsView`
+// is the `Config`-view shape (the 7 trait levels); it is the core `Personality`
+// struct verbatim, so converting between the wire view and the core type is the
+// identity `From` impl.
+pub use desktop_assistant_core::prompts::{Personality, PersonalityLevel};
+pub type PersonalitySettingsView = Personality;
 
 /// Protocol-neutral purpose config. String `"primary"` in the connection or
 /// model field means "inherit from interactive" — the daemon resolves this
@@ -2004,7 +2035,7 @@ mod tests {
                 remote_name: "origin".into(),
                 push_on_update: false,
             },
-            personality: PersonalitySettingsView::from(Personality::default()),
+            personality: PersonalitySettingsView::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let back: Config = serde_json::from_str(&json).unwrap();
@@ -2014,15 +2045,19 @@ mod tests {
     }
 
     #[test]
-    fn personality_settings_view_round_trips_to_core() {
-        // The wire view converts losslessly to/from the core `Personality`.
+    fn personality_settings_view_is_the_core_type() {
+        // `PersonalitySettingsView` is the canonical core `Personality` (one
+        // schema, no parallel definition), so a value flows between the wire
+        // view and the core type with no lossy conversion.
         let core = Personality {
             humor: PersonalityLevel::Never,
             sarcasm: PersonalityLevel::Always,
             ..Personality::default()
         };
-        let view = PersonalitySettingsView::from(core.clone());
-        assert_eq!(Personality::from(view), core);
+        let view: PersonalitySettingsView = core;
+        assert_eq!(view, core);
+        assert_eq!(view.humor, PersonalityLevel::Never);
+        assert_eq!(view.sarcasm, PersonalityLevel::Always);
     }
 
     #[test]

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -1982,4 +1982,66 @@ mod tests {
             other => panic!("unexpected variant: {other:?}"),
         }
     }
+
+    // --- Personality config wire types (#226) ------------------------------
+
+    #[test]
+    fn config_carries_default_personality() {
+        // A `Config` view round-trips its personality block, and the view's
+        // levels match the Expressive-7 defaults.
+        let cfg = Config {
+            embeddings: EmbeddingsSettingsView {
+                connector: "openai".into(),
+                model: "text-embedding-3-small".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                has_api_key: true,
+                available: true,
+                is_default: true,
+            },
+            persistence: PersistenceSettingsView {
+                enabled: false,
+                remote_url: String::new(),
+                remote_name: "origin".into(),
+                push_on_update: false,
+            },
+            personality: PersonalitySettingsView::from(Personality::default()),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+        assert_eq!(back.personality.professionalism, PersonalityLevel::Always);
+        assert_eq!(back.personality.humor, PersonalityLevel::Sometimes);
+    }
+
+    #[test]
+    fn personality_settings_view_round_trips_to_core() {
+        // The wire view converts losslessly to/from the core `Personality`.
+        let core = Personality {
+            humor: PersonalityLevel::Never,
+            sarcasm: PersonalityLevel::Always,
+            ..Personality::default()
+        };
+        let view = PersonalitySettingsView::from(core.clone());
+        assert_eq!(Personality::from(view), core);
+    }
+
+    #[test]
+    fn config_changes_personality_fields_optional_and_round_trip() {
+        // Default `ConfigChanges` omits every personality field from the wire.
+        let empty = ConfigChanges::default();
+        let json = serde_json::to_string(&empty).unwrap();
+        assert!(!json.contains("personality_humor"), "json: {json}");
+
+        // A single personality change serializes only that field.
+        let changes = ConfigChanges {
+            personality_humor: Some(PersonalityLevel::Never),
+            ..ConfigChanges::default()
+        };
+        let json = serde_json::to_string(&changes).unwrap();
+        assert!(json.contains("personality_humor"), "json: {json}");
+        assert!(json.contains("\"never\""), "json: {json}");
+        assert!(!json.contains("personality_warmth"), "json: {json}");
+        let back: ConfigChanges = serde_json::from_str(&json).unwrap();
+        assert_eq!(changes, back);
+    }
 }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -3325,6 +3325,60 @@ mod tests {
         assert!(!config.persistence.push_on_update);
     }
 
+    #[tokio::test]
+    async fn get_config_returns_default_personality() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::clone(&settings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        );
+
+        let res = h.handle_command(api::Command::GetConfig).await.unwrap();
+        let api::CommandResult::Config(config) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(
+            config.personality.professionalism,
+            api::PersonalityLevel::Always
+        );
+        assert_eq!(config.personality.humor, api::PersonalityLevel::Sometimes);
+    }
+
+    #[tokio::test]
+    async fn set_config_changes_personality() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::clone(&settings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        );
+
+        let res = h
+            .handle_command(api::Command::SetConfig {
+                changes: api::ConfigChanges {
+                    personality_humor: Some(api::PersonalityLevel::Never),
+                    ..Default::default()
+                },
+            })
+            .await
+            .unwrap();
+
+        let api::CommandResult::Config(config) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(config.personality.humor, api::PersonalityLevel::Never);
+        // Other traits untouched.
+        assert_eq!(
+            config.personality.professionalism,
+            api::PersonalityLevel::Always
+        );
+    }
+
     // ---- RequestContext tests (issue #105) -----------------------------
 
     #[test]

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -519,6 +519,11 @@ where
             .get_persistence_settings()
             .await
             .map_err(Self::map_core_err)?;
+        let personality = self
+            .settings
+            .get_personality_settings()
+            .await
+            .map_err(Self::map_core_err)?;
 
         Ok(api::Config {
             embeddings: api::EmbeddingsSettingsView {
@@ -535,6 +540,9 @@ where
                 remote_name: persistence.remote_name,
                 push_on_update: persistence.push_on_update,
             },
+            // `PersonalitySettingsView` is the core `Personality` type in both
+            // the port and the api-model, so this is the identity conversion.
+            personality,
         })
     }
 
@@ -548,6 +556,13 @@ where
             persistence_remote_url,
             persistence_remote_name,
             persistence_push_on_update,
+            personality_professionalism,
+            personality_warmth,
+            personality_directness,
+            personality_enthusiasm,
+            personality_humor,
+            personality_sarcasm,
+            personality_pretentiousness,
         } = changes;
 
         let embeddings_changed = embeddings_connector.is_some()
@@ -601,6 +616,46 @@ where
 
             self.settings
                 .set_persistence_settings(enabled, remote_url, remote_name, push_on_update)
+                .await
+                .map_err(Self::map_core_err)?;
+        }
+
+        // Personality (#226): apply per-trait overrides over the current value.
+        // Each `None` leaves that trait unchanged; only a present level updates
+        // it. We write the whole struct back so the daemon refreshes the
+        // in-memory config the next send reads.
+        let personality_changed = personality_professionalism.is_some()
+            || personality_warmth.is_some()
+            || personality_directness.is_some()
+            || personality_enthusiasm.is_some()
+            || personality_humor.is_some()
+            || personality_sarcasm.is_some()
+            || personality_pretentiousness.is_some();
+        if personality_changed {
+            let mut p = current.personality;
+            if let Some(v) = personality_professionalism {
+                p.professionalism = v;
+            }
+            if let Some(v) = personality_warmth {
+                p.warmth = v;
+            }
+            if let Some(v) = personality_directness {
+                p.directness = v;
+            }
+            if let Some(v) = personality_enthusiasm {
+                p.enthusiasm = v;
+            }
+            if let Some(v) = personality_humor {
+                p.humor = v;
+            }
+            if let Some(v) = personality_sarcasm {
+                p.sarcasm = v;
+            }
+            if let Some(v) = personality_pretentiousness {
+                p.pretentiousness = v;
+            }
+            self.settings
+                .set_personality_settings(p)
                 .await
                 .map_err(Self::map_core_err)?;
         }
@@ -2184,7 +2239,8 @@ mod tests {
     use desktop_assistant_core::ports::inbound::{
         BackendTasksSettingsView, ConnectorDefaultsView, DatabaseSettingsView,
         EmbeddingsSettingsView, LlmSettingsView, ModelListing as CoreModelListing,
-        PersistenceSettingsView, PurposeKind, PurposesView as CorePurposesView,
+        PersistenceSettingsView, PersonalitySettingsView, PurposeKind,
+        PurposesView as CorePurposesView,
     };
     use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
     use std::sync::Mutex;
@@ -2525,6 +2581,7 @@ mod tests {
         llm: LlmSettingsView,
         embeddings: EmbeddingsSettingsView,
         persistence: PersistenceSettingsView,
+        personality: PersonalitySettingsView,
         api_key_set: bool,
     }
 
@@ -2560,6 +2617,7 @@ mod tests {
                         remote_name: "origin".into(),
                         push_on_update: true,
                     },
+                    personality: PersonalitySettingsView::default(),
                     api_key_set: false,
                 }),
             }
@@ -2678,6 +2736,18 @@ mod tests {
                 state.persistence.remote_name = remote_name;
             }
             state.persistence.push_on_update = push_on_update;
+            Ok(())
+        }
+
+        async fn get_personality_settings(&self) -> Result<PersonalitySettingsView, CoreError> {
+            Ok(self.state.lock().unwrap().personality)
+        }
+
+        async fn set_personality_settings(
+            &self,
+            personality: PersonalitySettingsView,
+        ) -> Result<(), CoreError> {
+            self.state.lock().unwrap().personality = personality;
             Ok(())
         }
 

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -422,6 +422,7 @@ mod tests {
                     remote_name: "origin".to_string(),
                     push_on_update: true,
                 },
+                personality: api::PersonalitySettingsView::default(),
             },
         });
         assert!(event.is_none());

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -352,6 +352,23 @@ fn build_demoted_tool_note(
 fn assemble_system_instruction(tool_note: String, system_refinement: &str) -> String {
     use crate::prompts::{self, PromptSection, PromptSectionKind};
     let mut sections = prompts::static_sections();
+
+    // Personality disposition (#226): read the active personality the same way
+    // the per-turn refinement is read (a task-local installed by the daemon
+    // dispatch wrapper). Injected *before* the tool note and the per-turn
+    // refinement so the standing disposition is established up front while a
+    // one-turn refinement can still adjust tone last. Always rendered — the
+    // blurb at minimum carries the adaptation clause — so every turn carries a
+    // personality, with the default disposition for callers that install no
+    // scope.
+    let personality_blurb = crate::ports::llm::current_personality().render_blurb();
+    if !personality_blurb.trim().is_empty() {
+        sections.push(PromptSection::new(
+            PromptSectionKind::Personality,
+            personality_blurb,
+        ));
+    }
+
     sections.push(PromptSection::new(
         PromptSectionKind::ToolAvailability,
         tool_note,
@@ -859,7 +876,7 @@ mod tests {
             sarcasm: PersonalityLevel::Always,
             ..Personality::default()
         };
-        let assembled = with_personality(personality.clone(), async {
+        let assembled = with_personality(personality, async {
             assemble_system_instruction("TOOLNOTE".to_string(), "REFINEMENT")
         })
         .await;

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -848,6 +848,49 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn assemble_system_instruction_injects_personality_before_tools_and_refinement() {
+        use crate::ports::llm::with_personality;
+        use crate::prompts::{Personality, PersonalityLevel};
+
+        // A personality with a recognizable trait so we can locate the
+        // injected section in the assembled output.
+        let personality = Personality {
+            sarcasm: PersonalityLevel::Always,
+            ..Personality::default()
+        };
+        let assembled = with_personality(personality.clone(), async {
+            assemble_system_instruction("TOOLNOTE".to_string(), "REFINEMENT")
+        })
+        .await;
+
+        // The personality blurb is present.
+        let blurb = personality.render_blurb();
+        assert!(
+            assembled.contains(&blurb),
+            "assembled prompt must contain the personality blurb:\n{assembled}"
+        );
+        // Ordering: personality blurb appears before the tool note, which
+        // appears before the per-turn refinement.
+        let p_idx = assembled.find(&blurb).unwrap();
+        let t_idx = assembled.find("TOOLNOTE").unwrap();
+        let r_idx = assembled.find("REFINEMENT").unwrap();
+        assert!(p_idx < t_idx, "personality must precede the tool note");
+        assert!(t_idx < r_idx, "tool note must precede the refinement");
+    }
+
+    #[tokio::test]
+    async fn assemble_system_instruction_default_personality_present_without_scope() {
+        // No `with_personality` scope installed → the default disposition is
+        // still injected (global personality applies to every turn).
+        let assembled = assemble_system_instruction("TOOLNOTE".to_string(), "");
+        let default_blurb = crate::prompts::Personality::default().render_blurb();
+        assert!(
+            assembled.contains(&default_blurb),
+            "default personality must be injected even without a scope:\n{assembled}"
+        );
+    }
+
     /// Mock LLM that returns canned chunks. Used by summary-generation
     /// tests that exercise [`generate_context_summary`] directly.
     struct MockLlm {

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -52,6 +52,11 @@ pub struct DatabaseSettingsView {
     pub max_connections: u32,
 }
 
+/// Resolved assistant-personality settings (issue #226). A thin alias for the
+/// canonical [`crate::prompts::Personality`] so the settings surface carries
+/// the same typed trait set the prompt assembler uses — no parallel schema.
+pub type PersonalitySettingsView = crate::prompts::Personality;
+
 #[derive(Debug, Clone)]
 pub struct McpServerView {
     pub name: String,
@@ -559,6 +564,31 @@ pub trait SettingsService: Send + Sync {
         url: Option<String>,
         max_connections: u32,
     ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    /// Return the active assistant personality (issue #226).
+    ///
+    /// Default returns the Expressive-7 [`crate::prompts::Personality::default`]
+    /// so test mocks and adapters that don't manage personality opt out without
+    /// boilerplate; the daemon's real service overrides it to read the resolved
+    /// config.
+    fn get_personality_settings(
+        &self,
+    ) -> impl std::future::Future<Output = Result<PersonalitySettingsView, CoreError>> + Send {
+        async { Ok(PersonalitySettingsView::default()) }
+    }
+
+    /// Update the active assistant personality (issue #226).
+    ///
+    /// Default is a no-op (`Ok`) so mocks/adapters that don't manage
+    /// personality opt out; the daemon's real service overrides it to persist
+    /// the change and refresh the in-memory config used by the next send.
+    fn set_personality_settings(
+        &self,
+        personality: PersonalitySettingsView,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send {
+        let _ = personality;
+        async { Ok(()) }
+    }
 
     fn get_backend_tasks_settings(
         &self,

--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -1344,6 +1344,48 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("429"));
     }
 
+    // --- PERSONALITY tests (issue #226) ---
+
+    #[tokio::test]
+    async fn current_personality_is_default_outside_scope() {
+        // Callers that never install a scope (tests, dreaming jobs, any path
+        // not routed through the daemon dispatch wrapper) observe the default
+        // disposition rather than an empty one.
+        assert_eq!(
+            current_personality(),
+            crate::prompts::Personality::default()
+        );
+    }
+
+    #[tokio::test]
+    async fn current_personality_observes_installed_scope() {
+        let custom = crate::prompts::Personality {
+            humor: crate::prompts::PersonalityLevel::Never,
+            ..crate::prompts::Personality::default()
+        };
+        let observed = with_personality(custom.clone(), async { current_personality() }).await;
+        assert_eq!(observed, custom);
+        // After the scope exits the task-local is unset again (back to default).
+        assert_eq!(
+            current_personality(),
+            crate::prompts::Personality::default()
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_personality_shadows_outer() {
+        let outer = crate::prompts::Personality::default();
+        let inner = crate::prompts::Personality {
+            sarcasm: crate::prompts::PersonalityLevel::Always,
+            ..crate::prompts::Personality::default()
+        };
+        let observed = with_personality(outer, async {
+            with_personality(inner.clone(), async { current_personality() }).await
+        })
+        .await;
+        assert_eq!(observed, inner);
+    }
+
     // --- MODEL_OVERRIDE tests (issue #34) ---
 
     #[tokio::test]

--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -139,6 +139,30 @@ tokio::task_local! {
     /// cross); the task-local is installed only at the final dispatch hop,
     /// inside the spawned body.
     static SYSTEM_REFINEMENT: String;
+
+    /// The active assistant personality for this turn (issue #226, Phase 1:
+    /// global). Installed by the daemon's dispatch wrapper via
+    /// [`with_personality`] from the resolved global config, and read by the
+    /// context assembler via [`current_personality`] when it builds the system
+    /// message. The rendered disposition blurb is injected as a system-prompt
+    /// section before the tool note and the per-turn system refinement.
+    ///
+    /// Unlike [`SYSTEM_REFINEMENT`] this is *configuration*, not per-request
+    /// client input: it carries the standing personality the user configured,
+    /// not a one-turn instruction. It still rides a task-local for the same
+    /// reason the others do — it threads to the assembler without changing the
+    /// `LlmClient` trait or the `send_prompt` signature.
+    ///
+    /// Phase 1 resolves it from the global config on every send. Phase 2 will
+    /// add per-conversation resolution; that future seam belongs at the install
+    /// site (the dispatch wrapper picks *which* personality to install), so the
+    /// read side here stays unchanged.
+    ///
+    /// Unset outside the dispatch path — which [`current_personality`] returns
+    /// as [`crate::prompts::Personality::default`], so tests, dreaming jobs, and
+    /// any caller that doesn't route through the dispatch wrapper still get the
+    /// default Expressive-7 disposition.
+    static PERSONALITY: crate::prompts::Personality;
 }
 
 /// Run `fut` with the given reasoning config installed as the current
@@ -176,6 +200,25 @@ pub fn current_system_refinement() -> String {
     SYSTEM_REFINEMENT
         .try_with(|r| r.clone())
         .unwrap_or_default()
+}
+
+/// Run `fut` with `personality` installed as the active personality for this
+/// turn. The context assembler reads it via [`current_personality`] and injects
+/// the rendered disposition blurb into the system message. See [`PERSONALITY`].
+pub async fn with_personality<F, T>(personality: crate::prompts::Personality, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    PERSONALITY.scope(personality, fut).await
+}
+
+/// Current task-local personality, or [`crate::prompts::Personality::default`]
+/// when not set. The default means "the Expressive-7 disposition" — callers
+/// that don't route through the daemon dispatch wrapper (tests, dreaming jobs)
+/// still get the standard personality blurb. Safe to call from any async
+/// context.
+pub fn current_personality() -> crate::prompts::Personality {
+    PERSONALITY.try_with(|p| *p).unwrap_or_default()
 }
 
 /// Run `fut` with `model` installed as the current turn's model override.
@@ -1363,7 +1406,7 @@ mod tests {
             humor: crate::prompts::PersonalityLevel::Never,
             ..crate::prompts::Personality::default()
         };
-        let observed = with_personality(custom.clone(), async { current_personality() }).await;
+        let observed = with_personality(custom, async { current_personality() }).await;
         assert_eq!(observed, custom);
         // After the scope exits the task-local is unset again (back to default).
         assert_eq!(
@@ -1380,7 +1423,7 @@ mod tests {
             ..crate::prompts::Personality::default()
         };
         let observed = with_personality(outer, async {
-            with_personality(inner.clone(), async { current_personality() }).await
+            with_personality(inner, async { current_personality() }).await
         })
         .await;
         assert_eq!(observed, inner);

--- a/crates/core/src/prompts/mod.rs
+++ b/crates/core/src/prompts/mod.rs
@@ -114,4 +114,134 @@ mod tests {
         // The reserved goal note must be called out.
         assert!(assembled.contains("\"goal\""));
     }
+
+    // --- Personality (#226) ------------------------------------------------
+
+    /// The fixed adaptation clause is appended to every personality blurb,
+    /// regardless of trait levels. Pinned here so the copy can't drift away
+    /// from the rest of the suite without a deliberate edit.
+    const ADAPTATION_CLAUSE: &str = "Treat this as a starting point, not a script. \
+         Take your cues from the conversation and adapt both ways \u{2014} if the user is \
+         playful or jokes around, it's fine to loosen up and joke back a bit; if things \
+         turn serious or they seem stressed, ease off the humor and sarcasm unless a light \
+         touch genuinely helps. Match the user's energy rather than forcing a trait that \
+         doesn't fit the moment.";
+
+    #[test]
+    fn personality_level_ordinal_round_trip() {
+        // The D-Bus contract exposes levels as integers 0..=4. Every level
+        // must map to a stable ordinal and back.
+        for (level, ordinal) in [
+            (PersonalityLevel::Never, 0u8),
+            (PersonalityLevel::Rarely, 1),
+            (PersonalityLevel::Sometimes, 2),
+            (PersonalityLevel::Often, 3),
+            (PersonalityLevel::Always, 4),
+        ] {
+            assert_eq!(level.as_ordinal(), ordinal);
+            assert_eq!(PersonalityLevel::from_ordinal(ordinal), Some(level));
+        }
+        // Out-of-range ordinals are rejected (no silent clamp).
+        assert_eq!(PersonalityLevel::from_ordinal(5), None);
+    }
+
+    #[test]
+    fn personality_defaults_match_expressive_7_table() {
+        let p = Personality::default();
+        assert_eq!(p.professionalism, PersonalityLevel::Always);
+        assert_eq!(p.warmth, PersonalityLevel::Often);
+        assert_eq!(p.directness, PersonalityLevel::Often);
+        assert_eq!(p.enthusiasm, PersonalityLevel::Sometimes);
+        assert_eq!(p.humor, PersonalityLevel::Sometimes);
+        assert_eq!(p.sarcasm, PersonalityLevel::Rarely);
+        assert_eq!(p.pretentiousness, PersonalityLevel::Rarely);
+    }
+
+    #[test]
+    fn render_blurb_defaults_emits_disposition_then_adaptation() {
+        let blurb = Personality::default().render_blurb();
+        // Disposition paragraph mentions each non-Never trait.
+        assert!(blurb.contains("professional"), "blurb: {blurb}");
+        assert!(blurb.contains("warm"), "blurb: {blurb}");
+        assert!(blurb.contains("direct"), "blurb: {blurb}");
+        assert!(blurb.contains("enthusias"), "blurb: {blurb}");
+        assert!(blurb.contains("humor") || blurb.contains("humour"), "blurb: {blurb}");
+        assert!(blurb.contains("sarcas"), "blurb: {blurb}");
+        assert!(blurb.contains("pretenti"), "blurb: {blurb}");
+        // The adaptation clause is always present and comes last.
+        assert!(blurb.contains(ADAPTATION_CLAUSE), "blurb: {blurb}");
+        assert!(blurb.trim_end().ends_with(ADAPTATION_CLAUSE), "blurb: {blurb}");
+    }
+
+    #[test]
+    fn render_blurb_omits_never_traits() {
+        // Set Humor and Sarcasm to Never; their clauses must disappear while
+        // the other traits remain.
+        let p = Personality {
+            humor: PersonalityLevel::Never,
+            sarcasm: PersonalityLevel::Never,
+            ..Personality::default()
+        };
+        let blurb = p.render_blurb();
+        assert!(!blurb.contains("humor") && !blurb.contains("humour"), "blurb: {blurb}");
+        assert!(!blurb.contains("sarcas"), "blurb: {blurb}");
+        // Remaining traits still rendered.
+        assert!(blurb.contains("professional"), "blurb: {blurb}");
+        assert!(blurb.contains("warm"), "blurb: {blurb}");
+        // Adaptation clause still appended.
+        assert!(blurb.contains(ADAPTATION_CLAUSE), "blurb: {blurb}");
+    }
+
+    #[test]
+    fn render_blurb_all_never_is_adaptation_clause_only() {
+        let p = Personality {
+            professionalism: PersonalityLevel::Never,
+            warmth: PersonalityLevel::Never,
+            directness: PersonalityLevel::Never,
+            enthusiasm: PersonalityLevel::Never,
+            humor: PersonalityLevel::Never,
+            sarcasm: PersonalityLevel::Never,
+            pretentiousness: PersonalityLevel::Never,
+        };
+        let blurb = p.render_blurb();
+        // No disposition sentence at all — only the adaptation clause.
+        assert_eq!(blurb.trim(), ADAPTATION_CLAUSE);
+    }
+
+    #[test]
+    fn render_blurb_adaptation_clause_always_present() {
+        // Property: every possible single-trait setting still appends the
+        // adaptation clause. Exhaustive over levels for one representative
+        // trait is enough to pin the invariant.
+        for level in [
+            PersonalityLevel::Never,
+            PersonalityLevel::Rarely,
+            PersonalityLevel::Sometimes,
+            PersonalityLevel::Often,
+            PersonalityLevel::Always,
+        ] {
+            let p = Personality {
+                humor: level,
+                ..Personality::default()
+            };
+            assert!(
+                p.render_blurb().contains(ADAPTATION_CLAUSE),
+                "level {level:?} dropped the adaptation clause"
+            );
+        }
+    }
+
+    #[test]
+    fn personality_serde_round_trip_lowercase() {
+        // TOML/JSON config persists levels as lowercase strings; round-trip
+        // must be lossless so a stored `[personality]` reloads identically.
+        let p = Personality {
+            humor: PersonalityLevel::Never,
+            ..Personality::default()
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"never\""), "json: {json}");
+        let parsed: Personality = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, p);
+    }
 }

--- a/crates/core/src/prompts/mod.rs
+++ b/crates/core/src/prompts/mod.rs
@@ -10,6 +10,11 @@ pub enum PromptSectionKind {
     Learning,
     ToolUse,
     // Dynamic (built per-turn):
+    /// Configurable disposition blurb (issue #226). Rendered from the active
+    /// [`Personality`] and injected before [`Self::ToolAvailability`] and the
+    /// per-turn [`Self::SystemRefinement`] so the standing personality is set
+    /// up front but a per-turn refinement can still adjust it last.
+    Personality,
     ToolAvailability,
     ContextSummary,
     MessageSummary,
@@ -19,6 +24,247 @@ pub enum PromptSectionKind {
     /// Never persisted; see `crate::ports::llm::SYSTEM_REFINEMENT`.
     SystemRefinement,
 }
+
+// --- Personality (#226) ----------------------------------------------------
+
+/// Qualitative level for a single personality trait.
+///
+/// Ordered `Never < Rarely < Sometimes < Often < Always`. The numeric
+/// ordinal (0..=4, via [`Self::as_ordinal`] / [`Self::from_ordinal`]) is a
+/// **stable wire contract**: the D-Bus settings surface exposes each trait as
+/// an integer 0..=4 so the KCM can bind a slider directly (Never=0 … Always=4).
+/// The serde representation is the lowercase variant name (e.g. `"always"`)
+/// for human-friendly TOML/JSON config, mirroring [`crate::ports::llm::ReasoningLevel`].
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum PersonalityLevel {
+    Never,
+    Rarely,
+    Sometimes,
+    Often,
+    Always,
+}
+
+impl PersonalityLevel {
+    /// Stable ordinal 0..=4 used by the D-Bus int contract (Never=0 … Always=4).
+    pub fn as_ordinal(self) -> u8 {
+        match self {
+            Self::Never => 0,
+            Self::Rarely => 1,
+            Self::Sometimes => 2,
+            Self::Often => 3,
+            Self::Always => 4,
+        }
+    }
+
+    /// Inverse of [`Self::as_ordinal`]. Returns `None` for out-of-range input
+    /// rather than clamping, so a malformed wire value surfaces as an error at
+    /// the boundary instead of silently snapping to a level.
+    pub fn from_ordinal(n: u8) -> Option<Self> {
+        match n {
+            0 => Some(Self::Never),
+            1 => Some(Self::Rarely),
+            2 => Some(Self::Sometimes),
+            3 => Some(Self::Often),
+            4 => Some(Self::Always),
+            _ => None,
+        }
+    }
+}
+
+/// The assistant's configurable disposition — the "Expressive 7" traits, each
+/// at a [`PersonalityLevel`] (issue #226, Phase 1: global).
+///
+/// Why a typed struct rather than a free `HashMap<String, Level>`: the trait
+/// set is fixed and small, so naming each field gives compile-time safety (no
+/// typo'd keys, exhaustive `render_blurb` matching) and a **stable wire schema**
+/// — config files, the api-model `Config` view, and the D-Bus `ConfigData`
+/// tuple all derive from these named fields, so adding/removing a trait is a
+/// deliberate, type-checked change rather than a silent string drift.
+///
+/// The levels are an *initial disposition*, not a rulebook: [`Self::render_blurb`]
+/// always appends an adaptation clause telling the model to take cues from the
+/// conversation and adapt both ways.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Personality {
+    #[serde(default = "default_professionalism")]
+    pub professionalism: PersonalityLevel,
+    #[serde(default = "default_warmth")]
+    pub warmth: PersonalityLevel,
+    #[serde(default = "default_directness")]
+    pub directness: PersonalityLevel,
+    #[serde(default = "default_enthusiasm")]
+    pub enthusiasm: PersonalityLevel,
+    #[serde(default = "default_humor")]
+    pub humor: PersonalityLevel,
+    #[serde(default = "default_sarcasm")]
+    pub sarcasm: PersonalityLevel,
+    #[serde(default = "default_pretentiousness")]
+    pub pretentiousness: PersonalityLevel,
+}
+
+// Per-field default fns so a partial `[personality]` TOML block (only some
+// traits specified) fills the rest from the Expressive-7 table rather than
+// from `PersonalityLevel`'s arbitrary first variant.
+fn default_professionalism() -> PersonalityLevel {
+    PersonalityLevel::Always
+}
+fn default_warmth() -> PersonalityLevel {
+    PersonalityLevel::Often
+}
+fn default_directness() -> PersonalityLevel {
+    PersonalityLevel::Often
+}
+fn default_enthusiasm() -> PersonalityLevel {
+    PersonalityLevel::Sometimes
+}
+fn default_humor() -> PersonalityLevel {
+    PersonalityLevel::Sometimes
+}
+fn default_sarcasm() -> PersonalityLevel {
+    PersonalityLevel::Rarely
+}
+fn default_pretentiousness() -> PersonalityLevel {
+    PersonalityLevel::Rarely
+}
+
+impl Default for Personality {
+    /// The "Expressive 7" defaults from the issue table.
+    fn default() -> Self {
+        Self {
+            professionalism: default_professionalism(),
+            warmth: default_warmth(),
+            directness: default_directness(),
+            enthusiasm: default_enthusiasm(),
+            humor: default_humor(),
+            sarcasm: default_sarcasm(),
+            pretentiousness: default_pretentiousness(),
+        }
+    }
+}
+
+/// The fixed adaptation clause appended to every personality blurb. It tells
+/// the model the levels are a starting point and to match the user's energy
+/// rather than rigidly enforcing a trait.
+const ADAPTATION_CLAUSE: &str = "Treat this as a starting point, not a script. \
+     Take your cues from the conversation and adapt both ways \u{2014} if the user is \
+     playful or jokes around, it's fine to loosen up and joke back a bit; if things \
+     turn serious or they seem stressed, ease off the humor and sarcasm unless a light \
+     touch genuinely helps. Match the user's energy rather than forcing a trait that \
+     doesn't fit the moment.";
+
+impl Personality {
+    /// Render the disposition into a natural-language blurb for the system
+    /// prompt.
+    ///
+    /// The blurb is a single disposition sentence — one clause per trait whose
+    /// level is not [`PersonalityLevel::Never`], phrased by level — followed by
+    /// the fixed [`ADAPTATION_CLAUSE`]. A `Never` trait contributes no clause.
+    /// When every trait is `Never`, only the adaptation clause is emitted.
+    pub fn render_blurb(&self) -> String {
+        // (trait clause builder, level) pairs in a fixed, readable order. Each
+        // builder turns a non-Never level into a natural clause; `None` means
+        // the trait is omitted (Never).
+        let clauses: Vec<String> = [
+            trait_clause(self.professionalism, &PROFESSIONALISM_PHRASING),
+            trait_clause(self.warmth, &WARMTH_PHRASING),
+            trait_clause(self.directness, &DIRECTNESS_PHRASING),
+            trait_clause(self.enthusiasm, &ENTHUSIASM_PHRASING),
+            trait_clause(self.humor, &HUMOR_PHRASING),
+            trait_clause(self.sarcasm, &SARCASM_PHRASING),
+            trait_clause(self.pretentiousness, &PRETENTIOUSNESS_PHRASING),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        if clauses.is_empty() {
+            return ADAPTATION_CLAUSE.to_string();
+        }
+
+        let disposition = format!("In your default manner, you {}.", join_clauses(&clauses));
+        format!("{disposition} {ADAPTATION_CLAUSE}")
+    }
+}
+
+/// Per-level phrasing for a single trait. Each field is the clause body used at
+/// that level; `Never` has no field because a Never trait is omitted entirely.
+struct TraitPhrasing {
+    rarely: &'static str,
+    sometimes: &'static str,
+    often: &'static str,
+    always: &'static str,
+}
+
+/// Pick the clause for a level, or `None` when the trait is `Never`.
+fn trait_clause(level: PersonalityLevel, p: &TraitPhrasing) -> Option<String> {
+    let body = match level {
+        PersonalityLevel::Never => return None,
+        PersonalityLevel::Rarely => p.rarely,
+        PersonalityLevel::Sometimes => p.sometimes,
+        PersonalityLevel::Often => p.often,
+        PersonalityLevel::Always => p.always,
+    };
+    Some(body.to_string())
+}
+
+/// Join clauses into a single grammatical list ("a, b, and c").
+fn join_clauses(clauses: &[String]) -> String {
+    match clauses {
+        [] => String::new(),
+        [one] => one.clone(),
+        [first, second] => format!("{first}, and {second}"),
+        [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
+    }
+}
+
+// Phrasing tables. The clause body completes "you ...": e.g. Always warmth →
+// "you are always warm and personable". Rarely uses a hedged "occasionally /
+// a touch of"; Sometimes a "now and then / at times"; Often a "usually".
+const PROFESSIONALISM_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "keep things professional only on rare occasion",
+    sometimes: "stay professional at times",
+    often: "usually keep a professional tone",
+    always: "always keep a professional, polished tone",
+};
+const WARMTH_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "show a touch of warmth on rare occasion",
+    sometimes: "come across as warm now and then",
+    often: "are usually warm and personable",
+    always: "are always warm and personable",
+};
+const DIRECTNESS_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "get straight to the point only on rare occasion",
+    sometimes: "are direct at times",
+    often: "are usually direct and to the point",
+    always: "are always direct and to the point",
+};
+const ENTHUSIASM_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "show enthusiasm only on rare occasion",
+    sometimes: "show some enthusiasm now and then",
+    often: "are usually enthusiastic",
+    always: "are always enthusiastic and energetic",
+};
+const HUMOR_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "crack a bit of humor only on rare occasion",
+    sometimes: "bring a little humor now and then",
+    often: "usually keep things light with some humor",
+    always: "always keep things light with humor",
+};
+const SARCASM_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "let a touch of sarcasm slip only on rare occasion",
+    sometimes: "use a bit of dry sarcasm at times",
+    often: "are usually a little sarcastic",
+    always: "are reliably sarcastic and dry",
+};
+const PRETENTIOUSNESS_PHRASING: TraitPhrasing = TraitPhrasing {
+    rarely: "get a touch pretentious only on rare occasion",
+    sometimes: "can be a little pretentious at times",
+    often: "are usually somewhat pretentious",
+    always: "are consistently pretentious and highbrow",
+};
 
 /// A single section of the system prompt.
 #[derive(Debug, Clone)]
@@ -165,29 +411,51 @@ mod tests {
         assert!(blurb.contains("warm"), "blurb: {blurb}");
         assert!(blurb.contains("direct"), "blurb: {blurb}");
         assert!(blurb.contains("enthusias"), "blurb: {blurb}");
-        assert!(blurb.contains("humor") || blurb.contains("humour"), "blurb: {blurb}");
+        assert!(
+            blurb.contains("humor") || blurb.contains("humour"),
+            "blurb: {blurb}"
+        );
         assert!(blurb.contains("sarcas"), "blurb: {blurb}");
         assert!(blurb.contains("pretenti"), "blurb: {blurb}");
         // The adaptation clause is always present and comes last.
         assert!(blurb.contains(ADAPTATION_CLAUSE), "blurb: {blurb}");
-        assert!(blurb.trim_end().ends_with(ADAPTATION_CLAUSE), "blurb: {blurb}");
+        assert!(
+            blurb.trim_end().ends_with(ADAPTATION_CLAUSE),
+            "blurb: {blurb}"
+        );
     }
 
     #[test]
     fn render_blurb_omits_never_traits() {
-        // Set Humor and Sarcasm to Never; their clauses must disappear while
-        // the other traits remain.
+        // Set Humor and Sarcasm to Never; their clauses must disappear from the
+        // disposition sentence while the other traits remain. NB: the fixed
+        // adaptation clause mentions "humor" and "sarcasm" by design, so we
+        // assert against the disposition portion (everything before the
+        // adaptation clause), not the whole blurb.
         let p = Personality {
             humor: PersonalityLevel::Never,
             sarcasm: PersonalityLevel::Never,
             ..Personality::default()
         };
         let blurb = p.render_blurb();
-        assert!(!blurb.contains("humor") && !blurb.contains("humour"), "blurb: {blurb}");
-        assert!(!blurb.contains("sarcas"), "blurb: {blurb}");
+        let disposition = blurb
+            .split(ADAPTATION_CLAUSE)
+            .next()
+            .expect("adaptation clause present");
+        assert!(
+            !disposition.contains("humor") && !disposition.contains("humour"),
+            "disposition: {disposition}"
+        );
+        assert!(
+            !disposition.contains("sarcas"),
+            "disposition: {disposition}"
+        );
         // Remaining traits still rendered.
-        assert!(blurb.contains("professional"), "blurb: {blurb}");
-        assert!(blurb.contains("warm"), "blurb: {blurb}");
+        assert!(
+            disposition.contains("professional"),
+            "disposition: {disposition}"
+        );
+        assert!(disposition.contains("warm"), "disposition: {disposition}");
         // Adaptation clause still appended.
         assert!(blurb.contains(ADAPTATION_CLAUSE), "blurb: {blurb}");
     }

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -38,8 +38,9 @@ use desktop_assistant_core::ports::inbound::{
 };
 use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
-    with_model_override, with_reasoning_config, with_system_refinement,
+    with_model_override, with_personality, with_reasoning_config, with_system_refinement,
 };
+use desktop_assistant_core::prompts::Personality;
 
 use crate::config::{
     DaemonConfig, default_daemon_config_path, load_daemon_config, save_daemon_config,
@@ -180,6 +181,29 @@ impl RegistryHandle {
             .expect("registry state poisoned")
             .config
             .clone()
+    }
+
+    /// The active assistant personality (issue #226). Read from the in-memory
+    /// config, which `mutate_config` (and `set_personality`) keep current, so
+    /// the dispatch wrapper and the settings GET observe the same value and a
+    /// `SetConfig` takes effect on the next turn without a separate reload.
+    pub fn personality(&self) -> Personality {
+        self.state
+            .read()
+            .expect("registry state poisoned")
+            .config
+            .personality
+    }
+
+    /// Update the active assistant personality. Persists to the config file and
+    /// refreshes the in-memory config (via `mutate_config`) so the next send's
+    /// task-local reflects the change. Cheap — the registry rebuild it triggers
+    /// only re-reads connection config, which is unchanged here.
+    pub fn set_personality(&self, personality: Personality) -> Result<(), CoreError> {
+        self.mutate_config(|cfg| {
+            cfg.personality = personality;
+            Ok(())
+        })
     }
 
     /// Test-only: swap the in-memory `DaemonConfig` and rebuild the
@@ -914,6 +938,14 @@ where
             // string = no refinement (unchanged prompt). It is request-scoped
             // and never persisted; see `SYSTEM_REFINEMENT`.
             let dispatch = with_system_refinement(system_refinement, dispatch);
+            // Install the active personality (#226). Phase 1 resolves it from
+            // the global config on every send; the in-memory config is the
+            // single source of truth a `SetConfig` updates, so a personality
+            // change takes effect on the next turn. The Phase-2 seam is here:
+            // future per-conversation resolution swaps *which* personality this
+            // line installs (e.g. `self.resolve_personality(conversation_id)`),
+            // leaving the core read side unchanged.
+            let dispatch = with_personality(self.registry.personality(), dispatch);
             let dispatch = with_reasoning_config(reasoning, dispatch);
             let dispatch = with_context_budget(budget, dispatch);
             let dispatch =

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -117,7 +117,26 @@ pub struct DaemonConfig {
     pub ws_auth: WsAuthConfig,
     #[serde(default)]
     pub tls: TlsConfig,
+    /// Configurable assistant disposition (issue #226, Phase 1: global). The
+    /// resolved value is installed as a task-local on every send and rendered
+    /// into a system-prompt blurb. Defaults to the Expressive-7 table when the
+    /// `[personality]` section is absent. Reuses the core [`Personality`] type
+    /// directly (re-exported below) so config, the api-model view, and the
+    /// D-Bus surface share one schema.
+    #[serde(default)]
+    pub personality: Personality,
 }
+
+// Reuse the canonical core type rather than duplicating the trait set in the
+// daemon. `Personality` derives `Serialize`/`Deserialize` with a lowercase
+// representation, so it slots straight into the TOML `[personality]` section.
+pub use desktop_assistant_core::prompts::Personality;
+// `PersonalityLevel` is re-exported at `config::` for callers that spell the
+// level out (and the in-file tests); only test code references it directly, so
+// the non-test build sees it as unused — same pattern as the other `config::`
+// re-exports above (e.g. `DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS`).
+#[allow(unused_imports)]
+pub use desktop_assistant_core::prompts::PersonalityLevel;
 
 impl DaemonConfig {
     /// Validate the raw `connections` map and return a [`ConnectionsMap`].

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -2449,4 +2449,41 @@ max_context_tokens = 1000000
         let reparsed: DaemonConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(parsed.purposes, reparsed.purposes);
     }
+
+    // --- [personality] section (#226) --------------------------------------
+
+    #[test]
+    fn personality_defaults_when_section_absent() {
+        // A config with no `[personality]` block still resolves the
+        // Expressive-7 defaults so every install has a disposition.
+        let config: DaemonConfig = toml::from_str("").unwrap();
+        assert_eq!(config.personality, Personality::default());
+        assert_eq!(config.personality.professionalism, PersonalityLevel::Always);
+        assert_eq!(config.personality.humor, PersonalityLevel::Sometimes);
+    }
+
+    #[test]
+    fn personality_section_parses_and_round_trips() {
+        let config: DaemonConfig = toml::from_str(
+            r#"
+            [personality]
+            professionalism = "always"
+            warmth = "often"
+            directness = "often"
+            enthusiasm = "sometimes"
+            humor = "never"
+            sarcasm = "rarely"
+            pretentiousness = "rarely"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.personality.humor, PersonalityLevel::Never);
+        assert_eq!(config.personality.warmth, PersonalityLevel::Often);
+
+        // Serialize → reparse is lossless.
+        let serialized = toml::to_string(&config).unwrap();
+        let reparsed: DaemonConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(config.personality, reparsed.personality);
+    }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1575,8 +1575,13 @@ async fn main() -> Result<()> {
         &registry_handle,
     )));
 
-    let settings_service =
-        Arc::new(DaemonSettingsService::new(config_path.clone()).with_mcp_control(mcp_handle));
+    let settings_service = Arc::new(
+        DaemonSettingsService::new(config_path.clone())
+            .with_mcp_control(mcp_handle)
+            // Personality (#226) reads/writes through the shared registry handle
+            // so settings changes hit the in-memory config the dispatch reads.
+            .with_registry(Arc::clone(&registry_handle)),
+    );
 
     // Knowledge management service (#73). When a Postgres pool is
     // configured, wire the embedding closure so client-authored entries

--- a/crates/daemon/src/settings_service.rs
+++ b/crates/daemon/src/settings_service.rs
@@ -1,17 +1,26 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use desktop_assistant_core::CoreError;
 use desktop_assistant_core::ports::inbound::{
     BackendTasksSettingsView, ConnectorDefaultsView, DatabaseSettingsView, EmbeddingsSettingsView,
-    LlmSettingsView, McpServerView, PersistenceSettingsView, SettingsService, WsAuthSettingsView,
+    LlmSettingsView, McpServerView, PersistenceSettingsView, PersonalitySettingsView,
+    SettingsService, WsAuthSettingsView,
 };
 use desktop_assistant_mcp_client::executor::McpControlHandle;
 
+use crate::api_surface::RegistryHandle;
 use crate::config;
 
 pub struct DaemonSettingsService {
     config_path: PathBuf,
     mcp_handle: Option<McpControlHandle>,
+    /// Shared handle to the live registry + config. Personality (#226) is read
+    /// and written through here rather than via disk-only `config::` helpers, so
+    /// the settings GET, the dispatch wrapper's per-send read, and a `SetConfig`
+    /// all share the registry's in-memory config — making personality changes
+    /// take effect on the next turn without a separate reload.
+    registry: Option<Arc<RegistryHandle>>,
 }
 
 impl DaemonSettingsService {
@@ -19,12 +28,24 @@ impl DaemonSettingsService {
         Self {
             config_path,
             mcp_handle: None,
+            registry: None,
         }
     }
 
     pub fn with_mcp_control(mut self, handle: McpControlHandle) -> Self {
         self.mcp_handle = Some(handle);
         self
+    }
+
+    pub fn with_registry(mut self, registry: Arc<RegistryHandle>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    fn registry(&self) -> Result<&Arc<RegistryHandle>, CoreError> {
+        self.registry
+            .as_ref()
+            .ok_or_else(|| CoreError::SystemService("registry handle not configured".to_string()))
     }
 
     fn mcp_handle(&self) -> Result<&McpControlHandle, CoreError> {
@@ -177,6 +198,21 @@ impl SettingsService for DaemonSettingsService {
     ) -> Result<(), CoreError> {
         config::set_database_settings(&self.config_path, url.as_deref(), max_connections)
             .map_err(|e| CoreError::SystemService(e.to_string()))
+    }
+
+    async fn get_personality_settings(&self) -> Result<PersonalitySettingsView, CoreError> {
+        // Read from the registry's in-memory config — the same value the
+        // dispatch wrapper installs as the per-turn task-local (#226).
+        Ok(self.registry()?.personality())
+    }
+
+    async fn set_personality_settings(
+        &self,
+        personality: PersonalitySettingsView,
+    ) -> Result<(), CoreError> {
+        // Persists to the config file and refreshes the in-memory config, so
+        // the next send's task-local reflects the change (hot reload).
+        self.registry()?.set_personality(personality)
     }
 
     async fn get_backend_tasks_settings(&self) -> Result<BackendTasksSettingsView, CoreError> {

--- a/crates/daemon/tests/fixtures/connections_migration/migrated_openai.toml
+++ b/crates/daemon/tests/fixtures/connections_migration/migrated_openai.toml
@@ -64,3 +64,12 @@ allowed_origins = []
 
 [tls]
 enabled = true
+
+[personality]
+professionalism = "always"
+warmth = "often"
+directness = "often"
+enthusiasm = "sometimes"
+humor = "sometimes"
+sarcasm = "rarely"
+pretentiousness = "rarely"

--- a/crates/daemon/tests/fixtures/purposes_migration/migrated_anthropic_backend.toml
+++ b/crates/daemon/tests/fixtures/purposes_migration/migrated_anthropic_backend.toml
@@ -54,3 +54,12 @@ allowed_origins = []
 
 [tls]
 enabled = true
+
+[personality]
+professionalism = "always"
+warmth = "often"
+directness = "often"
+enthusiasm = "sometimes"
+humor = "sometimes"
+sarcasm = "rarely"
+pretentiousness = "rarely"

--- a/crates/dbus-bridge/src/adapter/settings.rs
+++ b/crates/dbus-bridge/src/adapter/settings.rs
@@ -75,6 +75,16 @@ pub struct ConfigData {
     pub llm_top_p: f64,
     pub llm_max_tokens: u32,
     pub llm_hosted_tool_search: i32,
+    // Personality (#226): each trait as a 0..=4 ordinal (Never=0..=Always=4),
+    // matching the in-process adapter's contract so the KCM sees the same shape
+    // regardless of which D-Bus surface it talks to.
+    pub personality_professionalism: u32,
+    pub personality_warmth: u32,
+    pub personality_directness: u32,
+    pub personality_enthusiasm: u32,
+    pub personality_humor: u32,
+    pub personality_sarcasm: u32,
+    pub personality_pretentiousness: u32,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, zbus::zvariant::Type)]
@@ -109,6 +119,22 @@ pub struct ConfigPatchArgs {
     pub llm_max_tokens: u32,
     pub set_llm_hosted_tool_search: bool,
     pub llm_hosted_tool_search: i32,
+    // Personality (#226): set `set_personality_* = true` to apply the paired
+    // 0..=4 ordinal. Validation/clamping happens daemon-side.
+    pub set_personality_professionalism: bool,
+    pub personality_professionalism: u32,
+    pub set_personality_warmth: bool,
+    pub personality_warmth: u32,
+    pub set_personality_directness: bool,
+    pub personality_directness: u32,
+    pub set_personality_enthusiasm: bool,
+    pub personality_enthusiasm: u32,
+    pub set_personality_humor: bool,
+    pub personality_humor: u32,
+    pub set_personality_sarcasm: bool,
+    pub personality_sarcasm: u32,
+    pub set_personality_pretentiousness: bool,
+    pub personality_pretentiousness: u32,
 }
 
 /// Build a `ConfigData` from the wire-level `api::Config`. LLM fields
@@ -137,6 +163,13 @@ fn config_from_wire(c: &api::Config) -> ConfigData {
         llm_top_p: -1.0,
         llm_max_tokens: 0,
         llm_hosted_tool_search: -1,
+        personality_professionalism: c.personality.professionalism.as_ordinal() as u32,
+        personality_warmth: c.personality.warmth.as_ordinal() as u32,
+        personality_directness: c.personality.directness.as_ordinal() as u32,
+        personality_enthusiasm: c.personality.enthusiasm.as_ordinal() as u32,
+        personality_humor: c.personality.humor.as_ordinal() as u32,
+        personality_sarcasm: c.personality.sarcasm.as_ordinal() as u32,
+        personality_pretentiousness: c.personality.pretentiousness.as_ordinal() as u32,
     }
 }
 
@@ -330,6 +363,45 @@ impl<T: BridgeTransport + 'static> DbusSettingsAdapter<T> {
             wire_changes.persistence_push_on_update = Some(changes.persistence_push_on_update);
         }
 
+        // Personality (#226): translate each set ordinal into the wire level.
+        // An out-of-range ordinal is a clean InvalidArgs error rather than a
+        // silent clamp, matching the in-process adapter.
+        ordinal_to_level(
+            changes.set_personality_professionalism,
+            changes.personality_professionalism,
+            &mut wire_changes.personality_professionalism,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_warmth,
+            changes.personality_warmth,
+            &mut wire_changes.personality_warmth,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_directness,
+            changes.personality_directness,
+            &mut wire_changes.personality_directness,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_enthusiasm,
+            changes.personality_enthusiasm,
+            &mut wire_changes.personality_enthusiasm,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_humor,
+            changes.personality_humor,
+            &mut wire_changes.personality_humor,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_sarcasm,
+            changes.personality_sarcasm,
+            &mut wire_changes.personality_sarcasm,
+        )?;
+        ordinal_to_level(
+            changes.set_personality_pretentiousness,
+            changes.personality_pretentiousness,
+            &mut wire_changes.personality_pretentiousness,
+        )?;
+
         let result = self
             .dispatch(api::Command::SetConfig {
                 changes: wire_changes,
@@ -379,6 +451,28 @@ fn normalize(s: &str) -> Option<String> {
     } else {
         Some(t.to_string())
     }
+}
+
+/// When `set` is true, validate the 0..=4 `ordinal` into a [`api::PersonalityLevel`]
+/// and store it in `slot`; otherwise leave `slot` as `None`. Out-of-range input
+/// is a clean `InvalidArgs` error rather than a silent clamp (#226).
+fn ordinal_to_level(
+    set: bool,
+    ordinal: u32,
+    slot: &mut Option<api::PersonalityLevel>,
+) -> fdo::Result<()> {
+    if set {
+        let level = u8::try_from(ordinal)
+            .ok()
+            .and_then(api::PersonalityLevel::from_ordinal)
+            .ok_or_else(|| {
+                fdo::Error::InvalidArgs(format!(
+                    "personality level {ordinal} out of range; expected 0..=4 (Never..=Always)"
+                ))
+            })?;
+        *slot = Some(level);
+    }
+    Ok(())
 }
 
 /// Translate an `api::Config` from a `ConfigChanged` wire event into

--- a/crates/dbus-bridge/tests/bridge.rs
+++ b/crates/dbus-bridge/tests/bridge.rs
@@ -423,6 +423,7 @@ async fn event_translator_handles_config_changed() {
                 remote_name: "origin".into(),
                 push_on_update: true,
             },
+            personality: api::PersonalitySettingsView::default(),
         },
     };
     let action = translate(event);

--- a/crates/dbus-interface/src/settings.rs
+++ b/crates/dbus-interface/src/settings.rs
@@ -1235,6 +1235,48 @@ mod tests {
         assert_eq!(token, "jwt-for-tui");
     }
 
+    // --- Personality int<->level contract (#226) ---------------------------
+
+    #[tokio::test]
+    async fn get_config_exposes_personality_as_ordinals() {
+        // The KCM binds sliders to integers 0..=4 (Never=0 .. Always=4).
+        // `GetConfig` must surface the default Expressive-7 levels as those
+        // ordinals.
+        let service = Arc::new(StatefulSettingsService::new());
+        let adapter = DbusSettingsAdapter::new(service);
+        let config = adapter.get_config_tuple().await.unwrap();
+
+        assert_eq!(config.personality_professionalism, 4); // Always
+        assert_eq!(config.personality_warmth, 3); // Often
+        assert_eq!(config.personality_directness, 3); // Often
+        assert_eq!(config.personality_enthusiasm, 2); // Sometimes
+        assert_eq!(config.personality_humor, 2); // Sometimes
+        assert_eq!(config.personality_sarcasm, 1); // Rarely
+        assert_eq!(config.personality_pretentiousness, 1); // Rarely
+    }
+
+    #[tokio::test]
+    async fn set_config_personality_ordinal_round_trips() {
+        // Setting Humor=Never (0) via the patch must be reflected back as an
+        // ordinal in the returned `ConfigData`.
+        let service = Arc::new(StatefulSettingsService::new());
+        let adapter = DbusSettingsAdapter::new(Arc::clone(&service));
+
+        let updated = adapter
+            .apply_config_patch(ConfigPatch {
+                personality_humor: Some(0), // Never
+                personality_sarcasm: Some(4), // Always
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(updated.personality_humor, 0);
+        assert_eq!(updated.personality_sarcasm, 4);
+        // Untouched traits keep their defaults.
+        assert_eq!(updated.personality_professionalism, 4);
+    }
+
     /// Issue #156: settings methods that touch per-user storage must
     /// scope to the local OS user, not the `"default"` sentinel. The
     /// recording fake captures `current_user_id()` at the inbound call

--- a/crates/dbus-interface/src/settings.rs
+++ b/crates/dbus-interface/src/settings.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use desktop_assistant_core::ports::auth::with_user_id;
 use desktop_assistant_core::ports::inbound::SettingsService;
+use desktop_assistant_core::prompts::PersonalityLevel;
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
 
@@ -27,6 +28,17 @@ pub struct ConfigData {
     pub llm_top_p: f64,
     pub llm_max_tokens: u32,
     pub llm_hosted_tool_search: i32,
+    // Personality (#226). Each trait is an integer 0..=4 (Never=0, Rarely=1,
+    // Sometimes=2, Often=3, Always=4) so the KCM can bind a 0..=4 slider
+    // directly. See `PersonalityLevel::as_ordinal` / `from_ordinal` for the
+    // canonical mapping.
+    pub personality_professionalism: u32,
+    pub personality_warmth: u32,
+    pub personality_directness: u32,
+    pub personality_enthusiasm: u32,
+    pub personality_humor: u32,
+    pub personality_sarcasm: u32,
+    pub personality_pretentiousness: u32,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, zbus::zvariant::Type)]
@@ -61,6 +73,23 @@ pub struct ConfigPatchArgs {
     pub llm_max_tokens: u32,
     pub set_llm_hosted_tool_search: bool,
     pub llm_hosted_tool_search: i32,
+    // Personality (#226). For each trait, set `set_personality_* = true` to
+    // apply the paired ordinal value (0..=4, Never..=Always). An out-of-range
+    // ordinal is rejected with an error rather than clamped.
+    pub set_personality_professionalism: bool,
+    pub personality_professionalism: u32,
+    pub set_personality_warmth: bool,
+    pub personality_warmth: u32,
+    pub set_personality_directness: bool,
+    pub personality_directness: u32,
+    pub set_personality_enthusiasm: bool,
+    pub personality_enthusiasm: u32,
+    pub set_personality_humor: bool,
+    pub personality_humor: u32,
+    pub set_personality_sarcasm: bool,
+    pub personality_sarcasm: u32,
+    pub set_personality_pretentiousness: bool,
+    pub personality_pretentiousness: u32,
 }
 
 #[derive(Debug, Default)]
@@ -80,6 +109,15 @@ struct ConfigPatch {
     llm_top_p: Option<f64>,
     llm_max_tokens: Option<u32>,
     llm_hosted_tool_search: Option<bool>,
+    // Personality (#226): each `Some(ordinal)` overrides that trait. The
+    // ordinal is validated against `PersonalityLevel::from_ordinal` when applied.
+    personality_professionalism: Option<u32>,
+    personality_warmth: Option<u32>,
+    personality_directness: Option<u32>,
+    personality_enthusiasm: Option<u32>,
+    personality_humor: Option<u32>,
+    personality_sarcasm: Option<u32>,
+    personality_pretentiousness: Option<u32>,
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
@@ -126,6 +164,11 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
             .get_persistence_settings()
             .await
             .map_err(to_fdo_error)?;
+        let personality = self
+            .service
+            .get_personality_settings()
+            .await
+            .map_err(to_fdo_error)?;
 
         Ok(ConfigData {
             llm_connector: llm.connector,
@@ -146,6 +189,14 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
             llm_top_p: llm.top_p.unwrap_or(-1.0),
             llm_max_tokens: llm.max_tokens.unwrap_or(0),
             llm_hosted_tool_search: llm.hosted_tool_search.map(|v| v as i32).unwrap_or(-1),
+            // Expose each trait as its 0..=4 ordinal for the KCM (#226).
+            personality_professionalism: personality.professionalism.as_ordinal() as u32,
+            personality_warmth: personality.warmth.as_ordinal() as u32,
+            personality_directness: personality.directness.as_ordinal() as u32,
+            personality_enthusiasm: personality.enthusiasm.as_ordinal() as u32,
+            personality_humor: personality.humor.as_ordinal() as u32,
+            personality_sarcasm: personality.sarcasm.as_ordinal() as u32,
+            personality_pretentiousness: personality.pretentiousness.as_ordinal() as u32,
         })
     }
 
@@ -166,6 +217,13 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
             llm_top_p,
             llm_max_tokens,
             llm_hosted_tool_search,
+            personality_professionalism,
+            personality_warmth,
+            personality_directness,
+            personality_enthusiasm,
+            personality_humor,
+            personality_sarcasm,
+            personality_pretentiousness,
         } = patch;
 
         let llm_changed = llm_connector.is_some()
@@ -308,8 +366,54 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
                 .map_err(to_fdo_error)?;
         }
 
+        // Personality (#226): apply per-trait ordinal overrides. Each
+        // `Some(ordinal)` is validated and overlaid onto the current value;
+        // an out-of-range ordinal is a clean error rather than a silent clamp.
+        let personality_changed = personality_professionalism.is_some()
+            || personality_warmth.is_some()
+            || personality_directness.is_some()
+            || personality_enthusiasm.is_some()
+            || personality_humor.is_some()
+            || personality_sarcasm.is_some()
+            || personality_pretentiousness.is_some();
+        if personality_changed {
+            let mut p = self
+                .service
+                .get_personality_settings()
+                .await
+                .map_err(to_fdo_error)?;
+            apply_level(&mut p.professionalism, personality_professionalism)?;
+            apply_level(&mut p.warmth, personality_warmth)?;
+            apply_level(&mut p.directness, personality_directness)?;
+            apply_level(&mut p.enthusiasm, personality_enthusiasm)?;
+            apply_level(&mut p.humor, personality_humor)?;
+            apply_level(&mut p.sarcasm, personality_sarcasm)?;
+            apply_level(&mut p.pretentiousness, personality_pretentiousness)?;
+            self.service
+                .set_personality_settings(p)
+                .await
+                .map_err(to_fdo_error)?;
+        }
+
         self.get_config_tuple().await
     }
+}
+
+/// Overlay an optional 0..=4 ordinal onto a personality level, validating it.
+/// `None` leaves the level unchanged; out-of-range input is a clean error.
+fn apply_level(slot: &mut PersonalityLevel, ordinal: Option<u32>) -> fdo::Result<()> {
+    if let Some(n) = ordinal {
+        let level = u8::try_from(n)
+            .ok()
+            .and_then(PersonalityLevel::from_ordinal)
+            .ok_or_else(|| {
+                fdo::Error::InvalidArgs(format!(
+                    "personality level {n} out of range; expected 0..=4 (Never..=Always)"
+                ))
+            })?;
+        *slot = level;
+    }
+    Ok(())
 }
 
 #[interface(name = "org.desktopAssistant.Settings")]
@@ -627,6 +731,20 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
                 llm_max_tokens,
                 set_llm_hosted_tool_search,
                 llm_hosted_tool_search,
+                set_personality_professionalism,
+                personality_professionalism,
+                set_personality_warmth,
+                personality_warmth,
+                set_personality_directness,
+                personality_directness,
+                set_personality_enthusiasm,
+                personality_enthusiasm,
+                set_personality_humor,
+                personality_humor,
+                set_personality_sarcasm,
+                personality_sarcasm,
+                set_personality_pretentiousness,
+                personality_pretentiousness,
             } = changes;
 
             self.apply_config_patch(ConfigPatch {
@@ -649,6 +767,17 @@ impl<S: SettingsService + 'static> DbusSettingsAdapter<S> {
                 llm_max_tokens: set_llm_max_tokens.then_some(llm_max_tokens),
                 llm_hosted_tool_search: set_llm_hosted_tool_search
                     .then_some(llm_hosted_tool_search == 1),
+                personality_professionalism: set_personality_professionalism
+                    .then_some(personality_professionalism),
+                personality_warmth: set_personality_warmth.then_some(personality_warmth),
+                personality_directness: set_personality_directness
+                    .then_some(personality_directness),
+                personality_enthusiasm: set_personality_enthusiasm
+                    .then_some(personality_enthusiasm),
+                personality_humor: set_personality_humor.then_some(personality_humor),
+                personality_sarcasm: set_personality_sarcasm.then_some(personality_sarcasm),
+                personality_pretentiousness: set_personality_pretentiousness
+                    .then_some(personality_pretentiousness),
             })
             .await
         })
@@ -899,8 +1028,8 @@ mod tests {
     use desktop_assistant_core::CoreError;
     use desktop_assistant_core::ports::inbound::{
         BackendTasksSettingsView, ConnectorDefaultsView, DatabaseSettingsView,
-        EmbeddingsSettingsView, LlmSettingsView, PersistenceSettingsView, SettingsService,
-        WsAuthSettingsView,
+        EmbeddingsSettingsView, LlmSettingsView, PersistenceSettingsView, PersonalitySettingsView,
+        SettingsService, WsAuthSettingsView,
     };
     use std::sync::Mutex;
 
@@ -909,6 +1038,7 @@ mod tests {
         llm: LlmSettingsView,
         embeddings: EmbeddingsSettingsView,
         persistence: PersistenceSettingsView,
+        personality: PersonalitySettingsView,
         database: DatabaseSettingsView,
         backend_tasks: BackendTasksSettingsView,
         api_key_set: bool,
@@ -946,6 +1076,7 @@ mod tests {
                         remote_name: "origin".to_string(),
                         push_on_update: true,
                     },
+                    personality: PersonalitySettingsView::default(),
                     database: DatabaseSettingsView {
                         url: String::new(),
                         max_connections: 5,
@@ -1074,6 +1205,18 @@ mod tests {
                 state.persistence.remote_name = remote_name;
             }
             state.persistence.push_on_update = push_on_update;
+            Ok(())
+        }
+
+        async fn get_personality_settings(&self) -> Result<PersonalitySettingsView, CoreError> {
+            Ok(self.state.lock().unwrap().personality)
+        }
+
+        async fn set_personality_settings(
+            &self,
+            personality: PersonalitySettingsView,
+        ) -> Result<(), CoreError> {
+            self.state.lock().unwrap().personality = personality;
             Ok(())
         }
 
@@ -1264,7 +1407,7 @@ mod tests {
 
         let updated = adapter
             .apply_config_patch(ConfigPatch {
-                personality_humor: Some(0), // Never
+                personality_humor: Some(0),   // Never
                 personality_sarcasm: Some(4), // Always
                 ..Default::default()
             })


### PR DESCRIPTION
Implements **#226** — Phase 1 (global) configurable assistant personality.

## What
The assistant gets a configurable **disposition**: 7 "Expressive 7" traits, each at a qualitative level (Never · Rarely · Sometimes · Often · Always), rendered into a natural-language **blurb** injected into the SYSTEM prompt **daemon-side** so every client (voice/tui/gtk/kde/socket) inherits it. The levels are an **initial disposition, not a rulebook** — a fixed **adaptation clause** is always appended telling the model to take cues from the conversation and adapt both ways.

Reuses the existing `system_refinement` plumbing as the template throughout (task-local + prompt section).

### Defaults (Expressive 7)
Professionalism=Always, Warmth=Often, Directness=Often, Enthusiasm=Sometimes, Humor=Sometimes, Sarcasm=Rarely, Pretentiousness=Rarely.

### Default blurb (exact `render_blurb()` output)
> In your default manner, you always keep a professional, polished tone, are usually warm and personable, are usually direct and to the point, show some enthusiasm now and then, bring a little humor now and then, let a touch of sarcasm slip only on rare occasion, and get a touch pretentious only on rare occasion. Treat this as a starting point, not a script. Take your cues from the conversation and adapt both ways — if the user is playful or jokes around, it's fine to loosen up and joke back a bit; if things turn serious or they seem stressed, ease off the humor and sarcasm unless a light touch genuinely helps. Match the user's energy rather than forcing a trait that doesn't fit the moment.

A `Never` trait omits its clause; all-`Never` yields only the adaptation clause.

## Where things go
- **core/prompts**: `PersonalityLevel` (lowercase serde + stable 0..=4 ordinal) + typed `Personality` struct (Default = table) + `render_blurb()`; `PromptSectionKind::Personality`. Typed struct over a free map for compile-time safety + a stable wire schema (justified in code).
- **core/context**: `assemble_system_instruction` injects the blurb **before** ToolAvailability and the per-turn SystemRefinement.
- **core/ports/llm**: `PERSONALITY` task-local + `with_personality`/`current_personality` mirroring `SYSTEM_REFINEMENT`; unset reads as the default disposition.
- **daemon/config**: `[personality]` on `DaemonConfig` (re-exports the core type; per-field serde defaults).
- **daemon/api_surface**: `RegistryHandle::personality()/set_personality()`; dispatch installs `with_personality(self.registry.personality())` every send. The in-memory config is the single source of truth a `SetConfig` updates, so a change takes effect on the **next turn** (hot reload). Phase-2 per-conversation seam is noted at the install site (swap *which* personality is installed; core read side unchanged).
- **daemon/settings_service**: personality get/set route through the registry handle so GET, per-send read, and SetConfig share one config.
- **api-model**: `personality` on `Config`; 7 optional level fields on `ConfigChanges`.
- **application**: `get_config`/`set_config` read/write personality (per-trait overlay), same shape as embeddings/persistence.
- **dbus-interface + dbus-bridge**: personality on `ConfigData`/`ConfigPatchArgs`.

## D-Bus int↔level contract (for the KCM)
Each trait is exposed as an **integer 0..=4**: `Never=0, Rarely=1, Sometimes=2, Often=3, Always=4` (`PersonalityLevel::as_ordinal`/`from_ordinal`). `ConfigData` has per-trait `personality_<trait>: u32`; `ConfigPatchArgs` has `set_personality_<trait>: bool` + `personality_<trait>: u32`. Out-of-range ordinals are a clean `InvalidArgs` error, not a silent clamp. Same shape on both the in-process `dbus-interface` adapter and the `dbus-bridge`.

## Tests (TDD — failing tests committed first)
One named test per acceptance criterion: ordinal round-trip; defaults render expected blurb; `Never` clause omitted; all-`Never` = adaptation clause only; adaptation clause always present; serde lowercase round-trip; `PERSONALITY` task-local (default/scope/nested); personality section injected before tools+refinement; `[personality]` TOML defaults + round-trip; `Config`/`ConfigChanges` round-trip; D-Bus int↔level round-trip; application get/set.

`just check` (fmt-check + clippy `-D warnings` + build + workspace tests) is green. No new dependencies.

## Scope
Global only. No per-conversation work (Phase 2, separate issue).

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)