### PR TITLE
Activate client-tool execution: wire RegisterClientTools/ClientToolResult + suspend the turn (#234)

### DIFF
--- a/crates/application/src/client_tools.rs
+++ b/crates/application/src/client_tools.rs
@@ -38,16 +38,18 @@
 //! disagrees with the resolver's, exactly the
 //! `turn_cross_user_isolation` test acceptance criterion.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_auth_jwt::UserId;
 use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::ToolDefinition;
 use desktop_assistant_core::ports::auth::current_user_id;
+use desktop_assistant_core::ports::client_tools::ClientToolPort;
 use desktop_assistant_core::ports::llm::current_cancellation_token;
 use desktop_assistant_core::ports::store::{
-    PendingClientToolCall, TurnStateJson, TurnStateStore, TurnStatus,
+    PendingClientToolCall, TurnRow, TurnStateJson, TurnStateStore, TurnStatus,
 };
 use thiserror::Error;
 use tokio::sync::oneshot;
@@ -111,14 +113,17 @@ const MAX_CLIENT_TOOL_RESULT_BYTES: usize = 1_048_576;
 /// internal mutexes around small `HashMap`s — there is no async work
 /// inside the mutex critical sections, so blocking is bounded.
 pub struct ClientToolCoordinator {
-    /// Per-user set of currently-registered tool names. The
+    /// Per-user map of currently-registered client-local tools, keyed by
+    /// tool name → full registration (description + input schema). The
     /// architecture's "per-session" registration semantic collapses to
     /// "per-user" in this slice: the application layer has no native
     /// concept of a connection session yet, and the tests pin that
     /// registration is overwritten on each new `RegisterClientTools`
     /// call so a reconnecting client gets the same per-session
-    /// behaviour without us tracking the connection.
-    registrations: Mutex<HashMap<String, HashSet<String>>>,
+    /// behaviour without us tracking the connection. The full registration
+    /// (not just the name) is retained so the turn loop can offer the tool's
+    /// schema to the LLM (#234).
+    registrations: Mutex<HashMap<String, HashMap<String, api::ClientToolRegistration>>>,
     /// In-flight suspensions, keyed by task_id. Each entry holds the
     /// expected `tool_call_id` so the resolver can refuse mismatches
     /// without consulting the DB, and the oneshot sender used to wake
@@ -151,7 +156,7 @@ impl ClientToolCoordinator {
         let entry = regs.entry(user_id).or_default();
         entry.clear();
         for t in tools {
-            entry.insert(t.name.clone());
+            entry.insert(t.name.clone(), t.clone());
         }
         u32::try_from(entry.len()).unwrap_or(u32::MAX)
     }
@@ -161,8 +166,31 @@ impl ClientToolCoordinator {
         let user_id = current_user_id().as_str().to_string();
         let regs = self.registrations.lock().unwrap();
         regs.get(&user_id)
-            .map(|set| set.contains(name))
+            .map(|set| set.contains_key(name))
             .unwrap_or(false)
+    }
+
+    /// The tool definitions registered as client-local for the current user,
+    /// in the shape the LLM tool list expects (#234). Maps each
+    /// [`api::ClientToolRegistration`] to a core [`ToolDefinition`] so the
+    /// turn loop can offer them to the model without `core` depending on
+    /// `api-model`.
+    pub async fn registered_definitions(&self) -> Vec<ToolDefinition> {
+        let user_id = current_user_id().as_str().to_string();
+        let regs = self.registrations.lock().unwrap();
+        regs.get(&user_id)
+            .map(|set| {
+                set.values()
+                    .map(|r| {
+                        ToolDefinition::new(
+                            r.name.clone(),
+                            r.description.clone(),
+                            r.input_schema.clone(),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -398,4 +426,170 @@ pub async fn sweep_non_terminal_turns_on_startup(
         count = count.saturating_add(1);
     }
     Ok(count)
+}
+
+/// Per-turn adapter implementing the core [`ClientToolPort`] (#234).
+///
+/// The shared [`ClientToolCoordinator`] and [`TurnStateStore`] live for the
+/// life of the daemon; the `task_id`, `conversation_id`, and the turn's
+/// [`EventSink`] are only known once a `send_prompt` is in flight. The
+/// application's send-turn body constructs one of these per turn (cheap — all
+/// `Arc` clones plus three owned strings) and installs it via
+/// [`desktop_assistant_core::ports::client_tools::with_client_tools`] so the
+/// core dispatch loop can consult the registered set and suspend on a
+/// client-local tool call without `core` depending on `application`.
+///
+/// User scoping is implicit: every coordinator entry point reads
+/// `current_user_id()` from the task-local the dispatcher installed, so this
+/// adapter's `tool_definitions`/`is_registered`/`execute` are all scoped to
+/// the connection's user.
+pub struct CoordinatorClientToolPort {
+    coord: Arc<ClientToolCoordinator>,
+    store: Arc<dyn TurnStateStore>,
+    sink: Arc<dyn EventSink>,
+    task_id: api::TaskId,
+    conversation_id: String,
+}
+
+impl CoordinatorClientToolPort {
+    /// Build the per-turn adapter. `task_id` is the registry task id for the
+    /// turn — the same id the client received in `SendMessageAck` and the id
+    /// the emitted `ClientToolCall` / inbound `ClientToolResult` correlate on.
+    pub fn new(
+        coord: Arc<ClientToolCoordinator>,
+        store: Arc<dyn TurnStateStore>,
+        sink: Arc<dyn EventSink>,
+        task_id: api::TaskId,
+        conversation_id: String,
+    ) -> Self {
+        Self {
+            coord,
+            store,
+            sink,
+            task_id,
+            conversation_id,
+        }
+    }
+
+    /// Ensure a turn row exists before the coordinator's `update_turn` writes
+    /// the `pending_client_tool` transition. The row is created lazily on the
+    /// first client-tool suspension of the turn (turns that never call a
+    /// client tool never create a row). A row created by an earlier suspension
+    /// in the same turn — or by a concurrent racer — is fine: a duplicate-id
+    /// `create_turn` error is swallowed, leaving the existing row untouched.
+    async fn ensure_turn_row(&self) {
+        let row = TurnRow {
+            id: self.task_id.0.clone(),
+            user_id: current_user_id().as_str().to_string(),
+            conversation_id: self.conversation_id.clone(),
+            status: TurnStatus::PendingLlm,
+            state: TurnStateJson::default(),
+            last_error: None,
+        };
+        // Best-effort: a dup id just means the row already exists. Any other
+        // storage error is left for `suspend_for_client_tool`'s own
+        // `update_turn` to surface.
+        let _ = self.store.create_turn(row).await;
+    }
+}
+
+/// In-memory [`TurnStateStore`] for the live single-node deploy (#234).
+///
+/// Phase-2 of the architecture (`docs/architecture-evolution.md`) calls for
+/// a DB-persisted turn-state machine so a crashed daemon can sweep abandoned
+/// turns and a Lambda invocation can resume one. That durable store is future
+/// work; this slice activates client-tool execution on the live UDS path,
+/// where the daemon is a long-lived single process and the turn row only
+/// needs to survive within that process. This map provides exactly that: it
+/// records the `pending_client_tool` transition so the coordinator's
+/// suspend/resolve dance has a backing row, and `scan_non_terminal` lets the
+/// startup sweep clear anything a restart left behind (here, nothing, since
+/// the map starts empty). Swapping in a `PgTurnStateStore` later is a drop-in
+/// behind the same trait.
+#[derive(Default)]
+pub struct InMemoryTurnStateStore {
+    rows: Mutex<HashMap<String, TurnRow>>,
+}
+
+impl InMemoryTurnStateStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl TurnStateStore for InMemoryTurnStateStore {
+    async fn create_turn(&self, row: TurnRow) -> Result<(), CoreError> {
+        let mut rows = self.rows.lock().unwrap();
+        if rows.contains_key(&row.id) {
+            return Err(CoreError::Storage(format!("duplicate turn id: {}", row.id)));
+        }
+        rows.insert(row.id.clone(), row);
+        Ok(())
+    }
+
+    async fn get_turn(&self, id: &str) -> Result<Option<TurnRow>, CoreError> {
+        Ok(self.rows.lock().unwrap().get(id).cloned())
+    }
+
+    async fn update_turn(
+        &self,
+        id: &str,
+        status: TurnStatus,
+        state: &TurnStateJson,
+        last_error: Option<&str>,
+    ) -> Result<(), CoreError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .get_mut(id)
+            .ok_or_else(|| CoreError::Storage(format!("turn missing: {id}")))?;
+        row.status = status;
+        row.state = state.clone();
+        row.last_error = last_error.map(String::from);
+        Ok(())
+    }
+
+    async fn scan_non_terminal(&self) -> Result<Vec<TurnRow>, CoreError> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|r| !r.status.is_terminal())
+            .cloned()
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl ClientToolPort for CoordinatorClientToolPort {
+    async fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.coord.registered_definitions().await
+    }
+
+    async fn is_registered(&self, name: &str) -> bool {
+        self.coord.is_client_registered(name).await
+    }
+
+    async fn execute(
+        &self,
+        tool_call_id: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<String, CoreError> {
+        self.ensure_turn_row().await;
+        suspend_for_client_tool(
+            &self.coord,
+            &*self.store,
+            &*self.sink,
+            self.task_id.clone(),
+            self.conversation_id.clone(),
+            PendingClientToolCall {
+                tool_call_id: tool_call_id.to_string(),
+                tool_name: tool_name.to_string(),
+                arguments,
+            },
+        )
+        .await
+    }
 }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -14,6 +14,7 @@ use desktop_assistant_api_model as api;
 pub use desktop_assistant_auth_jwt::UserId;
 use desktop_assistant_core::domain::{DEFAULT_NOTE_TYPE, KnowledgeEntry, ScratchpadNote};
 use desktop_assistant_core::ports::auth::with_user_id;
+use desktop_assistant_core::ports::client_tools::with_client_tools;
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
     ConversationModelSelection, ConversationService, DispatchWarning, KnowledgeService,
@@ -23,11 +24,15 @@ use desktop_assistant_core::ports::scratchpad::{
     MAX_KEYS_PER_CALL, MAX_NOTE_BYTES, MAX_RESULTS_CEILING, NewScratchpadNote, ScratchpadClearFn,
     ScratchpadDeleteManyFn, ScratchpadGetManyFn, ScratchpadListFn, ScratchpadWriteFn,
 };
-use desktop_assistant_core::ports::store::IdempotencyKeyStore;
+use desktop_assistant_core::ports::store::{IdempotencyKeyStore, TurnStateStore};
 use thiserror::Error;
 use tracing::warn;
 
 use crate::background_tasks::{BackgroundTaskRegistry, TaskError};
+use crate::client_tools::{
+    ClientToolCoordinator, ClientToolResolutionError, CoordinatorClientToolPort,
+    register_client_tools, resolve_client_tool_result,
+};
 use crate::inflight::{InFlightRegistry, InFlightTurn, TeeSink, forward_inflight};
 
 #[derive(Debug, Error)]
@@ -339,6 +344,24 @@ where
     /// live) instead of running a second turn. Always present (no DB needed);
     /// only consulted when a request carries a key.
     inflight: Arc<InFlightRegistry>,
+    /// Shared client-tool coordinator + turn-state store (#107 / #234). When
+    /// attached, `RegisterClientTools` / `ClientToolResult` are served and a
+    /// per-turn [`CoordinatorClientToolPort`] is installed around each
+    /// send-turn so the LLM can call client-local tools (suspending the turn
+    /// and resuming on the client's result). `None` (the default) keeps the
+    /// pre-#234 behaviour: the two commands return `Unsupported` and every
+    /// tool is server-side.
+    client_tools: Option<ClientToolWiring>,
+}
+
+/// The handler-resident client-tool dependencies (#234). Both halves are
+/// daemon-lifetime singletons: one `ClientToolCoordinator` shared across all
+/// turns, paired with the `TurnStateStore` the coordinator writes its
+/// suspend/resolve transitions into.
+#[derive(Clone)]
+struct ClientToolWiring {
+    coord: Arc<ClientToolCoordinator>,
+    store: Arc<dyn TurnStateStore>,
 }
 
 impl<A, C, S, N, K> DefaultAssistantApiHandler<A, C, S, N, K>
@@ -370,7 +393,24 @@ where
             scratchpad_clear: None,
             idempotency: None,
             inflight: Arc::new(InFlightRegistry::default()),
+            client_tools: None,
         }
+    }
+
+    /// Attach the shared client-tool coordinator + turn-state store (#234) so
+    /// `RegisterClientTools` / `ClientToolResult` are served and send-turns
+    /// offer the connection's client-local tools to the LLM (suspending the
+    /// turn and resuming on the client's result). The daemon wires this in
+    /// `main.rs` to one shared `ClientToolCoordinator` and an
+    /// `InMemoryTurnStateStore`; callers that skip it keep the prior
+    /// server-side-only behaviour.
+    pub fn with_client_tool_coordinator(
+        mut self,
+        coord: Arc<ClientToolCoordinator>,
+        store: Arc<dyn TurnStateStore>,
+    ) -> Self {
+        self.client_tools = Some(ClientToolWiring { coord, store });
+        self
     }
 
     /// Attach the per-conversation scratchpad closures (#190) so the
@@ -812,6 +852,20 @@ fn dispatch_warning_to_api(w: DispatchWarning) -> api::ConversationWarning {
                 effort: fallback_to.effort,
             },
         },
+    }
+}
+
+/// Map a [`ClientToolResolutionError`] (#234) to the wire-level
+/// [`ApiError`]. A missing/cross-user turn is reported as `NotFound` (the
+/// existence-hiding rule of #105 — a cross-user probe can't tell "no such
+/// turn" from "not yours"); a `tool_call_id` mismatch or a malformed payload
+/// is a caller mistake reported as `Core`; storage failures surface as `Core`.
+fn map_client_tool_resolution_err(e: ClientToolResolutionError) -> ApiError {
+    match e {
+        ClientToolResolutionError::TurnNotFound { .. } => ApiError::NotFound,
+        ClientToolResolutionError::ToolCallIdMismatch { .. }
+        | ClientToolResolutionError::MalformedResult(_)
+        | ClientToolResolutionError::Storage(_) => ApiError::Core(e.to_string()),
     }
 }
 
@@ -1529,8 +1583,51 @@ where
                 Ok(api::CommandResult::Ack)
             }
 
-            api::Command::RegisterClientTools { .. } | api::Command::ClientToolResult { .. } => {
-                Err(ApiError::Unsupported)
+            // Client-side tool execution (#107 / #234). Served only when the
+            // handler carries a client-tool coordinator (wired by the daemon);
+            // otherwise the feature is off and we reject explicitly so
+            // transports surface a clean "not enabled" rather than silently
+            // dropping the command. User scope is already installed by the
+            // dispatcher's `with_user_id`, so the coordinator's per-user
+            // registration/resolution is automatically scoped to the
+            // connection's user.
+            api::Command::RegisterClientTools { tools } => {
+                let wiring = self.client_tools.as_ref().ok_or(ApiError::Unsupported)?;
+                let count = register_client_tools(&wiring.coord, &tools).await;
+                Ok(api::CommandResult::ClientToolsRegistered { count })
+            }
+            api::Command::ClientToolResult {
+                task_id,
+                tool_call_id,
+                result,
+                error,
+            } => {
+                let wiring = self.client_tools.as_ref().ok_or(ApiError::Unsupported)?;
+                // Exactly one of result/error should be set; both-None is a
+                // malformed result the coordinator's validator rejects, which
+                // we map to a clean request error.
+                let payload: Result<String, String> = match (result, error) {
+                    (Some(r), _) => Ok(r),
+                    (None, Some(e)) => Err(e),
+                    (None, None) => {
+                        return Err(ApiError::Core(
+                            "client tool result must populate exactly one of `result` or `error`"
+                                .to_string(),
+                        ));
+                    }
+                };
+                let user_id = desktop_assistant_core::ports::auth::current_user_id();
+                resolve_client_tool_result(
+                    &wiring.coord,
+                    &*wiring.store,
+                    user_id,
+                    task_id,
+                    tool_call_id,
+                    payload,
+                )
+                .await
+                .map_err(map_client_tool_resolution_err)?;
+                Ok(api::CommandResult::Ack)
             }
         }
     }
@@ -1601,6 +1698,11 @@ where
             )
             .await
         } else {
+            // No-registry direct path (single-tenant tests / non-streaming
+            // callers): there is no registry `task_id` to correlate a
+            // `ClientToolResult` against, so client-tool execution is off
+            // here. The live daemon always attaches a registry, so this never
+            // applies to the real client-tool path.
             run_send_turn(
                 Arc::clone(&self.conversations),
                 conversation_id,
@@ -1611,6 +1713,7 @@ where
                 idempotency,
                 sink,
                 tokio_util::sync::CancellationToken::new(),
+                None,
             )
             .await
             .map_err(Self::map_core_err)
@@ -1715,6 +1818,10 @@ where
         // Pair the store with the key (both-or-neither) so the turn body
         // records the reply on completion for a future retry (#204).
         let idempotency = self.idempotency.clone().zip(idempotency_key);
+        // Client-tool wiring (#234), if attached, so the turn body can install
+        // a per-turn `CoordinatorClientToolPort` (keyed on the registry
+        // `task_id`) around the LLM loop.
+        let client_tools = self.client_tools.clone();
         let kind = api::TaskKind::Conversation {
             conversation_id: conversation_id.clone(),
         };
@@ -1747,6 +1854,22 @@ where
                 None,
             );
 
+            // Build the per-turn client-tool port from the registry task id so
+            // a client-local tool call suspends THIS turn and correlates with
+            // the client's `ClientToolResult` (#234). The port shares the
+            // turn's `turn_sink`, so emitted `ClientToolCall` events reach the
+            // same connection the response streams to.
+            let client_tool_port = client_tools.map(|wiring| {
+                Arc::new(CoordinatorClientToolPort::new(
+                    wiring.coord,
+                    wiring.store,
+                    Arc::clone(&turn_sink),
+                    ctx.task_id.clone(),
+                    conv_id_for_body.clone(),
+                ))
+                    as Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>
+            });
+
             let result = with_user_id(
                 user_id_for_body,
                 run_send_turn(
@@ -1759,6 +1882,7 @@ where
                     idempotency,
                     turn_sink,
                     ctx.token.clone(),
+                    client_tool_port,
                 ),
             )
             .await;
@@ -1823,6 +1947,7 @@ where
     ) -> ApiResult<()> {
         let user_id = desktop_assistant_core::ports::auth::current_user_id();
         let conversations = Arc::clone(&self.conversations);
+        let client_tools = self.client_tools.clone();
         let kind = api::TaskKind::Conversation {
             conversation_id: conversation_id.clone(),
         };
@@ -1849,6 +1974,18 @@ where
                 None,
             );
 
+            // Per-turn client-tool port (#234) keyed on the registry task id.
+            let client_tool_port = client_tools.map(|wiring| {
+                Arc::new(CoordinatorClientToolPort::new(
+                    wiring.coord,
+                    wiring.store,
+                    Arc::clone(&sink_for_body),
+                    ctx.task_id.clone(),
+                    conv_id_for_body.clone(),
+                ))
+                    as Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>
+            });
+
             let result = with_user_id(
                 user_id_for_body,
                 run_send_turn(
@@ -1861,6 +1998,7 @@ where
                     idempotency,
                     sink_for_body,
                     ctx.token.clone(),
+                    client_tool_port,
                 ),
             )
             .await;
@@ -2099,6 +2237,7 @@ async fn run_send_turn<C>(
     idempotency: Option<(Arc<dyn IdempotencyKeyStore>, String)>,
     sink: Arc<dyn EventSink>,
     cancellation: tokio_util::sync::CancellationToken,
+    client_tool_port: Option<Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>>,
 ) -> Result<(), desktop_assistant_core::CoreError>
 where
     C: ConversationService + Send + Sync + 'static,
@@ -2151,17 +2290,26 @@ where
         effort: o.effort,
     });
 
-    let outcome = conversations
-        .send_prompt_with_override(
-            &desktop_assistant_core::domain::ConversationId::from(conversation_id.as_str()),
-            content,
-            override_for_core,
-            system_refinement,
-            callback,
-            on_status,
-            cancellation,
-        )
-        .await;
+    let core_conv_id =
+        desktop_assistant_core::domain::ConversationId::from(conversation_id.as_str());
+    let dispatch = conversations.send_prompt_with_override(
+        &core_conv_id,
+        content,
+        override_for_core,
+        system_refinement,
+        callback,
+        on_status,
+        cancellation,
+    );
+
+    // Install the per-turn client-tool port (#234) as a task-local around the
+    // dispatch so the core loop can offer the connection's client-local tools
+    // and suspend on a call. No port → the loop is server-side only, exactly
+    // as before.
+    let outcome = match client_tool_port {
+        Some(port) => with_client_tools(port, dispatch).await,
+        None => dispatch.await,
+    };
 
     if let Err(e) = forwarder.await {
         warn!("stream forwarder task failed: {e}");

--- a/crates/application/tests/client_tool_turn_loop.rs
+++ b/crates/application/tests/client_tool_turn_loop.rs
@@ -1,0 +1,334 @@
+//! End-to-end integration test for the activated client-tool turn loop
+//! (#234).
+//!
+//! Unlike `client_tool_turn_state.rs` (which drives the coordinator's
+//! suspend/resolve primitives directly), this test wires the *real* core
+//! [`ConversationHandler`] turn loop to the *real*
+//! [`ClientToolCoordinator`] via the [`CoordinatorClientToolPort`] adapter —
+//! exactly the path a live `SendMessage` takes. A fake LLM calls a
+//! registered client tool; the test asserts the turn:
+//!
+//! 1. offers + invokes the client tool, emitting `Event::ClientToolCall`,
+//! 2. parks (the `send_prompt` future stays pending) until a result arrives,
+//! 3. resumes when `resolve_client_tool_result` posts the client's output,
+//!    feeding that output back to the LLM, which then finishes the turn.
+//!
+//! Cross-user isolation is re-verified at the turn-loop level: a result
+//! posted under the wrong user must not wake the parked turn.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use desktop_assistant_api_model as api;
+use desktop_assistant_application::EventSink;
+use desktop_assistant_application::client_tools::{
+    ClientToolCoordinator, CoordinatorClientToolPort, InMemoryTurnStateStore,
+    register_client_tools, resolve_client_tool_result,
+};
+use desktop_assistant_auth_jwt::UserId;
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{
+    Conversation, ConversationId, Message, ToolCall, ToolDefinition,
+};
+use desktop_assistant_core::ports::auth::with_user_id;
+use desktop_assistant_core::ports::client_tools::{ClientToolPort, with_client_tools};
+use desktop_assistant_core::ports::inbound::ConversationService;
+use desktop_assistant_core::ports::llm::{ChunkCallback, LlmClient, LlmResponse, ReasoningConfig};
+use desktop_assistant_core::ports::store::{ConversationStore, TurnStateStore};
+use desktop_assistant_core::service::ConversationHandler;
+
+// ---- Fakes ---------------------------------------------------------------
+
+/// In-memory conversation store (mirrors the core test `MockStore`).
+#[derive(Default)]
+struct MockStore {
+    conversations: Mutex<HashMap<String, Conversation>>,
+}
+
+impl ConversationStore for MockStore {
+    async fn create(&self, conv: Conversation) -> Result<(), CoreError> {
+        self.conversations
+            .lock()
+            .unwrap()
+            .insert(conv.id.0.clone(), conv);
+        Ok(())
+    }
+    async fn get(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+        self.conversations
+            .lock()
+            .unwrap()
+            .get(&id.0)
+            .cloned()
+            .ok_or_else(|| CoreError::ConversationNotFound(id.0.clone()))
+    }
+    async fn list(&self) -> Result<Vec<Conversation>, CoreError> {
+        Ok(self
+            .conversations
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect())
+    }
+    async fn update(&self, conv: Conversation) -> Result<(), CoreError> {
+        self.conversations
+            .lock()
+            .unwrap()
+            .insert(conv.id.0.clone(), conv);
+        Ok(())
+    }
+    async fn delete(&self, id: &ConversationId) -> Result<(), CoreError> {
+        self.conversations.lock().unwrap().remove(&id.0);
+        Ok(())
+    }
+    async fn archive(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn unarchive(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn create_summary(
+        &self,
+        _conversation_id: &ConversationId,
+        _summary: String,
+        _start_ordinal: usize,
+        _end_ordinal: usize,
+    ) -> Result<String, CoreError> {
+        Ok("summary-1".to_string())
+    }
+    async fn expand_summary(&self, _summary_id: &str) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+/// Fake LLM that returns a queued sequence of responses.
+struct ScriptedLlm {
+    responses: Mutex<Vec<LlmResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<LlmResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClient for ScriptedLlm {
+    async fn stream_completion(
+        &self,
+        _messages: Vec<Message>,
+        _tools: &[ToolDefinition],
+        _reasoning: ReasoningConfig,
+        mut on_chunk: ChunkCallback,
+    ) -> Result<LlmResponse, CoreError> {
+        let response = {
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                return Ok(LlmResponse::text("fallback"));
+            }
+            responses.remove(0)
+        };
+        if !response.text.is_empty() {
+            on_chunk(response.text.clone());
+        }
+        Ok(response)
+    }
+}
+
+/// Captures emitted events for assertions.
+#[derive(Default)]
+struct CapturingSink {
+    events: Mutex<Vec<api::Event>>,
+}
+
+impl CapturingSink {
+    fn snapshot(&self) -> Vec<api::Event> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl EventSink for CapturingSink {
+    async fn emit(&self, event: api::Event) -> bool {
+        self.events.lock().unwrap().push(event);
+        true
+    }
+}
+
+fn noop_chunk() -> ChunkCallback {
+    Box::new(|_| true)
+}
+fn noop_status() -> desktop_assistant_core::ports::llm::StatusCallback {
+    Box::new(|_| {})
+}
+
+fn make_handler(responses: Vec<LlmResponse>) -> ConversationHandler<MockStore, ScriptedLlm> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    let counter = Arc::new(AtomicU64::new(0));
+    // `ConversationHandler::new` uses the `NoopToolExecutor`, so there are no
+    // server-side tools at all — a `fs_read` call can only succeed via the
+    // client-tool port, which is what this test pins.
+    ConversationHandler::new(
+        MockStore::default(),
+        ScriptedLlm::new(responses),
+        Box::new(move || {
+            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            format!("conv-{n}")
+        }),
+    )
+}
+
+// ---- Test ----------------------------------------------------------------
+
+/// The genuine #234 acceptance test: a fake LLM calls a registered client
+/// tool, the turn emits `ClientToolCall` and parks, and posting a
+/// `ClientToolResult` wakes it so the LLM finishes the turn.
+#[tokio::test]
+async fn turn_loop_suspends_on_client_tool_then_resumes_on_result() {
+    let alice = UserId::new("alice");
+    let task_id = api::TaskId("task-1".into());
+
+    // The model first asks for `fs_read`, then answers using its output.
+    let responses = vec![
+        LlmResponse::with_tool_calls(
+            "",
+            vec![ToolCall::new(
+                "call-1",
+                "fs_read",
+                r#"{"path":"/etc/hosts"}"#,
+            )],
+        ),
+        LlmResponse::text("The hosts file maps 127.0.0.1 to localhost"),
+    ];
+    let handler = Arc::new(make_handler(responses));
+    let conv = handler.create_conversation("Test".into()).await.unwrap();
+    let conv_id = conv.id.0.clone();
+
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn TurnStateStore> = Arc::new(InMemoryTurnStateStore::new());
+    let sink = Arc::new(CapturingSink::default());
+
+    // Alice registers the client-local tool.
+    with_user_id(alice.clone(), async {
+        register_client_tools(
+            &coord,
+            &[api::ClientToolRegistration {
+                name: "fs_read".into(),
+                description: "Read a file on the client".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }],
+        )
+        .await;
+    })
+    .await;
+
+    // The per-turn adapter, exactly as `run_send_turn` builds it.
+    let port: Arc<dyn ClientToolPort> = Arc::new(CoordinatorClientToolPort::new(
+        Arc::clone(&coord),
+        Arc::clone(&store),
+        sink.clone() as Arc<dyn EventSink>,
+        task_id.clone(),
+        conv_id.clone(),
+    ));
+
+    // Drive the real turn loop under alice's scope with the port installed.
+    let handler_for_task = Arc::clone(&handler);
+    let conv_id_for_task = conv_id.clone();
+    let turn = tokio::spawn(async move {
+        with_user_id(alice.clone(), async {
+            with_client_tools(
+                port,
+                handler_for_task.send_prompt(
+                    &ConversationId::from(conv_id_for_task.as_str()),
+                    "Read /etc/hosts".into(),
+                    noop_chunk(),
+                    noop_status(),
+                ),
+            )
+            .await
+        })
+        .await
+    });
+
+    // Let the turn run up to the suspension point.
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+
+    // The turn emitted exactly one ClientToolCall and is parked.
+    let calls: Vec<_> = sink
+        .snapshot()
+        .into_iter()
+        .filter(|e| matches!(e, api::Event::ClientToolCall { .. }))
+        .collect();
+    assert_eq!(calls.len(), 1, "expected one ClientToolCall; got {calls:?}");
+    match &calls[0] {
+        api::Event::ClientToolCall {
+            task_id: t,
+            tool_call_id,
+            tool_name,
+            ..
+        } => {
+            assert_eq!(t, &task_id);
+            assert_eq!(tool_call_id, "call-1");
+            assert_eq!(tool_name, "fs_read");
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+    assert!(
+        !turn.is_finished(),
+        "turn must remain parked until a ClientToolResult arrives"
+    );
+
+    // A cross-user result must NOT wake the parked turn (isolation).
+    let cross_user_err = resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("mallory"),
+        task_id.clone(),
+        "call-1".to_string(),
+        Ok("malicious".into()),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        cross_user_err,
+        desktop_assistant_application::client_tools::ClientToolResolutionError::TurnNotFound { .. }
+    ));
+    assert!(
+        !turn.is_finished(),
+        "cross-user result must not wake the turn"
+    );
+
+    // The legitimate result wakes the turn; the LLM sees it and finishes.
+    resolve_client_tool_result(
+        &coord,
+        &*store,
+        UserId::new("alice"),
+        task_id.clone(),
+        "call-1".to_string(),
+        Ok("127.0.0.1 localhost".into()),
+    )
+    .await
+    .unwrap();
+
+    let response = turn.await.unwrap().unwrap();
+    assert_eq!(response, "The hosts file maps 127.0.0.1 to localhost");
+
+    // The client's result was threaded into history as the tool result.
+    let updated = handler
+        .get_conversation(&ConversationId::from(conv_id.as_str()))
+        .await
+        .unwrap();
+    let tool_msg = updated
+        .messages
+        .iter()
+        .find(|m| m.role == desktop_assistant_core::domain::Role::Tool)
+        .expect("a tool result message");
+    assert_eq!(tool_msg.content, "127.0.0.1 localhost");
+    assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call-1"));
+}

--- a/crates/core/src/ports/client_tools.rs
+++ b/crates/core/src/ports/client_tools.rs
@@ -1,0 +1,161 @@
+//! Client-side tool execution port (#107 / #234).
+//!
+//! Rule #8 of `docs/architecture-evolution.md` says client-local MCPs
+//! (file access, terminal, the user's own laptop tooling) execute on the
+//! *client's* machine, not on the daemon. When the LLM picks one of those
+//! tools the daemon must suspend the turn, emit a `client_tool_call`
+//! event, and resume when the client posts the result back.
+//!
+//! The turn loop lives in [`crate::service`]; the coordinator that owns
+//! the suspension state machine and the wire event lives one layer up in
+//! `desktop-assistant-application` (it depends on the transport
+//! `EventSink` and the turn-state store, which core does not know about).
+//! To let the core loop *consult and suspend* without taking a dependency
+//! on `application`, this module defines a thin outbound port —
+//! [`ClientToolPort`] — that the application implements as an adapter
+//! over its `ClientToolCoordinator`.
+//!
+//! ## Why a task-local rather than a handler field
+//!
+//! The port is per-*turn*: it closes over the turn's `task_id`, its
+//! event sink, and the conversation id, which are only known once a
+//! `send_prompt` is in flight. The [`crate::service::ConversationHandler`]
+//! is constructed once at daemon start, so the port can't live on it.
+//! This mirrors how the cancellation token, model override, and
+//! system-prompt refinement are threaded (see [`crate::ports::llm`] and
+//! [`crate::ports::auth`]): the application installs the per-turn adapter
+//! via [`with_client_tools`] right before invoking the service, and the
+//! dispatch loop reads it via [`current_client_tools`]. When the slot is
+//! unset (single-tenant callers that registered no client tools, tests,
+//! background workers) the loop behaves exactly as before — every tool is
+//! server-side.
+
+use std::sync::Arc;
+
+use crate::CoreError;
+use crate::domain::ToolDefinition;
+
+/// Outbound port the turn loop uses to (a) learn which client-local tools
+/// the current connection registered and (b) suspend the turn on one of
+/// those calls, awaiting the client's result.
+///
+/// Scoped to the current user via the task-local `UserId` (the
+/// implementing adapter reads `current_user_id()`), so registrations and
+/// suspensions can never cross tenants.
+///
+/// Uses [`async_trait::async_trait`] so it is dyn-compatible — the
+/// application installs a boxed adapter behind an `Arc<dyn ClientToolPort>`.
+#[async_trait::async_trait]
+pub trait ClientToolPort: Send + Sync {
+    /// Tool definitions registered as client-local for the current user.
+    /// These are merged into the tool set offered to the LLM for the turn
+    /// so the model can actually pick them.
+    async fn tool_definitions(&self) -> Vec<ToolDefinition>;
+
+    /// True iff `name` is a client-local tool registered for the current
+    /// user. The dispatch loop consults this before each tool execution:
+    /// a match routes to [`ClientToolPort::execute`] (client-side
+    /// suspension) instead of the server-side [`crate::ports::tools::ToolExecutor`].
+    async fn is_registered(&self, name: &str) -> bool;
+
+    /// Suspend the turn on a client-local tool call: emit the
+    /// `client_tool_call` event and await the matching `client_tool_result`.
+    ///
+    /// Returns the result string the LLM should see as this tool's
+    /// output, or a [`CoreError`] (e.g. `Cancelled` if the turn's
+    /// cancellation token trips while suspended, or `ToolExecution` if the
+    /// client reports a tool error). The caller threads the returned
+    /// string back into the conversation exactly as it would a server-side
+    /// tool result, so the LLM loop continues transparently.
+    async fn execute(
+        &self,
+        tool_call_id: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<String, CoreError>;
+}
+
+tokio::task_local! {
+    /// The per-turn client-tool adapter. Installed by the application's
+    /// send-turn body via [`with_client_tools`] immediately before invoking
+    /// the conversation service; read by the dispatch loop via
+    /// [`current_client_tools`]. Unset for callers that never register
+    /// client tools, so [`current_client_tools`] returns `None` and the
+    /// loop keeps its pre-#234 server-side-only behaviour.
+    static CLIENT_TOOLS: Arc<dyn ClientToolPort>;
+}
+
+/// Run `fut` with `port` installed as the current task-local client-tool
+/// adapter. All [`current_client_tools`] calls inside the future (and any
+/// sub-tasks that inherit the scope) observe `port`.
+pub async fn with_client_tools<F, T>(port: Arc<dyn ClientToolPort>, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CLIENT_TOOLS.scope(port, fut).await
+}
+
+/// The current task-local client-tool adapter, or `None` when no scope is
+/// installed. Safe to call from any async context — never panics, never
+/// blocks.
+pub fn current_client_tools() -> Option<Arc<dyn ClientToolPort>> {
+    CLIENT_TOOLS.try_with(Arc::clone).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakePort;
+
+    #[async_trait::async_trait]
+    impl ClientToolPort for FakePort {
+        async fn tool_definitions(&self) -> Vec<ToolDefinition> {
+            vec![ToolDefinition::new(
+                "fs_read",
+                "read a file",
+                serde_json::json!({}),
+            )]
+        }
+        async fn is_registered(&self, name: &str) -> bool {
+            name == "fs_read"
+        }
+        async fn execute(
+            &self,
+            _tool_call_id: &str,
+            tool_name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<String, CoreError> {
+            Ok(format!("client result from {tool_name}"))
+        }
+    }
+
+    #[tokio::test]
+    async fn current_client_tools_outside_scope_is_none() {
+        assert!(current_client_tools().is_none());
+    }
+
+    #[tokio::test]
+    async fn current_client_tools_inside_scope_returns_installed_port() {
+        let port: Arc<dyn ClientToolPort> = Arc::new(FakePort);
+        let (registered, defs_len) = with_client_tools(port, async {
+            let p = current_client_tools().expect("port installed");
+            (
+                p.is_registered("fs_read").await,
+                p.tool_definitions().await.len(),
+            )
+        })
+        .await;
+        assert!(registered);
+        assert_eq!(defs_len, 1);
+    }
+
+    #[tokio::test]
+    async fn spawned_task_outside_scope_sees_none() {
+        // task_local slots do not cross `tokio::spawn`.
+        let observed = tokio::spawn(async { current_client_tools().is_some() })
+            .await
+            .unwrap();
+        assert!(!observed);
+    }
+}

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -41,6 +41,11 @@ pub mod auth;
 /// executors can scope per-conversation side state (e.g. the scratchpad).
 pub mod conversation_ctx;
 
+/// Client-side tool execution port — outbound trait the turn loop uses to
+/// consult the current user's registered client-local tools and suspend the
+/// turn on a client-tool call (#107 / #234).
+pub mod client_tools;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -7,6 +7,7 @@ use crate::context::{
 use crate::domain::{
     Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition, ToolNamespace,
 };
+use crate::ports::client_tools::current_client_tools;
 use crate::ports::conversation_ctx::with_conversation_id;
 use crate::ports::inbound::ConversationService;
 use crate::ports::llm::{
@@ -436,6 +437,20 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
         // follow from the dispatch loop below.
         on_status(TURN_START_STATUS.to_string());
 
+        // Client-side tool execution (#107 / #234). When the connection
+        // registered client-local tools, the application installs a per-turn
+        // adapter as a task-local. Resolve it once: its `tool_definitions()`
+        // are merged into every round's tool set so the LLM can pick them, and
+        // a call to a registered name is routed through `port.execute(..)`
+        // (which suspends the turn) instead of the server-side `ToolExecutor`.
+        // Unset (no client tools registered, tests, background workers) leaves
+        // the loop's behaviour exactly as before — every tool is server-side.
+        let client_tool_port = current_client_tools();
+        let client_tool_defs: Vec<ToolDefinition> = match &client_tool_port {
+            Some(port) => port.tool_definitions().await,
+            None => Vec::new(),
+        };
+
         for round in 0..MAX_TOOL_ROUNDS {
             // Between-turns cancellation checkpoint (issue #109): if the
             // caller cancelled while the previous tool round was
@@ -454,6 +469,15 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 core_tools_for_llm.clone()
             };
             tool_defs.extend(activated_tools.values().cloned());
+            // Offer the connection's registered client-local tools alongside
+            // the server-side set so the LLM can invoke them (#234). Skip any
+            // whose name already collides with a server-side tool — the
+            // server-side definition wins to keep dispatch unambiguous.
+            for def in &client_tool_defs {
+                if !tool_defs.iter().any(|t| t.name == def.name) {
+                    tool_defs.push(def.clone());
+                }
+            }
 
             let deferred_ns: &[ToolNamespace] = if !hosted_search_demoted {
                 &namespaces
@@ -772,19 +796,54 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     serde_json::from_str(&tool_call.arguments).unwrap_or_default();
                 on_status(tool_status_message(&tool_call.name, &arguments));
                 tracing::info!(tool = %tool_call.name, %arguments, "executing tool");
-                // Install the conversation as a task-local for the duration of
-                // tool execution so conversation-scoped builtins (the
-                // scratchpad) can resolve which pad they operate on without
-                // the `ToolExecutor` port growing a conversation parameter.
-                let exec = self.tools.execute_tool(&tool_call.name, arguments);
-                let result = match with_conversation_id(conversation_id.clone(), exec).await {
-                    Ok(output) => {
-                        tracing::debug!(tool = %tool_call.name, output = %output, "tool result");
-                        output
+
+                // Route client-local tools to the client (#107 / #234): if a
+                // per-turn client-tool port is installed and the called name is
+                // registered for this user, suspend the turn and await the
+                // client's result instead of running a server-side executor.
+                // A registered client tool whose name collides with a
+                // server-side one never reaches here — the tool-set merge above
+                // gives the server-side definition precedence, so the LLM was
+                // offered (and called) the server-side tool.
+                let client_exec = match &client_tool_port {
+                    Some(port) if port.is_registered(&tool_call.name).await => Some(port),
+                    _ => None,
+                };
+
+                let result = if let Some(port) = client_exec {
+                    match port
+                        .execute(&tool_call.id, &tool_call.name, arguments)
+                        .await
+                    {
+                        Ok(output) => {
+                            tracing::debug!(tool = %tool_call.name, output = %output, "client tool result");
+                            output
+                        }
+                        // Cancellation while a client tool was suspended (e.g.
+                        // the user pressed Cancel) must abort the turn, not be
+                        // folded into a tool result the LLM would keep looping
+                        // on.
+                        Err(CoreError::Cancelled) => return Err(CoreError::Cancelled),
+                        Err(e) => {
+                            tracing::warn!(tool = %tool_call.name, error = %e, "client tool execution failed");
+                            format!("Error: {e}")
+                        }
                     }
-                    Err(e) => {
-                        tracing::warn!(tool = %tool_call.name, error = %e, "tool execution failed");
-                        format!("Error: {e}")
+                } else {
+                    // Install the conversation as a task-local for the duration
+                    // of tool execution so conversation-scoped builtins (the
+                    // scratchpad) can resolve which pad they operate on without
+                    // the `ToolExecutor` port growing a conversation parameter.
+                    let exec = self.tools.execute_tool(&tool_call.name, arguments);
+                    match with_conversation_id(conversation_id.clone(), exec).await {
+                        Ok(output) => {
+                            tracing::debug!(tool = %tool_call.name, output = %output, "tool result");
+                            output
+                        }
+                        Err(e) => {
+                            tracing::warn!(tool = %tool_call.name, error = %e, "tool execution failed");
+                            format!("Error: {e}")
+                        }
                     }
                 };
 
@@ -1476,6 +1535,140 @@ mod tests {
             statuses.contains(&"Searching your notes".to_string()),
             "expected a notes status; got {statuses:?}"
         );
+    }
+
+    /// Fake [`ClientToolPort`] (#234) for the core turn-loop integration
+    /// tests. Records the names it was asked to execute and returns a
+    /// canned result so the loop can feed it back to the LLM. A parking
+    /// variant (held behind a oneshot) is used to prove the loop suspends.
+    struct FakeClientToolPort {
+        defs: Vec<ToolDefinition>,
+        executed: Arc<Mutex<Vec<(String, String)>>>,
+        result: String,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::client_tools::ClientToolPort for FakeClientToolPort {
+        async fn tool_definitions(&self) -> Vec<ToolDefinition> {
+            self.defs.clone()
+        }
+        async fn is_registered(&self, name: &str) -> bool {
+            self.defs.iter().any(|d| d.name == name)
+        }
+        async fn execute(
+            &self,
+            tool_call_id: &str,
+            tool_name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<String, CoreError> {
+            self.executed
+                .lock()
+                .unwrap()
+                .push((tool_call_id.to_string(), tool_name.to_string()));
+            Ok(self.result.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_routes_registered_client_tool_through_port_and_feeds_result_back() {
+        use crate::ports::client_tools::with_client_tools;
+
+        // The LLM first calls `fs_read` (a client-local tool the server-side
+        // executor knows nothing about), then returns final text after seeing
+        // the client's result.
+        let responses = vec![
+            LlmResponse::with_tool_calls(
+                "",
+                vec![ToolCall::new(
+                    "call-1",
+                    "fs_read",
+                    r#"{"path":"/etc/hosts"}"#,
+                )],
+            ),
+            LlmResponse::text("The file says: 127.0.0.1 localhost"),
+        ];
+        // No server-side tools and no server-side result for `fs_read`: if the
+        // loop tried to run it server-side it would error, proving the client
+        // path is the one taken.
+        let handler = make_tool_handler(responses, vec![], HashMap::new());
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let executed = Arc::new(Mutex::new(Vec::new()));
+        let port: Arc<dyn crate::ports::client_tools::ClientToolPort> =
+            Arc::new(FakeClientToolPort {
+                defs: vec![ToolDefinition::new(
+                    "fs_read",
+                    "Read a file on the client",
+                    serde_json::json!({"type": "object"}),
+                )],
+                executed: Arc::clone(&executed),
+                result: "127.0.0.1 localhost".to_string(),
+            });
+
+        let result = with_client_tools(
+            port,
+            handler.send_prompt(
+                &conv.id,
+                "Read /etc/hosts".into(),
+                noop_callback(),
+                noop_status(),
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, "The file says: 127.0.0.1 localhost");
+        // The client-tool port — not the server-side executor — ran `fs_read`.
+        let ran = executed.lock().unwrap().clone();
+        assert_eq!(ran, vec![("call-1".to_string(), "fs_read".to_string())]);
+
+        // The client's result was threaded into history as the tool result so
+        // the LLM saw it on the next round.
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let tool_msg = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .expect("a tool result message");
+        assert_eq!(tool_msg.content, "127.0.0.1 localhost");
+        assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call-1"));
+    }
+
+    #[tokio::test]
+    async fn turn_without_client_tool_port_runs_server_side_only() {
+        // Same tool name, but no port installed: the loop must fall through to
+        // the server-side executor (which here supplies the result). This pins
+        // that the client-tool hook is strictly opt-in and never changes the
+        // server-side path when unset.
+        let responses = vec![
+            LlmResponse::with_tool_calls("", vec![ToolCall::new("call-1", "fs_read", "{}")]),
+            LlmResponse::text("done"),
+        ];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("fs_read".to_string(), "server output".to_string());
+        let handler = make_tool_handler(
+            responses,
+            vec![ToolDefinition::new(
+                "fs_read",
+                "server tool",
+                serde_json::json!({}),
+            )],
+            tool_results,
+        );
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let result = handler
+            .send_prompt(&conv.id, "go".into(), noop_callback(), noop_status())
+            .await
+            .unwrap();
+        assert_eq!(result, "done");
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let tool_msg = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .expect("a tool result message");
+        assert_eq!(tool_msg.content, "server output");
     }
 
     #[tokio::test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1765,6 +1765,20 @@ async fn main() -> Result<()> {
             ));
         api_handler_impl = api_handler_impl.with_idempotency_store(idempotency_store);
     }
+    // Client-side tool execution (#107 / #234): one shared coordinator plus an
+    // in-memory turn-state store, so `RegisterClientTools` / `ClientToolResult`
+    // are served and the LLM can invoke client-local tools (suspending the turn
+    // and resuming on the client's `ClientToolResult`). The in-memory store is
+    // sufficient for the live single-process deploy; a DB-backed
+    // `TurnStateStore` for crash-recovery is Phase-2 follow-up work.
+    let client_tool_coordinator =
+        Arc::new(desktop_assistant_application::client_tools::ClientToolCoordinator::new());
+    let turn_state_store: Arc<dyn desktop_assistant_core::ports::store::TurnStateStore> =
+        Arc::new(desktop_assistant_application::client_tools::InMemoryTurnStateStore::new());
+    api_handler_impl = api_handler_impl.with_client_tool_coordinator(
+        Arc::clone(&client_tool_coordinator),
+        Arc::clone(&turn_state_store),
+    );
     let api_handler: Arc<dyn desktop_assistant_application::AssistantApiHandler> =
         Arc::new(api_handler_impl);
 


### PR DESCRIPTION
## What

Activates the #107 server-side client-tool machinery, which existed in `crates/application/src/client_tools.rs` but was dead code: `RegisterClientTools` / `ClientToolResult` returned `Unsupported`, and the turn loop never suspended on a client-local tool.

Closes #234.

## How it's wired

**Port (no layering violation).** New outbound port `desktop_assistant_core::ports::client_tools::ClientToolPort` with `tool_definitions()`, `is_registered(name)`, `execute(tool_call_id, name, args)`. It's installed per-turn as a task-local via `with_client_tools(port, fut)` and read by the loop via `current_client_tools()` — the same threading pattern used for the cancellation token, model override, and system-prompt refinement. `core` depends only on the trait; `application` provides the adapter.

**Turn-loop integration (`crates/core/src/service.rs`).** The send-turn loop resolves the installed port once, merges its `tool_definitions()` into the tool set offered to the LLM each round (server-side names win on collision), and — when the LLM calls a registered client-tool name — routes it through `port.execute(..)` (which suspends the turn) instead of the server-side `ToolExecutor`. Cancellation while suspended aborts the turn. The server-side path is byte-for-byte unchanged when no port is installed.

**Command dispatch (`crates/application/src/lib.rs`).** Replaced the `Unsupported` arm:
- `RegisterClientTools { tools }` → `register_client_tools(coord, tools)` → `ClientToolsRegistered { count }`.
- `ClientToolResult { task_id, tool_call_id, result/error }` → `resolve_client_tool_result(..)` → `Ack`. `ClientToolResolutionError` is mapped: `TurnNotFound` → `NotFound` (keeps the #105 existence-hiding rule for cross-user probes), mismatch/malformed/storage → `Core`. Both-`None` payload is a clean request error.

**Adapter + state (`crates/application/src/client_tools.rs`).** New `CoordinatorClientToolPort` (per-turn: shared coordinator + turn-state store + the turn's `EventSink` + the registry `task_id` + conversation id). The coordinator now retains full `ClientToolRegistration`s (not just names) so it can hand the loop `ToolDefinition`s; existing name-based behaviour and all coordinator tests are unchanged. Added `InMemoryTurnStateStore` for the live single-node deploy (a DB-backed `TurnStateStore` for crash recovery is Phase-2 follow-up).

**Daemon (`crates/daemon/src/main.rs`).** Holds one shared `ClientToolCoordinator` + `InMemoryTurnStateStore` and attaches them via `with_client_tool_coordinator`.

## End-to-end flow

`RegisterClientTools` records the user's tools → a turn offers them to the LLM → the LLM calls one → `port.execute` writes the `pending_client_tool` turn row, emits `Event::ClientToolCall { task_id, tool_call_id, tool_name, arguments }`, and parks on a oneshot → the client runs it locally and sends `ClientToolResult { task_id, tool_call_id, result }` → `resolve_client_tool_result` wakes the turn → the result is threaded back as the tool's output and the LLM finishes. `task_id` is the registry task id the client already received in `SendMessageAck`, so correlation is automatic.

**Works over UDS/WS with no transport changes:** `ClientToolCall` is an event (rides #218 correlation / #221 stall handling); the two commands are send-path through the existing dispatcher's `with_user_id`-scoped `handle_command`.

## Tests

- Existing coordinator tests (`client_tool_turn_state.rs`) stay green.
- `crates/core`: `turn_routes_registered_client_tool_through_port_and_feeds_result_back` (loop offers + routes the client tool, result fed back) and `turn_without_client_tool_port_runs_server_side_only` (opt-in; server path unchanged); plus task-local scope tests.
- `crates/application` (`client_tool_turn_loop.rs`): real `ConversationHandler` + real `ClientToolCoordinator` — emits `ClientToolCall`, parks, resumes on `resolve_client_tool_result`, LLM finishes; cross-user result is refused (`TurnNotFound`).

`just check` is green (fmt + clippy `--workspace --all-targets -D warnings` + build + test).

Unblocks voice#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)