### PR TITLE
feat: per-conversation personality override (Phase 2) (#227)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -83,6 +83,21 @@ pub enum Command {
         idempotency_key: Option<String>,
     },
 
+    /// Set (or clear) a conversation's personality override (issue #227,
+    /// Phase 2). `personality` is a *partial* [`ConversationPersonalityView`]
+    /// (a [`PersonalityOverride`]): each `Some` trait pins that trait for the
+    /// conversation, each `None` falls back to the global config on every send.
+    /// An all-`None`/empty override clears the stored override (back to
+    /// global-only). The override sets only the *initial disposition* — the
+    /// assistant stays soft/adaptive. Returns
+    /// [`CommandResult::ConversationPersonality`] echoing the stored value.
+    /// Mirrors the per-conversation model selection: stored on the
+    /// conversation, resolved on the send path against the global config.
+    SetConversationPersonality {
+        conversation_id: String,
+        personality: ConversationPersonalityView,
+    },
+
     // Settings (legacy `[llm]`-block single-connection surface).
     //
     // The legacy `SetLlmSettings` / `GetLlmSettings` commands have been
@@ -386,6 +401,12 @@ pub enum CommandResult {
     /// requested (or just-saved) scratchpad notes for the conversation.
     Scratchpad(Vec<ScratchpadNoteView>),
 
+    /// Response to `SetConversationPersonality` — the conversation's stored
+    /// personality override after the write (#227). An empty/all-`None` view
+    /// means the override was cleared and the conversation falls back to the
+    /// global personality on every send.
+    ConversationPersonality(ConversationPersonalityView),
+
     // --- Background tasks (issue #110) ------------------------------------
     /// Response to `ListBackgroundTasks`.
     BackgroundTasks(Vec<TaskView>),
@@ -645,6 +666,12 @@ pub struct ConversationView {
     /// longer resolves (see `ConversationWarning::DanglingModelSelection`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_selection: Option<ConversationModelSelectionView>,
+    /// The conversation's stored personality override (#227), when one has been
+    /// pinned by a prior `SetConversationPersonality`. `None` means the
+    /// conversation uses the global personality. Like `model_selection`, this is
+    /// a partial override resolved against the global config on each send.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation_personality: Option<ConversationPersonalityView>,
 }
 
 /// Advisory conditions attached to a conversation view. Modeled as an enum
@@ -851,6 +878,14 @@ pub use desktop_assistant_core::ports::inbound::PurposeKind as PurposeKindApi;
 // identity `From` impl.
 pub use desktop_assistant_core::prompts::{Personality, PersonalityLevel};
 pub type PersonalitySettingsView = Personality;
+
+// Per-conversation personality override (#227, Phase 2). Re-export the canonical
+// core [`PersonalityOverride`] (7 optional trait levels) so the per-conversation
+// command/view shares one schema with the resolution logic in core. The view
+// returned by `GetConversation` / `SetConversationPersonality` is that override
+// verbatim, so converting between wire and core is the identity.
+pub use desktop_assistant_core::prompts::PersonalityOverride;
+pub type ConversationPersonalityView = PersonalityOverride;
 
 /// Protocol-neutral purpose config. String `"primary"` in the connection or
 /// model field means "inherit from interactive" — the daemon resolves this
@@ -2078,5 +2113,77 @@ mod tests {
         assert!(!json.contains("personality_warmth"), "json: {json}");
         let back: ConfigChanges = serde_json::from_str(&json).unwrap();
         assert_eq!(changes, back);
+    }
+
+    // --- Per-conversation personality override wire types (#227) ------------
+
+    #[test]
+    fn set_conversation_personality_command_round_trips() {
+        // The command carries the conversation id and a partial override; it
+        // must round-trip losslessly so the daemon parses exactly what the
+        // client (tui/gtk picker) sent.
+        let cmd = Command::SetConversationPersonality {
+            conversation_id: "conv-1".into(),
+            personality: ConversationPersonalityView {
+                humor: Some(PersonalityLevel::Never),
+                directness: Some(PersonalityLevel::Always),
+                ..ConversationPersonalityView::default()
+            },
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(
+            json.contains("\"set_conversation_personality\""),
+            "json: {json}"
+        );
+        // Only the pinned traits are on the wire (skip_serializing_if).
+        assert!(json.contains("\"humor\""), "json: {json}");
+        assert!(json.contains("\"directness\""), "json: {json}");
+        assert!(!json.contains("\"warmth\""), "json: {json}");
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn conversation_personality_result_round_trips() {
+        let res = CommandResult::ConversationPersonality(ConversationPersonalityView {
+            sarcasm: Some(PersonalityLevel::Never),
+            ..ConversationPersonalityView::default()
+        });
+        let json = serde_json::to_string(&res).unwrap();
+        assert!(
+            json.contains("\"conversation_personality\""),
+            "json: {json}"
+        );
+        let back: CommandResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(res, back);
+    }
+
+    #[test]
+    fn conversation_view_carries_optional_personality_override() {
+        // `conversation_personality` is omitted from the wire when `None`
+        // (no override) and present when an override is stored — mirrors
+        // `model_selection`.
+        let mut view = ConversationView {
+            id: "c1".into(),
+            title: "t".into(),
+            messages: vec![],
+            warnings: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        };
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(
+            !json.contains("conversation_personality"),
+            "absent override must not appear on the wire: {json}"
+        );
+
+        view.conversation_personality = Some(ConversationPersonalityView {
+            humor: Some(PersonalityLevel::Never),
+            ..ConversationPersonalityView::default()
+        });
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(json.contains("conversation_personality"), "json: {json}");
+        let back: ConversationView = serde_json::from_str(&json).unwrap();
+        assert_eq!(view, back);
     }
 }

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -911,6 +911,13 @@ where
                     .await
                     .map_err(Self::map_core_err)?
                     .map(model_selection_to_view);
+                // #227: surface the conversation's personality override
+                // alongside the model selection. `None` = no override (global).
+                let conversation_personality = self
+                    .conversations
+                    .get_conversation_personality(&conv_id)
+                    .await
+                    .map_err(Self::map_core_err)?;
 
                 Ok(api::CommandResult::Conversation(api::ConversationView {
                     id: conv.id.0,
@@ -925,7 +932,29 @@ where
                         .collect(),
                     warnings: Vec::new(),
                     model_selection,
+                    conversation_personality,
                 }))
+            }
+
+            api::Command::SetConversationPersonality {
+                conversation_id,
+                personality,
+            } => {
+                let conv_id =
+                    desktop_assistant_core::domain::ConversationId::from(conversation_id.as_str());
+                self.conversations
+                    .set_conversation_personality(&conv_id, personality)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                // Echo the stored value (cleared → empty/all-None) so the
+                // client confirms the write, mirroring `SetScratchpadNote`.
+                let stored = self
+                    .conversations
+                    .get_conversation_personality(&conv_id)
+                    .await
+                    .map_err(Self::map_core_err)?
+                    .unwrap_or_default();
+                Ok(api::CommandResult::ConversationPersonality(stored))
             }
 
             api::Command::DeleteConversation { id } => {

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -417,6 +417,37 @@ pub trait AssistantCommands: Send + Sync {
         Ok(())
     }
 
+    // --- Per-conversation personality override (issue #227) ----------------
+
+    /// Set (or clear) a conversation's personality override (#227, Phase 2).
+    ///
+    /// `personality` is a *partial* [`api::ConversationPersonalityView`] (a
+    /// [`api::PersonalityOverride`]): each `Some` trait pins that trait for the
+    /// conversation, each `None` falls back to the global config on every send.
+    /// An empty/all-`None` override clears it (back to global-only). Returns the
+    /// stored override after the write (cleared → empty). The current value is
+    /// also surfaced on [`ConversationDetail::conversation_personality`] from
+    /// `get_conversation`, which a picker pre-fills from. Used by the tui/gtk
+    /// personality pickers.
+    async fn set_conversation_personality(
+        &self,
+        conversation_id: &str,
+        personality: api::ConversationPersonalityView,
+    ) -> Result<api::ConversationPersonalityView> {
+        let result = self
+            .send_command(api::Command::SetConversationPersonality {
+                conversation_id: conversation_id.to_string(),
+                personality,
+            })
+            .await?;
+        let api::CommandResult::ConversationPersonality(stored) = result else {
+            return Err(anyhow!(
+                "unexpected response for set_conversation_personality"
+            ));
+        };
+        Ok(stored)
+    }
+
     // --- Client-side tool execution (issue #107 / #231) -------------------
 
     /// Advertise the set of client-local MCP tools this connection can run
@@ -783,6 +814,38 @@ mod tests {
                 assert!(!all);
             }
             other => panic!("expected DeleteScratchpadNotes, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_conversation_personality_emits_command_and_returns_stored() {
+        // The picker-facing client method must emit the
+        // `SetConversationPersonality` command with the partial override and
+        // unwrap the stored value from `ConversationPersonality`.
+        let stored = api::ConversationPersonalityView {
+            humor: Some(api::PersonalityLevel::Never),
+            ..api::ConversationPersonalityView::default()
+        };
+        let client = RecordingClient::new(api::CommandResult::ConversationPersonality(stored));
+        let sent = api::ConversationPersonalityView {
+            humor: Some(api::PersonalityLevel::Never),
+            directness: Some(api::PersonalityLevel::Always),
+            ..api::ConversationPersonalityView::default()
+        };
+        let got = client
+            .set_conversation_personality("conv-1", sent)
+            .await
+            .unwrap();
+        assert_eq!(got, stored);
+        match client.last() {
+            api::Command::SetConversationPersonality {
+                conversation_id,
+                personality,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(personality, sent);
+            }
+            other => panic!("expected SetConversationPersonality, got {other:?}"),
         }
     }
 

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -234,6 +234,7 @@ impl DbusClient {
                 .map(|(role, content)| ChatMessage { role, content })
                 .collect(),
             model_selection: None,
+            conversation_personality: None,
         })
     }
 

--- a/crates/client-common/src/types.rs
+++ b/crates/client-common/src/types.rs
@@ -20,6 +20,9 @@ pub struct ConversationDetail {
     pub title: String,
     pub messages: Vec<ChatMessage>,
     pub model_selection: Option<api::ConversationModelSelectionView>,
+    /// The conversation's stored personality override (#227), or `None` when it
+    /// uses the global personality. A picker pre-fills its sliders from this.
+    pub conversation_personality: Option<api::ConversationPersonalityView>,
 }
 
 impl From<api::ConversationSummary> for ConversationSummary {
@@ -49,6 +52,7 @@ impl From<api::ConversationView> for ConversationDetail {
             title: value.title,
             messages: value.messages.into_iter().map(ChatMessage::from).collect(),
             model_selection: value.model_selection,
+            conversation_personality: value.conversation_personality,
         }
     }
 }

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -147,6 +147,34 @@ pub trait ConversationService: Send + Sync {
         Ok(None)
     }
 
+    /// Read the conversation's stored personality override (#227, Phase 2), if
+    /// one has been pinned by `SetConversationPersonality`. Returns `Ok(None)`
+    /// when the conversation has no override (the daemon falls back to the
+    /// global personality on the next send).
+    ///
+    /// Default returns `Ok(None)`; the daemon's routing wrapper overrides this
+    /// to consult the persistent store, mirroring
+    /// [`Self::get_conversation_model_selection`].
+    async fn get_conversation_personality(
+        &self,
+        id: &ConversationId,
+    ) -> Result<Option<crate::prompts::PersonalityOverride>, CoreError> {
+        let _ = id;
+        Ok(None)
+    }
+
+    /// Set (or clear) the conversation's personality override (#227). Passing an
+    /// empty/all-`None` override clears it (back to global-only). Default is a
+    /// no-op; the routing wrapper overrides it to persist through the store.
+    async fn set_conversation_personality(
+        &self,
+        id: &ConversationId,
+        personality: crate::prompts::PersonalityOverride,
+    ) -> Result<(), CoreError> {
+        let _ = (id, personality);
+        Ok(())
+    }
+
     async fn delete_conversation(&self, id: &ConversationId) -> Result<(), CoreError>;
 
     async fn rename_conversation(

--- a/crates/core/src/prompts/mod.rs
+++ b/crates/core/src/prompts/mod.rs
@@ -189,6 +189,61 @@ impl Personality {
     }
 }
 
+/// A partial, per-conversation override of the global [`Personality`] (issue
+/// #227, Phase 2). Each trait is an `Option<PersonalityLevel>`: `Some(level)`
+/// pins that trait for the conversation, `None` falls back to the global value.
+///
+/// Why a separate type rather than reusing `Personality` directly: the global
+/// config is always a *complete* disposition (every trait has a level), but a
+/// conversation override is *partial by design* — a "no-nonsense" client may
+/// only want to force `humor = Never` and `directness = Always` and inherit the
+/// rest of the user's global tuning. Modeling each trait as `Option` makes that
+/// partial intent explicit and type-checked, and keeps [`Self::resolve`] a
+/// trait-by-trait merge rather than an all-or-nothing replacement. The override
+/// only sets the *initial disposition*; it still flows through
+/// [`Personality::render_blurb`], so the adaptation clause continues to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct PersonalityOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub professionalism: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warmth: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directness: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enthusiasm: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub humor: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sarcasm: Option<PersonalityLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pretentiousness: Option<PersonalityLevel>,
+}
+
+impl PersonalityOverride {
+    /// Resolve this partial override against the `global` disposition into a
+    /// concrete [`Personality`]: each `Some` trait wins, each `None` falls back
+    /// to `global`. An all-`None` override resolves to `global` unchanged.
+    pub fn resolve(&self, global: &Personality) -> Personality {
+        Personality {
+            professionalism: self.professionalism.unwrap_or(global.professionalism),
+            warmth: self.warmth.unwrap_or(global.warmth),
+            directness: self.directness.unwrap_or(global.directness),
+            enthusiasm: self.enthusiasm.unwrap_or(global.enthusiasm),
+            humor: self.humor.unwrap_or(global.humor),
+            sarcasm: self.sarcasm.unwrap_or(global.sarcasm),
+            pretentiousness: self.pretentiousness.unwrap_or(global.pretentiousness),
+        }
+    }
+
+    /// `true` when every trait is `None` — i.e. the override pins nothing and
+    /// [`Self::resolve`] returns the global value verbatim. Used by the
+    /// persistence layer to store `NULL` rather than an empty object.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 /// Per-level phrasing for a single trait. Each field is the clause body used at
 /// that level; `Never` has no field because a Never trait is omitted entirely.
 struct TraitPhrasing {
@@ -511,5 +566,99 @@ mod tests {
         assert!(json.contains("\"never\""), "json: {json}");
         let parsed: Personality = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, p);
+    }
+
+    // --- PersonalityOverride (#227, Phase 2) -------------------------------
+
+    #[test]
+    fn override_empty_resolves_to_global_unchanged() {
+        // No override → resolution is the global disposition verbatim. This is
+        // the "no per-conversation override" baseline.
+        let global = Personality {
+            humor: PersonalityLevel::Often,
+            sarcasm: PersonalityLevel::Always,
+            ..Personality::default()
+        };
+        let ovr = PersonalityOverride::default();
+        assert!(ovr.is_empty());
+        assert_eq!(ovr.resolve(&global), global);
+    }
+
+    #[test]
+    fn override_some_trait_wins_per_trait() {
+        // A "no-nonsense" override forces humor/sarcasm off and directness up;
+        // each pinned trait wins over the global value.
+        let global = Personality::default();
+        let ovr = PersonalityOverride {
+            humor: Some(PersonalityLevel::Never),
+            sarcasm: Some(PersonalityLevel::Never),
+            directness: Some(PersonalityLevel::Always),
+            ..PersonalityOverride::default()
+        };
+        let resolved = ovr.resolve(&global);
+        assert_eq!(resolved.humor, PersonalityLevel::Never);
+        assert_eq!(resolved.sarcasm, PersonalityLevel::Never);
+        assert_eq!(resolved.directness, PersonalityLevel::Always);
+    }
+
+    #[test]
+    fn override_unspecified_traits_fall_back_to_global() {
+        // Traits the override leaves `None` inherit the global value, even when
+        // the global differs from the built-in default.
+        let global = Personality {
+            professionalism: PersonalityLevel::Rarely,
+            warmth: PersonalityLevel::Always,
+            enthusiasm: PersonalityLevel::Always,
+            pretentiousness: PersonalityLevel::Often,
+            ..Personality::default()
+        };
+        let ovr = PersonalityOverride {
+            humor: Some(PersonalityLevel::Never),
+            ..PersonalityOverride::default()
+        };
+        let resolved = ovr.resolve(&global);
+        // Pinned trait wins.
+        assert_eq!(resolved.humor, PersonalityLevel::Never);
+        // Every unspecified trait falls back to the (non-default) global.
+        assert_eq!(resolved.professionalism, PersonalityLevel::Rarely);
+        assert_eq!(resolved.warmth, PersonalityLevel::Always);
+        assert_eq!(resolved.directness, global.directness);
+        assert_eq!(resolved.enthusiasm, PersonalityLevel::Always);
+        assert_eq!(resolved.sarcasm, global.sarcasm);
+        assert_eq!(resolved.pretentiousness, PersonalityLevel::Often);
+    }
+
+    #[test]
+    fn override_is_empty_only_when_all_none() {
+        assert!(PersonalityOverride::default().is_empty());
+        assert!(
+            !PersonalityOverride {
+                humor: Some(PersonalityLevel::Never),
+                ..PersonalityOverride::default()
+            }
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn override_serde_omits_none_traits_and_round_trips() {
+        // Only the pinned trait should appear on the wire; the rest are omitted
+        // (skip_serializing_if) so a partial override stays compact. Round-trip
+        // must be lossless.
+        let ovr = PersonalityOverride {
+            humor: Some(PersonalityLevel::Never),
+            ..PersonalityOverride::default()
+        };
+        let json = serde_json::to_string(&ovr).unwrap();
+        assert!(json.contains("\"humor\""), "json: {json}");
+        assert!(json.contains("\"never\""), "json: {json}");
+        assert!(!json.contains("\"warmth\""), "json: {json}");
+        let parsed: PersonalityOverride = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, ovr);
+        // An empty override serializes to `{}` and round-trips to empty.
+        let empty_json = serde_json::to_string(&PersonalityOverride::default()).unwrap();
+        assert_eq!(empty_json, "{}");
+        let back: PersonalityOverride = serde_json::from_str("{}").unwrap();
+        assert!(back.is_empty());
     }
 }

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -40,7 +40,7 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
     with_model_override, with_personality, with_reasoning_config, with_system_refinement,
 };
-use desktop_assistant_core::prompts::Personality;
+use desktop_assistant_core::prompts::{Personality, PersonalityOverride};
 
 use crate::config::{
     DaemonConfig, default_daemon_config_path, load_daemon_config, save_daemon_config,
@@ -576,6 +576,21 @@ pub trait ConversationSelectionStore: Send + Sync {
         id: &ConversationId,
         selection: Option<&ConversationModelSelection>,
     ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
+
+    /// Read the conversation's stored personality override (#227), or `None`
+    /// when no override is pinned. Mirrors [`Self::get_selection`].
+    fn get_personality(
+        &self,
+        id: &ConversationId,
+    ) -> impl std::future::Future<Output = Result<Option<PersonalityOverride>, CoreError>> + Send;
+
+    /// Set (or clear, with `None`) the conversation's personality override
+    /// (#227). Mirrors [`Self::set_selection`].
+    fn set_personality(
+        &self,
+        id: &ConversationId,
+        personality: Option<&PersonalityOverride>,
+    ) -> impl std::future::Future<Output = Result<(), CoreError>> + Send;
 }
 
 pub struct RoutingConversationHandler<S, Inner>
@@ -621,6 +636,30 @@ where
                 effort: p.effort,
             })
         })
+    }
+
+    /// Resolve the effective personality for a send (#227, Phase 2):
+    /// conversation override (partial) → global config → built-in default.
+    ///
+    /// The global config already folds in the built-in default (an absent
+    /// `[personality]` block resolves to `Personality::default()`), so the
+    /// merge is just "per-trait override over the global". When the
+    /// conversation has no stored override the global personality is returned
+    /// unchanged — identical to Phase-1 behaviour. A failed lookup logs and
+    /// falls back to the global so a storage hiccup never blocks a turn.
+    async fn resolve_personality(&self, conversation_id: &ConversationId) -> Personality {
+        let global = self.registry.personality();
+        match self.selection_store.get_personality(conversation_id).await {
+            Ok(Some(ovr)) => ovr.resolve(&global),
+            Ok(None) => global,
+            Err(e) => {
+                tracing::warn!(
+                    conversation_id = %conversation_id.0,
+                    "failed to read conversation personality override; using global: {e}"
+                );
+                global
+            }
+        }
     }
 
     /// Check a stored selection against the live registry. Returns
@@ -767,6 +806,30 @@ where
         id: &ConversationId,
     ) -> Result<Option<ConversationModelSelection>, CoreError> {
         self.selection_store.get_selection(id).await
+    }
+
+    async fn get_conversation_personality(
+        &self,
+        id: &ConversationId,
+    ) -> Result<Option<PersonalityOverride>, CoreError> {
+        self.selection_store.get_personality(id).await
+    }
+
+    async fn set_conversation_personality(
+        &self,
+        id: &ConversationId,
+        personality: PersonalityOverride,
+    ) -> Result<(), CoreError> {
+        // An empty (all-`None`) override means "no override" — clear the column
+        // (store `None`) so a later `GetConversation` reports no override and
+        // the send path falls back to global-only, rather than persisting an
+        // empty object that resolves to the global anyway.
+        let to_store = if personality.is_empty() {
+            None
+        } else {
+            Some(&personality)
+        };
+        self.selection_store.set_personality(id, to_store).await
     }
 
     async fn delete_conversation(&self, id: &ConversationId) -> Result<(), CoreError> {
@@ -1019,6 +1082,12 @@ where
         //   - `current_cancellation_token()` (issue #109) surfaces the
         //     per-turn cancellation token so the agentic loop and each
         //     LLM adapter can `tokio::select!` against it.
+        // Resolve the effective personality for this send (#227, Phase 2):
+        // conversation override (partial) → global config → built-in default.
+        // Computed before the dispatch block so the lookup's `&self` borrow
+        // doesn't outlive the `'static` dispatch future.
+        let effective_personality = self.resolve_personality(conversation_id).await;
+
         let inner = Arc::clone(&self.inner);
         let conv_id = conversation_id.clone();
         let response = {
@@ -1032,14 +1101,12 @@ where
             // string = no refinement (unchanged prompt). It is request-scoped
             // and never persisted; see `SYSTEM_REFINEMENT`.
             let dispatch = with_system_refinement(system_refinement, dispatch);
-            // Install the active personality (#226). Phase 1 resolves it from
-            // the global config on every send; the in-memory config is the
-            // single source of truth a `SetConfig` updates, so a personality
-            // change takes effect on the next turn. The Phase-2 seam is here:
-            // future per-conversation resolution swaps *which* personality this
-            // line installs (e.g. `self.resolve_personality(conversation_id)`),
-            // leaving the core read side unchanged.
-            let dispatch = with_personality(self.registry.personality(), dispatch);
+            // Install the active personality (#226/#227). The effective value is
+            // resolved above as: conversation override (partial) → global config
+            // → built-in default. With no stored override this equals the global
+            // personality, identical to Phase-1 behaviour; the core read side
+            // (`current_personality`) is unchanged.
+            let dispatch = with_personality(effective_personality, dispatch);
             let dispatch = with_reasoning_config(reasoning, dispatch);
             let dispatch = with_context_budget(budget, dispatch);
             let dispatch =
@@ -1220,6 +1287,7 @@ fn purposes_referencing(
 mod tests {
     use super::*;
     use crate::connections::{BedrockConnection, ConnectionConfig, OllamaConnection};
+    use desktop_assistant_core::prompts::PersonalityLevel;
 
     use std::sync::Mutex;
 
@@ -1228,12 +1296,14 @@ mod tests {
     /// storage crate.
     pub struct InMemoryConversationSelectionStore {
         inner: Mutex<std::collections::HashMap<String, ConversationModelSelection>>,
+        personality: Mutex<std::collections::HashMap<String, PersonalityOverride>>,
     }
 
     impl Default for InMemoryConversationSelectionStore {
         fn default() -> Self {
             Self {
                 inner: Mutex::new(std::collections::HashMap::new()),
+                personality: Mutex::new(std::collections::HashMap::new()),
             }
         }
     }
@@ -1260,6 +1330,35 @@ mod tests {
             match selection {
                 Some(sel) => {
                     map.insert(id.0.clone(), sel.clone());
+                }
+                None => {
+                    map.remove(&id.0);
+                }
+            }
+            Ok(())
+        }
+
+        async fn get_personality(
+            &self,
+            id: &ConversationId,
+        ) -> Result<Option<PersonalityOverride>, CoreError> {
+            Ok(self
+                .personality
+                .lock()
+                .expect("selection store poisoned")
+                .get(&id.0)
+                .copied())
+        }
+
+        async fn set_personality(
+            &self,
+            id: &ConversationId,
+            personality: Option<&PersonalityOverride>,
+        ) -> Result<(), CoreError> {
+            let mut map = self.personality.lock().expect("selection store poisoned");
+            match personality {
+                Some(p) => {
+                    map.insert(id.0.clone(), *p);
                 }
                 None => {
                     map.remove(&id.0);
@@ -1781,6 +1880,11 @@ api_key_env = "{unused}"
             /// `send_prompt`. `None` means no override was installed —
             /// connectors will fall back to their baked-in `self.model`.
             captured_model_override: StdMutex<Vec<Option<String>>>,
+            /// Snapshot of the `PERSONALITY` task-local (#227) at each
+            /// `send_prompt`. Asserting on this proves the routing wrapper
+            /// resolved the conversation override against the global config and
+            /// installed the effective personality on the dispatch scope.
+            captured_personality: StdMutex<Vec<Personality>>,
         }
 
         impl CapturingInner {
@@ -1789,6 +1893,7 @@ api_key_env = "{unused}"
                     captured_reasoning: StdMutex::new(Vec::new()),
                     captured_active_client_set: StdMutex::new(Vec::new()),
                     captured_model_override: StdMutex::new(Vec::new()),
+                    captured_personality: StdMutex::new(Vec::new()),
                 }
             }
         }
@@ -1848,6 +1953,8 @@ api_key_env = "{unused}"
                 self.captured_active_client_set.lock().unwrap().push(active);
                 let model = desktop_assistant_core::ports::llm::current_model_override();
                 self.captured_model_override.lock().unwrap().push(model);
+                let personality = desktop_assistant_core::ports::llm::current_personality();
+                self.captured_personality.lock().unwrap().push(personality);
                 Ok("ok".to_string())
             }
         }
@@ -1896,6 +2003,112 @@ api_key_env = "{unused}"
                 Box::new(|_: String| -> bool { true }),
                 Box::new(|_: String| {}),
             )
+        }
+
+        // ─── Issue #227: per-conversation personality resolution at send ───
+
+        #[tokio::test]
+        async fn send_installs_global_personality_when_no_conversation_override() {
+            // With no stored override, the personality task-local the inner
+            // handler observes must equal the registry's global personality —
+            // identical to Phase-1 behaviour.
+            let (routing, inner, registry, _store) = make_handler();
+            let global = registry.personality();
+
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("plain send_prompt should succeed via interactive purpose");
+
+            let captured = inner.captured_personality.lock().unwrap();
+            assert_eq!(captured.len(), 1);
+            assert_eq!(
+                captured[0], global,
+                "no override → the global personality must be installed verbatim"
+            );
+        }
+
+        #[tokio::test]
+        async fn send_installs_resolved_override_over_global() {
+            // A stored partial override must be resolved against the global
+            // config (override wins per-trait, unspecified traits fall back)
+            // and the *resolved* personality installed on the dispatch scope.
+            let (routing, inner, registry, store) = make_handler();
+            let global = registry.personality();
+
+            // "No-nonsense" override: force humor off, directness max; leave the
+            // rest to fall back to the global.
+            let ovr = PersonalityOverride {
+                humor: Some(PersonalityLevel::Never),
+                directness: Some(PersonalityLevel::Always),
+                ..PersonalityOverride::default()
+            };
+            store
+                .set_personality(&ConversationId::from("c1"), Some(&ovr))
+                .await
+                .unwrap();
+
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("plain send_prompt should succeed via interactive purpose");
+
+            let captured = inner.captured_personality.lock().unwrap();
+            assert_eq!(captured.len(), 1);
+            let installed = captured[0];
+            // Pinned traits win.
+            assert_eq!(installed.humor, PersonalityLevel::Never);
+            assert_eq!(installed.directness, PersonalityLevel::Always);
+            // Unspecified traits fall back to the global.
+            assert_eq!(installed.professionalism, global.professionalism);
+            assert_eq!(installed.warmth, global.warmth);
+            assert_eq!(installed.sarcasm, global.sarcasm);
+            // Exactly the per-trait merge of the override over the global.
+            assert_eq!(installed, ovr.resolve(&global));
+        }
+
+        #[tokio::test]
+        async fn set_then_get_conversation_personality_round_trips_and_clears() {
+            // The routing wrapper's setter/getter persist through the store;
+            // an empty override clears it (getter reports None).
+            let (routing, _inner, _reg, _store) = make_handler();
+            let id = ConversationId::from("c1");
+
+            let ovr = PersonalityOverride {
+                sarcasm: Some(PersonalityLevel::Never),
+                ..PersonalityOverride::default()
+            };
+            routing
+                .set_conversation_personality(&id, ovr)
+                .await
+                .unwrap();
+            assert_eq!(
+                routing.get_conversation_personality(&id).await.unwrap(),
+                Some(ovr)
+            );
+
+            // Empty override clears the stored value.
+            routing
+                .set_conversation_personality(&id, PersonalityOverride::default())
+                .await
+                .unwrap();
+            assert_eq!(
+                routing.get_conversation_personality(&id).await.unwrap(),
+                None,
+                "an all-None override must clear the stored override"
+            );
         }
 
         #[tokio::test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -637,6 +637,29 @@ impl api_surface::ConversationSelectionStore for SharedConversationStore {
         )
         .await
     }
+
+    async fn get_personality(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<Option<desktop_assistant_core::prompts::PersonalityOverride>, CoreError> {
+        <AnyConversationStore as api_surface::ConversationSelectionStore>::get_personality(
+            &self.0, id,
+        )
+        .await
+    }
+
+    async fn set_personality(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+        personality: Option<&desktop_assistant_core::prompts::PersonalityOverride>,
+    ) -> Result<(), CoreError> {
+        <AnyConversationStore as api_surface::ConversationSelectionStore>::set_personality(
+            &self.0,
+            id,
+            personality,
+        )
+        .await
+    }
 }
 
 // Per-conversation model selection. Only the Postgres backend persists
@@ -669,6 +692,32 @@ impl api_surface::ConversationSelectionStore for AnyConversationStore {
             Self::Json(_) => {
                 // No-op on the JSON backend — see comment on `get_selection`.
                 let _ = selection;
+                Ok(())
+            }
+        }
+    }
+
+    // Per-conversation personality override (#227). Same backend split as the
+    // model selection above: only Postgres persists; the JSON fallback drops it.
+    async fn get_personality(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+    ) -> Result<Option<desktop_assistant_core::prompts::PersonalityOverride>, CoreError> {
+        match self {
+            Self::Postgres(s) => s.get_conversation_personality(id).await,
+            Self::Json(_) => Ok(None),
+        }
+    }
+
+    async fn set_personality(
+        &self,
+        id: &desktop_assistant_core::domain::ConversationId,
+        personality: Option<&desktop_assistant_core::prompts::PersonalityOverride>,
+    ) -> Result<(), CoreError> {
+        match self {
+            Self::Postgres(s) => s.set_conversation_personality(id, personality).await,
+            Self::Json(_) => {
+                let _ = personality;
                 Ok(())
             }
         }

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -17,6 +17,68 @@ fn to_fdo<E: std::fmt::Display>(error: E) -> fdo::Error {
     fdo::Error::Failed(error.to_string())
 }
 
+/// D-Bus ordinal contract for one personality-override trait (#227): `-1` =
+/// unset (fall back to global), `0..=4` pins the level (Never=0 … Always=4).
+/// Mirrors `dbus-interface`'s `trait_from_dbus_ordinal`.
+fn trait_from_dbus_ordinal(name: &str, n: i32) -> fdo::Result<Option<api::PersonalityLevel>> {
+    if n < 0 {
+        return Ok(None);
+    }
+    let ordinal = u8::try_from(n).ok().filter(|v| *v <= 4).ok_or_else(|| {
+        fdo::Error::InvalidArgs(format!(
+            "personality trait {name}: ordinal {n} out of range 0..=4 (or -1 to leave unset)"
+        ))
+    })?;
+    Ok(api::PersonalityLevel::from_ordinal(ordinal))
+}
+
+/// Inverse of [`trait_from_dbus_ordinal`]: `None` → `-1`, `Some` → 0..=4.
+fn trait_to_dbus_ordinal(level: Option<api::PersonalityLevel>) -> i32 {
+    match level {
+        None => -1,
+        Some(l) => l.as_ordinal() as i32,
+    }
+}
+
+/// Build a [`api::PersonalityOverride`] from the 7-ordinal tuple in fixed trait
+/// order (professionalism, warmth, directness, enthusiasm, humor, sarcasm,
+/// pretentiousness).
+#[allow(clippy::too_many_arguments)]
+fn personality_override_from_ordinals(
+    professionalism: i32,
+    warmth: i32,
+    directness: i32,
+    enthusiasm: i32,
+    humor: i32,
+    sarcasm: i32,
+    pretentiousness: i32,
+) -> fdo::Result<api::PersonalityOverride> {
+    Ok(api::PersonalityOverride {
+        professionalism: trait_from_dbus_ordinal("professionalism", professionalism)?,
+        warmth: trait_from_dbus_ordinal("warmth", warmth)?,
+        directness: trait_from_dbus_ordinal("directness", directness)?,
+        enthusiasm: trait_from_dbus_ordinal("enthusiasm", enthusiasm)?,
+        humor: trait_from_dbus_ordinal("humor", humor)?,
+        sarcasm: trait_from_dbus_ordinal("sarcasm", sarcasm)?,
+        pretentiousness: trait_from_dbus_ordinal("pretentiousness", pretentiousness)?,
+    })
+}
+
+/// Inverse of [`personality_override_from_ordinals`].
+fn personality_override_to_ordinals(
+    ovr: &api::PersonalityOverride,
+) -> (i32, i32, i32, i32, i32, i32, i32) {
+    (
+        trait_to_dbus_ordinal(ovr.professionalism),
+        trait_to_dbus_ordinal(ovr.warmth),
+        trait_to_dbus_ordinal(ovr.directness),
+        trait_to_dbus_ordinal(ovr.enthusiasm),
+        trait_to_dbus_ordinal(ovr.humor),
+        trait_to_dbus_ordinal(ovr.sarcasm),
+        trait_to_dbus_ordinal(ovr.pretentiousness),
+    )
+}
+
 /// Translate a transport-level error to a D-Bus error. Daemon-level
 /// errors propagate verbatim; everything else gets a `Failed` with a
 /// descriptive prefix.
@@ -282,6 +344,72 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         }
     }
 
+    /// Set (or clear) a conversation's personality override (#227, Phase 2).
+    /// Each trait is a signed ordinal: `-1` = unset (fall back to global),
+    /// `0..=4` pins the level (Never=0 … Always=4); all `-1` clears the
+    /// override. Args in fixed trait order: professionalism, warmth,
+    /// directness, enthusiasm, humor, sarcasm, pretentiousness. Returns the
+    /// stored override echoed as the same 7-ordinal tuple. Mirrors the
+    /// in-process `dbus-interface` method.
+    #[allow(clippy::too_many_arguments)]
+    async fn set_conversation_personality(
+        &self,
+        conversation_id: &str,
+        professionalism: i32,
+        warmth: i32,
+        directness: i32,
+        enthusiasm: i32,
+        humor: i32,
+        sarcasm: i32,
+        pretentiousness: i32,
+    ) -> fdo::Result<(i32, i32, i32, i32, i32, i32, i32)> {
+        let personality = personality_override_from_ordinals(
+            professionalism,
+            warmth,
+            directness,
+            enthusiasm,
+            humor,
+            sarcasm,
+            pretentiousness,
+        )?;
+        let result = self
+            .dispatch(api::Command::SetConversationPersonality {
+                conversation_id: conversation_id.to_string(),
+                personality,
+            })
+            .await?;
+        match result {
+            api::CommandResult::ConversationPersonality(stored) => {
+                Ok(personality_override_to_ordinals(&stored))
+            }
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected SetConversationPersonality result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Read a conversation's personality override (#227) as the 7-ordinal
+    /// tuple (`-1` = unset; `0..=4` = pinned). All `-1` when no override is
+    /// stored. Reads `conversation_personality` from `GetConversation`.
+    async fn get_conversation_personality(
+        &self,
+        conversation_id: &str,
+    ) -> fdo::Result<(i32, i32, i32, i32, i32, i32, i32)> {
+        let result = self
+            .dispatch(api::Command::GetConversation {
+                id: conversation_id.to_string(),
+            })
+            .await?;
+        match result {
+            api::CommandResult::Conversation(view) => Ok(personality_override_to_ordinals(
+                &view.conversation_personality.unwrap_or_default(),
+            )),
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected GetConversation result: {other:?}"
+            ))),
+        }
+    }
+
     /// Send a prompt; daemon streams back via `AssistantDelta` events
     /// which the event forwarder turns into `ResponseChunk` /
     /// `ResponseComplete` / `ResponseError` signals.
@@ -469,5 +597,92 @@ mod tests {
             }
             other => panic!("expected SendMessage, got {other:?}"),
         }
+    }
+
+    /// Transport that records commands and returns a caller-supplied result,
+    /// so methods whose result is not `SendMessageAck` (e.g. personality) can
+    /// exercise their result-mapping path.
+    struct CannedTransport {
+        commands: Mutex<Vec<api::Command>>,
+        result: api::CommandResult,
+    }
+
+    impl CannedTransport {
+        fn new(result: api::CommandResult) -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+                result,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeTransport for CannedTransport {
+        async fn request(
+            &self,
+            command: api::Command,
+        ) -> Result<api::CommandResult, BridgeTransportError> {
+            self.commands.lock().await.push(command);
+            Ok(self.result.clone())
+        }
+
+        fn subscribe_events(&self) -> broadcast::Receiver<api::Event> {
+            let (tx, rx) = broadcast::channel(1);
+            std::mem::forget(tx);
+            rx
+        }
+    }
+
+    #[tokio::test]
+    async fn set_conversation_personality_builds_command_and_maps_ordinals() {
+        // The bridge must translate the 7-ordinal tuple into a partial
+        // `PersonalityOverride` (only pinned traits present) and map the
+        // `ConversationPersonality` result back to ordinals.
+        let stored = api::PersonalityOverride {
+            humor: Some(api::PersonalityLevel::Never),
+            directness: Some(api::PersonalityLevel::Always),
+            ..api::PersonalityOverride::default()
+        };
+        let transport = Arc::new(CannedTransport::new(
+            api::CommandResult::ConversationPersonality(stored),
+        ));
+        let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
+
+        // Pin directness=Always(4), humor=Never(0); rest unset(-1).
+        let echoed = adapter
+            .set_conversation_personality("conv-1", -1, -1, 4, -1, 0, -1, -1)
+            .await
+            .unwrap();
+        assert_eq!(echoed, (-1, -1, 4, -1, 0, -1, -1));
+
+        let commands = transport.commands.lock().await;
+        assert_eq!(commands.len(), 1);
+        match &commands[0] {
+            api::Command::SetConversationPersonality {
+                conversation_id,
+                personality,
+            } => {
+                assert_eq!(conversation_id, "conv-1");
+                assert_eq!(personality.directness, Some(api::PersonalityLevel::Always));
+                assert_eq!(personality.humor, Some(api::PersonalityLevel::Never));
+                // Unset traits are `None` (fall back to global).
+                assert_eq!(personality.warmth, None);
+            }
+            other => panic!("expected SetConversationPersonality, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_conversation_personality_rejects_out_of_range_before_dispatch() {
+        let transport = Arc::new(CannedTransport::new(
+            api::CommandResult::ConversationPersonality(api::PersonalityOverride::default()),
+        ));
+        let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
+        let err = adapter
+            .set_conversation_personality("conv-1", -1, -1, -1, -1, 9, -1, -1)
+            .await;
+        assert!(err.is_err(), "out-of-range ordinal must be rejected");
+        // Validation happens before dispatch — no command sent.
+        assert!(transport.commands.lock().await.is_empty());
     }
 }

--- a/crates/dbus-interface/src/conversation.rs
+++ b/crates/dbus-interface/src/conversation.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use desktop_assistant_core::domain::ConversationId;
 use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 use desktop_assistant_core::ports::inbound::ConversationService;
+use desktop_assistant_core::prompts::{PersonalityLevel, PersonalityOverride};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use zbus::object_server::SignalEmitter;
@@ -195,6 +196,33 @@ where
         user_id_for_body,
         run_send_prompt_llm_task(service, conversation_id, prompt, system_refinement, tx),
     ))
+}
+
+/// D-Bus ordinal contract for one personality-override trait (#227): `-1`
+/// means "unset" (fall back to the global config), `0..=4` pins the level
+/// (Never=0 … Always=4). Out-of-range positives are rejected. Mirrors the
+/// signed-int "unset" convention the settings interface uses (e.g.
+/// `llm_hosted_tool_search = -1`), while reusing the 0..=4 personality ordinal
+/// contract the KCM already binds to.
+fn trait_from_dbus_ordinal(name: &str, n: i32) -> fdo::Result<Option<PersonalityLevel>> {
+    if n < 0 {
+        return Ok(None);
+    }
+    let ordinal = u8::try_from(n).ok().filter(|v| *v <= 4).ok_or_else(|| {
+        fdo::Error::InvalidArgs(format!(
+            "personality trait {name}: ordinal {n} out of range 0..=4 (or -1 to leave unset)"
+        ))
+    })?;
+    Ok(PersonalityLevel::from_ordinal(ordinal))
+}
+
+/// Inverse of [`trait_from_dbus_ordinal`]: `None` → `-1`, `Some(level)` → its
+/// 0..=4 ordinal.
+fn trait_to_dbus_ordinal(level: Option<PersonalityLevel>) -> i32 {
+    match level {
+        None => -1,
+        Some(l) => l.as_ordinal() as i32,
+    }
 }
 
 #[interface(name = "org.desktopAssistant.Conversations")]
@@ -393,6 +421,90 @@ impl<S: ConversationService + 'static> DbusConversationAdapter<S> {
                 .clear_all_history()
                 .await
                 .map_err(|e| fdo::Error::Failed(e.to_string()))
+        })
+        .await
+    }
+
+    /// Set (or clear) a conversation's personality override (#227, Phase 2).
+    ///
+    /// Each trait is a signed ordinal: `-1` leaves it unset (falls back to the
+    /// global config on every send), `0..=4` pins the level (Never=0 …
+    /// Always=4). When every trait is `-1` the override is cleared
+    /// (global-only). The override sets only the *initial disposition* — the
+    /// assistant stays soft/adaptive. Arguments are in the fixed trait order:
+    /// professionalism, warmth, directness, enthusiasm, humor, sarcasm,
+    /// pretentiousness. Returns the stored override echoed back as the same
+    /// 7-ordinal tuple (cleared → all `-1`).
+    #[allow(clippy::too_many_arguments)]
+    async fn set_conversation_personality(
+        &self,
+        conversation_id: &str,
+        professionalism: i32,
+        warmth: i32,
+        directness: i32,
+        enthusiasm: i32,
+        humor: i32,
+        sarcasm: i32,
+        pretentiousness: i32,
+    ) -> fdo::Result<(i32, i32, i32, i32, i32, i32, i32)> {
+        let ovr = PersonalityOverride {
+            professionalism: trait_from_dbus_ordinal("professionalism", professionalism)?,
+            warmth: trait_from_dbus_ordinal("warmth", warmth)?,
+            directness: trait_from_dbus_ordinal("directness", directness)?,
+            enthusiasm: trait_from_dbus_ordinal("enthusiasm", enthusiasm)?,
+            humor: trait_from_dbus_ordinal("humor", humor)?,
+            sarcasm: trait_from_dbus_ordinal("sarcasm", sarcasm)?,
+            pretentiousness: trait_from_dbus_ordinal("pretentiousness", pretentiousness)?,
+        };
+        with_user_id(resolve_dbus_user_id(), async {
+            let id = ConversationId::from(conversation_id);
+            self.service
+                .set_conversation_personality(&id, ovr)
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+            // Echo the stored value (cleared → all-None → all -1).
+            let stored = self
+                .service
+                .get_conversation_personality(&id)
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?
+                .unwrap_or_default();
+            Ok((
+                trait_to_dbus_ordinal(stored.professionalism),
+                trait_to_dbus_ordinal(stored.warmth),
+                trait_to_dbus_ordinal(stored.directness),
+                trait_to_dbus_ordinal(stored.enthusiasm),
+                trait_to_dbus_ordinal(stored.humor),
+                trait_to_dbus_ordinal(stored.sarcasm),
+                trait_to_dbus_ordinal(stored.pretentiousness),
+            ))
+        })
+        .await
+    }
+
+    /// Read a conversation's personality override (#227) as the 7-ordinal tuple
+    /// (`-1` = unset / global fallback; `0..=4` = pinned level). When no
+    /// override is stored every value is `-1`.
+    async fn get_conversation_personality(
+        &self,
+        conversation_id: &str,
+    ) -> fdo::Result<(i32, i32, i32, i32, i32, i32, i32)> {
+        with_user_id(resolve_dbus_user_id(), async {
+            let stored = self
+                .service
+                .get_conversation_personality(&ConversationId::from(conversation_id))
+                .await
+                .map_err(|e| fdo::Error::Failed(e.to_string()))?
+                .unwrap_or_default();
+            Ok((
+                trait_to_dbus_ordinal(stored.professionalism),
+                trait_to_dbus_ordinal(stored.warmth),
+                trait_to_dbus_ordinal(stored.directness),
+                trait_to_dbus_ordinal(stored.enthusiasm),
+                trait_to_dbus_ordinal(stored.humor),
+                trait_to_dbus_ordinal(stored.sarcasm),
+                trait_to_dbus_ordinal(stored.pretentiousness),
+            ))
         })
         .await
     }
@@ -836,6 +948,149 @@ mod tests {
             Some("Respond briefly, by voice."),
             "the configured hint must be carried as the per-request system_refinement"
         );
+    }
+
+    // --- #227: per-conversation personality ordinal contract ---------------
+
+    #[test]
+    fn personality_trait_ordinal_round_trips_through_dbus() {
+        // -1 means "unset / fall back to global".
+        assert_eq!(trait_from_dbus_ordinal("humor", -1).unwrap(), None);
+        assert_eq!(trait_to_dbus_ordinal(None), -1);
+        // 0..=4 round-trips to the level and back.
+        for (n, level) in [
+            (0, PersonalityLevel::Never),
+            (1, PersonalityLevel::Rarely),
+            (2, PersonalityLevel::Sometimes),
+            (3, PersonalityLevel::Often),
+            (4, PersonalityLevel::Always),
+        ] {
+            assert_eq!(
+                trait_from_dbus_ordinal("humor", n).unwrap(),
+                Some(level),
+                "ordinal {n} must map to {level:?}"
+            );
+            assert_eq!(trait_to_dbus_ordinal(Some(level)), n);
+        }
+        // Out-of-range positive is rejected, not clamped.
+        assert!(trait_from_dbus_ordinal("humor", 5).is_err());
+    }
+
+    /// Conversation service double that stores a per-conversation personality
+    /// override in memory so the D-Bus method's persist + echo can be asserted.
+    struct PersonalityStoringService {
+        stored: Mutex<Option<PersonalityOverride>>,
+    }
+
+    impl PersonalityStoringService {
+        fn new() -> Self {
+            Self {
+                stored: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ConversationService for PersonalityStoringService {
+        async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new("c", title))
+        }
+        async fn list_conversations(
+            &self,
+            _: Option<u32>,
+            _: bool,
+        ) -> Result<Vec<ConversationSummary>, CoreError> {
+            Ok(vec![])
+        }
+        async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+            Ok(Conversation::new(id.as_str(), "t"))
+        }
+        async fn delete_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn rename_conversation(
+            &self,
+            _: &ConversationId,
+            _: String,
+        ) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn archive_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn unarchive_conversation(&self, _: &ConversationId) -> Result<(), CoreError> {
+            Ok(())
+        }
+        async fn clear_all_history(&self) -> Result<u32, CoreError> {
+            Ok(0)
+        }
+        async fn send_prompt(
+            &self,
+            _: &ConversationId,
+            _: String,
+            _: ChunkCallback,
+            _: StatusCallback,
+        ) -> Result<String, CoreError> {
+            Ok(String::new())
+        }
+        async fn get_conversation_personality(
+            &self,
+            _: &ConversationId,
+        ) -> Result<Option<PersonalityOverride>, CoreError> {
+            Ok(*self.stored.lock().unwrap())
+        }
+        async fn set_conversation_personality(
+            &self,
+            _: &ConversationId,
+            personality: PersonalityOverride,
+        ) -> Result<(), CoreError> {
+            // Mirror the routing wrapper: an empty override clears the store.
+            *self.stored.lock().unwrap() = if personality.is_empty() {
+                None
+            } else {
+                Some(personality)
+            };
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn dbus_set_get_conversation_personality_round_trips_and_clears() {
+        let service = Arc::new(PersonalityStoringService::new());
+        let adapter = DbusConversationAdapter::new(Arc::clone(&service));
+        let _guard = crate::testing::UserEnvGuard::set("alice");
+
+        // Pin humor=Never(0) and directness=Always(4); leave the rest unset(-1).
+        let echoed = adapter
+            .set_conversation_personality("c1", -1, -1, 4, -1, 0, -1, -1)
+            .await
+            .unwrap();
+        // Echo: directness=4, humor=0, rest -1.
+        assert_eq!(echoed, (-1, -1, 4, -1, 0, -1, -1));
+
+        // GET reflects the stored value.
+        let got = adapter.get_conversation_personality("c1").await.unwrap();
+        assert_eq!(got, (-1, -1, 4, -1, 0, -1, -1));
+
+        // All -1 clears the override → GET returns all -1.
+        let cleared = adapter
+            .set_conversation_personality("c1", -1, -1, -1, -1, -1, -1, -1)
+            .await
+            .unwrap();
+        assert_eq!(cleared, (-1, -1, -1, -1, -1, -1, -1));
+        assert!(service.stored.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn dbus_set_conversation_personality_rejects_out_of_range() {
+        let service = Arc::new(PersonalityStoringService::new());
+        let adapter = DbusConversationAdapter::new(service);
+        let _guard = crate::testing::UserEnvGuard::set("alice");
+        // ordinal 5 is out of range for the humor slot.
+        let err = adapter
+            .set_conversation_personality("c1", -1, -1, -1, -1, 5, -1, -1)
+            .await;
+        assert!(err.is_err(), "out-of-range ordinal must be rejected");
     }
 
     struct FakeConversationService;

--- a/crates/storage/migrations/024_conversation_personality.sql
+++ b/crates/storage/migrations/024_conversation_personality.sql
@@ -1,0 +1,10 @@
+-- Issue #227: per-conversation personality override (Phase 2).
+--
+-- Stores an optional partial `PersonalityOverride` (per-trait
+-- `Option<PersonalityLevel>`) for a conversation so a client can pin a
+-- disposition (e.g. a "no-nonsense" client forcing humor=never) that survives
+-- daemon restart and conversation switching. NULL = no override (fall back to
+-- the global personality on every send). JSONB keeps the column
+-- forward-compatible, mirroring `last_model_selection` (migration 011).
+ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS personality_override JSONB;

--- a/crates/storage/src/conversation.rs
+++ b/crates/storage/src/conversation.rs
@@ -5,6 +5,7 @@ use desktop_assistant_core::domain::{
 use desktop_assistant_core::ports::auth::current_user_id;
 use desktop_assistant_core::ports::inbound::ConversationModelSelection;
 use desktop_assistant_core::ports::store::ConversationStore;
+use desktop_assistant_core::prompts::PersonalityOverride;
 use sqlx::PgPool;
 
 pub struct PgConversationStore {
@@ -81,6 +82,71 @@ impl PgConversationStore {
             CoreError::Storage(format!("last_model_selection JSON in DB is malformed: {e}"))
         })?;
         Ok(Some(sel))
+    }
+
+    /// Set (or clear) the stored personality override for a conversation (#227).
+    ///
+    /// Passing `None` (or an empty/all-`None` override — handled by the caller)
+    /// clears the column (NULL). Mirrors
+    /// [`Self::set_conversation_model_selection`]: JSONB column, user-scoped,
+    /// `ConversationNotFound` on a missing/cross-user row (#105: don't leak
+    /// existence).
+    pub async fn set_conversation_personality(
+        &self,
+        conversation_id: &ConversationId,
+        personality: Option<&PersonalityOverride>,
+    ) -> Result<(), CoreError> {
+        let user_id = current_user_id();
+        let json = match personality {
+            Some(p) => Some(
+                serde_json::to_value(p)
+                    .map_err(|e| CoreError::Storage(format!("personality json: {e}")))?,
+            ),
+            None => None,
+        };
+        let result = sqlx::query(
+            "UPDATE conversations SET personality_override = $3 \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&conversation_id.0)
+        .bind(json)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            return Err(CoreError::ConversationNotFound(conversation_id.0.clone()));
+        }
+        Ok(())
+    }
+
+    /// Read the stored personality override for a conversation (#227). Returns
+    /// `None` when the conversation exists but has no stored override; returns
+    /// `ConversationNotFound` when the id is unknown OR belongs to a different
+    /// user. Mirrors [`Self::get_conversation_model_selection`].
+    pub async fn get_conversation_personality(
+        &self,
+        conversation_id: &ConversationId,
+    ) -> Result<Option<PersonalityOverride>, CoreError> {
+        let user_id = current_user_id();
+        let row: Option<(Option<serde_json::Value>,)> = sqlx::query_as(
+            "SELECT personality_override FROM conversations \
+             WHERE user_id = $1 AND id = $2",
+        )
+        .bind(user_id.as_str())
+        .bind(&conversation_id.0)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        let row = row.ok_or_else(|| CoreError::ConversationNotFound(conversation_id.0.clone()))?;
+        let Some(json) = row.0 else {
+            return Ok(None);
+        };
+        let ovr: PersonalityOverride = serde_json::from_value(json).map_err(|e| {
+            CoreError::Storage(format!("personality_override JSON in DB is malformed: {e}"))
+        })?;
+        Ok(Some(ovr))
     }
 }
 

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -187,5 +187,13 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // #227: per-conversation personality override (JSONB column on
+    // conversations), mirroring 011's last_model_selection.
+    sqlx::raw_sql(include_str!(
+        "../migrations/024_conversation_personality.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
Closes #227

## Summary

Phase 2 of the configurable personality (Phase 1 / global = #233). A conversation can now carry a **partial personality override**, resolved on each send as:

**conversation override (partial) → global config → built-in default**

The override sets only the *initial disposition* — it stays soft/adaptive (no change to `render_blurb`; the adaptation clause still applies). This mirrors the per-conversation **model** selection end-to-end (storage column, store accessor, read-on-send) and adds a dedicated `SetConversationPersonality` command so a client (e.g. a "no-nonsense" client) can pin a disposition.

## Client-facing contract (for the tui/gtk picker agents)

**Socket transports (WS/UDS) — `AssistantCommands`:**
```rust
async fn set_conversation_personality(
    &self,
    conversation_id: &str,
    personality: api::ConversationPersonalityView, // = api::PersonalityOverride
) -> Result<api::ConversationPersonalityView>; // stored value; empty = cleared
```
- `ConversationPersonalityView` / `PersonalityOverride` = 7 `Option<PersonalityLevel>` fields (`professionalism, warmth, directness, enthusiasm, humor, sarcasm, pretentiousness`); `Some` pins, `None` falls back to global. An all-`None` override clears it.
- The current value is also surfaced on `ConversationDetail::conversation_personality` (from `get_conversation`) for picker pre-fill.

**Raw command/result:** `Command::SetConversationPersonality { conversation_id, personality }` → `CommandResult::ConversationPersonality(view)`. `ConversationView.conversation_personality: Option<...>` (omitted when none).

**D-Bus (`org.desktopAssistant.Conversations`, both in-process + bridge):**
- `SetConversationPersonality(conversation_id: s, professionalism..pretentiousness: 7×i32) -> (7×i32)`
- `GetConversationPersonality(conversation_id: s) -> (7×i32)`
- Signed-ordinal contract per trait: `-1` = unset (global fallback), `0..=4` = pinned level (Never=0 … Always=4), consistent with the KCM personality contract. Out-of-range rejected, not clamped.

## Persistence
Migration 024 adds `conversations.personality_override JSONB` (mirrors 011's `last_model_selection`). Postgres persists; the JSON fallback drops it (same as model selection).

## Tests (TDD)
Resolution precedence (override wins per-trait / unspecified → global / none → global); command round-trip (api-model, client-common, dbus-bridge); D-Bus ordinal round-trip + clear + out-of-range reject; send-path installs the resolved personality.

`just check` is green (fmt + clippy `-D warnings` + build + workspace tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)