### PR TITLE
fix(voice#49): keep the Connector fan-out alive on an idle UDS link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "desktop-assistant-api-model",
  "desktop-assistant-application",
  "desktop-assistant-auth-jwt",
+ "desktop-assistant-core",
  "desktop-assistant-uds",
  "futures",
  "reqwest",

--- a/crates/client-common/Cargo.toml
+++ b/crates/client-common/Cargo.toml
@@ -35,6 +35,7 @@ optional = true
 # clients never link the daemon stack.
 desktop-assistant-uds = { path = "../uds-interface" }
 desktop-assistant-application = { path = "../application" }
+desktop-assistant-core.workspace = true
 desktop-assistant-auth-jwt.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = [

--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -22,17 +22,28 @@ use crate::transport::{AssistantClient, TransportClient, connect_transport, tran
 
 type Subscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<SignalEvent>>>>;
 
-/// Pump a transport's signal stream out to subscribers, surfacing both a closed
-/// AND a *stalled* (open but silent) connection as a terminal
-/// [`SignalEvent::Disconnected`] (#221).
+/// Pump a transport's signal stream out to subscribers.
 ///
-/// Every received event resets the stall clock; if no event arrives within
-/// `stall_timeout` the connection is assumed wedged and subscribers get a
-/// `Disconnected { reason }` so a client waiting on the stream errors out
-/// instead of hanging forever. This pairs with the orchestrator emitting
-/// periodic `AssistantStatus`, which keeps a healthy connection's clock fresh
-/// even between LLM chunks. `stall_timeout` is a parameter so tests can drive a
-/// short window without waiting the production minute-plus.
+/// Closing the upstream stream is terminal: every subscriber gets a
+/// `Disconnected { reason: "signal stream closed" }` and the pump stops.
+///
+/// A *stall* (open but silent) is treated as a **per-turn** signal, not a reason
+/// to tear the connection down (voice#49, reopened). The stall clock only runs
+/// while at least one subscriber is attached — i.e. a turn is potentially in
+/// flight: if no event arrives within `stall_timeout`, every *current*
+/// subscriber gets a terminal `Disconnected { reason: "…stalled…" }` so a client
+/// waiting on a wedged turn errors out instead of hanging (#221), but the pump
+/// **keeps reading** so the next turn still streams.
+///
+/// While there are no subscribers, the connection is simply idle — the gap
+/// between connecting and the first request, or between turns — and the pump
+/// waits without a stall deadline. This is essential on transports without a
+/// keepalive (UDS): otherwise a healthy-but-idle connection would trip the
+/// stall and the pump would die before the first turn ever arrived, so every
+/// later subscriber would be attached to a dead pump and receive ZERO events
+/// (the reopened voice#49: send acks, turn completes, client gets nothing).
+/// `stall_timeout` is a parameter so tests can drive a short window without
+/// waiting the production minute-plus.
 fn spawn_fanout_with_stall_timeout(
     mut signal_rx: mpsc::UnboundedReceiver<SignalEvent>,
     stall_timeout: Duration,
@@ -40,32 +51,54 @@ fn spawn_fanout_with_stall_timeout(
     let subscribers: Subscribers = Arc::new(Mutex::new(Vec::new()));
     let pump = Arc::clone(&subscribers);
     tokio::spawn(async move {
-        // The terminal reason depends on *why* we stopped: a closed upstream vs.
-        // a stall the client should distinguish (and may choose to reconnect on).
-        let reason = loop {
-            match tokio::time::timeout(stall_timeout, signal_rx.recv()).await {
-                Ok(Some(event)) => {
-                    // Deliver to every live subscriber; drop those whose
-                    // receiver is gone. Receipt also resets the stall clock,
-                    // since the next `timeout` starts fresh on the next iter.
+        loop {
+            // The stall clock only applies while a subscriber is waiting (a turn
+            // may be in flight). With no subscribers the connection is idle, not
+            // wedged, so we wait unbounded — never stalling out a healthy link
+            // that simply has no traffic yet (voice#49).
+            let has_subscribers = !pump.lock().unwrap().is_empty();
+            let next = if has_subscribers {
+                match tokio::time::timeout(stall_timeout, signal_rx.recv()).await {
+                    Ok(item) => item,
+                    Err(_elapsed) => {
+                        // No progress for a turn that had a waiter: unstick the
+                        // current subscribers, but KEEP the pump alive so the
+                        // next turn still streams.
+                        let reason = format!(
+                            "connection stalled: no events for {}s",
+                            stall_timeout.as_secs()
+                        );
+                        for tx in pump.lock().unwrap().drain(..) {
+                            let _ = tx.send(SignalEvent::Disconnected {
+                                reason: reason.clone(),
+                            });
+                        }
+                        continue;
+                    }
+                }
+            } else {
+                signal_rx.recv().await
+            };
+
+            match next {
+                Some(event) => {
+                    // Deliver to every live subscriber; drop those whose receiver
+                    // is gone. Receipt resets the stall clock implicitly — the
+                    // next iteration re-arms the timeout from now.
                     pump.lock()
                         .unwrap()
                         .retain(|tx| tx.send(event.clone()).is_ok());
                 }
-                Ok(None) => break "signal stream closed".to_string(),
-                Err(_elapsed) => {
-                    break format!(
-                        "connection stalled: no events for {}s",
-                        stall_timeout.as_secs()
-                    );
+                // Upstream closed — terminal. Notify whoever is left and stop.
+                None => {
+                    for tx in pump.lock().unwrap().drain(..) {
+                        let _ = tx.send(SignalEvent::Disconnected {
+                            reason: "signal stream closed".to_string(),
+                        });
+                    }
+                    break;
                 }
             }
-        };
-        // The transport closed or stalled — give subscribers a terminal event.
-        for tx in pump.lock().unwrap().drain(..) {
-            let _ = tx.send(SignalEvent::Disconnected {
-                reason: reason.clone(),
-            });
         }
     });
     subscribers
@@ -93,10 +126,12 @@ impl Connector {
     }
 
     /// Like [`connect`](Self::connect) but with an explicit event-stream stall
-    /// window (#221). A connection that stays open but emits no event for
-    /// `stall_timeout` surfaces a terminal [`SignalEvent::Disconnected`] to
-    /// every subscriber. Mainly for tests; production callers normally want the
-    /// default via [`connect`](Self::connect).
+    /// window (#221). While a subscriber is attached (a turn may be in flight), a
+    /// connection that stays open but emits no event for `stall_timeout` surfaces
+    /// a terminal [`SignalEvent::Disconnected`] to the *current* subscribers — but
+    /// the pump keeps running so later turns still stream (voice#49). An idle
+    /// connection with no subscribers is never stalled out. Mainly for tests;
+    /// production callers normally want the default via [`connect`](Self::connect).
     pub async fn connect_with_stall_timeout(
         config: &ConnectionConfig,
         stall_timeout: Duration,
@@ -358,6 +393,77 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(40)).await;
         }
         // Still alive: no Disconnected yet (we've only ever waited < window).
+        drop(tx);
+    }
+
+    /// voice#49 (reopened): a connection that sits IDLE with no subscribers past
+    /// the stall window must NOT tear the pump down. A subscriber that registers
+    /// for the first turn *after* that idle period must still receive its events.
+    /// (UDS has no keepalive, so this idle gap always exceeds the window.)
+    #[tokio::test]
+    async fn fanout_idle_without_subscribers_does_not_stall_out() {
+        let (tx, rx) = mpsc::unbounded_channel::<SignalEvent>();
+        let stall = Duration::from_millis(40);
+        let subs = spawn_fanout_with_stall_timeout(rx, stall);
+
+        // Idle well past the stall window with NO subscribers (the
+        // connect→first-turn gap). The pump must survive.
+        tokio::time::sleep(stall * 4).await;
+
+        // First turn: subscribe, then events arrive — they must be delivered.
+        let mut a = register(&subs);
+        tx.send(SignalEvent::Chunk {
+            request_id: "r".into(),
+            chunk: "hi".into(),
+        })
+        .unwrap();
+
+        let event = tokio::time::timeout(Duration::from_secs(2), a.recv())
+            .await
+            .expect("a turn after an idle period must still deliver, not be a dead pump");
+        assert!(
+            matches!(event, Some(SignalEvent::Chunk { .. })),
+            "expected the first turn's chunk after idle, got {event:?}"
+        );
+        drop(tx);
+    }
+
+    /// A stall unsticks the *current* subscribers (so a wedged turn errors out)
+    /// but must NOT kill the pump: a fresh subscriber for the next turn still
+    /// gets its events. This is the per-turn-vs-terminal distinction at the
+    /// heart of the voice#49 fix.
+    #[tokio::test]
+    async fn fanout_stall_unsticks_waiters_but_keeps_serving_later_turns() {
+        let (tx, rx) = mpsc::unbounded_channel::<SignalEvent>();
+        let stall = Duration::from_millis(40);
+        let subs = spawn_fanout_with_stall_timeout(rx, stall);
+
+        // Turn 1: a subscriber waits on a wedged (silent) connection → gets a
+        // terminal Disconnected once the stall fires.
+        let mut first = register(&subs);
+        let event = tokio::time::timeout(Duration::from_secs(2), first.recv())
+            .await
+            .expect("the waiting subscriber must be unstuck by the stall");
+        assert!(
+            matches!(event, Some(SignalEvent::Disconnected { ref reason }) if reason.contains("stalled")),
+            "the waiter on a wedged turn should get a stall Disconnected, got {event:?}"
+        );
+
+        // Turn 2: a NEW subscriber on the SAME (still-open) connection must
+        // still receive events — the pump survived the stall.
+        let mut second = register(&subs);
+        tx.send(SignalEvent::Chunk {
+            request_id: "r2".into(),
+            chunk: "next".into(),
+        })
+        .unwrap();
+        let event = tokio::time::timeout(Duration::from_secs(2), second.recv())
+            .await
+            .expect("the next turn must still stream after a prior stall");
+        assert!(
+            matches!(event, Some(SignalEvent::Chunk { ref chunk, .. }) if chunk == "next"),
+            "expected the next turn's chunk, got {event:?}"
+        );
         drop(tx);
     }
 }

--- a/crates/client-common/tests/uds_real_turn.rs
+++ b/crates/client-common/tests/uds_real_turn.rs
@@ -1,0 +1,639 @@
+//! Real-path regression test for voice#49 (reopened): a `SendMessage` that
+//! arrives over UDS must stream ALL its events back to the *same* UDS
+//! connection.
+//!
+//! ## Why this test exists (the gap #218's test had)
+//!
+//! `tests/uds_streaming.rs` (the #218 regression test) used a hand-written
+//! `start_send_message` that emitted directly to the per-connection sink. It
+//! proved the *correlation* fix (ack `request_id` == streamed events'
+//! `request_id`) but it never drove the REAL application turn pipeline:
+//! `DefaultAssistantApiHandler::start_send_message` → registry spawn → the
+//! in-flight/TeeSink path (taken whenever the send carries an
+//! `idempotency_key`) → `run_send_turn` → the per-connection sink.
+//!
+//! Crucially, the voice client sends with an **idempotency key** on every turn
+//! (`assistant-connector`'s `send_prompt_with_system_refinement`), which routes
+//! the real handler through the keyed branch that #218 never exercised. This
+//! test drives a SendMessage with a key through the *real* handler (wired like
+//! the daemon: registry + client-tool coordinator) standing behind the *real*
+//! UDS server, and asserts the connecting client receives every streamed event
+//! correlated to the id `send_prompt` returned.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use desktop_assistant_application::{
+    DefaultAssistantApiHandler,
+    background_tasks::BackgroundTaskRegistry,
+    client_tools::{ClientToolCoordinator, InMemoryTurnStateStore},
+};
+use desktop_assistant_auth_jwt as jwt;
+use desktop_assistant_client_common::{ConnectionConfig, Connector, SignalEvent, TransportMode};
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{
+    Conversation, ConversationId, ConversationSummary, KnowledgeEntry, Message, Role,
+};
+use desktop_assistant_core::ports::inbound::{
+    AssistantService, BackendTasksSettingsView, ConnectionConfigPayload, ConnectionView,
+    ConnectionsService, ConnectorDefaultsView, ConversationService, DatabaseSettingsView,
+    EmbeddingsSettingsView, KnowledgeService, LlmSettingsView, McpServerView, ModelListing,
+    PersistenceSettingsView, PurposeConfigPayload, PurposeKind, PurposesView, SettingsService,
+    WsAuthSettingsView,
+};
+use desktop_assistant_core::ports::llm::{ChunkCallback, StatusCallback};
+use desktop_assistant_uds::{UdsAuthValidator, UdsServer, UdsServerConfig};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::time::{Duration, timeout};
+
+const ISS: &str = "test-real-iss";
+const AUD: &str = "test-real-aud";
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn mint_test_jwt(signing_key: &str, subject: &str) -> String {
+    let now = unix_now();
+    let claims = jwt::Claims {
+        iss: ISS.into(),
+        sub: subject.into(),
+        aud: AUD.into(),
+        exp: now + 600,
+        iat: now,
+        nbf: now.saturating_sub(1),
+        jti: uuid::Uuid::new_v4().to_string(),
+    };
+    jwt::encode(&claims, signing_key).expect("encode jwt")
+}
+
+// ---------------------------------------------------------------------------
+// Minimal real services. The send-turn path only touches the conversation
+// service; the other four exist solely to satisfy the handler's generics.
+// ---------------------------------------------------------------------------
+
+/// A conversation service whose `send_prompt` streams two chunks plus a status
+/// message, then returns a final response — exactly the shape `run_send_turn`
+/// bridges into `AssistantStatus` / `AssistantDelta` / `AssistantCompleted`.
+struct StreamingConversations;
+
+#[async_trait::async_trait]
+impl ConversationService for StreamingConversations {
+    async fn create_conversation(&self, title: String) -> Result<Conversation, CoreError> {
+        Ok(Conversation::new("conv-1", title))
+    }
+    async fn list_conversations(
+        &self,
+        _max_age_days: Option<u32>,
+        _include_archived: bool,
+    ) -> Result<Vec<ConversationSummary>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_conversation(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
+        let mut c = Conversation::new(id.as_str(), "Real Turn");
+        c.messages.push(Message::new(Role::User, "hi"));
+        Ok(c)
+    }
+    async fn delete_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn rename_conversation(
+        &self,
+        _id: &ConversationId,
+        _title: String,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn archive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn unarchive_conversation(&self, _id: &ConversationId) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn clear_all_history(&self) -> Result<u32, CoreError> {
+        Ok(0)
+    }
+    async fn send_prompt(
+        &self,
+        _conversation_id: &ConversationId,
+        _prompt: String,
+        mut on_chunk: ChunkCallback,
+        mut on_status: StatusCallback,
+    ) -> Result<String, CoreError> {
+        // A status update (turn-start narration / heartbeat), then streamed
+        // chunks, then the final reply — mirroring a real LLM turn.
+        on_status("thinking".into());
+        on_chunk("hel".into());
+        on_chunk("lo".into());
+        Ok("hello".into())
+    }
+}
+
+struct FakeAssistant;
+impl AssistantService for FakeAssistant {
+    fn version(&self) -> &str {
+        "0.0.0-test"
+    }
+    fn ping(&self) -> &str {
+        "pong"
+    }
+}
+
+struct FakeConnections;
+impl ConnectionsService for FakeConnections {
+    async fn list_connections(&self) -> Result<Vec<ConnectionView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_connection(
+        &self,
+        _id: String,
+        _config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn update_connection(
+        &self,
+        _id: String,
+        _config: ConnectionConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn delete_connection(&self, _id: String, _force: bool) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn list_available_models(
+        &self,
+        _connection_id: Option<String>,
+        _refresh: bool,
+    ) -> Result<Vec<ModelListing>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_purposes(&self) -> Result<PurposesView, CoreError> {
+        Ok(PurposesView::default())
+    }
+    async fn set_purpose(
+        &self,
+        _purpose: PurposeKind,
+        _config: PurposeConfigPayload,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+struct FakeSettings;
+impl SettingsService for FakeSettings {
+    async fn get_llm_settings(&self) -> Result<LlmSettingsView, CoreError> {
+        Ok(LlmSettingsView {
+            connector: "x".into(),
+            model: "y".into(),
+            base_url: "z".into(),
+            has_api_key: false,
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            hosted_tool_search: None,
+        })
+    }
+    async fn set_llm_settings(
+        &self,
+        _connector: String,
+        _model: Option<String>,
+        _base_url: Option<String>,
+        _temperature: Option<f64>,
+        _top_p: Option<f64>,
+        _max_tokens: Option<u32>,
+        _hosted_tool_search: Option<bool>,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn set_api_key(&self, _api_key: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn generate_ws_jwt(&self, _subject: Option<String>) -> Result<String, CoreError> {
+        Ok("jwt".into())
+    }
+    async fn validate_ws_jwt(&self, _token: String) -> Result<bool, CoreError> {
+        Ok(true)
+    }
+    async fn get_embeddings_settings(&self) -> Result<EmbeddingsSettingsView, CoreError> {
+        Ok(EmbeddingsSettingsView {
+            connector: "x".into(),
+            model: "y".into(),
+            base_url: "z".into(),
+            has_api_key: false,
+            available: false,
+            is_default: true,
+        })
+    }
+    async fn set_embeddings_settings(
+        &self,
+        _connector: Option<String>,
+        _model: Option<String>,
+        _base_url: Option<String>,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_connector_defaults(
+        &self,
+        _connector: String,
+    ) -> Result<ConnectorDefaultsView, CoreError> {
+        Ok(ConnectorDefaultsView {
+            llm_model: "m".into(),
+            llm_base_url: "u".into(),
+            backend_llm_model: "bm".into(),
+            embeddings_model: "em".into(),
+            embeddings_base_url: "eu".into(),
+            embeddings_available: false,
+            hosted_tool_search_available: false,
+        })
+    }
+    async fn get_persistence_settings(&self) -> Result<PersistenceSettingsView, CoreError> {
+        Ok(PersistenceSettingsView {
+            enabled: false,
+            remote_url: "".into(),
+            remote_name: "origin".into(),
+            push_on_update: false,
+        })
+    }
+    async fn set_persistence_settings(
+        &self,
+        _enabled: bool,
+        _remote_url: Option<String>,
+        _remote_name: Option<String>,
+        _push_on_update: bool,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_database_settings(&self) -> Result<DatabaseSettingsView, CoreError> {
+        Ok(DatabaseSettingsView {
+            url: String::new(),
+            max_connections: 5,
+        })
+    }
+    async fn set_database_settings(
+        &self,
+        _url: Option<String>,
+        _max_connections: u32,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn get_backend_tasks_settings(&self) -> Result<BackendTasksSettingsView, CoreError> {
+        Ok(BackendTasksSettingsView {
+            has_separate_llm: false,
+            llm_connector: "openai".into(),
+            llm_model: "gpt-5".into(),
+            llm_base_url: "https://api.openai.com/v1".into(),
+            dreaming_enabled: false,
+            dreaming_interval_secs: 3600,
+            archive_after_days: 0,
+        })
+    }
+    async fn set_backend_tasks_settings(
+        &self,
+        _llm_connector: Option<String>,
+        _llm_model: Option<String>,
+        _llm_base_url: Option<String>,
+        _dreaming_enabled: bool,
+        _dreaming_interval_secs: u64,
+        _archive_after_days: u32,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn add_mcp_server(
+        &self,
+        _name: String,
+        _command: String,
+        _args: Vec<String>,
+        _namespace: Option<String>,
+        _enabled: bool,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn remove_mcp_server(&self, _name: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn set_mcp_server_enabled(&self, _name: String, _enabled: bool) -> Result<(), CoreError> {
+        Ok(())
+    }
+    async fn mcp_server_action(
+        &self,
+        _action: String,
+        _server: Option<String>,
+    ) -> Result<Vec<McpServerView>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_ws_auth_settings(&self) -> Result<WsAuthSettingsView, CoreError> {
+        Ok(WsAuthSettingsView {
+            methods: vec![],
+            oidc_issuer: String::new(),
+            oidc_auth_endpoint: String::new(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+            oidc_scopes: String::new(),
+        })
+    }
+    async fn set_ws_auth_settings(
+        &self,
+        _methods: Vec<String>,
+        _oidc_issuer: String,
+        _oidc_auth_endpoint: String,
+        _oidc_token_endpoint: String,
+        _oidc_client_id: String,
+        _oidc_scopes: String,
+    ) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+struct FakeKnowledge;
+impl KnowledgeService for FakeKnowledge {
+    async fn list_entries(
+        &self,
+        _limit: usize,
+        _offset: usize,
+        _tag_filter: Option<Vec<String>>,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn get_entry(&self, _id: String) -> Result<Option<KnowledgeEntry>, CoreError> {
+        Ok(None)
+    }
+    async fn search_entries(
+        &self,
+        _query: String,
+        _tag_filter: Option<Vec<String>>,
+        _limit: usize,
+    ) -> Result<Vec<KnowledgeEntry>, CoreError> {
+        Ok(vec![])
+    }
+    async fn create_entry(
+        &self,
+        content: String,
+        tags: Vec<String>,
+        _metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        Ok(KnowledgeEntry::new("kb-test", content, tags))
+    }
+    async fn update_entry(
+        &self,
+        _id: String,
+        content: String,
+        tags: Vec<String>,
+        _metadata: serde_json::Value,
+    ) -> Result<KnowledgeEntry, CoreError> {
+        Ok(KnowledgeEntry::new("kb-test", content, tags))
+    }
+    async fn delete_entry(&self, _id: String) -> Result<(), CoreError> {
+        Ok(())
+    }
+}
+
+struct StaticJwtAuth {
+    signing_key: String,
+}
+
+#[async_trait::async_trait]
+impl UdsAuthValidator for StaticJwtAuth {
+    async fn validate_bearer_token(&self, token: &str) -> bool {
+        jwt::decode(token, &self.signing_key, ISS, AUD).is_ok()
+    }
+}
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if path.exists() && UnixStream::connect(path).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("uds socket {path:?} did not appear");
+}
+
+fn uds_config(socket_path: PathBuf, jwt: String) -> ConnectionConfig {
+    ConnectionConfig {
+        transport_mode: TransportMode::Uds,
+        socket_path: Some(socket_path),
+        ws_jwt: Some(jwt),
+        ..ConnectionConfig::default()
+    }
+}
+
+/// Build the *real* `DefaultAssistantApiHandler` wired exactly like the daemon:
+/// a `BackgroundTaskRegistry` (so `start_send_message` takes the registry path)
+/// plus the client-tool coordinator (#234 — installed for every live turn).
+fn real_handler() -> Arc<dyn desktop_assistant_application::AssistantApiHandler> {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let coord = Arc::new(ClientToolCoordinator::new());
+    let store: Arc<dyn desktop_assistant_core::ports::store::TurnStateStore> =
+        Arc::new(InMemoryTurnStateStore::new());
+    let handler = DefaultAssistantApiHandler::new(
+        Arc::new(FakeAssistant),
+        Arc::new(StreamingConversations),
+        Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
+    )
+    .with_registry(registry)
+    .with_client_tool_coordinator(coord, store);
+    Arc::new(handler)
+}
+
+fn start_server(socket_path: PathBuf, signing_key: String) -> tokio::sync::oneshot::Sender<()> {
+    let handler = real_handler();
+    let auth: Arc<dyn UdsAuthValidator> = Arc::new(StaticJwtAuth { signing_key });
+    let config = UdsServerConfig::new(socket_path);
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server = UdsServer::new(handler, auth, config);
+    tokio::spawn(async move {
+        let _ = server
+            .serve_with_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    tx
+}
+
+/// The real-path voice#49 assertion: a SendMessage carrying an idempotency key
+/// (the voice client's exact behaviour) driven through the REAL handler must
+/// stream Status + Delta + Completed events back to the connecting UDS client,
+/// each correlated to the id `send_prompt` returned.
+#[tokio::test]
+async fn keyed_send_over_uds_streams_real_turn_events() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let shutdown = start_server(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    let connector = Connector::connect(&cfg).await.expect("connector over uds");
+
+    // Subscribe BEFORE sending (the voice pipeline's ordering).
+    let mut events = connector.subscribe();
+
+    // Send WITH an idempotency key — this is what voice's
+    // `send_prompt_with_system_refinement` does on every turn, and it routes
+    // the real handler through the keyed in-flight/TeeSink branch that #218's
+    // hand-emitting stub never touched.
+    let returned_id = timeout(
+        Duration::from_secs(5),
+        connector.send_prompt_with_system_refinement_idempotent(
+            "conv-1",
+            "hi",
+            "",
+            Some(uuid::Uuid::new_v4().to_string()),
+        ),
+    )
+    .await
+    .expect("send should ack within the window")
+    .expect("ack ok");
+    assert!(
+        !returned_id.is_empty(),
+        "send must return the turn request_id"
+    );
+
+    let mut chunks = String::new();
+    let mut got_status = false;
+    let mut got_complete = false;
+    for _ in 0..20 {
+        match timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Some(SignalEvent::Status { request_id, .. })) if request_id == returned_id => {
+                got_status = true;
+            }
+            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
+                chunks.push_str(&chunk);
+            }
+            Ok(Some(SignalEvent::Complete {
+                request_id,
+                full_response,
+            })) if request_id == returned_id => {
+                assert_eq!(full_response, "hello");
+                got_complete = true;
+                break;
+            }
+            // An event correlated to a DIFFERENT id would be dropped by the
+            // real client's filter — that is precisely the bug (zero events
+            // reaching voice) we are guarding against.
+            Ok(Some(SignalEvent::Disconnected { reason })) => {
+                panic!("connection dropped before completion: {reason}")
+            }
+            Ok(Some(_other)) => {}
+            Ok(None) => panic!("signal stream closed before completion"),
+            Err(_) => panic!(
+                "timed out waiting for a correlated response event \
+                 (got status={got_status}, chunks so far={chunks:?})"
+            ),
+        }
+    }
+
+    assert!(
+        got_status,
+        "the turn's AssistantStatus must reach the UDS client"
+    );
+    assert_eq!(
+        chunks, "hello",
+        "the streamed chunks must reach the UDS client"
+    );
+    assert!(
+        got_complete,
+        "the AssistantCompleted must reach the UDS client"
+    );
+
+    let _ = shutdown.send(());
+}
+
+/// The reopened-voice#49 root cause: a Connector that sits IDLE past its
+/// event-stall window — exactly what a voice service does between connecting at
+/// startup and the first "Hey Adele" — must still deliver a turn's events.
+///
+/// Before the fix, the fan-out task tripped the stall on an idle-but-healthy
+/// connection and EXITED permanently (UDS has no keepalive to reset the clock,
+/// unlike WS), so the subscriber registered for the first turn was attached to a
+/// dead pump and received ZERO events. The send still acked (the command
+/// channel is independent), the turn completed server-side — but the response
+/// stream never reached the client. This drives that exact sequence: connect,
+/// stay idle past the stall window, THEN subscribe + send a real turn.
+#[tokio::test]
+async fn idle_past_stall_then_turn_still_streams_events() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let shutdown = start_server(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
+    // A short stall window so the test doesn't wait the production 90s. The
+    // connection is healthy and open the whole time — just idle (no turn yet).
+    let stall = Duration::from_millis(150);
+    let connector = Connector::connect_with_stall_timeout(&cfg, stall)
+        .await
+        .expect("connector over uds");
+
+    // Sit idle WELL past the stall window, no subscribers, no events — the
+    // between-connect-and-first-turn gap a voice service always has.
+    tokio::time::sleep(stall * 4).await;
+
+    // Now the first turn arrives. Subscribe, then send (voice's ordering).
+    let mut events = connector.subscribe();
+    let returned_id = timeout(
+        Duration::from_secs(5),
+        connector.send_prompt_with_system_refinement_idempotent(
+            "conv-1",
+            "hi",
+            "",
+            Some(uuid::Uuid::new_v4().to_string()),
+        ),
+    )
+    .await
+    .expect("send should ack after an idle period")
+    .expect("ack ok");
+
+    let mut chunks = String::new();
+    let mut got_complete = false;
+    for _ in 0..20 {
+        match timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
+                chunks.push_str(&chunk);
+            }
+            Ok(Some(SignalEvent::Complete {
+                request_id,
+                full_response,
+            })) if request_id == returned_id => {
+                assert_eq!(full_response, "hello");
+                got_complete = true;
+                break;
+            }
+            Ok(Some(SignalEvent::Disconnected { reason })) => {
+                panic!(
+                    "fan-out died on an idle-but-healthy connection and tore down \
+                     the first turn's stream (reopened voice#49): {reason}"
+                )
+            }
+            Ok(Some(_other)) => {}
+            Ok(None) => panic!("signal stream closed before completion"),
+            Err(_) => panic!(
+                "timed out waiting for the turn's events after an idle period \
+                 — the fan-out stalled out the healthy connection (chunks={chunks:?})"
+            ),
+        }
+    }
+
+    assert_eq!(
+        chunks, "hello",
+        "a turn after an idle period must still stream its chunks"
+    );
+    assert!(
+        got_complete,
+        "a turn after an idle period must still complete"
+    );
+
+    let _ = shutdown.send(());
+}


### PR DESCRIPTION
Fixes adelie-ai/voice#49 (reopened)

## Problem
With `[assistant] transport = "uds"` (the Connector default since voice#37) a voice turn **sends** fine and the orchestrator **completes** it (reply saved, shown in the KDE/GTK D-Bus clients), but the voice client receives **ZERO response events** and its no-progress heartbeat fires → apology. #218 fixed the ack/event `request_id` correlation and passes its unit test, but the live path was still broken by a **second bug** its test never exercised.

## Root cause
The event-stall detection added in #221/#228 tears the Connector's signal fan-out task down **permanently** on *any* `stall_timeout` (90s) gap — including a **healthy-but-idle** connection.

The voice service connects its Connector at startup and then sits idle until the first "Hey Adele". UDS has **no keepalive** (WS does, via Ping/Pong — which is why WS wasn't hit), so that idle gap always exceeds 90s:

1. The fan-out trips the stall, emits `Disconnected` to its (empty) subscriber list, and **`break`s out of its loop → the task exits**.
2. The underlying UDS socket stays open, but nothing reads `signal_rx` anymore.
3. The first turn arrives: `subscribe()` registers a receiver on a **dead pump**, `send_prompt` acks (the command channel is an independent `oneshot`), the turn streams events into `signal_rx` — and they're never read.
4. The client gets nothing → its response-stall apology fires.

This exactly matches the live evidence: send works, the turn completes, the D-Bus clients (no Connector fan-out) show the reply, and only the UDS Connector client gets nothing.

`crates/client-common/src/connector.rs` `spawn_fanout_with_stall_timeout` — the old loop `break`s out (terminal) on `Err(_elapsed)`.

### Why #218's test missed it
`tests/uds_streaming.rs` subscribes and sends **immediately** after connecting, so it never leaves the connection idle past the stall window — the only condition that triggers the teardown.

## Fix
Treat a stall as a **per-turn** signal, not a connection teardown:

- The stall clock only runs **while a subscriber is attached** (a turn may be in flight). With no subscribers the connection is idle, not wedged — wait unbounded, never stalling out a healthy link with no traffic yet.
- On a stall **with** subscribers, still emit a terminal `Disconnected` to the *current* subscribers (so a client waiting on a genuinely wedged turn is unstuck — #221's intent) but **keep the pump reading**, so the next turn streams.
- Only a **closed** upstream (`recv()` → `None`) terminates the task.

## Tests
- **`crates/client-common/tests/uds_real_turn.rs` (new)** drives the **real path** — the actual `UdsServer` + the real `DefaultAssistantApiHandler` (registry + client-tool coordinator, wired like the daemon) + a **keyed** `SendMessage` (voice's exact behaviour) through `run_send_turn`:
  - `keyed_send_over_uds_streams_real_turn_events` — Status + Delta + Completed all reach the UDS client, correlated to the returned id. Closes the real-path gap #218's hand-emitting stub had.
  - `idle_past_stall_then_turn_still_streams_events` — connect, sit idle **past** the stall window, then subscribe + send: events must still stream. **Reproduces the live bug** (fails before the fix).
- **`connector.rs` unit tests** — idle-without-subscribers must not stall out; a stall unsticks waiters but keeps serving later turns. Existing #221 stall tests still green.

## Validation
`just check` green: fmt + clippy `--workspace --all-targets -D warnings` + build + full workspace test (77 binaries, 0 failures). No warnings.

## Live verification PENDING
Can't drive a real "Hey Adele" over UDS here. This is client-side (`client-common`), so voice picks it up via its path-dep with no voice code change. **To verify:** rebuild + restart `adele-voice`, leave the daemon idle for >90s, then run a real voice turn on `transport = "uds"` and confirm the reply now streams (previously it apologized with no events). The daemon does NOT need reinstalling — the change is entirely client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)