### PR TITLE
feat(#213): D-Bus transport — implement the AssistantCommands command channel

### DIFF
--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use desktop_assistant_api_model as api;
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use zbus::Connection;
 
+use crate::commands::AssistantCommands;
 use crate::signal::SignalEvent;
 use crate::types::{ChatMessage, ConversationDetail, ConversationSummary};
 
@@ -45,6 +47,7 @@ const DEFAULT_DBUS_SERVICE: &str = "org.desktopAssistant";
 const DBUS_CONVERSATIONS_PATH: &str = "/org/desktopAssistant/Conversations";
 const DBUS_SETTINGS_PATH: &str = "/org/desktopAssistant/Settings";
 const DBUS_KNOWLEDGE_PATH: &str = "/org/desktopAssistant/Knowledge";
+const DBUS_COMMANDS_PATH: &str = "/org/desktopAssistant/Commands";
 
 /// Wire shape of a `list_conversations` row: `(id, title, message_count,
 /// updated_at, archived)` — mirrors the D-Bus `a(ssusb)` reply.
@@ -142,6 +145,15 @@ trait Knowledge {
     async fn delete_entry(&self, id: &str) -> zbus::fdo::Result<()>;
 }
 
+/// Generic command channel (#213). One method maps every request/response
+/// `api::Command` to its `api::CommandResult`, both passed as JSON strings —
+/// the D-Bus counterpart of the socket transports' `WsRequest`/`WsFrame`
+/// round-trip. This is what makes [`AssistantCommands`] reachable over D-Bus.
+#[zbus::proxy(interface = "org.desktopAssistant.Commands")]
+trait Commands {
+    async fn send_command(&self, command_json: &str) -> zbus::fdo::Result<String>;
+}
+
 fn resolve_dbus_service_name() -> String {
     std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
         .ok()
@@ -165,6 +177,7 @@ pub async fn generate_ws_jwt(subject: &str) -> Result<String> {
 pub struct DbusClient {
     proxy: ConversationsProxy<'static>,
     knowledge: KnowledgeProxy<'static>,
+    commands: CommandsProxy<'static>,
 }
 
 impl DbusClient {
@@ -177,11 +190,20 @@ impl DbusClient {
             .build()
             .await?;
         let knowledge = KnowledgeProxy::builder(&connection)
-            .destination(service_name)?
+            .destination(service_name.clone())?
             .path(DBUS_KNOWLEDGE_PATH)?
             .build()
             .await?;
-        Ok(Self { proxy, knowledge })
+        let commands = CommandsProxy::builder(&connection)
+            .destination(service_name)?
+            .path(DBUS_COMMANDS_PATH)?
+            .build()
+            .await?;
+        Ok(Self {
+            proxy,
+            knowledge,
+            commands,
+        })
     }
 
     pub async fn list_conversations(&self) -> Result<Vec<ConversationSummary>> {
@@ -380,5 +402,33 @@ impl DbusClient {
         });
 
         Ok(rx)
+    }
+}
+
+/// Generic command channel over D-Bus (#213).
+///
+/// `DbusClient` now implements the shared [`AssistantCommands`] trait by
+/// round-tripping each `api::Command` as a JSON string through the
+/// `org.desktopAssistant.Commands.SendCommand` method (the D-Bus counterpart
+/// of the WS/UDS `WsRequest`/`WsFrame` exchange). This is what lets
+/// [`crate::transport::TransportClient::as_commands`] return `Some` for the
+/// D-Bus transport, so the config Settings / model-override / purposes /
+/// named-connection management surface is reachable over D-Bus too.
+///
+/// The inherent typed methods above (`list_conversations`, the streaming
+/// `send_prompt`, the knowledge helpers) are retained: they win at the
+/// `AssistantClient` call sites (inherent methods shadow trait methods on a
+/// concrete `DbusClient`), while `&dyn AssistantCommands` callers reach this
+/// trait impl. The streaming `send_prompt` in particular keeps using the typed
+/// `Conversations.SendPrompt` path with its `ResponseChunk` signals — only the
+/// trait's `send_command` routes through the generic channel.
+#[async_trait]
+impl AssistantCommands for DbusClient {
+    async fn send_command(&self, command: api::Command) -> Result<api::CommandResult> {
+        let command_json = serde_json::to_string(&command)
+            .map_err(|e| anyhow::anyhow!("encoding command for D-Bus: {e}"))?;
+        let raw = self.commands.send_command(&command_json).await?;
+        serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("decoding D-Bus command result: {e}"))
     }
 }

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -61,33 +61,23 @@ pub enum TransportClient {
 }
 
 impl TransportClient {
-    /// Access the underlying WebSocket client when the transport is WS, so
-    /// callers can issue commands that aren't exposed on the shared
-    /// `AssistantClient` trait (e.g. named-connection management).
-    pub fn as_ws(&self) -> Option<&WsClient> {
-        match self {
-            #[cfg(feature = "dbus")]
-            Self::Dbus(_) => None,
-            Self::Ws(client) => Some(client),
-            Self::Uds(_) => None,
-        }
-    }
-
     /// Access the transport-agnostic command channel, so callers can issue
     /// commands that aren't exposed on the high-level [`AssistantClient`]
-    /// facade (config Settings, per-conversation model override, background
-    /// tasks) over *any* socket transport — WebSocket or local UDS.
+    /// facade (config Settings, per-conversation model override / model
+    /// selection, background tasks, purposes, named-connection management)
+    /// over *any* transport.
     ///
-    /// Returns `Some` for the `Ws` and `Uds` variants, which both speak the
-    /// shared `WsRequest`/`WsFrame` protocol via [`AssistantCommands`], and
-    /// `None` for `Dbus`, which talks a separate typed zbus interface and so
-    /// does not implement that trait. This supersedes [`as_ws`](Self::as_ws)
-    /// for command-channel access (adele-gtk#49); `as_ws` is retained until
-    /// downstream callers migrate.
+    /// Returns `Some` for **all three** transports (#213): `Ws` and `Uds`
+    /// speak the shared `WsRequest`/`WsFrame` protocol, and `Dbus` round-trips
+    /// the same `api::Command`/`api::CommandResult` as JSON over the
+    /// `org.desktopAssistant.Commands` interface — all via the single
+    /// [`AssistantCommands`] trait. This replaced the WS-only `as_ws`
+    /// accessor (adele-gtk#49 / #213): there is no longer any
+    /// connector-specific command surface.
     pub fn as_commands(&self) -> Option<&(dyn AssistantCommands + '_)> {
         match self {
             #[cfg(feature = "dbus")]
-            Self::Dbus(_) => None,
+            Self::Dbus(client) => Some(client),
             Self::Ws(client) => Some(client),
             Self::Uds(client) => Some(client),
         }

--- a/crates/client-common/tests/transport_command_channel.rs
+++ b/crates/client-common/tests/transport_command_channel.rs
@@ -1,8 +1,8 @@
-//! adele-gtk#49: the generic command channel must be reachable on every
-//! socket transport, so `TransportClient::as_commands` yields a
-//! `&dyn AssistantCommands` for the WebSocket *and* Unix-domain-socket
-//! variants and `None` for D-Bus (which speaks a separate typed zbus
-//! interface).
+//! adele-gtk#49 / #213: the generic command channel must be reachable on
+//! *every* transport, so `TransportClient::as_commands` yields a
+//! `&dyn AssistantCommands` for the WebSocket, Unix-domain-socket *and* D-Bus
+//! variants — there is no longer any connector-specific command surface and
+//! the WS-only `as_ws` accessor has been retired.
 //!
 //! The `Uds` arm and the round-trip of the two promoted command methods over
 //! UDS are exercised in `uds_transport.rs` against the real UDS server. This
@@ -52,22 +52,22 @@ async fn as_commands_returns_some_for_ws_transport() {
         transport.as_commands().is_some(),
         "as_commands must be Some for a WebSocket transport"
     );
-    // `as_ws` is retained alongside `as_commands` for now.
-    assert!(transport.as_ws().is_some());
 }
 
-/// The D-Bus transport speaks a separate typed zbus interface and does not
-/// implement `AssistantCommands`, so `as_commands` must be `None` for it.
+/// #213: the D-Bus transport now implements `AssistantCommands` (round-tripping
+/// `api::Command`/`api::CommandResult` as JSON over `org.desktopAssistant.
+/// Commands`), so `as_commands` must be `Some` for it too — no transport is
+/// left without the management command channel.
 ///
 /// zbus proxies build lazily, so `DbusClient::connect` succeeds against the
 /// session bus without the daemon's service being present. If no session bus
 /// is reachable at all (some CI sandboxes), the capability mapping is still
-/// guaranteed by the type system — the `Dbus` match arm cannot return
-/// `Some(client)` because `DbusClient: !AssistantCommands` — so we skip rather
+/// guaranteed by the type system — the `Dbus` match arm returns
+/// `Some(client)` because `DbusClient: AssistantCommands` — so we skip rather
 /// than fail.
 #[cfg(feature = "dbus")]
 #[tokio::test]
-async fn as_commands_returns_none_for_dbus_transport() {
+async fn as_commands_returns_some_for_dbus_transport() {
     let client = match desktop_assistant_client_common::dbus_client::DbusClient::connect().await {
         Ok(client) => client,
         Err(e) => {
@@ -78,8 +78,7 @@ async fn as_commands_returns_none_for_dbus_transport() {
 
     let transport = TransportClient::Dbus(client);
     assert!(
-        transport.as_commands().is_none(),
-        "as_commands must be None for a D-Bus transport"
+        transport.as_commands().is_some(),
+        "as_commands must be Some for a D-Bus transport (#213)"
     );
-    assert!(transport.as_ws().is_none());
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1876,6 +1876,18 @@ async fn main() -> Result<()> {
                 )
             })
             .and_then(|b| {
+                // Generic command channel (#213): the shared `AssistantCommands`
+                // surface over D-Bus, dispatching through the same handler the
+                // socket transports use, so `TransportClient::as_commands` works
+                // on every transport.
+                b.serve_at(
+                    "/org/desktopAssistant/Commands",
+                    desktop_assistant_dbus::commands::DbusCommandsAdapter::new(Arc::clone(
+                        &api_handler,
+                    )),
+                )
+            })
+            .and_then(|b| {
                 // Hot-reload trigger (#222): the KCM calls `Reload` after
                 // writing daemon.toml so changes apply without a restart.
                 b.serve_at(

--- a/crates/dbus-interface/src/commands.rs
+++ b/crates/dbus-interface/src/commands.rs
@@ -1,0 +1,372 @@
+//! Generic D-Bus command channel (#213).
+//!
+//! The shared [`AssistantCommands`] command channel (config Settings, the
+//! per-conversation model override / model selection, background tasks,
+//! purposes, named-connection management) funnels every typed method through
+//! one `send_command(api::Command) -> api::CommandResult` call. The WebSocket
+//! and Unix-domain-socket transports implement that by sending a `WsRequest`
+//! and awaiting the correlated `WsFrame`. This adapter gives the **D-Bus**
+//! transport the same single entry point so `TransportClient::as_commands`
+//! returns `Some` for every transport rather than dropping the management
+//! surface on D-Bus.
+//!
+//! Like the [`crate::connections`] and [`crate::knowledge`] adapters, the
+//! `api::CommandResult` is passed back as a JSON string (`busctl` shows
+//! `s`); the client re-parses it with `serde_json`. The single method maps
+//! every request/response `api::Command` 1:1, so there is no per-command
+//! marshaling to teach zbus about — the command JSON in, the result JSON out.
+//!
+//! ## Hot-reload parity (`SetConfig`)
+//!
+//! `SetConfig` is **not** special-cased here. The daemon's hot-reload of a
+//! config change happens *inside* `handle_command(SetConfig)` — the settings
+//! service writes the new value to the config file and refreshes the daemon's
+//! in-memory config (see `DaemonSettingsService::set_*` /
+//! `RegistryHandle::set_personality`), so the next turn reads the new value
+//! with no restart. The `Event::ConfigChanged` the socket dispatch loop emits
+//! after `SetConfig` is a *client notification only* — there is no
+//! server-side consumer of it (verified: no `ConfigChanged` handler exists in
+//! the daemon/application/core crates). So routing `SetConfig` through
+//! `handle_command` here hot-applies exactly as WS/UDS do; D-Bus clients that
+//! want a change notification subscribe to the existing
+//! `org.desktopAssistant.Settings.ConfigChanged` signal (emitted by the
+//! granular `Settings.SetConfig` path the KCM already uses).
+//!
+//! ## Background-task subscription limitation
+//!
+//! `SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks` set up a
+//! *streaming* subscription that pushes `Event::Task*` frames back over the
+//! persistent socket for the lifetime of the connection. That cannot be
+//! represented as a single request/response D-Bus method, so this adapter
+//! rejects both with a clear error rather than pretending to succeed. The
+//! in-process daemon's D-Bus interface does not expose background-task events
+//! as signals (only the out-of-process `dbus-bridge` does, by holding a socket
+//! `SubscribeBackgroundTasks` open itself); a D-Bus client that needs the
+//! live stream should use a socket transport (WS/UDS).
+
+use std::sync::Arc;
+
+use desktop_assistant_api_model::{self as api};
+use desktop_assistant_application::{AssistantApiHandler, RequestContext};
+use zbus::{fdo, interface};
+
+use crate::resolve_dbus_user_id;
+
+fn to_fdo_error<E: std::fmt::Display>(error: E) -> fdo::Error {
+    fdo::Error::Failed(error.to_string())
+}
+
+/// D-Bus adapter exposing the shared command channel over the session bus.
+///
+/// Wraps the same `Arc<dyn AssistantApiHandler>` the socket transports'
+/// dispatch loop holds, so the trust model and per-user scoping are identical
+/// across transports (#156).
+pub struct DbusCommandsAdapter {
+    handler: Arc<dyn AssistantApiHandler>,
+}
+
+impl DbusCommandsAdapter {
+    pub fn new(handler: Arc<dyn AssistantApiHandler>) -> Self {
+        Self { handler }
+    }
+}
+
+#[interface(name = "org.desktopAssistant.Commands")]
+impl DbusCommandsAdapter {
+    /// Run one request/response `api::Command` and return its
+    /// `api::CommandResult` as a JSON string.
+    ///
+    /// `command_json` is a serialized [`api::Command`]; the reply is a
+    /// serialized [`api::CommandResult`]. This is the D-Bus implementation of
+    /// the shared [`AssistantCommands::send_command`] entry point, so it
+    /// covers config Settings, the per-conversation model override, purposes,
+    /// named-connection management, knowledge, scratchpad, and the rest of the
+    /// management surface in one method.
+    ///
+    /// `SetConfig` hot-applies via the handler exactly as the socket
+    /// transports do (see module docs). The two streaming background-task
+    /// subscription commands are rejected — they need a persistent push
+    /// channel a single D-Bus method can't provide.
+    async fn send_command(&self, command_json: &str) -> fdo::Result<String> {
+        let command: api::Command = serde_json::from_str(command_json)
+            .map_err(|e| fdo::Error::InvalidArgs(format!("invalid command JSON: {e}")))?;
+
+        // Reject the streaming-subscription commands up front: they cannot be
+        // a single request/response (#213). The socket transports drive these
+        // via the dispatch loop's per-connection forwarder over the persistent
+        // socket; there is no equivalent over a one-shot D-Bus method, and the
+        // in-process D-Bus interface does not surface Task* events as signals.
+        if matches!(
+            command,
+            api::Command::SubscribeBackgroundTasks | api::Command::UnsubscribeBackgroundTasks
+        ) {
+            return Err(fdo::Error::NotSupported(
+                "background-task streaming is not available over the generic D-Bus command \
+                 channel (a single request/response method cannot push events); use a socket \
+                 transport (WS/UDS) and Command::SubscribeBackgroundTasks for the live stream"
+                    .to_string(),
+            ));
+        }
+
+        // #156: install the per-user scope at the D-Bus dispatch boundary so
+        // the handler (and the storage queries it composes) see the local OS
+        // user instead of the `"default"` sentinel. `handle_command_for` is the
+        // context-aware entry point the WS/UDS adapters already use; routing
+        // through it keeps the auth wiring identical across transports. For
+        // `SetConfig` this is the same call the socket dispatch loop makes, so
+        // the in-daemon config hot-reload happens here too (see module docs).
+        let ctx = RequestContext::for_user(resolve_dbus_user_id());
+        let result = self
+            .handler
+            .handle_command_for(ctx, command)
+            .await
+            .map_err(|e| fdo::Error::Failed(format!("{e:?}")))?;
+
+        serde_json::to_string(&result).map_err(to_fdo_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_application::{ApiError, ApiResult, EventSink};
+    use desktop_assistant_core::ports::auth::current_user_id;
+    use std::sync::Mutex;
+
+    /// Records every `Command` it sees (with the resolved user id at the call
+    /// site) and replies with a canned `CommandResult`. An optional error
+    /// forces the handler to fail so we can assert error propagation.
+    struct RecordingHandler {
+        seen: Mutex<Vec<(api::Command, String)>>,
+        reply: api::CommandResult,
+        fail_with: Option<String>,
+    }
+
+    impl RecordingHandler {
+        fn new(reply: api::CommandResult) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply,
+                fail_with: None,
+            })
+        }
+
+        fn failing(message: &str) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply: api::CommandResult::Ack,
+                fail_with: Some(message.to_string()),
+            })
+        }
+
+        fn last(&self) -> (api::Command, String) {
+            self.seen
+                .lock()
+                .unwrap()
+                .last()
+                .cloned()
+                .expect("no command")
+        }
+
+        fn count(&self) -> usize {
+            self.seen.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AssistantApiHandler for RecordingHandler {
+        async fn handle_command(&self, cmd: api::Command) -> ApiResult<api::CommandResult> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push((cmd, current_user_id().as_str().to_string()));
+            if let Some(message) = &self.fail_with {
+                return Err(ApiError::Core(message.clone()));
+            }
+            Ok(self.reply.clone())
+        }
+
+        async fn handle_send_message(
+            &self,
+            _conversation_id: String,
+            _content: String,
+            _request_id: String,
+            _sink: Arc<dyn EventSink>,
+        ) -> ApiResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn send_command_round_trips_request_and_response_json() {
+        // A representative request/response command (ListConversations)
+        // must reach the handler verbatim and its CommandResult must come
+        // back as the JSON-string envelope the client deserializes.
+        let reply = api::CommandResult::Conversations(vec![api::ConversationSummary {
+            id: "c1".into(),
+            title: "hello".into(),
+            message_count: 3,
+            updated_at: "2026-06-07T00:00:00Z".into(),
+            archived: false,
+        }]);
+        let handler = RecordingHandler::new(reply.clone());
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let request = serde_json::to_string(&api::Command::ListConversations {
+            max_age_days: None,
+            include_archived: false,
+        })
+        .unwrap();
+
+        let raw = adapter.send_command(&request).await.unwrap();
+        let decoded: api::CommandResult = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded, reply);
+
+        let (seen_cmd, _user) = handler.last();
+        assert!(matches!(
+            seen_cmd,
+            api::Command::ListConversations {
+                include_archived: false,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_command_routes_set_config_through_handler_for_hot_reload() {
+        // SetConfig must reach the handler (where the in-daemon hot-reload
+        // happens — the settings service writes the file and refreshes the
+        // in-memory config) rather than being dropped or special-cased away.
+        // The canned reply is `Config`, returned via the JSON envelope.
+        let reply = api::CommandResult::Config(api::Config {
+            embeddings: api::EmbeddingsSettingsView {
+                connector: "openai".into(),
+                model: "text-embedding-3-small".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                has_api_key: false,
+                available: true,
+                is_default: true,
+            },
+            persistence: api::PersistenceSettingsView {
+                enabled: false,
+                remote_url: String::new(),
+                remote_name: "origin".into(),
+                push_on_update: true,
+            },
+            personality: api::PersonalitySettingsView::default(),
+        });
+        let handler = RecordingHandler::new(reply.clone());
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let request = serde_json::to_string(&api::Command::SetConfig {
+            changes: api::ConfigChanges::default(),
+        })
+        .unwrap();
+
+        let raw = adapter.send_command(&request).await.unwrap();
+        let decoded: api::CommandResult = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded, reply);
+
+        let (seen_cmd, _user) = handler.last();
+        assert!(
+            matches!(seen_cmd, api::Command::SetConfig { .. }),
+            "SetConfig must be dispatched through the handler so the config hot-reload runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_command_installs_resolved_user_id_scope() {
+        // #156: the handler (and downstream storage) must see the resolved
+        // local OS user, not the "default" sentinel.
+        let handler = RecordingHandler::new(api::CommandResult::Ack);
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let _guard = crate::testing::UserEnvGuard::set("alice-cmd");
+
+        let request =
+            serde_json::to_string(&api::Command::DeleteConversation { id: "c1".into() }).unwrap();
+        adapter.send_command(&request).await.unwrap();
+
+        let (_cmd, user) = handler.last();
+        assert_eq!(
+            user, "alice-cmd",
+            "send_command must install the resolved user id before dispatching"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_command_rejects_subscribe_background_tasks() {
+        let handler = RecordingHandler::new(api::CommandResult::Ack);
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let request = serde_json::to_string(&api::Command::SubscribeBackgroundTasks).unwrap();
+        let err = adapter
+            .send_command(&request)
+            .await
+            .expect_err("subscribe must be rejected over the generic D-Bus channel");
+
+        assert!(
+            matches!(err, fdo::Error::NotSupported(_)),
+            "expected NotSupported, got {err:?}"
+        );
+        assert!(
+            format!("{err}").contains("background-task streaming"),
+            "error must explain the streaming limitation: {err}"
+        );
+        assert_eq!(
+            handler.count(),
+            0,
+            "a rejected subscription must never reach the handler"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_command_rejects_unsubscribe_background_tasks() {
+        let handler = RecordingHandler::new(api::CommandResult::Ack);
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let request = serde_json::to_string(&api::Command::UnsubscribeBackgroundTasks).unwrap();
+        let err = adapter
+            .send_command(&request)
+            .await
+            .expect_err("unsubscribe must be rejected over the generic D-Bus channel");
+
+        assert!(matches!(err, fdo::Error::NotSupported(_)));
+        assert_eq!(handler.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn send_command_propagates_handler_error_as_fdo_error() {
+        let handler = RecordingHandler::failing("boom: connection refused");
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let request = serde_json::to_string(&api::Command::Ping).unwrap();
+        let err = adapter
+            .send_command(&request)
+            .await
+            .expect_err("a handler error must surface as an fdo error");
+
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert!(
+            format!("{err}").contains("boom: connection refused"),
+            "the daemon's error message must be preserved: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_command_rejects_malformed_json() {
+        let handler = RecordingHandler::new(api::CommandResult::Ack);
+        let adapter = DbusCommandsAdapter::new(handler.clone() as Arc<dyn AssistantApiHandler>);
+
+        let err = adapter
+            .send_command("{not valid json")
+            .await
+            .expect_err("malformed command JSON must be rejected");
+
+        assert!(
+            matches!(err, fdo::Error::InvalidArgs(_)),
+            "expected InvalidArgs, got {err:?}"
+        );
+        assert_eq!(handler.count(), 0);
+    }
+}

--- a/crates/dbus-interface/src/lib.rs
+++ b/crates/dbus-interface/src/lib.rs
@@ -1,5 +1,6 @@
 //! D-Bus interface adapters exposing the assistant API over the session bus.
 
+pub mod commands;
 pub mod connections;
 pub mod conversation;
 pub mod knowledge;


### PR DESCRIPTION
Closes #213

## Problem
`TransportClient::as_commands()` returned `None` for the **D-Bus** variant because `DbusClient` did not implement the shared `AssistantCommands` management command channel (config Settings, per-conversation model override / model selection, purposes, named-connection management, knowledge, scratchpad). WS and UDS already implemented it, so those management features were dead over D-Bus in every client. After this PR `as_commands()` returns `Some` for **all three** transports — there is no connector-specific command surface — and the WS-only `as_ws()` accessor is retired.

## Daemon side
- **New interface `org.desktopAssistant.Commands` at `/org/desktopAssistant/Commands`** (`crates/dbus-interface/src/commands.rs`), registered in `crates/daemon/src/main.rs` next to the existing object-server registrations using the same `Arc<dyn AssistantApiHandler>` the socket dispatch loop holds.
- Single method: **`SendCommand(command_json: &str) -> fdo::Result<String>`** — deserialize `api::Command`, dispatch via `handle_command_for(RequestContext::for_user(resolve_dbus_user_id()), cmd)`, return the `api::CommandResult` as a JSON string. Mirrors the existing Connections/Knowledge JSON-string-over-D-Bus pattern exactly.

### `SetConfig` hot-reload parity
`SetConfig` is **not** special-cased. The mechanism reused: the in-daemon hot-reload already happens **inside `handle_command(SetConfig)`** — `set_config` writes through the settings service, which persists to the config file **and refreshes the daemon's in-memory config** (e.g. `RegistryHandle::set_personality`, documented as "refreshes the in-memory config so the next send's task-local reflects the change (hot reload)"). I verified there is **no server-side consumer** of `api::Event::ConfigChanged` anywhere in the daemon/application/core crates — that event is a *client notification only*. So routing `SetConfig` through `handle_command` here hot-applies identically to WS/UDS. D-Bus clients that want a change notification use the existing `org.desktopAssistant.Settings.ConfigChanged` signal (the granular path the KCM already uses).

### Background-task subscription limitation
`SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks` set up a *streaming* subscription that pushes `Event::Task*` frames over the persistent socket for the connection's lifetime — that cannot be a single request/response D-Bus method. `SendCommand` rejects both with a clear `fdo::Error::NotSupported` ("background-task streaming is not available over the generic D-Bus command channel … use a socket transport (WS/UDS)"). The in-process daemon D-Bus interface exposes no Task* signals (only the out-of-process `dbus-bridge` does, by holding a socket subscription itself), so this is referenced in the error and documented in a module comment.

## Client side
- `DbusClient` gains a `Commands` zbus proxy (built in `connect`, stored on the struct) and implements `AssistantCommands` by round-tripping `api::Command`/`api::CommandResult` as JSON. The inherent typed methods (`list_conversations`, the streaming `send_prompt` with its `ResponseChunk` signals, the knowledge helpers) are retained — inherent methods win at the `AssistantClient` call sites while `&dyn AssistantCommands` callers reach the trait impl.
- `TransportClient::as_commands()` returns `Some` for the `Dbus` arm; doc comment updated.

## `as_ws()` retirement
Grepped the whole workspace for `as_ws`: only **test/doc references** (no production callers). Removed the method and migrated the test to assert `as_commands` is `Some` for all three transports. (tui/gtk are separate repos already on `as_commands`; voice uses the Connector — none touched here.)

## Tests
`crates/dbus-interface/src/commands.rs` (in-process, recording-fake `AssistantApiHandler`, no live bus needed):
- `send_command_round_trips_request_and_response_json`
- `send_command_routes_set_config_through_handler_for_hot_reload`
- `send_command_installs_resolved_user_id_scope`
- `send_command_rejects_subscribe_background_tasks`
- `send_command_rejects_unsubscribe_background_tasks`
- `send_command_propagates_handler_error_as_fdo_error`
- `send_command_rejects_malformed_json`

`crates/client-common/tests/transport_command_channel.rs` updated: `as_commands_returns_some_for_dbus_transport` (was `_none_`), `as_ws` assertions removed.

`just check` (fmt + clippy `-D warnings` + build + workspace tests) is **green**; the pre-push hook ran it to completion (no ollama hang this run) so no `--no-verify` was needed.

## Security
Adversarial diff read: the generic `SendCommand` lets any session-bus peer invoke `handle_command` with an arbitrary `api::Command` — but this is **no broader** than the existing surface. The Settings/Connections/Knowledge adapters already route to the **same handler** with the **same `resolve_dbus_user_id()` trust model** (local session bus, single-tenant — see the trust-boundary note in `dbus-interface/src/lib.rs`), already exposing `SetApiKey`, `SetPurpose`, `CreateConnection`, all config setters, etc. Write-only `SetApiKey` stays write-only (its result is `Ack`, never the key). The streaming subscription commands are refused. No new auth was added (out of scope) and no escalation was found.

## Follow-ups / caveats
- The D-Bus `as_commands_returns_some_for_dbus_transport` test exercised against a live session bus locally; in a bus-less CI sandbox it skips (proxies build lazily), with the capability still type-guaranteed.
- Multi-tenant peer-credential auth (SO_PEERCRED) remains the pre-existing follow-up noted in `dbus-interface/src/lib.rs`, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)