### PR TITLE
feat(#240): scratchpad as a planning + context-compaction notepad

### DIFF
--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -190,7 +190,7 @@ pub(crate) fn overflow_truncation_notice(
 // outer wrapper threads the same set plus the budget pair. Bundling them
 // just to satisfy the lint would obscure the code at every call site.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn llm_messages_for_turn(
+pub(crate) fn llm_messages_for_turn_with_plan(
     conversation_messages: &[Message],
     summaries: &[MessageSummary],
     tool_defs: &[ToolDefinition],
@@ -198,6 +198,7 @@ pub(crate) fn llm_messages_for_turn(
     context_summary: &str,
     max_messages: usize,
     active_task: Option<&str>,
+    plan: Option<&str>,
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
@@ -213,6 +214,7 @@ pub(crate) fn llm_messages_for_turn(
         context_summary,
         current_max,
         active_task,
+        plan,
         tool_rounds_since_anchor,
         system_refinement,
         budget,
@@ -260,6 +262,7 @@ pub(crate) fn llm_messages_for_turn(
             context_summary,
             current_max,
             active_task,
+            plan,
             tool_rounds_since_anchor,
             system_refinement,
             Some(budget),
@@ -425,6 +428,43 @@ fn render_locality_list(entries: &[ToolLocalityEntry], co_located: bool) -> Stri
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Back-compat shim for [`llm_messages_for_turn_with_plan`] with no surfaced
+/// plan. The existing test suite exercises assembly through this plan-less
+/// form; production (the dispatch loop) calls the plan-aware entry directly
+/// (#240), so the shim is only compiled for tests.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn llm_messages_for_turn(
+    conversation_messages: &[Message],
+    summaries: &[MessageSummary],
+    tool_defs: &[ToolDefinition],
+    deferred_namespaces: &[ToolNamespace],
+    context_summary: &str,
+    max_messages: usize,
+    active_task: Option<&str>,
+    tool_rounds_since_anchor: u32,
+    system_refinement: &str,
+    budget: Option<ContextBudget>,
+    locality: Option<&ToolLocalityContext>,
+    estimate: &dyn Fn(&str) -> u64,
+) -> Vec<Message> {
+    llm_messages_for_turn_with_plan(
+        conversation_messages,
+        summaries,
+        tool_defs,
+        deferred_namespaces,
+        context_summary,
+        max_messages,
+        active_task,
+        None,
+        tool_rounds_since_anchor,
+        system_refinement,
+        budget,
+        locality,
+        estimate,
+    )
 }
 
 /// Build the full tool-availability note enumerating every tool name and
@@ -593,6 +633,7 @@ fn assemble_messages_inner(
     context_summary: &str,
     max_messages: usize,
     active_task: Option<&str>,
+    plan: Option<&str>,
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
@@ -691,6 +732,15 @@ fn assemble_messages_inner(
         if !anchor_visible || many_tool_rounds {
             messages.push(Message::new(Role::System, format!("[Current task] {task}")));
         }
+    }
+
+    // Surface the open plan (#240) right after the task anchor. The dispatch
+    // loop renders the conversation's `todo` notes into a compact tree each
+    // round, so the plan stays in view (cheap) while the verbose raw work that
+    // produced it is evicted from the message log. Request-scoped — never
+    // persisted to `conv.messages`.
+    if let Some(plan) = plan.filter(|p| !p.is_empty()) {
+        messages.push(Message::new(Role::System, format!("[Plan]\n{plan}")));
     }
 
     // Track which summaries have already been injected.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod chunking;
 pub mod context;
 pub mod domain;
 pub mod error_classify;
+pub mod planning;
 pub mod ports;
 pub mod prompts;
 pub mod sanitize;

--- a/crates/core/src/planning.rs
+++ b/crates/core/src/planning.rs
@@ -1,0 +1,668 @@
+//! Step-scoped planning and context compaction for long agentic turns (#240).
+//!
+//! The model works a non-trivial request the way a person with a scratchpad
+//! and pen would: break it into ordered steps, work each one, and — when a
+//! step turns out to need its own sub-plan — open nested sub-steps. As each
+//! step finishes, the *gist* of what was learned is jotted to the scratchpad
+//! and the verbose raw work (tool results) is **dropped from working
+//! context**, replaced by a short searchable pointer to the note. The plan
+//! itself stays cheaply in view; the firehose does not.
+//!
+//! This module is the pure mechanism behind that behaviour:
+//!
+//! - [`StepStack`] — a per-turn stack of [`StepFrame`]s. `begin` pushes a
+//!   frame and auto-assigns a dotted path from stack depth + a per-frame child
+//!   counter (step 1 → 1.1, 1.2, …; 1.2 → 1.2.1 … 1.2.6). `complete` pops it.
+//! - [`evict_tool_results`] — replaces the content of sizeable `Role::Tool`
+//!   messages in a scope with a pointer to the scratchpad note that distilled
+//!   them, **preserving role + `tool_call_id`** so provider ToolUse↔ToolResult
+//!   pairing stays valid (Bedrock/Ollama). Idempotent and structure-preserving.
+//! - [`render_plan`] — renders the open todos as a compact indented tree for
+//!   per-round surfacing.
+//! - [`begin_step_tool`] / [`complete_step_tool`] — the tool definitions the
+//!   dispatch loop advertises and intercepts (they are core-loop tools, not
+//!   MCP/builtin-executor tools, because only the loop owns `conv.messages`).
+//!
+//! The async orchestration (writing the todo/outcome notes through the wired
+//! scratchpad closures, then mutating `conv.messages`) lives in the service
+//! dispatch loop; everything here is synchronous and unit-tested in isolation.
+
+use crate::domain::{Message, Role, ToolDefinition};
+
+/// Tool the model calls to begin a (possibly nested) step. Advertised in the
+/// per-turn tool set and intercepted by name in the dispatch loop.
+pub const BEGIN_STEP_TOOL: &str = "begin_step";
+
+/// Tool the model calls to complete the current step — distil + evict.
+pub const COMPLETE_STEP_TOOL: &str = "complete_step";
+
+/// `note_type` used for plan steps so they sort/filter as ordered todos
+/// (matching the existing scratchpad `todo`/`sequence`/`done` convention).
+pub const STEP_NOTE_TYPE: &str = "todo";
+
+/// `note_type` used for the distilled carry-forward outcome of a step.
+pub const OUTCOME_NOTE_TYPE: &str = "note";
+
+/// Key prefix under which a step's distilled outcome note is stored
+/// (`outcome:<step-key>`). The plan renderer uses it to attach a step's finding
+/// to its todo and to decide when a finding has been rolled up.
+pub(crate) const OUTCOME_KEY_PREFIX: &str = "outcome:";
+
+/// Only `Role::Tool` results at least this many bytes are worth evicting —
+/// below it the pointer can be larger than the payload, so the savings are
+/// negligible. This threshold also conveniently skips the tiny JSON acks of
+/// the step-control tools themselves.
+pub(crate) const COMPACTION_MIN_EVICT_BYTES: usize = 512;
+
+/// Recognisable opening of an eviction pointer. Used to skip results that are
+/// already compacted, so a parent `complete_step` whose scope contains
+/// already-compacted child results does not re-stamp them.
+pub(crate) const COMPACTION_POINTER_PREFIX: &str = "<compacted to scratchpad";
+
+/// Maximum plan todos rendered into the per-round `[Plan]` surface. Keeps the
+/// re-sent-every-round plan cheap; deeper plans show a "… and N more" tail.
+pub(crate) const MAX_PLAN_ITEMS: usize = 40;
+
+/// One frame of an in-progress plan: a step and the working scope opened when
+/// it began.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StepFrame {
+    /// Dotted step path, e.g. `"1"`, `"1.2"`, `"1.2.3"`.
+    pub key: String,
+    /// The step's objective — becomes the `todo` note's content.
+    pub goal: String,
+    /// `conv.messages.len()` captured when this step began. `complete_step`
+    /// evicts `Role::Tool` results from here to the current end of the log.
+    pub watermark: usize,
+    /// Child steps minted under this frame so far (drives `.1`, `.2`, …).
+    pub child_counter: u32,
+    /// Ordering hint for the todo note (the leaf number of `key`).
+    pub sequence: i32,
+}
+
+/// A per-turn stack of plan steps. Auto-numbers dotted paths from structure,
+/// so the model never has to track step numbers — it just begins and completes.
+#[derive(Debug, Default)]
+pub(crate) struct StepStack {
+    frames: Vec<StepFrame>,
+    /// Top-level steps minted so far (children of the implicit root).
+    root_counter: u32,
+}
+
+impl StepStack {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// The dotted key of the current (innermost) step, if any.
+    pub fn current_key(&self) -> Option<&str> {
+        self.frames.last().map(|f| f.key.as_str())
+    }
+
+    /// Push a new step capturing `watermark` as its scope start, and return
+    /// its assigned `(dotted_key, sequence)`. A new top-level step gets the
+    /// next root number; a step begun while another is active becomes its
+    /// next numbered child.
+    pub fn begin(&mut self, goal: impl Into<String>, watermark: usize) -> (String, i32) {
+        let (key, sequence) = match self.frames.last_mut() {
+            Some(parent) => {
+                parent.child_counter += 1;
+                let seq = i32::try_from(parent.child_counter).unwrap_or(i32::MAX);
+                (format!("{}.{}", parent.key, parent.child_counter), seq)
+            }
+            None => {
+                self.root_counter += 1;
+                let seq = i32::try_from(self.root_counter).unwrap_or(i32::MAX);
+                (self.root_counter.to_string(), seq)
+            }
+        };
+        self.frames.push(StepFrame {
+            key: key.clone(),
+            goal: goal.into(),
+            watermark,
+            child_counter: 0,
+            sequence,
+        });
+        (key, sequence)
+    }
+
+    /// Pop and return the innermost step, or `None` if no step is active.
+    pub fn complete(&mut self) -> Option<StepFrame> {
+        self.frames.pop()
+    }
+
+    /// Drop every frame. Called by the dispatch loop after overflow recovery,
+    /// which can drain messages and invalidate the absolute watermarks. The
+    /// root counter is intentionally preserved: the todos written before the
+    /// clear still live on the scratchpad, so a fresh step must keep advancing
+    /// the numbering rather than reuse a key (e.g. `"1"`) that would clobber an
+    /// existing todo via upsert.
+    pub fn clear(&mut self) {
+        self.frames.clear();
+    }
+}
+
+/// Truncate `s` to at most `max_bytes`, landing on a UTF-8 char boundary.
+pub(crate) fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut cut = max_bytes;
+    while cut > 0 && !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    s[..cut].to_string()
+}
+
+/// Build the pointer that replaces an evicted tool result. Addressed to the
+/// model so it knows the detail still exists (in the named note, or via a
+/// re-run) and was removed only to keep the turn lean.
+pub(crate) fn compaction_pointer(tool_name: Option<&str>, note_keys: &[String]) -> String {
+    let ran = match tool_name {
+        Some(n) if !n.is_empty() => format!(" (ran {n})"),
+        _ => String::new(),
+    };
+    if note_keys.is_empty() {
+        return format!(
+            "{COMPACTION_POINTER_PREFIX}{ran}: this result was dropped from working \
+             context when its step completed (no carry-forward note was recorded). \
+             Re-run the tool if you need it again.>"
+        );
+    }
+    let keys = note_keys
+        .iter()
+        .map(|k| format!("\"{k}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{COMPACTION_POINTER_PREFIX}{ran}: this result was distilled into scratchpad \
+         note(s) {keys} and dropped from working context to keep the turn lean. Re-read \
+         the note(s) with builtin_scratchpad_search, or re-run the tool for the full output.>"
+    )
+}
+
+/// Replace the content of every sizeable `Role::Tool` message in
+/// `messages[from..]` with a [`compaction_pointer`], freeing context while
+/// leaving the message structure (role + `tool_call_id`) intact so provider
+/// tool-call/result pairing is never broken.
+///
+/// Returns `(results_evicted, bytes_freed)`.
+///
+/// Idempotent: results already bearing a pointer are skipped. `from` is
+/// clamped to the slice length. Only the rare overflow-recovery path drains
+/// messages mid-turn, and it drains from the left — shifting absolute
+/// watermarks so this *under*-evicts (safe) rather than over-evicts; the
+/// dispatch loop additionally clears the step stack on overflow recovery, so
+/// a stale watermark never reaches here.
+pub(crate) fn evict_tool_results(
+    messages: &mut [Message],
+    from: usize,
+    note_keys: &[String],
+) -> (usize, usize) {
+    let from = from.min(messages.len());
+
+    // Map each tool_call_id to the tool that produced it, from the assistant
+    // tool-call requests, so the pointer can name what ran. Owned to avoid
+    // holding an immutable borrow across the mutation below.
+    let mut names: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for m in messages.iter() {
+        if m.role == Role::Assistant {
+            for tc in &m.tool_calls {
+                names.insert(tc.id.clone(), tc.name.clone());
+            }
+        }
+    }
+
+    let mut evicted = 0usize;
+    let mut freed = 0usize;
+    for m in messages[from..].iter_mut() {
+        if m.role != Role::Tool || m.content.len() < COMPACTION_MIN_EVICT_BYTES {
+            continue;
+        }
+        if m.content.starts_with(COMPACTION_POINTER_PREFIX) {
+            continue; // already compacted by an inner step
+        }
+        let tool_name = m
+            .tool_call_id
+            .as_deref()
+            .and_then(|id| names.get(id))
+            .map(String::as_str);
+        let pointer = compaction_pointer(tool_name, note_keys);
+        freed += m.content.len().saturating_sub(pointer.len());
+        evicted += 1;
+        m.content = pointer;
+    }
+    (evicted, freed)
+}
+
+/// A single plan entry for [`render_plan`] (a `todo`-typed scratchpad note).
+pub(crate) struct PlanItem<'a> {
+    pub key: &'a str,
+    pub goal: &'a str,
+    pub done: bool,
+    /// The step's distilled finding, when it is still in view — a completed
+    /// step whose parent hasn't yet rolled it up. Rendered nested under the step.
+    pub outcome: Option<&'a str>,
+}
+
+/// Parse a dotted step key into numeric segments for tree ordering. A
+/// non-numeric segment sorts last within its level (defensive — auto-numbered
+/// keys are always numeric).
+fn dotted_key(key: &str) -> Vec<u64> {
+    key.split('.')
+        .map(|seg| seg.parse::<u64>().unwrap_or(u64::MAX))
+        .collect()
+}
+
+/// Render the open plan as a compact indented tree for per-round surfacing.
+/// Returns `None` when there are no steps to show. `current` marks the live
+/// step (you-are-here); `max_items` caps the rendered size so it stays cheap
+/// to re-send every round.
+pub(crate) fn render_plan(
+    items: &[PlanItem<'_>],
+    current: Option<&str>,
+    max_items: usize,
+) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut sorted: Vec<&PlanItem> = items.iter().collect();
+    sorted.sort_by_key(|a| dotted_key(a.key));
+
+    let mut out = String::from(
+        "Your plan (steps on the scratchpad, with findings so far — keep working it; \
+         mark steps done as you go, and roll a step's sub-step findings up into its outcome):",
+    );
+    for item in sorted.iter().take(max_items) {
+        let depth = item.key.matches('.').count();
+        let indent = "  ".repeat(depth);
+        let check = if item.done { "[x]" } else { "[ ]" };
+        let here = if current == Some(item.key) {
+            "  ← you are here"
+        } else {
+            ""
+        };
+        let goal = truncate_on_char_boundary(item.goal, 160);
+        out.push_str(&format!("\n{indent}{} {check} {goal}{here}", item.key));
+        if let Some(outcome) = item.outcome.filter(|o| !o.is_empty()) {
+            let outcome = truncate_on_char_boundary(outcome, 200);
+            out.push_str(&format!("\n{indent}  → {outcome}"));
+        }
+    }
+    if sorted.len() > max_items {
+        out.push_str(&format!("\n… and {} more.", sorted.len() - max_items));
+    }
+    Some(out)
+}
+
+/// A scratchpad note as the plan renderer needs it — just the fields it reads,
+/// so the renderer stays decoupled from the storage row type.
+pub(crate) struct RawNote<'a> {
+    pub key: &'a str,
+    pub content: &'a str,
+    pub note_type: &'a str,
+    pub done: bool,
+}
+
+/// Build the plan surface from a conversation's scratchpad notes (#240).
+///
+/// Steps are the `todo`-typed notes; each step's distilled finding lives in a
+/// companion `outcome:<step-key>` note. A finding is surfaced (nested under its
+/// step) only while it is still *waiting to be rolled up* — i.e. its parent step
+/// is not yet done. Once a parent completes (summarising its children up into
+/// its own outcome), the children's findings drop from view, so the model always
+/// sees exactly the findings pending summary into the currently-open ancestor.
+/// Top-level findings (no parent) stay in view as the material for the final
+/// summary to the user. Returns `None` when there are no steps.
+pub(crate) fn render_plan_from_notes(
+    notes: &[RawNote<'_>],
+    current: Option<&str>,
+    max_items: usize,
+) -> Option<String> {
+    use std::collections::HashMap;
+
+    let done_by_key: HashMap<&str, bool> = notes
+        .iter()
+        .filter(|n| n.note_type == STEP_NOTE_TYPE)
+        .map(|n| (n.key, n.done))
+        .collect();
+    if done_by_key.is_empty() {
+        return None;
+    }
+
+    // Findings still pending roll-up, keyed by their step. Absorbed (dropped)
+    // once the parent step is done.
+    let outcomes: HashMap<&str, &str> = notes
+        .iter()
+        .filter_map(|n| {
+            n.key
+                .strip_prefix(OUTCOME_KEY_PREFIX)
+                .map(|step| (step, n.content))
+        })
+        .filter(|(step, _)| {
+            step.rsplit_once('.')
+                .map(|(parent, _)| !done_by_key.get(parent).copied().unwrap_or(false))
+                .unwrap_or(true)
+        })
+        .collect();
+
+    let items: Vec<PlanItem> = notes
+        .iter()
+        .filter(|n| n.note_type == STEP_NOTE_TYPE)
+        .map(|n| PlanItem {
+            key: n.key,
+            goal: n.content,
+            done: n.done,
+            outcome: outcomes.get(n.key).copied(),
+        })
+        .collect();
+    render_plan(&items, current, max_items)
+}
+
+/// The `begin_step` tool definition advertised to the model.
+pub(crate) fn begin_step_tool() -> ToolDefinition {
+    ToolDefinition::new(
+        BEGIN_STEP_TOOL,
+        "Begin a step of a multi-step task. Pushes a step onto your plan and opens a \
+         fresh working scope. Use it to break a non-trivial request into ordered steps, \
+         and again — nested — when a step turns out to need its own sub-plan (a step begun \
+         inside step 1.2 becomes 1.2.1, 1.2.2, …). The step is recorded as an ordered todo \
+         on the scratchpad and numbered for you. Pair every begin_step with a later \
+         complete_step. For small one-shot tasks, don't use steps at all — just answer or act.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": "What this step aims to accomplish or find out — a short, concrete objective (e.g. 'Get the 7-day forecast for Cary, NC')."
+                }
+            },
+            "required": ["goal"]
+        }),
+    )
+}
+
+/// The `complete_step` tool definition advertised to the model.
+pub(crate) fn complete_step_tool() -> ToolDefinition {
+    ToolDefinition::new(
+        COMPLETE_STEP_TOOL,
+        "Complete the current step (the most recently begun one). Marks its todo done, \
+         records what you learned as a carry-forward note on the scratchpad, and removes \
+         the step's raw tool results from working context — they're distilled into the note, \
+         which stays searchable, so nothing important is lost and the turn stays lean. Write \
+         the `outcome` whenever the result matters to later steps, or when in doubt; omit it \
+         only for trivial steps. If this step had sub-steps, roll their findings up into your \
+         outcome — summarise them into one, don't repeat each. Use status \"abandoned\" for a \
+         dead end you're backing out of: the wasted exploration is still cleared and the note \
+         records why, so you don't repeat it.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "outcome": {
+                    "type": "string",
+                    "description": "The distilled finding(s) to carry forward — the gist, not the raw output (e.g. 'Cary, NC 7-day: highs low-80s°F, rain likely Tue'). Omit only for trivial steps."
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["done", "abandoned"],
+                    "description": "done (default) = the step succeeded. abandoned = a dead end you're backing out of."
+                }
+            }
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{Message, Role, ToolCall};
+
+    #[test]
+    fn stack_auto_numbers_roots_and_nested_children() {
+        let mut stack = StepStack::new();
+        let (k1, s1) = stack.begin("research", 0);
+        assert_eq!(k1, "1");
+        assert_eq!(s1, 1);
+        assert_eq!(stack.current_key(), Some("1"));
+
+        // Nested children of step 1.
+        let (k11, _) = stack.begin("sub a", 3);
+        assert_eq!(k11, "1.1");
+        assert_eq!(stack.depth(), 2);
+        // Completing 1.1 pops back to 1.
+        let popped = stack.complete().unwrap();
+        assert_eq!(popped.key, "1.1");
+        assert_eq!(popped.watermark, 3);
+        assert_eq!(stack.current_key(), Some("1"));
+
+        // Next child of 1 continues the counter: 1.2, then 1.2.1.
+        let (k12, _) = stack.begin("sub b", 5);
+        assert_eq!(k12, "1.2");
+        let (k121, _) = stack.begin("sub b i", 7);
+        assert_eq!(k121, "1.2.1");
+
+        // Unwind fully, then a new root step is 2 (not 1).
+        stack.complete();
+        stack.complete();
+        stack.complete();
+        assert_eq!(stack.depth(), 0);
+        let (k2, s2) = stack.begin("write up", 9);
+        assert_eq!(k2, "2");
+        assert_eq!(s2, 2);
+    }
+
+    #[test]
+    fn complete_on_empty_stack_is_none() {
+        let mut stack = StepStack::new();
+        assert!(stack.complete().is_none());
+    }
+
+    #[test]
+    fn clear_drops_frames_but_preserves_numbering() {
+        let mut stack = StepStack::new();
+        stack.begin("a", 0);
+        stack.begin("b", 1);
+        stack.clear();
+        assert_eq!(stack.depth(), 0);
+        // Numbering does NOT reset: a fresh step after a clear must not reuse a
+        // key (e.g. "1") that an earlier, still-persisted todo already owns.
+        let (k, _) = stack.begin("c", 2);
+        assert_eq!(k, "2");
+    }
+
+    fn tool_msg(id: &str, content: &str) -> Message {
+        Message::tool_result(id, content)
+    }
+
+    #[test]
+    fn evict_shrinks_large_results_preserving_pairing() {
+        let big = "x".repeat(5000);
+        let mut messages = vec![
+            Message::new(Role::User, "do it"),
+            Message::assistant_with_tool_calls(vec![ToolCall::new("c1", "weather_forecast", "{}")]),
+            tool_msg("c1", &big),
+        ];
+        let keys = vec!["outcome:1".to_string()];
+        let (evicted, freed) = evict_tool_results(&mut messages, 1, &keys);
+        assert_eq!(evicted, 1);
+        assert!(freed > 4000);
+        // Structure preserved: still a Tool message with its tool_call_id.
+        assert_eq!(messages[2].role, Role::Tool);
+        assert_eq!(messages[2].tool_call_id.as_deref(), Some("c1"));
+        // Content is now the pointer, naming the tool and the note.
+        assert!(messages[2].content.starts_with(COMPACTION_POINTER_PREFIX));
+        assert!(messages[2].content.contains("weather_forecast"));
+        assert!(messages[2].content.contains("outcome:1"));
+        // The assistant tool-call request is untouched.
+        assert_eq!(messages[1].role, Role::Assistant);
+        assert_eq!(messages[1].tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn evict_skips_small_and_already_compacted_results() {
+        let big = "y".repeat(5000);
+        let mut messages = vec![
+            Message::assistant_with_tool_calls(vec![
+                ToolCall::new("c1", "t", "{}"),
+                ToolCall::new("c2", "t", "{}"),
+            ]),
+            tool_msg("c1", "tiny"), // below threshold
+            tool_msg("c2", &big),
+        ];
+        let keys = vec!["k".to_string()];
+        let (evicted, _) = evict_tool_results(&mut messages, 0, &keys);
+        assert_eq!(evicted, 1); // only the big one
+        assert_eq!(messages[1].content, "tiny");
+
+        // Second pass over the same range is a no-op (idempotent).
+        let (evicted2, freed2) = evict_tool_results(&mut messages, 0, &keys);
+        assert_eq!(evicted2, 0);
+        assert_eq!(freed2, 0);
+    }
+
+    #[test]
+    fn evict_clamps_out_of_range_watermark() {
+        let mut messages = vec![Message::new(Role::User, "hi")];
+        let (evicted, freed) = evict_tool_results(&mut messages, 99, &[]);
+        assert_eq!((evicted, freed), (0, 0));
+    }
+
+    #[test]
+    fn pointer_without_notes_says_dropped() {
+        let p = compaction_pointer(Some("geocode"), &[]);
+        assert!(p.contains("geocode"));
+        assert!(p.contains("no carry-forward"));
+    }
+
+    #[test]
+    fn render_plan_sorts_indents_and_marks_current() {
+        let items = vec![
+            PlanItem {
+                key: "1",
+                goal: "research",
+                done: true,
+                outcome: None,
+            },
+            PlanItem {
+                key: "1.2",
+                goal: "draft",
+                done: false,
+                outcome: None,
+            },
+            PlanItem {
+                key: "1.10",
+                goal: "late",
+                done: false,
+                outcome: None,
+            },
+            PlanItem {
+                key: "1.2.1",
+                goal: "pick crate",
+                done: true,
+                outcome: None,
+            },
+        ];
+        let rendered = render_plan(&items, Some("1.2"), 50).unwrap();
+        let lines: Vec<&str> = rendered.lines().collect();
+        // Header + 4 items.
+        assert_eq!(lines.len(), 5);
+        // Numeric (not lexical) ordering: 1, 1.2, 1.2.1, 1.10.
+        assert!(lines[1].contains("1 [x] research"));
+        assert!(lines[2].contains("1.2 [ ] draft"));
+        assert!(lines[2].contains("← you are here"));
+        assert!(lines[3].contains("1.2.1 [x] pick crate"));
+        assert!(lines[4].trim_start().starts_with("1.10"));
+        // Depth-based indentation: 1.2.1 is deeper than 1.2.
+        let indent_12 = lines[2].len() - lines[2].trim_start().len();
+        let indent_121 = lines[3].len() - lines[3].trim_start().len();
+        assert!(indent_121 > indent_12);
+    }
+
+    #[test]
+    fn render_plan_empty_is_none() {
+        assert!(render_plan(&[], None, 10).is_none());
+    }
+
+    #[test]
+    fn render_plan_caps_items() {
+        let items: Vec<PlanItem> = (1..=10)
+            .map(|_| PlanItem {
+                key: "1",
+                goal: "g",
+                done: false,
+                outcome: None,
+            })
+            .collect();
+        let rendered = render_plan(&items, None, 3).unwrap();
+        assert!(rendered.contains("… and 7 more."));
+    }
+
+    #[test]
+    fn render_plan_shows_outcome_nested_under_step() {
+        let items = vec![PlanItem {
+            key: "1",
+            goal: "research",
+            done: true,
+            outcome: Some("API is OAuth2, 100 req/min"),
+        }];
+        let rendered = render_plan(&items, None, 10).unwrap();
+        assert!(rendered.contains("1 [x] research"));
+        assert!(rendered.contains("→ API is OAuth2, 100 req/min"));
+    }
+
+    fn raw(
+        key: &'static str,
+        content: &'static str,
+        ty: &'static str,
+        done: bool,
+    ) -> RawNote<'static> {
+        RawNote {
+            key,
+            content,
+            note_type: ty,
+            done,
+        }
+    }
+
+    #[test]
+    fn plan_surfaces_findings_until_parent_rolls_them_up() {
+        // Step 1 open; 1.1 done with a finding (parent 1 still open → shown).
+        // 1.2 done; 1.2.1 done with a finding whose parent 1.2 IS done → that
+        // finding was rolled up into 1.2, so it drops from view.
+        let notes = vec![
+            raw("1", "build it", "todo", false),
+            raw("1.1", "research", "todo", true),
+            raw("outcome:1.1", "API is OAuth2", "note", false),
+            raw("1.2", "wire the client", "todo", true),
+            raw("outcome:1.2", "client built on reqwest", "note", false),
+            raw("1.2.1", "pick crate", "todo", true),
+            raw("outcome:1.2.1", "chose reqwest 0.12", "note", false),
+            raw("goal", "the overall goal", "note", false),
+        ];
+        let rendered = render_plan_from_notes(&notes, Some("1"), 50).unwrap();
+        // Pending roll-up into the still-open step 1 → shown.
+        assert!(rendered.contains("→ API is OAuth2"));
+        // 1.2's own finding is top-of-its-subtree and 1.2's parent (1) is open → shown.
+        assert!(rendered.contains("→ client built on reqwest"));
+        // 1.2.1's finding was absorbed when 1.2 completed → hidden.
+        assert!(!rendered.contains("chose reqwest"));
+        // The `goal` note is not a step and must not render as a todo line.
+        assert!(!rendered.contains("the overall goal"));
+    }
+
+    #[test]
+    fn render_plan_from_notes_none_without_todos() {
+        let notes = vec![raw("goal", "g", "note", false)];
+        assert!(render_plan_from_notes(&notes, None, 10).is_none());
+    }
+
+    #[test]
+    fn step_tools_have_stable_names() {
+        assert_eq!(begin_step_tool().name, "begin_step");
+        assert_eq!(complete_step_tool().name, "complete_step");
+    }
+}

--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -34,32 +34,31 @@ Writing:
 - If unsure whether to save or how to tag, ask briefly.
 
 == Scratchpad ==
-The scratchpad (builtin_scratchpad_write/search/delete) is an ephemeral, per-conversation notepad. Use it to keep working facts high in context for THIS conversation only: an evolving plan, open questions, a working set of facts or IDs, intermediate results. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base. Notes are keyed; writing the same key replaces it. Batch several at once with notes: [{key, content}].
+The scratchpad (builtin_scratchpad_write/search/delete) is your ephemeral, per-conversation notepad — and the way you keep a long task on track without dragging every detail through context. Picture a person with a notepad and pen: jot the important bits and what you'll need to remember, skip the trivial, summarize rather than transcribe. Notes are keyed; writing the same key replaces it. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base.
 
 When to use it — be selective:
-- Use it ONLY when you genuinely need to carry information forward across a large or multi-step task: a multi-step plan you're working through, findings/notes from an investigation you'll reference later, intermediate results you must hold across many turns or tool calls.
-- For small, one-shot tasks — a single question, a quick lookup, a one-line action — do NOT touch the scratchpad. Just answer or act. Writing notes you'll never reread is noise.
+- Reach for it ONLY on a genuinely multi-step task: a plan you're working through, findings you'll reference later, intermediate results you must hold across many tool calls.
+- For a small one-shot task — a single question, a quick lookup, a one-line action — don't touch the pad. Just answer or act. (A person wouldn't pull out a notepad to answer one question.)
 
-Current goal:
-- Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
-- Evolve it as the objective shifts; clear it when the task is done.
+The goal note:
+- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it when done.
 
-Plan and TODOs:
-- For any multi-step task, keep your plan in the scratchpad as notes with type "todo" and an integer "sequence" (1, 2, 3, …). Notes of the same type come back sorted by sequence, so your plan always reads in order.
-- As you finish a step, set that todo's "done": true (re-write the same key) to check it off — it stays visible so you don't redo it — or delete it. Add, re-sequence, or revise todos as the plan changes.
-- Use builtin_scratchpad_search with type "todo" to read just your plan.
+Work a multi-step task as plan → step → compact:
+- Decide the steps the request needs, then work them with begin_step / complete_step.
+- begin_step {goal} opens a step: it's numbered for you and recorded as an ordered todo, shown back to you under [Plan] each round. When a step turns out to need its own sub-plan, just begin_step again inside it — nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6.
+- Do the step's work (search the KB, call tools, reason).
+- complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
+- Summarize up. Completed steps show their finding beneath them in [Plan]. When you complete a step that had sub-steps, roll their findings up into its outcome — one summary that captures the children (their individual findings then drop from view). The top-level findings that remain are your material for the closing summary to the user.
+- Backed into a dead end? complete_step {outcome, status: "abandoned"} still clears the wasted exploration and records why, so you don't repeat it.
 
-Work incrementally:
-- Prefer many small, targeted lookups over one giant context pull. After each fact search (knowledge base, past conversations, tools), record the outcome as its own note rather than holding everything in your head — batch-write several notes when a step yields multiple facts.
+Finishing:
+- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write.
 
 Reading:
-- builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. If a result says it was truncated, narrow with a query or fewer keys.
+- builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. To recover the detail behind a "<compacted to scratchpad …>" pointer, re-read the named note or re-run the tool.
 
 Deleting:
 - builtin_scratchpad_delete removes notes by keys, or pass all: true to clear the whole pad.
-
-Promotion:
-- When a scratchpad note is worth keeping beyond this conversation, write it to the knowledge base with builtin_knowledge_base_write, then delete it from the scratchpad.
 
 == Database design ==
 Your Postgres database is yours to shape. Beyond reading and writing the existing public tables, you may CREATE your own schemas, tables, views, materialized views, functions, and stored procedures whenever it helps you track, correlate, or summarize information more efficiently than prose-in-the-KB. Examples: a rollup of weather lookups by location, a normalized log of timeclock corrections, a view that joins conversation activity with knowledge_base touches.

--- a/crates/core/src/prompts/sections/scratchpad.txt
+++ b/crates/core/src/prompts/sections/scratchpad.txt
@@ -1,27 +1,26 @@
 == Scratchpad ==
-The scratchpad (builtin_scratchpad_write/search/delete) is an ephemeral, per-conversation notepad. Use it to keep working facts high in context for THIS conversation only: an evolving plan, open questions, a working set of facts or IDs, intermediate results. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base. Notes are keyed; writing the same key replaces it. Batch several at once with notes: [{key, content}].
+The scratchpad (builtin_scratchpad_write/search/delete) is your ephemeral, per-conversation notepad — and the way you keep a long task on track without dragging every detail through context. Picture a person with a notepad and pen: jot the important bits and what you'll need to remember, skip the trivial, summarize rather than transcribe. Notes are keyed; writing the same key replaces it. It is discarded when the conversation is deleted and is not shared across conversations — unlike the durable knowledge base.
 
 When to use it — be selective:
-- Use it ONLY when you genuinely need to carry information forward across a large or multi-step task: a multi-step plan you're working through, findings/notes from an investigation you'll reference later, intermediate results you must hold across many turns or tool calls.
-- For small, one-shot tasks — a single question, a quick lookup, a one-line action — do NOT touch the scratchpad. Just answer or act. Writing notes you'll never reread is noise.
+- Reach for it ONLY on a genuinely multi-step task: a plan you're working through, findings you'll reference later, intermediate results you must hold across many tool calls.
+- For a small one-shot task — a single question, a quick lookup, a one-line action — don't touch the pad. Just answer or act. (A person wouldn't pull out a notepad to answer one question.)
 
-Current goal:
-- Keep a note under the key "goal" describing what you are trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad.
-- Evolve it as the objective shifts; clear it when the task is done.
+The goal note:
+- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it when done.
 
-Plan and TODOs:
-- For any multi-step task, keep your plan in the scratchpad as notes with type "todo" and an integer "sequence" (1, 2, 3, …). Notes of the same type come back sorted by sequence, so your plan always reads in order.
-- As you finish a step, set that todo's "done": true (re-write the same key) to check it off — it stays visible so you don't redo it — or delete it. Add, re-sequence, or revise todos as the plan changes.
-- Use builtin_scratchpad_search with type "todo" to read just your plan.
+Work a multi-step task as plan → step → compact:
+- Decide the steps the request needs, then work them with begin_step / complete_step.
+- begin_step {goal} opens a step: it's numbered for you and recorded as an ordered todo, shown back to you under [Plan] each round. When a step turns out to need its own sub-plan, just begin_step again inside it — nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6.
+- Do the step's work (search the KB, call tools, reason).
+- complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
+- Summarize up. Completed steps show their finding beneath them in [Plan]. When you complete a step that had sub-steps, roll their findings up into its outcome — one summary that captures the children (their individual findings then drop from view). The top-level findings that remain are your material for the closing summary to the user.
+- Backed into a dead end? complete_step {outcome, status: "abandoned"} still clears the wasted exploration and records why, so you don't repeat it.
 
-Work incrementally:
-- Prefer many small, targeted lookups over one giant context pull. After each fact search (knowledge base, past conversations, tools), record the outcome as its own note rather than holding everything in your head — batch-write several notes when a step yields multiple facts.
+Finishing:
+- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write.
 
 Reading:
-- builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. If a result says it was truncated, narrow with a query or fewer keys.
+- builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. To recover the detail behind a "<compacted to scratchpad …>" pointer, re-read the named note or re-run the tool.
 
 Deleting:
 - builtin_scratchpad_delete removes notes by keys, or pass all: true to clear the whole pad.
-
-Promotion:
-- When a scratchpad note is worth keeping beyond this conversation, write it to the knowledge base with builtin_knowledge_base_write, then delete it from the scratchpad.

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -2,11 +2,14 @@ use crate::CoreError;
 use crate::context::{
     COMPACTION_TOKEN_RATIO, DEFAULT_MAX_TOOL_RESULT_BYTES, MAX_CONTEXT_MESSAGES,
     MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES, ToolLocalityContext, cap_tool_result,
-    compaction_range, generate_context_summary, llm_messages_for_turn, recover_from_overflow,
+    compaction_range, generate_context_summary, llm_messages_for_turn_with_plan,
+    recover_from_overflow,
 };
 use crate::domain::{
-    Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition, ToolNamespace,
+    Conversation, ConversationId, ConversationSummary, Message, Role, ToolCall, ToolDefinition,
+    ToolNamespace,
 };
+use crate::planning::{self, StepStack};
 use crate::ports::client_tools::current_client_tools;
 use crate::ports::conversation_ctx::with_conversation_id;
 use crate::ports::inbound::ConversationService;
@@ -14,7 +17,10 @@ use crate::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, StatusCallback, current_cancellation_token,
     current_context_budget, current_system_refinement,
 };
-use crate::ports::scratchpad::{SCRATCHPAD_GOAL_KEY, ScratchpadGetManyFn};
+use crate::ports::scratchpad::{
+    MAX_NOTE_BYTES, NewScratchpadNote, SCRATCHPAD_GOAL_KEY, ScratchpadGetManyFn, ScratchpadListFn,
+    ScratchpadWriteFn,
+};
 use crate::ports::store::ConversationStore;
 use crate::ports::tools::ToolExecutor;
 use crate::ports::transport::current_transport_kind;
@@ -171,6 +177,18 @@ pub struct ConversationHandler<S, L, T = NoopToolExecutor> {
     /// windowing/compaction. `None` (the default) preserves the prior
     /// verbatim-prompt-only anchor behaviour.
     scratchpad_goal_read: Option<ScratchpadGetManyFn>,
+    /// Optional writer for scratchpad notes. When set, the planning tools
+    /// (`begin_step`/`complete_step`, #240) are advertised each turn and the
+    /// dispatch loop uses this to record plan todos + distilled step outcomes.
+    /// `None` (the default) leaves the planning tools off and the loop behaves
+    /// exactly as before. Wire the daemon's *event-emitting* write closure so
+    /// plan changes reach clients via `ScratchpadChanged`.
+    scratchpad_write: Option<ScratchpadWriteFn>,
+    /// Optional lister for scratchpad notes. When set, the dispatch loop reads
+    /// the conversation's `todo` notes each round and surfaces the open plan
+    /// as a compact `[Plan]` system message so it stays in view while raw work
+    /// is evicted. `None` disables per-round plan surfacing.
+    scratchpad_list: Option<ScratchpadListFn>,
     /// Maximum byte length a single tool result may occupy before it is
     /// truncated at ingestion (issue #174). Defaults to
     /// [`DEFAULT_MAX_TOOL_RESULT_BYTES`]; override via
@@ -200,6 +218,8 @@ impl<S, L> ConversationHandler<S, L, NoopToolExecutor> {
             id_generator,
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
+            scratchpad_write: None,
+            scratchpad_list: None,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
             host: DEFAULT_HOST_LABEL.to_string(),
         }
@@ -221,6 +241,8 @@ impl<S, L, T> ConversationHandler<S, L, T> {
             id_generator,
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
+            scratchpad_write: None,
+            scratchpad_list: None,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
             host: DEFAULT_HOST_LABEL.to_string(),
         }
@@ -251,12 +273,217 @@ impl<S, L, T> ConversationHandler<S, L, T> {
         self
     }
 
+    /// Wire a writer for scratchpad notes, enabling the step-planning +
+    /// context-compaction tools (`begin_step`/`complete_step`, #240). The
+    /// dispatch loop advertises those tools each turn and uses this closure to
+    /// record plan todos and distilled step outcomes. Wire the daemon's
+    /// *event-emitting* write closure so plan changes reach clients.
+    pub fn with_scratchpad_write(mut self, write: ScratchpadWriteFn) -> Self {
+        self.scratchpad_write = Some(write);
+        self
+    }
+
+    /// Wire a lister for scratchpad notes, enabling per-round surfacing of the
+    /// open plan (the conversation's `todo` notes) as a `[Plan]` system message.
+    pub fn with_scratchpad_list(mut self, list: ScratchpadListFn) -> Self {
+        self.scratchpad_list = Some(list);
+        self
+    }
+
     /// Override the per-tool-result ingestion cap (issue #174). Results
     /// larger than this are truncated with a notice before being stored so a
     /// single runaway tool call can't wedge the conversation or the database.
     pub fn with_max_tool_result_bytes(mut self, max_bytes: usize) -> Self {
         self.max_tool_result_bytes = max_bytes;
         self
+    }
+
+    /// Handle a `begin_step` / `complete_step` control call (#240).
+    ///
+    /// These are core-loop tools, not tool-executor tools: only the dispatch
+    /// loop owns `conv.messages` (for eviction) and the per-turn [`StepStack`].
+    /// `begin_step` pushes a step and records its goal as an ordered `todo`
+    /// note; `complete_step` pops the step, writes the distilled outcome as a
+    /// carry-forward note, marks the todo done, and evicts the step's raw tool
+    /// results from working context (replacing them with a searchable pointer
+    /// to the note). Returns the JSON ack the model sees as the tool result —
+    /// for `begin_step` it carries the assigned dotted step number.
+    ///
+    /// Note writes are best-effort: a failed write is logged and the turn
+    /// continues (the plan note is simply missing) rather than aborting.
+    async fn handle_step_control(
+        &self,
+        conv: &mut Conversation,
+        stack: &mut StepStack,
+        call: &ToolCall,
+        args: &serde_json::Value,
+        conversation_id: &ConversationId,
+    ) -> String {
+        let Some(write) = self.scratchpad_write.clone() else {
+            return r#"{"ok":false,"error":"planning is not available in this turn"}"#.to_string();
+        };
+        let conv_id = conversation_id.0.clone();
+
+        if call.name == planning::BEGIN_STEP_TOOL {
+            let goal = args
+                .get("goal")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim();
+            if goal.is_empty() {
+                return r#"{"ok":false,"error":"begin_step requires a non-empty 'goal'"}"#
+                    .to_string();
+            }
+            // Capture the scope start BEFORE this call's own ack is pushed, so
+            // complete_step evicts the work done *within* the step.
+            let watermark = conv.messages.len();
+            let (key, sequence) = stack.begin(goal, watermark);
+            let note = NewScratchpadNote {
+                key: key.clone(),
+                content: planning::truncate_on_char_boundary(goal, MAX_NOTE_BYTES),
+                note_type: planning::STEP_NOTE_TYPE.to_string(),
+                sequence: Some(sequence),
+                done: false,
+            };
+            if let Err(e) = write(conv_id, vec![note]).await {
+                tracing::warn!(step = %key, error = %e, "failed to record plan step note");
+            }
+            return serde_json::json!({
+                "ok": true,
+                "action": "begin_step",
+                "step": key,
+                "depth": stack.depth(),
+                "goal": goal,
+            })
+            .to_string();
+        }
+
+        // complete_step
+        let outcome = args
+            .get("outcome")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let abandoned = args
+            .get("status")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s.eq_ignore_ascii_case("abandoned"));
+
+        let Some(frame) = stack.complete() else {
+            // No active step to close. Still record a standalone note if the
+            // model handed us an outcome, so the finding isn't lost.
+            if let Some(o) = outcome {
+                let key = format!("note-{}", (self.id_generator)());
+                let body = if abandoned {
+                    format!("Abandoned: {o}")
+                } else {
+                    o.to_string()
+                };
+                let note = NewScratchpadNote {
+                    key: key.clone(),
+                    content: planning::truncate_on_char_boundary(&body, MAX_NOTE_BYTES),
+                    note_type: planning::OUTCOME_NOTE_TYPE.to_string(),
+                    sequence: None,
+                    done: false,
+                };
+                if let Err(e) = write(conv_id, vec![note]).await {
+                    tracing::warn!(error = %e, "failed to record standalone outcome note");
+                }
+                return serde_json::json!({
+                    "ok": true,
+                    "action": "complete_step",
+                    "note": "no active step; recorded a standalone note",
+                    "outcome_note": key,
+                })
+                .to_string();
+            }
+            return r#"{"ok":true,"action":"complete_step","note":"no active step to complete"}"#
+                .to_string();
+        };
+
+        // One write for the done-todo plus the optional carry-forward outcome.
+        let mut notes = vec![NewScratchpadNote {
+            key: frame.key.clone(),
+            content: planning::truncate_on_char_boundary(&frame.goal, MAX_NOTE_BYTES),
+            note_type: planning::STEP_NOTE_TYPE.to_string(),
+            sequence: Some(frame.sequence),
+            done: true,
+        }];
+        let mut note_keys: Vec<String> = Vec::new();
+        if let Some(o) = outcome {
+            let okey = format!("{}{}", planning::OUTCOME_KEY_PREFIX, frame.key);
+            let body = if abandoned {
+                format!("Abandoned: {o}")
+            } else {
+                o.to_string()
+            };
+            notes.push(NewScratchpadNote {
+                key: okey.clone(),
+                content: planning::truncate_on_char_boundary(&body, MAX_NOTE_BYTES),
+                note_type: planning::OUTCOME_NOTE_TYPE.to_string(),
+                sequence: None,
+                done: false,
+            });
+            note_keys.push(okey);
+        }
+        if let Err(e) = write(conv_id, notes).await {
+            tracing::warn!(step = %frame.key, error = %e, "failed to record step completion notes");
+        }
+
+        // Evict the step's raw tool results, leaving a pointer to the outcome
+        // note. This is what stops the per-round `msg_chars` growth (#239).
+        let (evicted, freed) =
+            planning::evict_tool_results(&mut conv.messages, frame.watermark, &note_keys);
+        tracing::info!(
+            step = %frame.key,
+            evicted_results = evicted,
+            freed_bytes = freed,
+            abandoned,
+            "completed step — compacted scope to scratchpad"
+        );
+
+        serde_json::json!({
+            "ok": true,
+            "action": "complete_step",
+            "step": frame.key,
+            "status": if abandoned { "abandoned" } else { "done" },
+            "evicted_results": evicted,
+            "freed_bytes": freed,
+            "outcome_note": note_keys.first(),
+        })
+        .to_string()
+    }
+
+    /// Render the open plan (#240) for per-round surfacing: read the
+    /// conversation's notes and render the step tree with each completed step's
+    /// finding nested under it (findings drop from view once a parent rolls them
+    /// up). Marks the live step. Returns `None` when no lister is wired or there
+    /// are no steps to show.
+    async fn render_current_plan(
+        &self,
+        conversation_id: &ConversationId,
+        current_key: Option<&str>,
+    ) -> Option<String> {
+        let list = self.scratchpad_list.clone()?;
+        // Fetch all notes (todo steps + their outcome notes), a bit beyond the
+        // render cap so a step's finding isn't dropped before the step itself.
+        let notes = list(
+            conversation_id.0.clone(),
+            None,
+            planning::MAX_PLAN_ITEMS.saturating_mul(3),
+        )
+        .await
+        .ok()?;
+        let raw: Vec<planning::RawNote> = notes
+            .iter()
+            .map(|n| planning::RawNote {
+                key: n.key.as_str(),
+                content: n.content.as_str(),
+                note_type: n.note_type.as_str(),
+                done: n.done,
+            })
+            .collect();
+        planning::render_plan_from_notes(&raw, current_key, planning::MAX_PLAN_ITEMS)
     }
 }
 
@@ -500,6 +727,11 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             client_tool_names: client_tool_defs.iter().map(|d| d.name.clone()).collect(),
         };
 
+        // Per-turn step stack for the planning + compaction tools (#240).
+        // Frames hold watermarks into `conv.messages`; `complete_step` evicts a
+        // scope's raw tool results down to a searchable scratchpad pointer.
+        let mut step_stack = StepStack::new();
+
         for round in 0..MAX_TOOL_ROUNDS {
             // Between-turns cancellation checkpoint (issue #109): if the
             // caller cancelled while the previous tool round was
@@ -526,6 +758,15 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 if !tool_defs.iter().any(|t| t.name == def.name) {
                     tool_defs.push(def.clone());
                 }
+            }
+            // Advertise the step-planning + compaction tools (#240) when a
+            // scratchpad writer is wired. They are core-loop tools — intercepted
+            // by name in the dispatch loop below rather than routed to the tool
+            // executor — so they're appended here, after the server/client sets,
+            // every round. Without a writer wired they stay off entirely.
+            if self.scratchpad_write.is_some() {
+                tool_defs.push(planning::begin_step_tool());
+                tool_defs.push(planning::complete_step_tool());
             }
 
             let deferred_ns: &[ToolNamespace] = if !hosted_search_demoted {
@@ -561,10 +802,20 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             };
             let anchor = goal.as_deref().or(conv.active_task.as_deref());
 
+            // Surface the open plan (#240): read the conversation's `todo`
+            // notes and render them as a compact tree so the plan stays in view
+            // across rounds while the expensive raw work is evicted. Reading per
+            // round means a step the model just began or completed shows up
+            // (with its updated done-mark) on the next round.
+            let current_step = step_stack.current_key().map(str::to_string);
+            let plan = self
+                .render_current_plan(conversation_id, current_step.as_deref())
+                .await;
+
             // The estimator borrows `&self.llm` so the closure is built
             // each iteration; constructing it is cheap (no allocation).
             let estimate = |text: &str| self.llm.estimate_tokens(text);
-            let llm_messages = llm_messages_for_turn(
+            let llm_messages = llm_messages_for_turn_with_plan(
                 &conv.messages,
                 &conv.summaries,
                 &tool_defs,
@@ -572,6 +823,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 &conv.context_summary,
                 target_window,
                 anchor,
+                plan.as_deref(),
                 tool_rounds_since_anchor,
                 &system_refinement,
                 current_context_budget(),
@@ -670,6 +922,11 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                         &estimate,
                     )
                     .await;
+                    // Overflow recovery can drain messages (trim_tool_pairs),
+                    // which invalidates the step stack's absolute watermarks.
+                    // Drop the frames so no later complete_step evicts the wrong
+                    // range — the plan todos persist on the scratchpad regardless.
+                    step_stack.clear();
                     on_chunk = Box::new(|_| true);
                     continue;
                 }
@@ -846,6 +1103,32 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     serde_json::from_str(&tool_call.arguments).unwrap_or_default();
                 on_status(tool_status_message(&tool_call.name, &arguments));
                 tracing::info!(tool = %tool_call.name, %arguments, "executing tool");
+
+                // Step-planning + compaction control (#240) is handled here in
+                // the loop, not by the tool executor: only the loop owns
+                // `conv.messages` (for eviction) and the per-turn step stack.
+                // Every tool call still needs a tool_result for provider
+                // pairing, so we push the (small) ack and move to the next call.
+                // Gate on the same condition that advertises these tools, so when
+                // planning is off the names aren't shadowed (an MCP tool could
+                // otherwise share one) and dispatch falls through as normal.
+                if self.scratchpad_write.is_some()
+                    && (tool_call.name == planning::BEGIN_STEP_TOOL
+                        || tool_call.name == planning::COMPLETE_STEP_TOOL)
+                {
+                    let ack = self
+                        .handle_step_control(
+                            &mut conv,
+                            &mut step_stack,
+                            tool_call,
+                            &arguments,
+                            conversation_id,
+                        )
+                        .await;
+                    conv.messages
+                        .push(Message::tool_result(&tool_call.id, &ack));
+                    continue;
+                }
 
                 // Route client-local tools to the client (#107 / #234): if a
                 // per-turn client-tool port is installed and the called name is
@@ -1534,6 +1817,240 @@ mod tests {
             updated.messages[3].content,
             "The file contains: hello world"
         );
+    }
+
+    // --- Planning + compaction (#240) ---
+
+    /// An in-memory scratchpad backing the write/list closures, plus a handle
+    /// to inspect what was written.
+    fn in_memory_scratchpad() -> (
+        ScratchpadWriteFn,
+        ScratchpadListFn,
+        Arc<Mutex<HashMap<String, crate::domain::ScratchpadNote>>>,
+    ) {
+        use crate::domain::ScratchpadNote;
+        let store: Arc<Mutex<HashMap<String, ScratchpadNote>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let w = Arc::clone(&store);
+        let write: ScratchpadWriteFn =
+            Arc::new(move |_conv: String, notes: Vec<NewScratchpadNote>| {
+                let w = Arc::clone(&w);
+                Box::pin(async move {
+                    let mut map = w.lock().unwrap();
+                    let saved: Vec<ScratchpadNote> = notes
+                        .into_iter()
+                        .map(|n| {
+                            let mut note = ScratchpadNote::new(
+                                format!("id-{}", n.key),
+                                "conv",
+                                &n.key,
+                                &n.content,
+                            );
+                            note.note_type = n.note_type;
+                            note.sequence = n.sequence;
+                            note.done = n.done;
+                            map.insert(n.key.clone(), note.clone());
+                            note
+                        })
+                        .collect();
+                    Ok(saved)
+                })
+            });
+
+        let l = Arc::clone(&store);
+        let list: ScratchpadListFn = Arc::new(move |_conv, note_type: Option<String>, _limit| {
+            let l = Arc::clone(&l);
+            Box::pin(async move {
+                let map = l.lock().unwrap();
+                let mut out: Vec<ScratchpadNote> = map
+                    .values()
+                    .filter(|n| note_type.as_deref().is_none_or(|t| n.note_type == t))
+                    .cloned()
+                    .collect();
+                out.sort_by(|a, b| a.key.cmp(&b.key));
+                Ok(out)
+            })
+        });
+
+        (write, list, store)
+    }
+
+    fn id_gen() -> Box<dyn Fn() -> String + Send + Sync> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let counter = Arc::new(AtomicU64::new(0));
+        Box::new(move || {
+            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            format!("conv-{n}")
+        })
+    }
+
+    #[tokio::test]
+    async fn complete_step_evicts_raw_tool_result_into_scratchpad_pointer() {
+        // The headline of #240: begin a step, run a tool that returns a big
+        // payload, complete the step — and the raw result leaves working context,
+        // replaced by a searchable pointer to the distilled outcome note, while
+        // the message structure (role + tool_call_id) is preserved.
+        let big = "DATA".repeat(2000); // ~8 KB, well above the eviction threshold
+        let tools = vec![ToolDefinition::new(
+            "weather_forecast",
+            "Get a forecast",
+            serde_json::json!({"type": "object"}),
+        )];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("weather_forecast".to_string(), big.clone());
+
+        let responses = vec![
+            LlmResponse::with_tool_calls(
+                "",
+                vec![ToolCall::new(
+                    "b1",
+                    "begin_step",
+                    r#"{"goal":"get the forecast"}"#,
+                )],
+            ),
+            LlmResponse::with_tool_calls("", vec![ToolCall::new("t1", "weather_forecast", "{}")]),
+            LlmResponse::with_tool_calls(
+                "",
+                vec![ToolCall::new(
+                    "c1",
+                    "complete_step",
+                    r#"{"outcome":"Cary NC 7-day: highs low-80s, rain Tue"}"#,
+                )],
+            ),
+            LlmResponse::text("All done — it'll be warm with rain Tuesday."),
+        ];
+
+        let (write, list, sp) = in_memory_scratchpad();
+        let handler = ConversationHandler::with_tools(
+            MockStore::new(),
+            ToolCallingLlm::new(responses),
+            MockToolExecutor::new(tools, tool_results),
+            id_gen(),
+        )
+        .with_scratchpad_write(write)
+        .with_scratchpad_list(list);
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        let result = handler
+            .send_prompt(&conv.id, "weather?".into(), noop_callback(), noop_status())
+            .await
+            .unwrap();
+        assert_eq!(result, "All done — it'll be warm with rain Tuesday.");
+
+        // The big tool result must have been compacted in place: still a Tool
+        // message bound to its call, but the payload is gone and replaced by a
+        // pointer naming the tool and the outcome note.
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let big_result = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool && m.tool_call_id.as_deref() == Some("t1"))
+            .expect("the weather tool result message must still exist");
+        assert!(
+            big_result.content.starts_with("<compacted to scratchpad"),
+            "raw result should be replaced by a pointer, got: {}",
+            big_result.content
+        );
+        assert!(big_result.content.contains("weather_forecast"));
+        assert!(big_result.content.contains("outcome:1"));
+        assert!(
+            !big_result.content.contains("DATADATA"),
+            "the raw payload must be gone from working context"
+        );
+
+        // The scratchpad holds the done todo + the distilled outcome note.
+        let notes = sp.lock().unwrap();
+        let todo = notes.get("1").expect("step todo must exist");
+        assert_eq!(todo.note_type, "todo");
+        assert!(todo.done, "the step todo must be checked off");
+        let outcome = notes.get("outcome:1").expect("outcome note must exist");
+        assert_eq!(outcome.content, "Cary NC 7-day: highs low-80s, rain Tue");
+    }
+
+    /// Capturing LLM that records the message list it is handed each round, then
+    /// returns the next scripted response.
+    struct PlanContextCapturingLlm {
+        responses: Mutex<Vec<LlmResponse>>,
+        captured: Arc<Mutex<Vec<Vec<Message>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmClient for PlanContextCapturingLlm {
+        async fn stream_completion(
+            &self,
+            messages: Vec<Message>,
+            _tools: &[ToolDefinition],
+            _reasoning: ReasoningConfig,
+            mut on_chunk: ChunkCallback,
+        ) -> Result<LlmResponse, CoreError> {
+            self.captured.lock().unwrap().push(messages);
+            let response = {
+                let mut responses = self.responses.lock().unwrap();
+                if responses.is_empty() {
+                    return Ok(LlmResponse::text("fallback"));
+                }
+                responses.remove(0)
+            };
+            if !response.text.is_empty() {
+                on_chunk(response.text.clone());
+            }
+            Ok(response)
+        }
+    }
+
+    #[tokio::test]
+    async fn open_plan_is_surfaced_into_the_next_round() {
+        // After begin_step records a todo, the next round's assembled context
+        // must carry a [Plan] system message so the plan stays in view.
+        let captured: Arc<Mutex<Vec<Vec<Message>>>> = Arc::new(Mutex::new(Vec::new()));
+        let llm = PlanContextCapturingLlm {
+            responses: Mutex::new(vec![
+                LlmResponse::with_tool_calls(
+                    "",
+                    vec![ToolCall::new(
+                        "b1",
+                        "begin_step",
+                        r#"{"goal":"map the plan"}"#,
+                    )],
+                ),
+                LlmResponse::text("done"),
+            ]),
+            captured: Arc::clone(&captured),
+        };
+
+        let (write, list, _sp) = in_memory_scratchpad();
+        let handler = ConversationHandler::with_tools(
+            MockStore::new(),
+            llm,
+            MockToolExecutor::new(vec![], HashMap::new()),
+            id_gen(),
+        )
+        .with_scratchpad_write(write)
+        .with_scratchpad_list(list);
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        handler
+            .send_prompt(
+                &conv.id,
+                "do a multi-step thing".into(),
+                noop_callback(),
+                noop_status(),
+            )
+            .await
+            .unwrap();
+
+        let rounds = captured.lock().unwrap();
+        // Once begin_step records a todo, a later round's assembled context must
+        // carry the [Plan] surface. (Round 0 — before any todo — does not; a
+        // separate title-generation call also has none, so search all rounds.)
+        let plan_msg = rounds
+            .iter()
+            .flatten()
+            .find(|m| m.role == Role::System && m.content.starts_with("[Plan]"))
+            .expect("the open plan must be surfaced once a todo exists");
+        assert!(plan_msg.content.contains("map the plan"));
+        assert!(plan_msg.content.contains("← you are here"));
     }
 
     #[tokio::test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1184,6 +1184,18 @@ async fn main() -> Result<()> {
         desktop_assistant_core::ports::scratchpad::ScratchpadGetManyFn,
     > = None;
 
+    // Writer + lister handed to the conversation handler for the step-planning +
+    // context-compaction tools (#240): the writer records plan todos / distilled
+    // outcomes (the same emit-wrapped closure, so changes reach clients via
+    // ScratchpadChanged), the lister surfaces the open plan each round. Populated
+    // alongside the builtin-tool wiring below; None without a Postgres pool.
+    let mut scratchpad_write_fn: Option<
+        desktop_assistant_core::ports::scratchpad::ScratchpadWriteFn,
+    > = None;
+    let mut scratchpad_list_fn: Option<
+        desktop_assistant_core::ports::scratchpad::ScratchpadListFn,
+    > = None;
+
     // Per-conversation scratchpad command closures (#190) for the API handler,
     // populated alongside the builtin-tool wiring below. The same emit-wrapped
     // closures the builtin tools get, so a mutation via either path notifies.
@@ -1302,6 +1314,12 @@ async fn main() -> Result<()> {
             Arc::clone(&delete_many_fn),
             Arc::clone(&clear_fn),
         );
+
+        // Capture the same event-emitting write + list closures for the
+        // conversation handler's planning/compaction tools (#240) before they
+        // are moved into the API-handler tuple below.
+        scratchpad_write_fn = Some(Arc::clone(&write_fn));
+        scratchpad_list_fn = Some(Arc::clone(&list_fn));
 
         // Hand the same (emit-wrapped) closures to the API handler so clients
         // can read/write/delete the scratchpad over the command channel (#190).
@@ -1766,6 +1784,16 @@ async fn main() -> Result<()> {
     // (#184). No-op when no Postgres pool is available.
     if let Some(goal_fn) = scratchpad_goal_fn {
         handler = handler.with_scratchpad_goal(goal_fn);
+    }
+
+    // Enable step-planning + context compaction (#240): the writer records plan
+    // todos and distilled step outcomes (emitting ScratchpadChanged); the lister
+    // surfaces the open plan each round. No-op without a Postgres pool.
+    if let Some(write_fn) = scratchpad_write_fn {
+        handler = handler.with_scratchpad_write(write_fn);
+    }
+    if let Some(list_fn) = scratchpad_list_fn {
+        handler = handler.with_scratchpad_list(list_fn);
     }
 
     // Wrap the core `ConversationHandler` in the routing wrapper so adapters

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -401,12 +401,13 @@ impl BuiltinToolService {
                  at once. Use the reserved key 'goal' for the current objective: it is \
                  auto-surfaced as your task anchor every turn (so it survives compaction), and \
                  you should evolve it as the goal shifts and delete it when done. Each note has \
-                 a `type` (default \"note\"; use \"todo\" for plan steps) and an optional integer \
-                 `sequence` — notes of the same type are returned sorted by `sequence`, so keep \
-                 your plan as `todo` notes numbered in order. Set `done: true` to check a todo \
-                 off (it stays visible). The scratchpad is discarded when the conversation is \
-                 deleted and is NOT durable across conversations — promote anything worth keeping \
-                 to the knowledge base with builtin_knowledge_base_write, then delete the note here.",
+                 a `type` (default \"note\") and an optional integer `sequence` (same-type notes \
+                 sort by it). For working a multi-step task, prefer the begin_step / complete_step \
+                 tools — they record and number your plan as todos for you and compact each finished \
+                 step's raw work into a note — rather than hand-managing `todo` notes here. The \
+                 scratchpad is discarded when the conversation is deleted and is NOT durable across \
+                 conversations — promote anything worth keeping to the knowledge base with \
+                 builtin_knowledge_base_write, then delete the note here.",
                 serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -559,10 +560,24 @@ impl BuiltinToolService {
 
         let content = required_string(&arguments, "content")?;
         let tags = optional_string_array(&arguments, "tags");
-        let metadata = arguments
+        let mut metadata = arguments
             .get("metadata")
             .cloned()
             .unwrap_or_else(|| serde_json::json!({}));
+        // Provenance (#240): stamp the originating conversation so a promoted
+        // finding is traceable back to where it was learned, mirroring the
+        // dreaming extractor. Only when a conversation scope is active (the
+        // task-local installed by the dispatch loop) and the model didn't set
+        // it explicitly. Tool-written entries previously carried no provenance.
+        if let Some(conv) = current_conversation_id()
+            && let Some(obj) = metadata.as_object_mut()
+            && !obj.contains_key("source_conversation_id")
+        {
+            obj.insert(
+                "source_conversation_id".to_string(),
+                serde_json::Value::String(conv.0),
+            );
+        }
         let id =
             optional_string(&arguments, "id").unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
 


### PR DESCRIPTION
## Summary
Closes #240. Implements the agreed design (see the design comment on #240): the scratchpad becomes the "notepad and pen" for long, planned agentic turns — the model plans into (nestable) steps, distils each step's outcome to the scratchpad, and the raw tool results leave working context behind a short searchable pointer. The plan stays cheaply in view; the firehose does not. Built P1–P3 in one branch.

## The core idea
The model could already *write* distilled notes; what was missing was **eviction** — nothing removed the raw tool results from working context, so they were re-sent every round (the `msg_chars` climb in #239). This adds the eviction half.

## What's here
- **Compaction engine** (`crates/core/src/planning.rs`): a per-turn `StepStack` with auto dotted-path numbering (`1 → 1.1`, `1.2 → 1.2.1 …`) and an in-place eviction primitive that replaces sizeable `Role::Tool` results with a pointer to the distilled note, **preserving `tool_call_id`** so Bedrock/Ollama tool-call/result pairing stays valid. Idempotent; watermark-clamped.
- **`begin_step` / `complete_step`** core-loop tools (advertised only when a scratchpad writer is wired; intercepted in the dispatch loop, not the tool executor — which can't reach `conv.messages`). `begin_step` opens a numbered step + todo; nest by calling it again inside a step. `complete_step` marks the todo done, writes the carry-forward outcome note, and compacts the scope. `status:"abandoned"` clears a dead-end branch while still recording why. The stack is cleared on overflow recovery so stale watermarks can't evict the wrong range.
- **Per-round `[Plan]` surfacing**: open todos render as a compact indented tree alongside the existing `[Current task]` anchor — cheap to re-send, so the plan persists while raw work is evicted.
- **Prompt rewrite**: the "notepad and pen" framing + `plan → step → compact → promote → summarize` workflow; keeps the #216 selective-use guidance (tiny tasks skip the pad). Golden file + the `builtin_scratchpad_write` description kept in sync.
- **KB provenance** (P3 close-out): `builtin_knowledge_base_write` now stamps `source_conversation_id` (previously dropped), so findings promoted at end-of-task are traceable.

## Testing
- 13 new tests: planning-primitive units (stack numbering, nesting, eviction byte-shrink + pairing invariants, idempotency, plan render) + two service-level e2e tests (begin→tool→complete evicts the raw result into a scratchpad pointer; the open plan is surfaced into the next round's context).
- `just check` green: fmt, clippy `-D warnings`, build, full workspace test (291 core tests).
- No dependency changes (audit surface unchanged from main).

## Notes for review
- **Tool naming**: `begin_step` / `complete_step` are intentionally *not* `builtin_`-prefixed — they're core-loop control verbs handled by the dispatch loop, not `BuiltinToolService` executor tools. Interception is gated on the same condition that advertises them, so when planning is off the names aren't shadowed. Happy to prefix if you'd prefer the convention.
- **Compaction is destructive to raw tool results in persisted history**, by design (per the refinement comments on #240: raw is not retained — re-run the tool if needed). The distilled outcome note is the durable, searchable form.
- #239's hard rails (lower round cap, wall-clock + per-tool timeouts, auto-compaction backstop) remain a **sibling** — this PR relieves the pressure; #239 adds the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
