### PR TITLE
Tool execution-locality model + server/client routing (+ KB-search & terminal awareness)

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -25,6 +25,7 @@ use desktop_assistant_core::ports::scratchpad::{
     ScratchpadDeleteManyFn, ScratchpadGetManyFn, ScratchpadListFn, ScratchpadWriteFn,
 };
 use desktop_assistant_core::ports::store::{IdempotencyKeyStore, TurnStateStore};
+use desktop_assistant_core::ports::transport::{current_transport_kind, with_transport_kind};
 use thiserror::Error;
 use tracing::warn;
 
@@ -1870,11 +1871,17 @@ where
         let request_id_for_body = request_id.clone();
         let user_id_for_body = user_id.clone();
         let user_id_for_cleanup = user_id.clone();
+        // Capture the connection's transport before the spawn (#243). Read here
+        // while still inside the dispatcher's `with_transport_kind` scope, then
+        // re-install in the spawned body — `task_local`s don't cross
+        // `tokio::spawn`, so this mirrors the `with_user_id` re-install.
+        let transport_for_body = current_transport_kind();
 
         // `registry.spawn` is sync; the body runs on its own `tokio::spawn` so
         // we can return the new task id immediately. `tokio::spawn` doesn't
-        // propagate task-locals, so the body re-installs `with_user_id` for
-        // storage queries inside `run_send_turn` (#154).
+        // propagate task-locals, so the body re-installs `with_user_id` (and
+        // `with_transport_kind`, #243) for the queries / tool-note inside
+        // `run_send_turn` (#154).
         let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
             ctx.logs.append(
                 api::LogLevel::Info,
@@ -1899,19 +1906,22 @@ where
                     as Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>
             });
 
-            let result = with_user_id(
-                user_id_for_body,
-                run_send_turn(
-                    conversations,
-                    conv_id_for_body,
-                    content,
-                    override_selection,
-                    system_refinement,
-                    request_id_for_body,
-                    idempotency,
-                    turn_sink,
-                    ctx.token.clone(),
-                    client_tool_port,
+            let result = with_transport_kind(
+                transport_for_body,
+                with_user_id(
+                    user_id_for_body,
+                    run_send_turn(
+                        conversations,
+                        conv_id_for_body,
+                        content,
+                        override_selection,
+                        system_refinement,
+                        request_id_for_body,
+                        idempotency,
+                        turn_sink,
+                        ctx.token.clone(),
+                        client_tool_port,
+                    ),
                 ),
             )
             .await;
@@ -1986,10 +1996,15 @@ where
         let request_id_for_body = request_id.clone();
         let sink_for_body = Arc::clone(&sink);
         let user_id_for_body = user_id.clone();
+        // Capture the connection's transport before the spawn and re-install it
+        // in the body (#243), the same way `user_id` is threaded across the
+        // `tokio::spawn` boundary.
+        let transport_for_body = current_transport_kind();
 
         // `tokio::spawn` does not propagate task-locals, so the body
         // must re-install `with_user_id` for storage queries inside
-        // `run_send_turn` to scope to the right user (#154). The
+        // `run_send_turn` to scope to the right user (#154), and
+        // `with_transport_kind` so the tool note tags localities (#243). The
         // `system_refinement` is moved into the closure as an explicit
         // value for the same reason (task-locals don't cross the spawn).
         let task_id = registry.spawn(user_id, kind, title, move |ctx| async move {
@@ -2015,19 +2030,22 @@ where
                     as Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>
             });
 
-            let result = with_user_id(
-                user_id_for_body,
-                run_send_turn(
-                    conversations,
-                    conv_id_for_body,
-                    content,
-                    override_selection,
-                    system_refinement,
-                    request_id_for_body,
-                    idempotency,
-                    sink_for_body,
-                    ctx.token.clone(),
-                    client_tool_port,
+            let result = with_transport_kind(
+                transport_for_body,
+                with_user_id(
+                    user_id_for_body,
+                    run_send_turn(
+                        conversations,
+                        conv_id_for_body,
+                        content,
+                        override_selection,
+                        system_refinement,
+                        request_id_for_body,
+                        idempotency,
+                        sink_for_body,
+                        ctx.token.clone(),
+                        client_tool_port,
+                    ),
                 ),
             )
             .await;

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -20,7 +20,10 @@
 //! `service.rs` to mirror this module's defaults (e.g., the floor on
 //! window size, the compaction-token-pressure threshold).
 
-use crate::domain::{Conversation, Message, MessageSummary, Role, ToolDefinition, ToolNamespace};
+use crate::domain::{
+    Conversation, Message, MessageSummary, Role, ToolDefinition, ToolLocality, ToolNamespace,
+    TransportKind,
+};
 use crate::ports::llm::{ContextBudget, LlmClient, ReasoningConfig};
 
 /// Default maximum number of conversation messages sent to the LLM per turn.
@@ -198,6 +201,7 @@ pub(crate) fn llm_messages_for_turn(
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
+    locality: Option<&ToolLocalityContext>,
     estimate: &dyn Fn(&str) -> u64,
 ) -> Vec<Message> {
     let mut current_max = max_messages;
@@ -212,6 +216,7 @@ pub(crate) fn llm_messages_for_turn(
         tool_rounds_since_anchor,
         system_refinement,
         budget,
+        locality,
         estimate,
     );
 
@@ -258,6 +263,7 @@ pub(crate) fn llm_messages_for_turn(
             tool_rounds_since_anchor,
             system_refinement,
             Some(budget),
+            locality,
             estimate,
         );
     }
@@ -265,13 +271,177 @@ pub(crate) fn llm_messages_for_turn(
     assembled
 }
 
+/// Per-turn tool execution-locality context (issue #243).
+///
+/// Bundles the inputs the tool-note builder needs to tag each tool with where
+/// it runs: the connection's [`TransportKind`] (the co-location signal), the
+/// daemon's self-identity `host` label, and the names of the tools registered
+/// as client-local for this turn. Cheap to build — the dispatch loop assembles
+/// it once per turn from the transport task-local, the handler's host label,
+/// and the client-tool port's definitions.
+#[derive(Debug, Clone)]
+pub(crate) struct ToolLocalityContext {
+    /// How the turn's connection reaches the daemon. Drives co-location:
+    /// local transports collapse the server/client distinction.
+    pub transport: TransportKind,
+    /// The daemon's self-identity label used for `Server { host }` (hostname
+    /// today; a stable machine-id in the follow-up phase).
+    pub host: String,
+    /// Label shown for a client tool's machine in the remote tool note (e.g.
+    /// `your device`). A per-client device name arrives with the system-id
+    /// handshake in the follow-up phase.
+    pub client_label: String,
+    /// Names of the tools that run server-side (MCP / built-in) on the daemon
+    /// host. A name in BOTH this set and [`Self::client_tool_names`] is a
+    /// capability duplicated across machines (the routing case).
+    pub server_tool_names: Vec<String>,
+    /// Names of the tools registered as client-local for this turn (run on the
+    /// registering client's machine).
+    pub client_tool_names: Vec<String>,
+}
+
+impl ToolLocalityContext {
+    /// Whether the connection is co-located with the daemon (same machine).
+    fn is_co_located(&self) -> bool {
+        self.transport.is_co_located()
+    }
+
+    fn is_server(&self, name: &str) -> bool {
+        self.server_tool_names.iter().any(|n| n == name)
+    }
+
+    fn is_client(&self, name: &str) -> bool {
+        self.client_tool_names.iter().any(|n| n == name)
+    }
+}
+
+/// One entry in the resolved per-turn locality plan (issue #243).
+///
+/// `resolve_tool_localities` turns the flat tool set plus the locality context
+/// into a plan the note renders. Each entry records the tool's `name`, its
+/// [`ToolLocality`], and whether it is the **primary** for its capability —
+/// the tool the service nudges the LLM toward when the same capability exists
+/// on both the server and a (remote) client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolLocalityEntry {
+    pub name: String,
+    pub locality: ToolLocality,
+    /// True when this entry is the primary for a capability that is duplicated
+    /// across localities. For a non-duplicated capability every entry is
+    /// trivially primary. Only meaningful in the remote case (the local case
+    /// collapses duplicates to the single server tool).
+    pub primary: bool,
+}
+
+/// Resolve the flat tool set into a locality plan (issue #243).
+///
+/// Behaviour:
+/// - **Co-located** (UDS / D-Bus): the client and daemon are the same machine,
+///   so a server tool and a client tool with the same name are physically the
+///   same capability. We collapse them — keep the server-side tool, drop the
+///   duplicate client one — so the LLM sees one tool per capability and the
+///   note carries no confusing per-machine distinction.
+/// - **Remote** (WebSocket): server and client are distinct hosts. Both tools
+///   of a duplicated capability are exposed, each tagged with its locality, and
+///   the **server-side** one is marked primary (daemon-side execution is the
+///   safe default; the prompt rule tells the model to prefer the client tool
+///   for work on the user's own device and to ask when genuinely ambiguous).
+///
+/// Tool order is preserved (server entries keep their position; in the remote
+/// case the matching client entry is appended right after its server twin).
+pub(crate) fn resolve_tool_localities(
+    tool_names: &[&str],
+    ctx: &ToolLocalityContext,
+) -> Vec<ToolLocalityEntry> {
+    let co_located = ctx.is_co_located();
+    let mut entries: Vec<ToolLocalityEntry> = Vec::with_capacity(tool_names.len());
+
+    for &name in tool_names {
+        let is_server = ctx.is_server(name);
+        let is_client = ctx.is_client(name);
+        let duplicated = is_server && is_client;
+
+        if duplicated {
+            // Capability on both machines. Co-located ⇒ the two are physically
+            // the same, so keep only the server-side tool. Remote ⇒ expose both
+            // with the server tool as the primary and the client tool as the
+            // labelled alternative.
+            entries.push(ToolLocalityEntry {
+                name: name.to_string(),
+                locality: ToolLocality::server(&ctx.host),
+                primary: true,
+            });
+            if !co_located {
+                entries.push(ToolLocalityEntry {
+                    name: name.to_string(),
+                    locality: ToolLocality::client(name, &ctx.client_label),
+                    primary: false,
+                });
+            }
+        } else if is_client {
+            // Client-only capability: a plain local tool when co-located, a
+            // labelled remote tool otherwise.
+            entries.push(ToolLocalityEntry {
+                name: name.to_string(),
+                locality: ToolLocality::client(name, &ctx.client_label),
+                primary: true,
+            });
+        } else {
+            // Server-side (MCP / built-in), the default for anything not
+            // registered as client-local.
+            entries.push(ToolLocalityEntry {
+                name: name.to_string(),
+                locality: ToolLocality::server(&ctx.host),
+                primary: true,
+            });
+        }
+    }
+    entries
+}
+
+/// Render a locality plan into the human-readable tool list used in the note.
+///
+/// - **Co-located**: a plain comma-joined name list — everything is on this
+///   machine, so no per-tool label is added.
+/// - **Remote**: each tool is labelled with its locality, e.g.
+///   `terminal — server 'daemon-host'` / `terminal — your device 'laptop'`,
+///   and a duplicated capability's non-primary alternative is noted.
+fn render_locality_list(entries: &[ToolLocalityEntry], co_located: bool) -> String {
+    if co_located {
+        return entries
+            .iter()
+            .map(|e| e.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+    }
+    entries
+        .iter()
+        .map(|e| match &e.locality {
+            ToolLocality::Server { host } => format!("{} — server '{host}'", e.name),
+            ToolLocality::Client { label, .. } => {
+                let alt = if e.primary { "" } else { " (alternative)" };
+                format!("{} — your device '{label}'{alt}", e.name)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Build the full tool-availability note enumerating every tool name and
 /// the deferred-namespace index. Returned by default; demoted to a
 /// namespace-only summary by [`build_demoted_tool_note`] when the
 /// assembled system block exceeds [`SYSTEM_BLOCK_BUDGET_RATIO`].
+///
+/// When `locality` is `Some`, tools are tagged with where they run (issue
+/// #243): co-located connections (UDS / D-Bus) get a plain list because
+/// everything is on this machine, while a remote (WebSocket) connection gets
+/// per-tool locality labels and a short routing hint. When `None` (callers
+/// that don't thread a transport context) the listing is the plain name list,
+/// byte-identical to the pre-#243 behaviour.
 fn build_full_tool_note(
     tool_defs: &[ToolDefinition],
     deferred_namespaces: &[ToolNamespace],
+    locality: Option<&ToolLocalityContext>,
 ) -> String {
     if tool_defs.is_empty() && deferred_namespaces.is_empty() {
         return "No tools are available in this turn.".to_string();
@@ -281,19 +451,46 @@ fn build_full_tool_note(
     let mut note = String::new();
 
     if !tool_defs.is_empty() {
-        let names = tool_defs
-            .iter()
-            .map(|t| t.name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
+        // Resolve locality and render the tool list. The co-located common
+        // case (and the no-context fallback) produce the plain comma-joined
+        // list; a remote connection produces per-tool locality labels.
+        let (names, remote_routing_hint) = match locality {
+            Some(ctx) => {
+                let tool_names: Vec<&str> = tool_defs.iter().map(|t| t.name.as_str()).collect();
+                let entries = resolve_tool_localities(&tool_names, ctx);
+                let co_located = ctx.is_co_located();
+                let rendered = render_locality_list(&entries, co_located);
+                // Only emit a routing hint when a capability is genuinely
+                // duplicated across distinct machines (remote case).
+                let has_remote_dup =
+                    !co_located && entries.iter().any(|e| !e.primary && e.locality.is_client());
+                let hint = if has_remote_dup {
+                    " Some capabilities exist on both the server and your device — \
+                     prefer the tool on your device for work on your own machine, the \
+                     server tool for daemon-side work, and ask which machine when it's \
+                     genuinely ambiguous."
+                } else {
+                    ""
+                };
+                (rendered, hint)
+            }
+            None => (
+                tool_defs
+                    .iter()
+                    .map(|t| t.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                "",
+            ),
+        };
         if has_tool_search {
             note = format!(
-                "Available tools in this turn: {names}. \
+                "Available tools in this turn: {names}.{remote_routing_hint} \
                  Additional tools may be available — use builtin_tool_search to discover \
                  tools for tasks not covered by the tools listed above."
             );
         } else {
-            note = format!("Available tools in this turn: {names}.");
+            note = format!("Available tools in this turn: {names}.{remote_routing_hint}");
         }
     }
 
@@ -399,9 +596,10 @@ fn assemble_messages_inner(
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
+    locality: Option<&ToolLocalityContext>,
     estimate: &dyn Fn(&str) -> u64,
 ) -> Vec<Message> {
-    let tool_note = build_full_tool_note(tool_defs, deferred_namespaces);
+    let tool_note = build_full_tool_note(tool_defs, deferred_namespaces, locality);
     let system_instruction = assemble_system_instruction(tool_note, system_refinement);
 
     // Measure the system block. The system instruction is always
@@ -1270,6 +1468,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
         // System message + all 10 conversation messages
@@ -1304,6 +1503,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1350,6 +1550,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1388,6 +1589,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1432,6 +1634,7 @@ mod tests {
             0,
             "",
             Some(budget),
+            None,
             &one_per_char,
         );
 
@@ -1478,6 +1681,7 @@ mod tests {
             0,
             "",
             Some(budget),
+            None,
             &one_per_char,
         );
 
@@ -1520,6 +1724,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1561,6 +1766,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1597,6 +1803,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1636,6 +1843,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1668,6 +1876,7 @@ mod tests {
             Some(task),
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1703,6 +1912,7 @@ mod tests {
             6,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1730,6 +1940,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1755,6 +1966,7 @@ mod tests {
             Some(""),
             99,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1792,6 +2004,7 @@ mod tests {
             Some(task),
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1845,6 +2058,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -1876,6 +2090,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1922,6 +2137,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -1977,6 +2193,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -2029,6 +2246,7 @@ mod tests {
             None,
             0,
             "",
+            None,
             None,
             &default_estimate,
         );
@@ -2165,6 +2383,7 @@ mod tests {
             0,
             "",
             Some(budget),
+            None,
             &default_estimate,
         );
 
@@ -2216,6 +2435,7 @@ mod tests {
             0,
             "",
             Some(budget),
+            None,
             &default_estimate,
         );
 
@@ -2257,6 +2477,7 @@ mod tests {
             0,
             "",
             None,
+            None,
             &default_estimate,
         );
 
@@ -2277,5 +2498,171 @@ mod tests {
                 .contains(&format!("There are {} tools across", tools.len())),
             "demoted summary must not appear when no budget installed"
         );
+    }
+
+    // --- Tool execution-locality (issue #243) ------------------------------
+
+    fn locality_ctx(
+        transport: TransportKind,
+        host: &str,
+        server_names: &[&str],
+        client_names: &[&str],
+    ) -> ToolLocalityContext {
+        ToolLocalityContext {
+            transport,
+            host: host.to_string(),
+            client_label: "your device".to_string(),
+            server_tool_names: server_names.iter().map(|s| s.to_string()).collect(),
+            client_tool_names: client_names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn resolve_localities_co_located_collapses_duplicates() {
+        // `terminal` exists on both server and client; `voice_stop` is
+        // client-only; `kb_search` is server-only. Co-located (UDS) ⇒ the
+        // duplicate collapses to the single server-side tool.
+        let ctx = locality_ctx(
+            TransportKind::Uds,
+            "daemon-host",
+            &["terminal", "kb_search"],
+            &["terminal", "voice_stop"],
+        );
+        let entries = resolve_tool_localities(&["terminal", "kb_search", "voice_stop"], &ctx);
+        // terminal exists both sides → only the server entry survives.
+        let terminal: Vec<_> = entries.iter().filter(|e| e.name == "terminal").collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "co-located duplicate must collapse to one"
+        );
+        assert!(terminal[0].locality.is_server());
+        // voice_stop is client-only → present once, client locality.
+        let voice: Vec<_> = entries.iter().filter(|e| e.name == "voice_stop").collect();
+        assert_eq!(voice.len(), 1);
+        assert!(voice[0].locality.is_client());
+        // kb_search is server-only.
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.name == "kb_search" && e.locality.is_server())
+        );
+    }
+
+    #[test]
+    fn resolve_localities_remote_exposes_both_with_primary_server() {
+        // `terminal` on both server and client + a remote (WebSocket)
+        // transport: both are exposed, server is primary, client is the
+        // labelled alternative.
+        let ctx = locality_ctx(
+            TransportKind::WebSocket,
+            "daemon-host",
+            &["terminal", "kb_search"],
+            &["terminal"],
+        );
+        let entries = resolve_tool_localities(&["terminal", "kb_search"], &ctx);
+        let terminal: Vec<_> = entries.iter().filter(|e| e.name == "terminal").collect();
+        assert_eq!(terminal.len(), 2, "remote duplicate must expose both tools");
+        // Exactly one is server (primary), one is client (alternative).
+        let server = terminal.iter().find(|e| e.locality.is_server()).unwrap();
+        let client = terminal.iter().find(|e| e.locality.is_client()).unwrap();
+        assert!(
+            server.primary,
+            "server side is the primary in the remote case"
+        );
+        assert!(
+            !client.primary,
+            "client side is the non-primary alternative"
+        );
+    }
+
+    #[test]
+    fn build_tool_note_co_located_omits_locality_labels() {
+        // Co-located: plain name list, no "server '...'" / "your device" labels.
+        let tools = vec![
+            ToolDefinition::new("terminal", "run", serde_json::json!({})),
+            ToolDefinition::new("kb_search", "search", serde_json::json!({})),
+        ];
+        let ctx = locality_ctx(
+            TransportKind::Uds,
+            "daemon-host",
+            &["terminal", "kb_search"],
+            &[],
+        );
+        let note = build_full_tool_note(&tools, &[], Some(&ctx));
+        assert!(note.contains("Available tools in this turn: terminal, kb_search."));
+        assert!(!note.contains("server 'daemon-host'"), "note: {note}");
+        assert!(!note.contains("your device"), "note: {note}");
+    }
+
+    #[test]
+    fn build_tool_note_remote_labels_localities_and_routes() {
+        // Remote duplicate: per-tool locality labels plus a routing hint. The
+        // flat list carries the deduped (server) `terminal`; the context marks
+        // it as also client-registered, so the note twins it.
+        let tools = vec![ToolDefinition::new(
+            "terminal",
+            "run",
+            serde_json::json!({}),
+        )];
+        let ctx = locality_ctx(
+            TransportKind::WebSocket,
+            "daemon-host",
+            &["terminal"],
+            &["terminal"],
+        );
+        let note = build_full_tool_note(&tools, &[], Some(&ctx));
+        assert!(
+            note.contains("terminal — server 'daemon-host'"),
+            "note: {note}"
+        );
+        assert!(note.contains("your device"), "note: {note}");
+        // Routing hint for the duplicated capability.
+        assert!(
+            note.contains("prefer the tool on your device") && note.contains("ask which machine"),
+            "remote routing hint must be present: {note}"
+        );
+    }
+
+    #[test]
+    fn build_tool_note_remote_client_only_labels_without_routing_hint() {
+        // A client-only capability over a remote transport still gets a
+        // locality label, but there's no duplicated capability so no routing
+        // hint is emitted.
+        let tools = vec![ToolDefinition::new(
+            "voice_stop",
+            "stop",
+            serde_json::json!({}),
+        )];
+        let ctx = locality_ctx(
+            TransportKind::WebSocket,
+            "daemon-host",
+            &[],
+            &["voice_stop"],
+        );
+        let note = build_full_tool_note(&tools, &[], Some(&ctx));
+        assert!(note.contains("voice_stop — your device"), "note: {note}");
+        assert!(
+            !note.contains("ask which machine"),
+            "no routing hint without a duplicated capability: {note}"
+        );
+    }
+
+    #[test]
+    fn build_tool_note_none_locality_is_plain_list() {
+        // No locality context (legacy callers) → byte-identical plain list.
+        let tools = vec![ToolDefinition::new(
+            "terminal",
+            "run",
+            serde_json::json!({}),
+        )];
+        let with_none = build_full_tool_note(&tools, &[], None);
+        let co_located = locality_ctx(TransportKind::Uds, "daemon-host", &["terminal"], &[]);
+        let with_local = build_full_tool_note(&tools, &[], Some(&co_located));
+        assert_eq!(
+            with_none, with_local,
+            "co-located note must match the no-context plain list"
+        );
+        assert!(with_none.contains("Available tools in this turn: terminal."));
     }
 }

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -8,4 +8,4 @@ pub use conversation::{Conversation, ConversationId, ConversationSummary, Messag
 pub use knowledge::KnowledgeEntry;
 pub use message::{Message, Role};
 pub use scratchpad::{DEFAULT_NOTE_TYPE, ScratchpadNote};
-pub use tool::{ToolCall, ToolDefinition, ToolNamespace, ToolResult};
+pub use tool::{ToolCall, ToolDefinition, ToolLocality, ToolNamespace, ToolResult, TransportKind};

--- a/crates/core/src/domain/tool.rs
+++ b/crates/core/src/domain/tool.rs
@@ -1,5 +1,91 @@
 use serde::{Deserialize, Serialize};
 
+/// Where a tool physically executes (issue #243).
+///
+/// MCP servers and built-in tools run on the **daemon's** host; tools a
+/// connection registers via `RegisterClientTools` run on the **registering
+/// client's** machine. The same capability (e.g. a terminal) can exist in
+/// both places, so the service needs to know the locality of each tool the
+/// LLM can call in order to route the work to the right machine and to
+/// describe it accurately in the per-turn tool note.
+///
+/// ## Co-location and the phase boundary
+///
+/// In the common single-machine setup the client and daemon are the *same*
+/// host, so a `Client` tool and a `Server` tool are physically co-located
+/// and the distinction collapses to "this machine". This PR infers
+/// co-location from the connection's [`TransportKind`] (a local transport ⇒
+/// same machine); a later phase will replace that heuristic with an explicit
+/// per-machine system-id handshake (clients send their id; the server
+/// compares it to its own, preferring `/etc/machine-id` when suitable). The
+/// `host` / `id` fields are populated by hostname today precisely so that
+/// future id can slot in without reshaping this type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "where")]
+pub enum ToolLocality {
+    /// Runs on the daemon's host. Used for MCP servers and built-in tools.
+    /// `host` is the daemon's self-identity label (hostname today; a stable
+    /// machine-id in the follow-up phase).
+    Server { host: String },
+    /// Runs on a connected client's machine. Used for tools registered via
+    /// `RegisterClientTools`. `id` is the connection/client identity and
+    /// `label` is a human-friendly device name for the tool note.
+    Client { id: String, label: String },
+}
+
+impl ToolLocality {
+    /// Convenience constructor for a server-side (daemon-host) locality.
+    pub fn server(host: impl Into<String>) -> Self {
+        Self::Server { host: host.into() }
+    }
+
+    /// Convenience constructor for a client-side (registering-machine) locality.
+    pub fn client(id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self::Client {
+            id: id.into(),
+            label: label.into(),
+        }
+    }
+
+    /// True for a server-side (daemon-host) tool.
+    pub fn is_server(&self) -> bool {
+        matches!(self, Self::Server { .. })
+    }
+
+    /// True for a client-side (registering-machine) tool.
+    pub fn is_client(&self) -> bool {
+        matches!(self, Self::Client { .. })
+    }
+}
+
+/// How a connection reaches the daemon, used to infer tool co-location
+/// (issue #243).
+///
+/// The signal is deliberately coarse: a local transport (Unix-domain socket
+/// or D-Bus) can only be reached from the daemon's own machine, so a client
+/// on such a transport and the daemon are the *same* host — a `Client` tool
+/// and a `Server` tool are co-located and the locality distinction collapses.
+/// A WebSocket connection can be remote, so `Server` (daemon host) and
+/// `Client` (the WS peer's machine) are treated as distinct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportKind {
+    /// Unix-domain socket: same machine as the daemon ⇒ co-located.
+    Uds,
+    /// D-Bus: same machine as the daemon ⇒ co-located.
+    Dbus,
+    /// WebSocket: potentially remote ⇒ server and client are distinct.
+    WebSocket,
+}
+
+impl TransportKind {
+    /// Whether a client on this transport is co-located with the daemon
+    /// (same machine). True for the local transports (UDS / D-Bus), false
+    /// for WebSocket, which may terminate on a different host.
+    pub fn is_co_located(self) -> bool {
+        matches!(self, Self::Uds | Self::Dbus)
+    }
+}
+
 /// Definition of a tool that can be called by the LLM.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolDefinition {
@@ -186,5 +272,52 @@ mod tests {
         let json = serde_json::to_string(&ns).unwrap();
         let deserialized: ToolNamespace = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, ns);
+    }
+
+    // --- ToolLocality / TransportKind (issue #243) -------------------------
+
+    #[test]
+    fn tool_locality_constructors_and_predicates() {
+        let server = ToolLocality::server("daemon-host");
+        assert!(server.is_server());
+        assert!(!server.is_client());
+        assert_eq!(
+            server,
+            ToolLocality::Server {
+                host: "daemon-host".into()
+            }
+        );
+
+        let client = ToolLocality::client("conn-7", "Dave's laptop");
+        assert!(client.is_client());
+        assert!(!client.is_server());
+        assert_eq!(
+            client,
+            ToolLocality::Client {
+                id: "conn-7".into(),
+                label: "Dave's laptop".into()
+            }
+        );
+    }
+
+    #[test]
+    fn tool_locality_serde_round_trip() {
+        for loc in [
+            ToolLocality::server("host-a"),
+            ToolLocality::client("id-1", "Laptop"),
+        ] {
+            let json = serde_json::to_string(&loc).unwrap();
+            let parsed: ToolLocality = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, loc);
+        }
+    }
+
+    #[test]
+    fn transport_kind_co_location() {
+        // Local transports collapse client/server to the same machine.
+        assert!(TransportKind::Uds.is_co_located());
+        assert!(TransportKind::Dbus.is_co_located());
+        // WebSocket may be remote, so locality is distinct.
+        assert!(!TransportKind::WebSocket.is_co_located());
     }
 }

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -37,6 +37,11 @@ pub mod conversation_search;
 /// Request-scoped auth context — task-local `UserId` for SQL scoping (#105).
 pub mod auth;
 
+/// Request-scoped transport context — task-local [`crate::domain::TransportKind`]
+/// so the turn loop can infer tool co-location (UDS/D-Bus ⇒ same machine,
+/// WebSocket ⇒ possibly remote) when tagging tools with locality (#243).
+pub mod transport;
+
 /// Request-scoped conversation context — task-local `ConversationId` so tool
 /// executors can scope per-conversation side state (e.g. the scratchpad).
 pub mod conversation_ctx;

--- a/crates/core/src/ports/transport.rs
+++ b/crates/core/src/ports/transport.rs
@@ -1,0 +1,96 @@
+//! Request-scoped transport context (issue #243).
+//!
+//! Tool execution-locality routing needs to know whether the connection
+//! driving the current turn is co-located with the daemon. A local transport
+//! (Unix-domain socket or D-Bus) can only be reached from the daemon's own
+//! machine, so a client-registered tool on such a connection runs on the same
+//! host as the server-side MCP tools — the [`crate::domain::ToolLocality`]
+//! distinction collapses to "this machine". A WebSocket connection may be
+//! remote, so the two localities stay distinct.
+//!
+//! This module exposes a task-local [`crate::domain::TransportKind`] slot,
+//! mirroring [`crate::ports::auth`]'s `UserId` plumbing: the transport adapter
+//! installs the connection's kind via [`with_transport_kind`] before invoking
+//! the handler, and the dispatch loop reads it via [`current_transport_kind`]
+//! when it assembles the per-turn tool set.
+//!
+//! ## Default
+//!
+//! When no scope is installed — tests, dreaming jobs, and any caller that does
+//! not route through a transport adapter — [`current_transport_kind`] returns
+//! [`TransportKind::Uds`]. UDS is the live default transport and is co-located,
+//! so the safe, common-case behaviour (treat tools as same-machine) applies
+//! without every test having to install a scope.
+
+use crate::domain::TransportKind;
+
+tokio::task_local! {
+    /// The transport the current turn's connection arrived on. Installed by
+    /// the transport adapter via [`with_transport_kind`]; read by the dispatch
+    /// loop via [`current_transport_kind`]. Unset outside a transport scope,
+    /// which [`current_transport_kind`] reports as [`TransportKind::Uds`] (the
+    /// co-located default).
+    static TRANSPORT_KIND: TransportKind;
+}
+
+/// Run `fut` with `kind` installed as the current task-local transport. All
+/// [`current_transport_kind`] calls inside the future (and any sub-tasks that
+/// inherit the scope) observe `kind`.
+///
+/// Note: like every `tokio::task_local!`, the slot does **not** cross a
+/// `tokio::spawn` boundary. Adapters whose turn body runs on a spawned task
+/// must thread the value explicitly and re-install it inside the spawn (the
+/// same discipline `with_user_id` follows).
+pub async fn with_transport_kind<F, T>(kind: TransportKind, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    TRANSPORT_KIND.scope(kind, fut).await
+}
+
+/// The current task-local transport kind, or [`TransportKind::Uds`] when no
+/// scope is installed. Safe to call from any async context — never panics,
+/// never blocks. The UDS default means callers that don't route through a
+/// transport adapter treat tools as co-located, which is the live common case.
+pub fn current_transport_kind() -> TransportKind {
+    TRANSPORT_KIND
+        .try_with(|k| *k)
+        .unwrap_or(TransportKind::Uds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn current_transport_kind_defaults_to_uds_outside_scope() {
+        assert_eq!(current_transport_kind(), TransportKind::Uds);
+    }
+
+    #[tokio::test]
+    async fn current_transport_kind_observes_installed_scope() {
+        let observed =
+            with_transport_kind(TransportKind::WebSocket, async { current_transport_kind() }).await;
+        assert_eq!(observed, TransportKind::WebSocket);
+        // After the scope exits the slot is unset again (back to the default).
+        assert_eq!(current_transport_kind(), TransportKind::Uds);
+    }
+
+    #[tokio::test]
+    async fn nested_transport_kind_shadows_outer() {
+        let observed = with_transport_kind(TransportKind::Uds, async {
+            with_transport_kind(TransportKind::WebSocket, async { current_transport_kind() }).await
+        })
+        .await;
+        assert_eq!(observed, TransportKind::WebSocket);
+    }
+
+    #[tokio::test]
+    async fn spawned_task_outside_scope_sees_default() {
+        // task_local slots don't cross `tokio::spawn`.
+        let observed = tokio::spawn(async { current_transport_kind() })
+            .await
+            .unwrap();
+        assert_eq!(observed, TransportKind::Uds);
+    }
+}

--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -18,6 +18,8 @@ Before responding, plan what you need, then gather it efficiently:
 == Knowledge base ==
 The KB (builtin_knowledge_base_write/search/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags.
 
+SEARCH BEFORE ASKING (mandatory): Before you ask the user for any fact, preference, or project detail — and before you say you don't know or can't recall something — you MUST first call builtin_knowledge_base_search. Only ask the user if the search comes up empty. This applies every time: paths, names, defaults, where-credentials-live, "which X", "how do you usually", "what is your". Searching is cheap; asking for something you already stored is not. Do not skip this step.
+
 Reading:
 - Prefer project-scoped entries (tagged "project:<name>") over global ones.
 - Global tags: "preference" (settings/defaults), "memory" (contextual facts), "instruction" (how-to procedures).
@@ -91,6 +93,9 @@ Helper tools for data management:
 == Tool discovery ==
 You start each conversation with a small set of core tools; many more are discoverable via builtin_tool_search. Activated tools persist for the rest of the conversation.
 - Search with focused queries describing the capability (e.g. "create calendar event", "manage files"). Use different queries for different capabilities; don't repeat the exact same query.
+
+== System access (terminal + files) ==
+You CAN run terminal/shell commands and read and write files on this machine. These are not in your starting set — find them with builtin_tool_search using queries like "run terminal command", "execute shell", or "read/write files", then call them. For the common local setup these act on the user's OWN machine. So when a task needs the system — inspect or change files, run a build or script, check what's installed, look something up on disk — reach for these tools and do it. Do NOT ask the user to run a command for you, and do NOT claim you can't run commands or touch the filesystem; you can. Where the tool's availability note labels a capability by location (e.g. "server" vs "your device"), let that guide which one you use.
 
 == Skills (procedural how-tos) ==
 You have a library of named procedures stored as skills, exposed via the skills_* tools. Skills are short, opinionated procedures the user or their team has captured for reuse (e.g. "stacked pull requests", "publish a crate", "rotate an api key"). They encode non-obvious steps and tool sequences.

--- a/crates/core/src/prompts/sections/knowledge_base.txt
+++ b/crates/core/src/prompts/sections/knowledge_base.txt
@@ -1,6 +1,8 @@
 == Knowledge base ==
 The KB (builtin_knowledge_base_write/search/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags.
 
+SEARCH BEFORE ASKING (mandatory): Before you ask the user for any fact, preference, or project detail — and before you say you don't know or can't recall something — you MUST first call builtin_knowledge_base_search. Only ask the user if the search comes up empty. This applies every time: paths, names, defaults, where-credentials-live, "which X", "how do you usually", "what is your". Searching is cheap; asking for something you already stored is not. Do not skip this step.
+
 Reading:
 - Prefer project-scoped entries (tagged "project:<name>") over global ones.
 - Global tags: "preference" (settings/defaults), "memory" (contextual facts), "instruction" (how-to procedures).

--- a/crates/core/src/prompts/sections/tool_use.txt
+++ b/crates/core/src/prompts/sections/tool_use.txt
@@ -2,6 +2,9 @@
 You start each conversation with a small set of core tools; many more are discoverable via builtin_tool_search. Activated tools persist for the rest of the conversation.
 - Search with focused queries describing the capability (e.g. "create calendar event", "manage files"). Use different queries for different capabilities; don't repeat the exact same query.
 
+== System access (terminal + files) ==
+You CAN run terminal/shell commands and read and write files on this machine. These are not in your starting set — find them with builtin_tool_search using queries like "run terminal command", "execute shell", or "read/write files", then call them. For the common local setup these act on the user's OWN machine. So when a task needs the system — inspect or change files, run a build or script, check what's installed, look something up on disk — reach for these tools and do it. Do NOT ask the user to run a command for you, and do NOT claim you can't run commands or touch the filesystem; you can. Where the tool's availability note labels a capability by location (e.g. "server" vs "your device"), let that guide which one you use.
+
 == Skills (procedural how-tos) ==
 You have a library of named procedures stored as skills, exposed via the skills_* tools. Skills are short, opinionated procedures the user or their team has captured for reuse (e.g. "stacked pull requests", "publish a crate", "rotate an api key"). They encode non-obvious steps and tool sequences.
 - Call skills_search_skills before any complex workflow; read full bodies with skills_get_skill and follow them as authoritative.

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -1,8 +1,8 @@
 use crate::CoreError;
 use crate::context::{
     COMPACTION_TOKEN_RATIO, DEFAULT_MAX_TOOL_RESULT_BYTES, MAX_CONTEXT_MESSAGES,
-    MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES, cap_tool_result, compaction_range,
-    generate_context_summary, llm_messages_for_turn, recover_from_overflow,
+    MAX_OVERFLOW_RETRIES, MIN_CONTEXT_MESSAGES, ToolLocalityContext, cap_tool_result,
+    compaction_range, generate_context_summary, llm_messages_for_turn, recover_from_overflow,
 };
 use crate::domain::{
     Conversation, ConversationId, ConversationSummary, Message, Role, ToolDefinition, ToolNamespace,
@@ -17,6 +17,7 @@ use crate::ports::llm::{
 use crate::ports::scratchpad::{SCRATCHPAD_GOAL_KEY, ScratchpadGetManyFn};
 use crate::ports::store::ConversationStore;
 use crate::ports::tools::ToolExecutor;
+use crate::ports::transport::current_transport_kind;
 use crate::sanitize::{sanitize_assistant_text, sanitize_assistant_text_for_stream};
 use crate::tools::{
     NoopToolExecutor, categorize_tool_namespaces, tool_set_hash, tool_status_message,
@@ -175,7 +176,19 @@ pub struct ConversationHandler<S, L, T = NoopToolExecutor> {
     /// [`DEFAULT_MAX_TOOL_RESULT_BYTES`]; override via
     /// [`Self::with_max_tool_result_bytes`].
     max_tool_result_bytes: usize,
+    /// The daemon's self-identity label, used as the `host` of a server-side
+    /// [`crate::domain::ToolLocality`] in the per-turn tool note (issue #243).
+    /// The daemon sets this to its hostname via [`Self::with_host`]; the
+    /// follow-up phase will replace it with a stable machine-id. Defaults to
+    /// [`DEFAULT_HOST_LABEL`] so callers that don't set it (tests, background
+    /// jobs) still produce a coherent note.
+    host: String,
 }
+
+/// Fallback `host` label for [`ConversationHandler`] when the daemon does not
+/// set one via [`ConversationHandler::with_host`] (issue #243). The live daemon
+/// always sets its hostname; this keeps tests and background jobs coherent.
+pub const DEFAULT_HOST_LABEL: &str = "this machine";
 
 impl<S, L> ConversationHandler<S, L, NoopToolExecutor> {
     pub fn new(store: S, llm: L, id_generator: Box<dyn Fn() -> String + Send + Sync>) -> Self {
@@ -188,6 +201,7 @@ impl<S, L> ConversationHandler<S, L, NoopToolExecutor> {
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
+            host: DEFAULT_HOST_LABEL.to_string(),
         }
     }
 }
@@ -208,7 +222,16 @@ impl<S, L, T> ConversationHandler<S, L, T> {
             namespace_cache: std::sync::Mutex::new(None),
             scratchpad_goal_read: None,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
+            host: DEFAULT_HOST_LABEL.to_string(),
         }
+    }
+
+    /// Set the daemon's self-identity `host` label used for server-side tool
+    /// localities in the per-turn tool note (issue #243). The daemon wires its
+    /// hostname here; the follow-up phase replaces it with a stable machine-id.
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
     }
 
     /// Set a separate LLM for backend tasks (title generation, context summary).
@@ -451,6 +474,32 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             None => Vec::new(),
         };
 
+        // Tool execution-locality context (issue #243). Resolve the turn's
+        // co-location signal (the connection's transport: UDS/D-Bus ⇒ same
+        // machine, WebSocket ⇒ possibly remote) plus the daemon's host label,
+        // the server-side tool names, and the client-local tool names once. The
+        // tool-note builder uses it to tag each tool with where it runs and to
+        // route a capability that exists on both the server and a remote
+        // client. The server set is the full core set plus every namespaced
+        // tool — activated tools are always a subset of these (they come from
+        // server-side search), so a tool that isn't in this set is client-only.
+        let server_tool_names: Vec<String> = core_tools
+            .iter()
+            .map(|t| t.name.clone())
+            .chain(
+                namespaces
+                    .iter()
+                    .flat_map(|ns| ns.tools.iter().map(|t| t.name.clone())),
+            )
+            .collect();
+        let tool_locality = ToolLocalityContext {
+            transport: current_transport_kind(),
+            host: self.host.clone(),
+            client_label: "your device".to_string(),
+            server_tool_names,
+            client_tool_names: client_tool_defs.iter().map(|d| d.name.clone()).collect(),
+        };
+
         for round in 0..MAX_TOOL_ROUNDS {
             // Between-turns cancellation checkpoint (issue #109): if the
             // caller cancelled while the previous tool round was
@@ -526,6 +575,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 tool_rounds_since_anchor,
                 &system_refinement,
                 current_context_budget(),
+                Some(&tool_locality),
                 &estimate,
             );
             let mut raw_stream = String::new();
@@ -932,7 +982,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
 mod tests {
     use super::*;
     use crate::context::MIN_TRUNCATION_TOKENS;
-    use crate::domain::{ToolCall, ToolDefinition};
+    use crate::domain::{ToolCall, ToolDefinition, TransportKind};
     use crate::ports::llm::{BudgetSource, ContextBudget, LlmResponse, TokenUsage};
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -2464,6 +2514,156 @@ mod tests {
             messages[0]
                 .content
                 .contains("Available tools in this turn: terminal.")
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_ws_turn_twins_duplicated_capability_with_locality_labels() {
+        // Issue #243 end-to-end through the dispatch loop: a server-side
+        // `terminal` plus a client-registered `terminal` over a REMOTE
+        // (WebSocket) connection. The per-turn tool note must expose BOTH with
+        // locality labels (server host vs your device) and a routing hint —
+        // i.e. the remote case does not collapse the capability.
+        use crate::ports::client_tools::with_client_tools;
+        use crate::ports::transport::with_transport_kind;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let seen = Arc::new(Mutex::new(Vec::<Message>::new()));
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let server_tools = vec![ToolDefinition::new(
+            "terminal",
+            "Run terminal command on the daemon host",
+            serde_json::json!({"type": "object"}),
+        )];
+        let handler = ConversationHandler::with_tools(
+            MockStore::new(),
+            CapturingLlm {
+                seen_messages: Arc::clone(&seen),
+            },
+            MockToolExecutor::new(server_tools, HashMap::new()),
+            Box::new(move || {
+                let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                format!("conv-{n}")
+            }),
+        )
+        .with_host("daemon-host");
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        // Client registers a tool with the SAME name as the server-side one.
+        let port: Arc<dyn crate::ports::client_tools::ClientToolPort> =
+            Arc::new(FakeClientToolPort {
+                defs: vec![ToolDefinition::new(
+                    "terminal",
+                    "Run terminal command on the user's device",
+                    serde_json::json!({"type": "object"}),
+                )],
+                executed: Arc::new(Mutex::new(Vec::new())),
+                result: String::new(),
+            });
+
+        // Drive the turn as if it arrived over a WebSocket connection.
+        with_transport_kind(
+            TransportKind::WebSocket,
+            with_client_tools(
+                port,
+                handler.send_prompt(&conv.id, "hi".into(), noop_callback(), noop_status()),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let messages = seen.lock().unwrap();
+        let system = &messages[0].content;
+        assert!(
+            system.contains("terminal — server 'daemon-host'"),
+            "remote note must label the server tool: {system}"
+        );
+        assert!(
+            system.contains("terminal — your device"),
+            "remote note must label the client twin: {system}"
+        );
+        assert!(
+            system.contains("ask which machine"),
+            "remote duplicated capability must carry the routing hint: {system}"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_uds_turn_collapses_duplicated_capability_to_plain_list() {
+        // Companion to the remote test: the SAME server+client `terminal` over
+        // a co-located (UDS) connection collapses to a single plain `terminal`
+        // entry — no locality labels, no routing hint.
+        use crate::ports::client_tools::with_client_tools;
+        use crate::ports::transport::with_transport_kind;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let seen = Arc::new(Mutex::new(Vec::<Message>::new()));
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let handler = ConversationHandler::with_tools(
+            MockStore::new(),
+            CapturingLlm {
+                seen_messages: Arc::clone(&seen),
+            },
+            MockToolExecutor::new(
+                vec![ToolDefinition::new(
+                    "terminal",
+                    "Run terminal command",
+                    serde_json::json!({"type": "object"}),
+                )],
+                HashMap::new(),
+            ),
+            Box::new(move || {
+                let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+                format!("conv-{n}")
+            }),
+        )
+        .with_host("daemon-host");
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        let port: Arc<dyn crate::ports::client_tools::ClientToolPort> =
+            Arc::new(FakeClientToolPort {
+                defs: vec![ToolDefinition::new(
+                    "terminal",
+                    "Run terminal command on the user's device",
+                    serde_json::json!({"type": "object"}),
+                )],
+                executed: Arc::new(Mutex::new(Vec::new())),
+                result: String::new(),
+            });
+
+        with_transport_kind(
+            TransportKind::Uds,
+            with_client_tools(
+                port,
+                handler.send_prompt(&conv.id, "hi".into(), noop_callback(), noop_status()),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let messages = seen.lock().unwrap();
+        let system = &messages[0].content;
+        // Inspect the tool-availability line specifically: the static prompt
+        // mentions "server"/"your device" as guidance, so assert against the
+        // generated tool listing rather than the whole system message.
+        let tool_line = system
+            .lines()
+            .find(|l| l.starts_with("Available tools in this turn:"))
+            .expect("a tool-availability line");
+        assert!(
+            tool_line.contains("Available tools in this turn: terminal."),
+            "co-located note must be a plain single entry: {tool_line}"
+        );
+        assert!(
+            !tool_line.contains("your device") && !tool_line.contains("server 'daemon-host'"),
+            "co-located note must omit locality labels: {tool_line}"
+        );
+        assert!(
+            !tool_line.contains("ask which machine"),
+            "co-located note must omit the routing hint: {tool_line}"
         );
     }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -215,6 +215,33 @@ fn env_bool(name: &str, default: bool) -> bool {
     parse_env_bool(std::env::var(name).ok().as_deref(), default)
 }
 
+/// The daemon's self-identity label for server-side tool localities (#243).
+///
+/// Hostname is the groundwork value; the follow-up phase replaces it with a
+/// stable per-machine system-id (e.g. `/etc/machine-id`) so a client can send
+/// its own id and the daemon can decide co-location precisely. Resolution is
+/// dependency-free and best-effort: the Linux kernel hostname
+/// (`/proc/sys/kernel/hostname`), then `/etc/hostname`, then the `HOSTNAME`
+/// env var, falling back to `"this machine"` so the tool note is always
+/// coherent.
+fn daemon_host_label() -> String {
+    let from_file = |path: &str| {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+    from_file("/proc/sys/kernel/hostname")
+        .or_else(|| from_file("/etc/hostname"))
+        .or_else(|| {
+            std::env::var("HOSTNAME")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "this machine".to_string())
+}
+
 /// Pure parser behind [`env_bool`], split out so the flag semantics are
 /// unit-testable without touching the process environment. `None` (unset) and
 /// unrecognized values fall back to `default`.
@@ -1615,7 +1642,12 @@ async fn main() -> Result<()> {
         llm,
         tool_executor,
         Box::new(|| uuid::Uuid::now_v7().to_string()),
-    );
+    )
+    // Server-side tool localities (#243) are labelled with the daemon's host
+    // identity. Hostname is the groundwork value; the follow-up phase swaps in
+    // a stable per-machine system-id (e.g. /etc/machine-id) shared with clients
+    // for the co-location handshake.
+    .with_host(daemon_host_label());
 
     // Build the shared registry handle (#11): wraps the in-memory
     // `ConnectionRegistry` plus the loaded `DaemonConfig` behind a single

--- a/crates/dbus-interface/src/conversation.rs
+++ b/crates/dbus-interface/src/conversation.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use desktop_assistant_core::domain::ConversationId;
+use desktop_assistant_core::domain::{ConversationId, TransportKind};
 use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 use desktop_assistant_core::ports::inbound::ConversationService;
+use desktop_assistant_core::ports::transport::with_transport_kind;
 use desktop_assistant_core::prompts::{PersonalityLevel, PersonalityOverride};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -192,9 +193,16 @@ where
     S: ConversationService + 'static,
 {
     let user_id_for_body = current_user_id();
-    tokio::spawn(with_user_id(
-        user_id_for_body,
-        run_send_prompt_llm_task(service, conversation_id, prompt, system_refinement, tx),
+    // A D-Bus connection always reaches the daemon from the same machine, so
+    // its tools are co-located with the server-side ones (#243). Install the
+    // transport in the spawned body the same way `with_user_id` is — task-locals
+    // don't cross `tokio::spawn`.
+    tokio::spawn(with_transport_kind(
+        TransportKind::Dbus,
+        with_user_id(
+            user_id_for_body,
+            run_send_prompt_llm_task(service, conversation_id, prompt, system_refinement, tx),
+        ),
     ))
 }
 

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -24,37 +24,51 @@ use std::sync::Arc;
 use desktop_assistant_api_model as api;
 use desktop_assistant_application::{ApiError, AssistantApiHandler, EventSink};
 use desktop_assistant_core::ports::auth::{UserId, with_user_id};
+use desktop_assistant_core::ports::transport::with_transport_kind;
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 pub use api::{WsFrame, WsRequest};
+// Re-exported so transport adapters can name their kind without each taking a
+// direct dependency on `desktop-assistant-core` (#243).
+pub use desktop_assistant_core::domain::TransportKind;
 
 /// Outbound frame buffer; matches the WS adapter's pre-refactor sizing.
 const OUTBOUND_BUFFER: usize = 64;
 
 /// Pre-validated identity for the connection.
 ///
-/// Today only `user_id` is used; structured as a type so #105 (per-user
-/// state lookup) can extend it without changing the dispatcher signature.
+/// Carries the JWT `sub` (`user_id`) and the connection's [`TransportKind`]
+/// so the dispatcher can scope per-user state (#105) and infer tool
+/// co-location (#243). Structured as a type so further per-connection fields
+/// can be added without changing the dispatcher signature.
 #[derive(Debug, Clone)]
 pub struct AuthContext {
     /// JWT `sub` claim.
     pub user_id: String,
+    /// How this connection reaches the daemon — drives tool co-location
+    /// (UDS/D-Bus ⇒ same machine, WebSocket ⇒ possibly remote) (#243).
+    pub transport: TransportKind,
 }
 
 impl AuthContext {
-    pub fn new(user_id: impl Into<String>) -> Self {
+    /// Build a context for a connection on `transport`. Each transport adapter
+    /// passes its own kind so the per-turn tool note can tag tool localities.
+    pub fn new(user_id: impl Into<String>, transport: TransportKind) -> Self {
         Self {
             user_id: user_id.into(),
+            transport,
         }
     }
 
-    /// Convenience for tests that don't need a real subject.
+    /// Convenience for tests that don't need a real subject. Defaults to the
+    /// co-located UDS transport.
     pub fn anonymous() -> Self {
         Self {
             user_id: "anonymous".to_string(),
+            transport: TransportKind::Uds,
         }
     }
 }
@@ -135,6 +149,13 @@ pub async fn dispatch_loop<R, W>(
     // across `tokio::spawn`).
     let user_id = UserId::new(auth.user_id.clone());
 
+    // The connection's transport (#243): installed around the send-message
+    // dispatch so the turn loop can infer tool co-location. Like `user_id` it
+    // is re-installed on spawned send tasks because `task_local`s don't cross
+    // `tokio::spawn`. Only the send-message paths run the LLM turn, so the
+    // command/subscribe paths don't need it.
+    let transport = auth.transport;
+
     // Per-connection state for `SubscribeBackgroundTasks` (#114).
     // At most one forwarder runs per connection — Subscribe is
     // idempotent (a second one observes the existing handle and Acks
@@ -176,16 +197,19 @@ pub async fn dispatch_loop<R, W>(
                 // streamed events are stamped with, so a socket client
                 // can correlate the response (voice#49); the legacy path
                 // simply leaves `task_id` empty.
-                let task_id = with_user_id(
-                    user_id.clone(),
-                    handler.start_send_message(
-                        conversation_id.clone(),
-                        content.clone(),
-                        override_selection.clone(),
-                        system_refinement.clone(),
-                        request_id.clone(),
-                        idempotency_key.clone(),
-                        Arc::clone(&sink),
+                let task_id = with_transport_kind(
+                    transport,
+                    with_user_id(
+                        user_id.clone(),
+                        handler.start_send_message(
+                            conversation_id.clone(),
+                            content.clone(),
+                            override_selection.clone(),
+                            system_refinement.clone(),
+                            request_id.clone(),
+                            idempotency_key.clone(),
+                            Arc::clone(&sink),
+                        ),
                     ),
                 )
                 .await;
@@ -239,17 +263,21 @@ pub async fn dispatch_loop<R, W>(
                         }
                         let handler = Arc::clone(&handler);
                         let user_id_for_task = user_id.clone();
+                        let transport_for_task = transport;
                         tokio::spawn(async move {
-                            let _ = with_user_id(
-                                user_id_for_task,
-                                handler.handle_send_message_with_override(
-                                    conversation_id,
-                                    content,
-                                    override_selection,
-                                    system_refinement,
-                                    request_id,
-                                    idempotency_key,
-                                    sink,
+                            let _ = with_transport_kind(
+                                transport_for_task,
+                                with_user_id(
+                                    user_id_for_task,
+                                    handler.handle_send_message_with_override(
+                                        conversation_id,
+                                        content,
+                                        override_selection,
+                                        system_refinement,
+                                        request_id,
+                                        idempotency_key,
+                                        sink,
+                                    ),
                                 ),
                             )
                             .await;

--- a/crates/transport-dispatch/tests/background_task_wiring.rs
+++ b/crates/transport-dispatch/tests/background_task_wiring.rs
@@ -177,7 +177,7 @@ impl AssistantApiHandler for NoSubscribeHandler {
 // ---------- Helpers ----------
 
 fn user(label: &str) -> AuthContext {
-    AuthContext::new(label)
+    AuthContext::new(label, desktop_assistant_core::domain::TransportKind::Uds)
 }
 
 /// Drive `dispatch_loop` against an in-memory stream of requests; return

--- a/crates/uds-interface/src/lib.rs
+++ b/crates/uds-interface/src/lib.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
 use desktop_assistant_application::AssistantApiHandler;
-use desktop_assistant_transport_dispatch::{AuthContext, dispatch_loop};
+use desktop_assistant_transport_dispatch::{AuthContext, TransportKind, dispatch_loop};
 use futures::stream;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
@@ -392,8 +392,10 @@ async fn handle_connection(
 
     // Per-connection identity resolved above (#105). The dispatcher
     // installs this into the `with_user_id` task-local around each
-    // command so storage queries scope to the right partition.
-    let auth_ctx = AuthContext::new(user_id.into_inner());
+    // command so storage queries scope to the right partition. A UDS
+    // connection can only come from the daemon's own machine, so its tools
+    // are co-located with the server-side ones (#243).
+    let auth_ctx = AuthContext::new(user_id.into_inner(), TransportKind::Uds);
 
     dispatch_loop(handler, auth_ctx, inbound, sink).await;
 

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -14,7 +14,7 @@ use axum::{
 use base64::Engine;
 use desktop_assistant_api_model as api;
 use desktop_assistant_application::{AssistantApiHandler, UserId};
-use desktop_assistant_transport_dispatch::{AuthContext, dispatch_loop};
+use desktop_assistant_transport_dispatch::{AuthContext, TransportKind, dispatch_loop};
 use futures::SinkExt;
 #[cfg(feature = "tls")]
 use tracing::debug;
@@ -391,7 +391,10 @@ async fn handle_socket(socket: WebSocket, state: WsServerState, user_id: UserId)
     // the schema sentinel for single-tenant fallback. The dispatcher
     // installs this into the per-task task-local on every dispatched
     // command so storage queries scope correctly.
-    let auth = AuthContext::new(user_id.into_inner());
+    // A WebSocket connection may terminate on a different host, so its
+    // client-registered tools are treated as remote — distinct from the
+    // daemon's server-side tools (#243).
+    let auth = AuthContext::new(user_id.into_inner(), TransportKind::WebSocket);
 
     dispatch_loop(Arc::clone(&state.handler), auth, inbound, sink).await;
 


### PR DESCRIPTION
Closes #243

## What

Adds a **tool execution-locality model** so the orchestrator knows WHERE each tool runs, infers co-location from the connection transport, surfaces locality in the per-turn tool note, routes a capability that exists on both server and client, and ships two coupled behavioral prompt fixes.

### Locality model
- New `ToolLocality` (`Server { host }` for MCP/builtins, `Client { id, label }` for `RegisterClientTools` tools) and `TransportKind` (`Uds`/`Dbus`/`WebSocket`, `is_co_located()`) in `crates/core/src/domain/tool.rs`.

### Co-location inferred from transport
- New task-local `with_transport_kind`/`current_transport_kind` (`crates/core/src/ports/transport.rs`, default UDS = co-located).
- Threaded per-connection: `AuthContext.transport` → `dispatch_loop` installs it around the send paths; UDS adapter passes `Uds`, WS passes `WebSocket`; the D-Bus send path installs `Dbus` in its spawned LLM task; the application re-installs it across the `tokio::spawn` turn-body boundary (mirrors `with_user_id`).

### Tool note + routing
- `build_full_tool_note` (`crates/core/src/context/mod.rs`) takes an optional `ToolLocalityContext`. **Co-located** ⇒ plain name list (byte-identical to pre-#243). **Remote** ⇒ per-tool labels `name — server '<host>'` / `name — your device '<label>'` + a routing hint.
- `resolve_tool_localities` is the pure routing/plan function: collapse a duplicated capability to the single server tool when co-located; expose both with the **server tool as primary** when remote. Respects the existing demoted/budget path.

### Daemon host identity (groundwork only)
- `ConversationHandler::with_host(hostname)`; `daemon/main.rs` resolves a dependency-free host label (kernel hostname → `/etc/hostname` → `$HOSTNAME` → fallback).

### Prompt fixes
- `knowledge_base.txt`: imperative **SEARCH-BEFORE-ASKING** rule.
- `tool_use.txt`: **System access** section — the model can run terminal commands and read/write files on this machine (discoverable via tool search), tied to the locality labels.

## Phase boundary
This PR = server-side full routing via the transport signal + prompt fixes. **Follow-up** = the per-machine system-ID/UUID co-location handshake (clients send their id; the server compares to its own, preferring `/etc/machine-id` if suitable) + client adoption. The `host`/`id` fields are shaped to accept the id later — hostname populates `host` now.

## Tests
New: ToolLocality/TransportKind tagging + serde; transport⇒co-location inference; tool-note local-collapse vs remote-labels; routing primary-selection with the **same tool name on a Server and a (WS) Client** (collapsed local / both-exposed-with-labels remote); the transport task-local. Existing prompt/tool-note tests updated. `just check` green, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
