### PR TITLE
client-common: Connector auto-reconnect with backoff (survive orchestrator restarts)

### DIFF
--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -7,6 +7,31 @@
 //! events through one object instead of juggling a `(client, receiver)` pair and
 //! per-transport channel wiring — the transport choice (D-Bus / local UDS /
 //! WebSocket) lives entirely in the [`ConnectionConfig`].
+//!
+//! ## Auto-reconnect (#246)
+//!
+//! The daemon is redeployed often (a binary restart), which closes every live
+//! socket. Rather than strand the client on a dead connection until its own
+//! process is restarted, the Connector runs a **supervisor** task that, when the
+//! underlying socket *closes*, reconnects to the same endpoint with capped
+//! exponential backoff + jitter — re-running the full handshake (re-auth via the
+//! credential in the stored [`ConnectionConfig`]) and **replaying** the last
+//! client-tool registration so a daemon restart doesn't silently drop a client's
+//! tools. The current waiters are unstuck with a terminal `Disconnected` (their
+//! in-flight turn is genuinely lost when the server restarts), but the Connector
+//! stays usable: the next `subscribe()` / `send_prompt` / command runs on the
+//! fresh transport.
+//!
+//! The reconnect happens *inside* the [`TransportClient`] (it swaps its own
+//! socket in place and keeps feeding the same persistent signal stream), so
+//! [`client`](Connector::client) keeps returning a stable `&TransportClient`
+//! across reconnects — callers holding that reference don't have to re-fetch it.
+//!
+//! Reconnect is triggered **only** by an actual transport close (the transport's
+//! drop-notifier fires), never by a per-turn *stall*: an open-but-silent
+//! connection still unsticks its waiters (#221) and keeps the same connection
+//! pumping for the next turn (voice#49/#241). An idle connection (no
+//! subscribers, no traffic) is never torn down or reconnected.
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -17,20 +42,33 @@ use tokio::sync::mpsc;
 
 use crate::config::ConnectionConfig;
 use crate::signal::SignalEvent;
-use crate::timeouts::EVENT_STALL_TIMEOUT;
-use crate::transport::{AssistantClient, TransportClient, connect_transport, transport_label};
+use crate::timeouts::{EVENT_STALL_TIMEOUT, RECONNECT_BACKOFF_INITIAL, RECONNECT_BACKOFF_MAX};
+use crate::transport::{
+    AssistantClient, DropNotifier, TransportClient, connect_transport, transport_label,
+};
 
 type Subscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<SignalEvent>>>>;
 
-/// Pump a transport's signal stream out to subscribers.
+/// The last client-tool registration the caller asked for, remembered so the
+/// supervisor can replay it after a reconnect (#246). `None` until the first
+/// [`Connector::register_client_tools`] call; an explicit empty `Vec` is
+/// remembered too (it clears the daemon's set on every connect).
+type RememberedTools = Arc<Mutex<Option<Vec<api::ClientToolRegistration>>>>;
+
+/// Pump a transport's signal stream out to subscribers (#241 semantics).
 ///
-/// Closing the upstream stream is terminal: every subscriber gets a
-/// `Disconnected { reason: "signal stream closed" }` and the pump stops.
+/// Closing the upstream stream is terminal *for this pump*: it stops and every
+/// subscriber gets a `Disconnected { reason: "signal stream closed" }`. With the
+/// reconnect supervisor (#246) the transport's signal stream is *persistent* —
+/// it does not close on a socket drop (the transport reconnects underneath and
+/// keeps feeding it), so in practice this pump only ends when the Connector is
+/// dropped. The terminal-on-close behaviour is retained for the D-Bus transport
+/// (no reconnect) and as a safety net.
 ///
 /// A *stall* (open but silent) is treated as a **per-turn** signal, not a reason
-/// to tear the connection down (voice#49, reopened). The stall clock only runs
-/// while at least one subscriber is attached — i.e. a turn is potentially in
-/// flight: if no event arrives within `stall_timeout`, every *current*
+/// to tear the connection down (voice#49, reopened #241). The stall clock only
+/// runs while at least one subscriber is attached — i.e. a turn is potentially
+/// in flight: if no event arrives within `stall_timeout`, every *current*
 /// subscriber gets a terminal `Disconnected { reason: "…stalled…" }` so a client
 /// waiting on a wedged turn errors out instead of hanging (#221), but the pump
 /// **keeps reading** so the next turn still streams.
@@ -41,9 +79,7 @@ type Subscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<SignalEvent>>>>;
 /// keepalive (UDS): otherwise a healthy-but-idle connection would trip the
 /// stall and the pump would die before the first turn ever arrived, so every
 /// later subscriber would be attached to a dead pump and receive ZERO events
-/// (the reopened voice#49: send acks, turn completes, client gets nothing).
-/// `stall_timeout` is a parameter so tests can drive a short window without
-/// waiting the production minute-plus.
+/// (the reopened voice#49).
 fn spawn_fanout_with_stall_timeout(
     mut signal_rx: mpsc::UnboundedReceiver<SignalEvent>,
     stall_timeout: Duration,
@@ -63,7 +99,8 @@ fn spawn_fanout_with_stall_timeout(
                     Err(_elapsed) => {
                         // No progress for a turn that had a waiter: unstick the
                         // current subscribers, but KEEP the pump alive so the
-                        // next turn still streams.
+                        // next turn still streams. This is a per-turn stall, NOT
+                        // a transport close — no reconnect (#246).
                         let reason = format!(
                             "connection stalled: no events for {}s",
                             stall_timeout.as_secs()
@@ -110,17 +147,130 @@ fn register(subscribers: &Subscribers) -> mpsc::UnboundedReceiver<SignalEvent> {
     rx
 }
 
-/// A connected assistant client plus its automatically-managed event stream.
-pub struct Connector {
-    client: TransportClient,
+/// Tell every current subscriber the connection dropped (so an in-flight turn
+/// errors out instead of hanging) and clear the set. New events on the
+/// reconnected stream go to whoever subscribes next.
+fn disconnect_waiters(subscribers: &Subscribers, reason: &str) {
+    for tx in subscribers.lock().unwrap().drain(..) {
+        let _ = tx.send(SignalEvent::Disconnected {
+            reason: reason.to_string(),
+        });
+    }
+}
+
+/// Next backoff delay: clamp `current` to the cap and add up to ~10% jitter so a
+/// fleet of clients reconnecting after one daemon restart doesn't thunder in
+/// lockstep. Jitter uses a cheap per-call varying source (sub-second nanos of
+/// the wall clock); a tiny bias is harmless for a backoff. (The
+/// `Math.random`/`Date::now` caveat is only for workflow scripts — fine here in
+/// Rust.)
+fn jittered_backoff(current: Duration) -> Duration {
+    let base = current.min(RECONNECT_BACKOFF_MAX);
+    let jitter_span = base.as_millis() as u64 / 10; // up to ~10%
+    let jitter = if jitter_span == 0 {
+        0
+    } else {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos() as u64)
+            .unwrap_or(0);
+        nanos % (jitter_span + 1)
+    };
+    base + Duration::from_millis(jitter)
+}
+
+/// The reconnect supervisor (#246). Waits on the transport's drop-notifier; on a
+/// socket close it unsticks the current waiters and reconnects the *same*
+/// `TransportClient` in place with capped exponential backoff + jitter,
+/// replaying the remembered client-tool registration after each successful
+/// reconnect. Runs until the task is aborted (Connector dropped) or the
+/// notifier's sender is gone.
+fn spawn_supervisor(
+    config: ConnectionConfig,
+    client: Arc<TransportClient>,
     subscribers: Subscribers,
+    tools: RememberedTools,
+    mut drop_rx: DropNotifier,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Each `()` is one underlying-socket close. The persistent signal stream
+        // keeps flowing across reconnects, so the fan-out never sees the gap —
+        // only this notifier does.
+        while drop_rx.recv().await.is_some() {
+            // The connection is gone. Unstick anyone still waiting on this turn
+            // — it's lost when the server goes away — then reconnect.
+            disconnect_waiters(&subscribers, "signal stream closed");
+
+            // Reconnect with capped exponential backoff + jitter, retrying
+            // indefinitely (a single attempt at a time — no thundering herd)
+            // until the daemon comes back or this task is aborted.
+            let mut backoff = RECONNECT_BACKOFF_INITIAL;
+            loop {
+                tokio::time::sleep(jittered_backoff(backoff)).await;
+                match client.reconnect(&config).await {
+                    Ok(()) => {
+                        // Replay the last client-tool registration (#246) so a
+                        // daemon restart doesn't silently lose this client's
+                        // tools. The daemon replaces its set per call, so
+                        // sending the full remembered list is correct. A failure
+                        // here isn't fatal — the connection is up; log and carry
+                        // on (the next explicit register, or the next reconnect,
+                        // fixes it).
+                        let remembered = tools.lock().unwrap().clone();
+                        if let Some(tools_to_replay) = remembered
+                            && let Some(commands) = client.as_commands()
+                            && let Err(e) = commands.register_client_tools(tools_to_replay).await
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                "failed to replay client-tool registration after reconnect"
+                            );
+                        }
+                        tracing::info!("connector reconnected after transport drop");
+                        break;
+                    }
+                    Err(e) => {
+                        // Keep retrying with backoff — a long outage (or an
+                        // expired JWT, acceptable for v1) backs off to the cap
+                        // rather than spinning. Surface the reason at debug so an
+                        // operator can see *why* it isn't reconnecting.
+                        tracing::debug!(error = %e, "connector reconnect attempt failed; backing off");
+                        backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// A connected assistant client plus its automatically-managed, auto-reconnecting
+/// event stream.
+pub struct Connector {
+    client: Arc<TransportClient>,
+    subscribers: Subscribers,
+    /// Last client-tool registration, replayed after a reconnect (#246).
+    tools: RememberedTools,
     label: String,
+    /// The reconnect supervisor, if the transport supports reconnect (#246).
+    /// `None` for D-Bus. Aborted on drop so the loop stops with the Connector.
+    supervisor: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for Connector {
+    fn drop(&mut self) {
+        // Stop the reconnect loop when the last handle goes away; otherwise it
+        // would keep trying to reconnect to a daemon no one is listening to.
+        if let Some(handle) = &self.supervisor {
+            handle.abort();
+        }
+    }
 }
 
 impl Connector {
     /// Connect over the transport named by `config` and start pumping the
-    /// daemon's signal stream to subscribers. Uses the default
-    /// [`EVENT_STALL_TIMEOUT`] for stall detection (#221).
+    /// daemon's signal stream to subscribers, auto-reconnecting on a transport
+    /// drop (#246). Uses the default [`EVENT_STALL_TIMEOUT`] for stall detection
+    /// (#221).
     pub async fn connect(config: &ConnectionConfig) -> Result<Self> {
         Self::connect_with_stall_timeout(config, EVENT_STALL_TIMEOUT).await
     }
@@ -129,24 +279,53 @@ impl Connector {
     /// window (#221). While a subscriber is attached (a turn may be in flight), a
     /// connection that stays open but emits no event for `stall_timeout` surfaces
     /// a terminal [`SignalEvent::Disconnected`] to the *current* subscribers — but
-    /// the pump keeps running so later turns still stream (voice#49). An idle
-    /// connection with no subscribers is never stalled out. Mainly for tests;
-    /// production callers normally want the default via [`connect`](Self::connect).
+    /// the pump keeps running so later turns still stream (voice#49) and the
+    /// transport is NOT torn down or reconnected (a stall is per-turn, not a
+    /// close). An idle connection with no subscribers is never stalled out.
+    /// Mainly for tests; production callers normally want the default via
+    /// [`connect`](Self::connect).
     pub async fn connect_with_stall_timeout(
         config: &ConnectionConfig,
         stall_timeout: Duration,
     ) -> Result<Self> {
-        let (client, signal_rx) = connect_transport(config).await?;
+        // The initial connect is awaited (and may fail) so the caller gets a
+        // clear error if the daemon isn't up at all; only *subsequent* drops
+        // trigger the background reconnect loop.
+        let (client, signal_rx, drop_rx) = connect_transport(config).await?;
+        let client = Arc::new(client);
+        let subscribers = spawn_fanout_with_stall_timeout(signal_rx, stall_timeout);
+        let tools: RememberedTools = Arc::new(Mutex::new(None));
+
+        // Only the socket transports hand back a drop-notifier; D-Bus doesn't
+        // reconnect (its clients don't use the Connector).
+        let supervisor = drop_rx.map(|drop_rx| {
+            spawn_supervisor(
+                config.clone(),
+                Arc::clone(&client),
+                Arc::clone(&subscribers),
+                Arc::clone(&tools),
+                drop_rx,
+            )
+        });
+
         Ok(Self {
             client,
-            subscribers: spawn_fanout_with_stall_timeout(signal_rx, stall_timeout),
+            subscribers,
+            tools,
             label: transport_label(config),
+            supervisor,
         })
     }
 
     /// A fresh receiver for the daemon's signal stream. Every subscriber sees
     /// every event from the moment it subscribes; drop the receiver to
     /// unsubscribe. Subscribe before sending a prompt so no early chunk is lost.
+    ///
+    /// Survives reconnects (#246): the underlying transport reconnects in place
+    /// and keeps feeding the same stream, so a subscriber registered *after* a
+    /// drop receives the new connection's events. A subscriber that was waiting
+    /// across the drop gets a terminal `Disconnected` (its turn is lost) and
+    /// should re-subscribe for the next turn.
     pub fn subscribe(&self) -> mpsc::UnboundedReceiver<SignalEvent> {
         register(&self.subscribers)
     }
@@ -154,12 +333,16 @@ impl Connector {
     /// The underlying transport client — the full [`AssistantClient`] surface
     /// plus [`as_commands`](TransportClient::as_commands) for socket-only
     /// commands not modelled on the convenience methods below.
+    ///
+    /// Stable across reconnects (#246): the same `TransportClient` swaps its own
+    /// socket in place, so a held `&TransportClient` keeps working after a
+    /// daemon restart — callers don't need to re-fetch it.
     pub fn client(&self) -> &TransportClient {
         &self.client
     }
 
     /// Human-readable description of the active connection (e.g. "Connected via
-    /// local socket …").
+    /// local socket …"). Stable across reconnects (the endpoint doesn't change).
     pub fn label(&self) -> &str {
         &self.label
     }
@@ -170,6 +353,13 @@ impl Connector {
     }
 
     /// Send a prompt (works over every transport).
+    ///
+    /// While the transport is mid-reconnect (the daemon is down), the underlying
+    /// socket client rejects the command immediately ("connection closed") or,
+    /// once a fresh connection is up, bounds the wait by the per-command
+    /// dispatch timeout (#221) — so a send during an outage fails fast or
+    /// succeeds on the reconnected transport, never hangs forever. After
+    /// reconnect, commands work normally.
     pub async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String> {
         self.client.send_prompt(conversation_id, prompt).await
     }
@@ -239,6 +429,11 @@ impl Connector {
     /// call — send the full list, not deltas — so re-register on every connect.
     /// Returns the count of tools the daemon accepted.
     ///
+    /// The Connector **remembers** the last registration and replays it
+    /// automatically after an auto-reconnect (#246), so a daemon restart doesn't
+    /// silently drop this client's tools — callers don't have to re-register on
+    /// every reconnect.
+    ///
     /// Client tools ride the socket command channel, so this is supported only
     /// over the UDS/WS transports; the D-Bus transport has no command channel
     /// for it and returns an error.
@@ -247,7 +442,13 @@ impl Connector {
         tools: Vec<api::ClientToolRegistration>,
     ) -> Result<usize> {
         match self.client.as_commands() {
-            Some(commands) => commands.register_client_tools(tools).await,
+            Some(commands) => {
+                let count = commands.register_client_tools(tools.clone()).await?;
+                // Remember the *accepted* registration only after the daemon
+                // confirms it, so a rejected payload isn't replayed on reconnect.
+                *self.tools.lock().unwrap() = Some(tools);
+                Ok(count)
+            }
             None => Err(anyhow::anyhow!(
                 "register_client_tools requires a socket transport (UDS or WS); \
                  the D-Bus transport does not support client tools"
@@ -465,5 +666,33 @@ mod tests {
             "expected the next turn's chunk, got {event:?}"
         );
         drop(tx);
+    }
+
+    #[tokio::test]
+    async fn jittered_backoff_never_exceeds_cap_plus_jitter() {
+        // Capped at MAX; jitter adds at most ~10% on top.
+        let d = jittered_backoff(Duration::from_secs(120));
+        let ceiling = RECONNECT_BACKOFF_MAX + RECONNECT_BACKOFF_MAX / 10;
+        assert!(
+            d <= ceiling,
+            "backoff {d:?} should be capped at MAX (+jitter) {ceiling:?}"
+        );
+        assert!(
+            d >= RECONNECT_BACKOFF_MAX,
+            "backoff should be at least the cap when input exceeds it"
+        );
+    }
+
+    #[tokio::test]
+    async fn jittered_backoff_grows_from_initial() {
+        let d = jittered_backoff(RECONNECT_BACKOFF_INITIAL);
+        assert!(
+            d >= RECONNECT_BACKOFF_INITIAL,
+            "backoff {d:?} should be at least the (non-jittered) initial delay"
+        );
+        assert!(
+            d < RECONNECT_BACKOFF_INITIAL * 2,
+            "initial backoff plus ~10% jitter should stay well under a doubling"
+        );
     }
 }

--- a/crates/client-common/src/lib.rs
+++ b/crates/client-common/src/lib.rs
@@ -21,6 +21,6 @@ pub use commands::AssistantCommands;
 pub use config::{ConnectionConfig, TransportMode, default_desktop_socket_path};
 pub use connector::Connector;
 pub use signal::SignalEvent;
-pub use transport::{AssistantClient, TransportClient, connect_transport};
+pub use transport::{AssistantClient, DropNotifier, TransportClient, connect_transport};
 pub use types::{ChatMessage, ConversationDetail, ConversationSummary};
 pub use uds_client::UdsClient;

--- a/crates/client-common/src/timeouts.rs
+++ b/crates/client-common/src/timeouts.rs
@@ -38,3 +38,16 @@ pub const EVENT_STALL_TIMEOUT: Duration = Duration::from_secs(90);
 /// [`EVENT_STALL_TIMEOUT`]. Well under the stall window so several pings ride
 /// inside one stall budget.
 pub const WS_PING_INTERVAL: Duration = Duration::from_secs(20);
+
+/// First delay before the [`Connector`](crate::Connector) retries connecting
+/// after the transport drops (#246). Each subsequent failure doubles the delay
+/// up to [`RECONNECT_BACKOFF_MAX`]; a small jitter is added so a fleet of
+/// clients reconnecting after a single daemon restart doesn't thunder in
+/// lockstep.
+pub const RECONNECT_BACKOFF_INITIAL: Duration = Duration::from_millis(500);
+
+/// Cap on the [`Connector`](crate::Connector) reconnect backoff (#246). The
+/// delay grows exponentially from [`RECONNECT_BACKOFF_INITIAL`] but never
+/// exceeds this, so a long outage settles into a steady ~30s retry cadence
+/// rather than spinning tightly or backing off into the minutes.
+pub const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(30);

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -82,7 +82,50 @@ impl TransportClient {
             Self::Uds(client) => Some(client),
         }
     }
+
+    /// Re-establish the underlying connection in place after a drop (#246),
+    /// re-running the handshake (re-auth via the credential in `config`) and
+    /// re-binding the persistent signal/drop channels — so the *same*
+    /// `TransportClient` (and any `&TransportClient` a caller holds) keeps
+    /// working without the Connector swapping the client. The socket transports
+    /// (UDS/WS) support this; the D-Bus transport doesn't reconnect this way and
+    /// returns an error (its clients don't use the Connector). Resolves the
+    /// bearer token from `config` on each attempt so a freshly-minted local JWT
+    /// is used (a long outage can still outlive a token's validity — surfaced as
+    /// an auth error the supervisor retries with backoff).
+    pub async fn reconnect(&self, config: &ConnectionConfig) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => Err(anyhow::anyhow!(
+                "the D-Bus transport does not support Connector auto-reconnect"
+            )),
+            Self::Ws(client) => {
+                let token = resolve_ws_bearer_token(config).await?;
+                client
+                    .reconnect(&config.ws_url, &token, config.tls_ca_cert.as_deref())
+                    .await
+            }
+            Self::Uds(client) => {
+                let token = resolve_ws_bearer_token(config).await?;
+                let path = config
+                    .socket_path
+                    .clone()
+                    .or_else(default_desktop_socket_path)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "no UDS socket path: set ConnectionConfig.socket_path or XDG_RUNTIME_DIR"
+                        )
+                    })?;
+                client.reconnect(&path, &token).await
+            }
+        }
+    }
 }
+
+/// A receiver that fires once per underlying-socket close, so the
+/// [`Connector`](crate::Connector) reconnect supervisor can react (#246). `None`
+/// for the D-Bus transport, which doesn't auto-reconnect.
+pub type DropNotifier = mpsc::UnboundedReceiver<()>;
 
 #[async_trait]
 impl AssistantClient for TransportClient {
@@ -290,15 +333,24 @@ pub fn transport_label(config: &ConnectionConfig) -> String {
     }
 }
 
+/// Connect over the transport named by `config`. Returns the client, the signal
+/// stream, and a [`DropNotifier`] that fires once per underlying-socket close
+/// for the socket transports (#246) — `None` for D-Bus, which doesn't
+/// auto-reconnect. The [`Connector`](crate::Connector) uses the notifier to
+/// drive its reconnect supervisor.
 pub async fn connect_transport(
     config: &ConnectionConfig,
-) -> Result<(TransportClient, mpsc::UnboundedReceiver<SignalEvent>)> {
+) -> Result<(
+    TransportClient,
+    mpsc::UnboundedReceiver<SignalEvent>,
+    Option<DropNotifier>,
+)> {
     match config.transport_mode {
         #[cfg(feature = "dbus")]
         TransportMode::Dbus => {
             let client = crate::dbus_client::DbusClient::connect().await?;
             let signal_rx = client.subscribe_signals().await?;
-            Ok((TransportClient::Dbus(client), signal_rx))
+            Ok((TransportClient::Dbus(client), signal_rx, None))
         }
         #[cfg(not(feature = "dbus"))]
         TransportMode::Dbus => Err(anyhow::anyhow!(
@@ -306,9 +358,9 @@ pub async fn connect_transport(
         )),
         TransportMode::Ws => {
             let token = resolve_ws_bearer_token(config).await?;
-            let (client, signal_rx) =
+            let (client, signal_rx, drop_rx) =
                 WsClient::connect(&config.ws_url, &token, config.tls_ca_cert.as_deref()).await?;
-            Ok((TransportClient::Ws(client), signal_rx))
+            Ok((TransportClient::Ws(client), signal_rx, Some(drop_rx)))
         }
         TransportMode::Uds => {
             // The local minter issues the same JWT the UDS server's handshake
@@ -323,8 +375,8 @@ pub async fn connect_transport(
                         "no UDS socket path: set ConnectionConfig.socket_path or XDG_RUNTIME_DIR"
                     )
                 })?;
-            let (client, signal_rx) = UdsClient::connect(&path, &token).await?;
-            Ok((TransportClient::Uds(client), signal_rx))
+            let (client, signal_rx, drop_rx) = UdsClient::connect(&path, &token).await?;
+            Ok((TransportClient::Uds(client), signal_rx, Some(drop_rx)))
         }
     }
 }

--- a/crates/client-common/src/uds_client.rs
+++ b/crates/client-common/src/uds_client.rs
@@ -12,6 +12,17 @@
 //! `crates/uds-interface/src/lib.rs`). Depending on that crate would drag the
 //! entire daemon stack into every client binary, so the ~20 lines are
 //! duplicated on purpose.
+//!
+//! ## Reconnect (#246)
+//!
+//! The live socket (the writer's `outbound_tx`) lives behind a swappable
+//! [`ConnState`] cell, while the request-correlation map, the signal stream the
+//! [`Connector`](crate::Connector) reads, and the drop-notification channel all
+//! **persist across reconnects**. [`UdsClient::reconnect`] re-runs the handshake
+//! and spawns fresh reader/writer tasks wired to those same persistent
+//! channels, then swaps the cell — so the connection comes back transparently
+//! under a stable `&TransportClient` without the Connector having to re-subscribe
+//! the event stream.
 
 use std::collections::HashMap;
 use std::io;
@@ -61,11 +72,31 @@ impl PendingState {
             let _ = tx.send(Err(reason.to_string()));
         }
     }
+
+    /// Re-arm the map for a fresh connection (#246): clear the closed marker so
+    /// new commands are accepted again. Any stragglers from the old connection
+    /// were already drained by `close`.
+    fn reopen(&mut self) {
+        self.closed = None;
+    }
+}
+
+/// The live connection's write handle, swapped on reconnect (#246).
+struct ConnState {
+    outbound_tx: mpsc::UnboundedSender<Vec<u8>>,
 }
 
 pub struct UdsClient {
-    outbound_tx: mpsc::UnboundedSender<Vec<u8>>,
+    /// The live writer, replaced in place by [`reconnect`](Self::reconnect).
+    conn: Arc<Mutex<ConnState>>,
     pending: Arc<Mutex<PendingState>>,
+    /// The persistent signal stream every reader (across reconnects) feeds. The
+    /// Connector subscribes to its receiver once and keeps it forever.
+    signal_tx: mpsc::UnboundedSender<SignalEvent>,
+    /// Fires once per underlying-socket close so the Connector's reconnect
+    /// supervisor knows to back off and reconnect (#246). Persistent across
+    /// reconnects; each fresh reader clones it.
+    drop_tx: mpsc::UnboundedSender<()>,
     /// Per-command response deadline (#221). Defaults to
     /// [`DISPATCH_TIMEOUT`]; tunable via [`set_dispatch_timeout`].
     dispatch_timeout: Duration,
@@ -79,10 +110,57 @@ impl UdsClient {
         self.dispatch_timeout = timeout;
     }
 
+    /// Connect a UDS transport. Returns the client, the persistent signal
+    /// stream, and a drop-notifier receiver that fires once per underlying
+    /// socket close (#246) — the Connector uses the latter to drive reconnect.
     pub async fn connect(
         socket_path: &Path,
         bearer_token: &str,
-    ) -> Result<(Self, mpsc::UnboundedReceiver<SignalEvent>)> {
+    ) -> Result<(
+        Self,
+        mpsc::UnboundedReceiver<SignalEvent>,
+        mpsc::UnboundedReceiver<()>,
+    )> {
+        let pending = Arc::new(Mutex::new(PendingState {
+            map: HashMap::new(),
+            closed: None,
+        }));
+        let (signal_tx, signal_rx) = mpsc::unbounded_channel::<SignalEvent>();
+        let (drop_tx, drop_rx) = mpsc::unbounded_channel::<()>();
+
+        let outbound_tx = Self::spawn_connection(
+            socket_path,
+            bearer_token,
+            Arc::clone(&pending),
+            signal_tx.clone(),
+            drop_tx.clone(),
+        )
+        .await?;
+
+        Ok((
+            Self {
+                conn: Arc::new(Mutex::new(ConnState { outbound_tx })),
+                pending,
+                signal_tx,
+                drop_tx,
+                dispatch_timeout: DISPATCH_TIMEOUT,
+            },
+            signal_rx,
+            drop_rx,
+        ))
+    }
+
+    /// Connect a fresh socket, perform the JWT handshake, and spawn the
+    /// reader/writer tasks wired to the **persistent** `pending` / `signal_tx` /
+    /// `drop_tx`. Returns the new writer handle. Shared by the initial
+    /// [`connect`](Self::connect) and [`reconnect`](Self::reconnect) (#246).
+    async fn spawn_connection(
+        socket_path: &Path,
+        bearer_token: &str,
+        pending: Arc<Mutex<PendingState>>,
+        signal_tx: mpsc::UnboundedSender<SignalEvent>,
+        drop_tx: mpsc::UnboundedSender<()>,
+    ) -> Result<mpsc::UnboundedSender<Vec<u8>>> {
         let stream = UnixStream::connect(socket_path)
             .await
             .map_err(|e| anyhow!("failed to connect uds {}: {e}", socket_path.display()))?;
@@ -107,13 +185,7 @@ impl UdsClient {
             }
         });
 
-        let pending = Arc::new(Mutex::new(PendingState {
-            map: HashMap::new(),
-            closed: None,
-        }));
         let pending_for_reader = Arc::clone(&pending);
-
-        let (signal_tx, signal_rx) = mpsc::unbounded_channel::<SignalEvent>();
         tokio::spawn(async move {
             loop {
                 let raw = match read_frame(&mut read_half).await {
@@ -152,27 +224,40 @@ impl UdsClient {
                 }
             }
 
-            // Teardown: mark closed (preserving a connection-level error reason
-            // if one was already set), drain any stragglers, notify once.
-            let reason = {
-                let mut state = pending_for_reader.lock().await;
-                state.close("uds connection closed");
-                state
-                    .closed
-                    .clone()
-                    .unwrap_or_else(|| "uds connection closed".to_string())
-            };
-            let _ = signal_tx.send(SignalEvent::Disconnected { reason });
+            // Teardown: fail any outstanding requests so callers don't hang.
+            // We do NOT emit a `Disconnected` on the signal stream here — that
+            // stream persists across reconnects (#246), so a close on it would
+            // wrongly read as a permanent end. Instead we notify the reconnect
+            // supervisor via `drop_tx`; it emits the terminal `Disconnected` to
+            // subscribers and drives the reconnect.
+            pending_for_reader
+                .lock()
+                .await
+                .close("uds connection closed");
+            let _ = drop_tx.send(());
         });
 
-        Ok((
-            Self {
-                outbound_tx,
-                pending,
-                dispatch_timeout: DISPATCH_TIMEOUT,
-            },
-            signal_rx,
-        ))
+        Ok(outbound_tx)
+    }
+
+    /// Re-establish the underlying socket after a drop (#246): re-run the JWT
+    /// handshake, spawn fresh reader/writer tasks bound to the persistent
+    /// channels, and swap in the new writer. On success the same
+    /// `&TransportClient` resumes working; on failure the error is returned so
+    /// the supervisor can back off and retry.
+    pub(crate) async fn reconnect(&self, socket_path: &Path, bearer_token: &str) -> Result<()> {
+        let outbound_tx = Self::spawn_connection(
+            socket_path,
+            bearer_token,
+            Arc::clone(&self.pending),
+            self.signal_tx.clone(),
+            self.drop_tx.clone(),
+        )
+        .await?;
+        // Accept commands again, then swap the writer.
+        self.pending.lock().await.reopen();
+        self.conn.lock().await.outbound_tx = outbound_tx;
+        Ok(())
     }
 }
 
@@ -195,7 +280,7 @@ impl AssistantCommands for UdsClient {
             state.map.insert(id.clone(), tx);
         }
 
-        if self.outbound_tx.send(body).is_err() {
+        if self.conn.lock().await.outbound_tx.send(body).is_err() {
             self.pending.lock().await.map.remove(&id);
             return Err(anyhow!("failed to send uds request: writer closed"));
         }

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -15,9 +15,43 @@ use crate::commands::{AssistantCommands, PendingResult};
 use crate::signal::SignalEvent;
 use crate::timeouts::{DISPATCH_TIMEOUT, WS_PING_INTERVAL};
 
-pub struct WsClient {
+/// In-flight request correlation map plus a terminal "closed" marker. Mirrors
+/// the UDS client's `PendingState` so a reconnect (#246) can re-arm the WS
+/// client after the reader drains it on a drop.
+struct PendingState {
+    map: HashMap<String, oneshot::Sender<PendingResult>>,
+    closed: Option<String>,
+}
+
+impl PendingState {
+    fn close(&mut self, reason: &str) {
+        if self.closed.is_none() {
+            self.closed = Some(reason.to_string());
+        }
+        for (_id, tx) in self.map.drain() {
+            let _ = tx.send(Err(reason.to_string()));
+        }
+    }
+
+    fn reopen(&mut self) {
+        self.closed = None;
+    }
+}
+
+/// The live connection's write handle, swapped on reconnect (#246).
+struct ConnState {
     outbound_tx: mpsc::UnboundedSender<Message>,
-    pending: Arc<Mutex<HashMap<String, oneshot::Sender<PendingResult>>>>,
+}
+
+pub struct WsClient {
+    /// The live writer, replaced in place by [`reconnect`](Self::reconnect).
+    conn: Arc<Mutex<ConnState>>,
+    pending: Arc<Mutex<PendingState>>,
+    /// The persistent signal stream every reader (across reconnects) feeds.
+    signal_tx: mpsc::UnboundedSender<SignalEvent>,
+    /// Fires once per underlying-socket close so the Connector's reconnect
+    /// supervisor knows to back off and reconnect (#246).
+    drop_tx: mpsc::UnboundedSender<()>,
     /// Per-command response deadline (#221). Defaults to
     /// [`DISPATCH_TIMEOUT`]; tunable via [`set_dispatch_timeout`].
     dispatch_timeout: std::time::Duration,
@@ -30,11 +64,60 @@ impl WsClient {
         self.dispatch_timeout = timeout;
     }
 
+    /// Connect a WebSocket transport. Returns the client, the persistent signal
+    /// stream, and a drop-notifier receiver that fires once per underlying
+    /// socket close (#246) — the Connector uses the latter to drive reconnect.
     pub async fn connect(
         ws_url: &str,
         bearer_token: &str,
         tls_ca_cert: Option<&Path>,
-    ) -> Result<(Self, mpsc::UnboundedReceiver<SignalEvent>)> {
+    ) -> Result<(
+        Self,
+        mpsc::UnboundedReceiver<SignalEvent>,
+        mpsc::UnboundedReceiver<()>,
+    )> {
+        let pending = Arc::new(Mutex::new(PendingState {
+            map: HashMap::new(),
+            closed: None,
+        }));
+        let (signal_tx, signal_rx) = mpsc::unbounded_channel::<SignalEvent>();
+        let (drop_tx, drop_rx) = mpsc::unbounded_channel::<()>();
+
+        let outbound_tx = Self::spawn_connection(
+            ws_url,
+            bearer_token,
+            tls_ca_cert,
+            Arc::clone(&pending),
+            signal_tx.clone(),
+            drop_tx.clone(),
+        )
+        .await?;
+
+        Ok((
+            Self {
+                conn: Arc::new(Mutex::new(ConnState { outbound_tx })),
+                pending,
+                signal_tx,
+                drop_tx,
+                dispatch_timeout: DISPATCH_TIMEOUT,
+            },
+            signal_rx,
+            drop_rx,
+        ))
+    }
+
+    /// Connect the socket, spawn the writer/keepalive/reader tasks bound to the
+    /// **persistent** `pending` / `signal_tx` / `drop_tx`, and return the new
+    /// writer handle. Shared by [`connect`](Self::connect) and
+    /// [`reconnect`](Self::reconnect) (#246).
+    async fn spawn_connection(
+        ws_url: &str,
+        bearer_token: &str,
+        tls_ca_cert: Option<&Path>,
+        pending: Arc<Mutex<PendingState>>,
+        signal_tx: mpsc::UnboundedSender<SignalEvent>,
+        drop_tx: mpsc::UnboundedSender<()>,
+    ) -> Result<mpsc::UnboundedSender<Message>> {
         let mut request = ws_url.into_client_request()?;
         request.headers_mut().insert(
             tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
@@ -82,12 +165,7 @@ impl WsClient {
             }
         });
 
-        let pending = Arc::new(Mutex::new(
-            HashMap::<String, oneshot::Sender<PendingResult>>::new(),
-        ));
         let pending_for_reader = Arc::clone(&pending);
-
-        let (signal_tx, signal_rx) = mpsc::unbounded_channel::<SignalEvent>();
         tokio::spawn(async move {
             while let Some(Ok(message)) = ws_rx.next().await {
                 let Message::Text(text) = message else {
@@ -99,12 +177,12 @@ impl WsClient {
 
                 match frame {
                     WsFrame::Result { id, result } => {
-                        if let Some(tx) = pending_for_reader.lock().await.remove(&id) {
+                        if let Some(tx) = pending_for_reader.lock().await.map.remove(&id) {
                             let _ = tx.send(Ok(result));
                         }
                     }
                     WsFrame::Error { id, error } => {
-                        if let Some(tx) = pending_for_reader.lock().await.remove(&id) {
+                        if let Some(tx) = pending_for_reader.lock().await.map.remove(&id) {
                             let _ = tx.send(Err(error));
                         }
                     }
@@ -116,24 +194,42 @@ impl WsClient {
                 }
             }
 
-            let _ = signal_tx.send(SignalEvent::Disconnected {
-                reason: "WebSocket connection closed".to_string(),
-            });
-
-            let mut pending = pending_for_reader.lock().await;
-            for (_id, tx) in pending.drain() {
-                let _ = tx.send(Err("websocket disconnected".to_string()));
-            }
+            // The socket closed. As with UDS (#246), do NOT emit a
+            // `Disconnected` on the persistent signal stream — fail any
+            // outstanding requests and notify the reconnect supervisor via
+            // `drop_tx`, which owns the terminal-Disconnected + reconnect.
+            pending_for_reader
+                .lock()
+                .await
+                .close("websocket disconnected");
+            let _ = drop_tx.send(());
         });
 
-        Ok((
-            Self {
-                outbound_tx,
-                pending,
-                dispatch_timeout: DISPATCH_TIMEOUT,
-            },
-            signal_rx,
-        ))
+        Ok(outbound_tx)
+    }
+
+    /// Re-establish the underlying WebSocket after a drop (#246): reconnect,
+    /// spawn fresh writer/keepalive/reader tasks bound to the persistent
+    /// channels, and swap in the new writer. On failure the error is returned so
+    /// the supervisor can back off and retry.
+    pub(crate) async fn reconnect(
+        &self,
+        ws_url: &str,
+        bearer_token: &str,
+        tls_ca_cert: Option<&Path>,
+    ) -> Result<()> {
+        let outbound_tx = Self::spawn_connection(
+            ws_url,
+            bearer_token,
+            tls_ca_cert,
+            Arc::clone(&self.pending),
+            self.signal_tx.clone(),
+            self.drop_tx.clone(),
+        )
+        .await?;
+        self.pending.lock().await.reopen();
+        self.conn.lock().await.outbound_tx = outbound_tx;
+        Ok(())
     }
 
     /// Send a prompt with an optional per-message model/connection override.
@@ -185,14 +281,23 @@ impl AssistantCommands for WsClient {
         let payload = serde_json::to_string(&request)?;
 
         let (tx, rx) = oneshot::channel::<PendingResult>();
-        self.pending.lock().await.insert(id.clone(), tx);
+        {
+            let mut state = self.pending.lock().await;
+            if let Some(reason) = &state.closed {
+                return Err(anyhow!("websocket connection closed: {reason}"));
+            }
+            state.map.insert(id.clone(), tx);
+        }
 
         if self
+            .conn
+            .lock()
+            .await
             .outbound_tx
             .send(Message::Text(payload.into()))
             .is_err()
         {
-            self.pending.lock().await.remove(&id);
+            self.pending.lock().await.map.remove(&id);
             return Err(anyhow!("failed to send websocket request"));
         }
 
@@ -204,7 +309,7 @@ impl AssistantCommands for WsClient {
             Ok(Ok(Err(error))) => Err(anyhow!(error)),
             Ok(Err(_closed)) => Err(anyhow!("websocket response channel closed")),
             Err(_elapsed) => {
-                self.pending.lock().await.remove(&id);
+                self.pending.lock().await.map.remove(&id);
                 Err(anyhow!(
                     "websocket command timed out after {:?} with no response from the server",
                     self.dispatch_timeout

--- a/crates/client-common/tests/transport_command_channel.rs
+++ b/crates/client-common/tests/transport_command_channel.rs
@@ -39,7 +39,7 @@ async fn as_commands_returns_some_for_ws_transport() {
     let ws_url = spawn_ws_accept_server().await;
 
     // No TLS for plain `ws://`; the accept server ignores the bearer token.
-    let (client, _signals) = timeout(
+    let (client, _signals, _drop) = timeout(
         Duration::from_secs(5),
         WsClient::connect(&ws_url, "test-token", None),
     )

--- a/crates/client-common/tests/transport_timeout.rs
+++ b/crates/client-common/tests/transport_timeout.rs
@@ -85,7 +85,7 @@ async fn uds_command_dispatch_times_out_on_a_silent_server() {
 
     // Connect at the raw-client level so we can shorten the dispatch deadline;
     // the production default is 30s, far too long for a unit test.
-    let (mut client, _signals) = UdsClient::connect(&path, "silent-server-no-validation")
+    let (mut client, _signals, _drop) = UdsClient::connect(&path, "silent-server-no-validation")
         .await
         .expect("connect to silent uds");
     client.set_dispatch_timeout(Duration::from_millis(150));
@@ -113,7 +113,7 @@ async fn uds_pending_slot_is_reclaimed_after_a_timeout() {
     spawn_silent_server(path.clone()).await;
     wait_for_socket(&path).await;
 
-    let (mut client, _signals) = UdsClient::connect(&path, "silent-server-no-validation")
+    let (mut client, _signals, _drop) = UdsClient::connect(&path, "silent-server-no-validation")
         .await
         .expect("connect to silent uds");
     client.set_dispatch_timeout(Duration::from_millis(100));

--- a/crates/client-common/tests/uds_real_turn.rs
+++ b/crates/client-common/tests/uds_real_turn.rs
@@ -461,6 +461,327 @@ fn start_server(socket_path: PathBuf, signing_key: String) -> tokio::sync::onesh
     tx
 }
 
+// ---------------------------------------------------------------------------
+// #246 reconnect harness: a server whose entire runtime can be dropped to
+// simulate a daemon *restart* (which closes every live connection — unlike a
+// graceful shutdown, whose spawned per-connection tasks would linger), then a
+// fresh server stood up on the same socket path.
+// ---------------------------------------------------------------------------
+
+/// Like [`real_handler`] but bound to a caller-supplied coordinator, so a test
+/// can inspect the tools registered against the *new* daemon after reconnect.
+fn real_handler_with_coord(
+    coord: Arc<ClientToolCoordinator>,
+) -> Arc<dyn desktop_assistant_application::AssistantApiHandler> {
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let store: Arc<dyn desktop_assistant_core::ports::store::TurnStateStore> =
+        Arc::new(InMemoryTurnStateStore::new());
+    let handler = DefaultAssistantApiHandler::new(
+        Arc::new(FakeAssistant),
+        Arc::new(StreamingConversations),
+        Arc::new(FakeSettings),
+        Arc::new(FakeConnections),
+        Arc::new(FakeKnowledge),
+    )
+    .with_registry(registry)
+    .with_client_tool_coordinator(coord, store);
+    Arc::new(handler)
+}
+
+/// A server instance running on its own dedicated runtime thread. Dropping it
+/// shuts the runtime down, aborting the accept loop **and** every spawned
+/// per-connection task — so any connected client sees its socket close, exactly
+/// like a daemon binary restart. The coordinator is shared so the test can
+/// assert what the (post-restart) daemon has registered.
+struct ServerInstance {
+    runtime: Option<tokio::runtime::Runtime>,
+    coord: Arc<ClientToolCoordinator>,
+}
+
+impl ServerInstance {
+    fn start(socket_path: PathBuf, signing_key: String) -> Self {
+        let coord = Arc::new(ClientToolCoordinator::new());
+        let coord_for_server = Arc::clone(&coord);
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build server runtime");
+        runtime.spawn(async move {
+            let handler = real_handler_with_coord(coord_for_server);
+            let auth: Arc<dyn UdsAuthValidator> = Arc::new(StaticJwtAuth { signing_key });
+            let server = UdsServer::new(handler, auth, UdsServerConfig::new(socket_path));
+            // Serve until the runtime is dropped (no graceful shutdown — a
+            // restart is abrupt).
+            let _ = server
+                .serve_with_shutdown(std::future::pending::<()>())
+                .await;
+        });
+        Self {
+            runtime: Some(runtime),
+            coord,
+        }
+    }
+}
+
+impl Drop for ServerInstance {
+    fn drop(&mut self) {
+        // Tear the runtime down without blocking the async test thread on its
+        // worker join (which would deadlock): hand the shutdown to a scratch
+        // thread.
+        if let Some(rt) = self.runtime.take() {
+            std::thread::spawn(move || drop(rt));
+        }
+    }
+}
+
+/// #246: after the daemon *restarts* (its runtime — and every live connection —
+/// is dropped, then a fresh daemon binds the same socket), the Connector must
+/// transparently reconnect: a `send_prompt` issued after the drop streams its
+/// turn on the new connection, and the client tools registered before the drop
+/// are **replayed** so the new daemon knows about them again.
+#[tokio::test]
+async fn connector_reconnects_and_replays_tools_after_daemon_restart() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+
+    // Daemon #1.
+    let server1 = ServerInstance::start(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path.clone(), mint_test_jwt(&signing_key, "dave"));
+    // Short backoff is built into the connector; we drive the timing with a
+    // generous wait loop below rather than tuning constants here.
+    let connector = Connector::connect(&cfg).await.expect("connector over uds");
+
+    // Register a client tool against daemon #1 (voice's stop_listening shape).
+    let tool = desktop_assistant_api_model::ClientToolRegistration {
+        name: "stop_listening".into(),
+        description: "stop the microphone".into(),
+        input_schema: serde_json::json!({ "type": "object" }),
+    };
+    let count = connector
+        .register_client_tools(vec![tool.clone()])
+        .await
+        .expect("initial register");
+    assert_eq!(count, 1, "daemon #1 accepted the tool");
+
+    // A turn works on the original connection.
+    drive_one_turn(&connector).await;
+
+    // --- Daemon restart: drop #1 (closing the connection), bind #2. ---
+    drop(server1);
+    let server2 = ServerInstance::start(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    // The fresh daemon starts with NO client tools — until the Connector
+    // replays the registration. Poll until the reconnect+replay lands.
+    let replayed = wait_until(Duration::from_secs(10), || {
+        let coord = Arc::clone(&server2.coord);
+        async move { coord.is_client_registered("stop_listening").await }
+    })
+    .await;
+    assert!(
+        replayed,
+        "the Connector must replay the client-tool registration to the restarted daemon (#246)"
+    );
+
+    // And a brand-new turn must stream on the reconnected transport. The send
+    // itself may transiently fail while the socket is between connections, so
+    // retry briefly until the reconnected transport accepts it.
+    drive_one_turn_with_retry(&connector, Duration::from_secs(10)).await;
+
+    drop(server2);
+}
+
+/// Drive a single SendMessage turn and assert it streams to completion on the
+/// connector's current connection.
+async fn drive_one_turn(connector: &Connector) {
+    let mut events = connector.subscribe();
+    let returned_id = timeout(
+        Duration::from_secs(5),
+        connector.send_prompt_with_system_refinement_idempotent(
+            "conv-1",
+            "hi",
+            "",
+            Some(uuid::Uuid::new_v4().to_string()),
+        ),
+    )
+    .await
+    .expect("send acks")
+    .expect("ack ok");
+    assert!(
+        collect_turn(&mut events, &returned_id).await,
+        "turn completed"
+    );
+}
+
+/// Like [`drive_one_turn`] but tolerant of the brief window right after a drop
+/// where the send may hit the dead socket before the reconnect lands: retries
+/// the send until it acks (or the deadline), then asserts the turn streams.
+async fn drive_one_turn_with_retry(connector: &Connector, within: Duration) {
+    let deadline = tokio::time::Instant::now() + within;
+    loop {
+        let mut events = connector.subscribe();
+        let send = connector.send_prompt_with_system_refinement_idempotent(
+            "conv-1",
+            "hi again",
+            "",
+            Some(uuid::Uuid::new_v4().to_string()),
+        );
+        match timeout(Duration::from_secs(5), send).await {
+            Ok(Ok(returned_id)) => {
+                if collect_turn(&mut events, &returned_id).await {
+                    return;
+                }
+            }
+            _ => {
+                if tokio::time::Instant::now() >= deadline {
+                    panic!("send never succeeded on the reconnected transport within {within:?}");
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("turn never completed on the reconnected transport within {within:?}");
+        }
+    }
+}
+
+/// Read from `events` until the turn for `request_id` completes. Returns `false`
+/// if the connection drops or stalls first (so a caller can retry).
+async fn collect_turn(
+    events: &mut tokio::sync::mpsc::UnboundedReceiver<SignalEvent>,
+    request_id: &str,
+) -> bool {
+    for _ in 0..30 {
+        match timeout(Duration::from_secs(5), events.recv()).await {
+            Ok(Some(SignalEvent::Complete {
+                request_id: rid,
+                full_response,
+            })) if rid == request_id => {
+                return full_response == "hello";
+            }
+            Ok(Some(SignalEvent::Disconnected { .. })) => return false,
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => return false,
+        }
+    }
+    false
+}
+
+/// Poll `cond` until it returns true or the deadline elapses.
+async fn wait_until<F, Fut>(within: Duration, mut cond: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + within;
+    while tokio::time::Instant::now() < deadline {
+        if cond().await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+/// #246 invariant guard: a per-turn **stall** (a waiter on an open-but-silent
+/// connection) must surface the stall `Disconnected` to the waiter (#221)
+/// WITHOUT tearing the transport down or reconnecting. A reconnect would emit a
+/// *second*, "signal stream closed" Disconnected and would replay the tool
+/// registration; neither must happen. After the stall, the SAME connection must
+/// still stream the next turn.
+#[tokio::test]
+async fn per_turn_stall_does_not_trigger_a_reconnect() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let server = ServerInstance::start(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path.clone(), mint_test_jwt(&signing_key, "dave"));
+    // A short stall window. The server stays up the whole time; the connection
+    // is open and healthy — it just has a waiter with no in-flight events.
+    let stall = Duration::from_millis(200);
+    let connector = Connector::connect_with_stall_timeout(&cfg, stall)
+        .await
+        .expect("connector over uds");
+
+    // A waiter on a silent connection (subscribe, but send nothing) trips the
+    // per-turn stall. It must get a "stalled" Disconnected, NOT a close.
+    let mut waiter = connector.subscribe();
+    let event = timeout(stall * 5, waiter.recv())
+        .await
+        .expect("the stall must unstick the waiter")
+        .expect("a terminal event");
+    match event {
+        SignalEvent::Disconnected { reason } => assert!(
+            reason.contains("stalled"),
+            "a per-turn stall must surface a 'stalled' Disconnected, not a close: {reason}"
+        ),
+        other => panic!("expected a stall Disconnected, got {other:?}"),
+    }
+
+    // No reconnect happened, so there must be NO follow-up "signal stream
+    // closed" Disconnected on a fresh subscriber, and the SAME connection must
+    // still stream the next turn (the transport was never torn down).
+    let mut probe = connector.subscribe();
+    // Give any (erroneous) reconnect a window to fire its close-Disconnected.
+    if let Ok(Some(SignalEvent::Disconnected { reason })) = timeout(stall, probe.recv()).await {
+        panic!("a stall must NOT trigger a transport close/reconnect, but got: {reason}");
+    }
+    drop(probe);
+
+    drive_one_turn(&connector).await;
+
+    drop(server);
+}
+
+/// #246 invariant guard: an **idle** Connector (connected, but no turns, no
+/// traffic) must NOT spuriously reconnect or tear its transport down — even
+/// well past the event-stall window. After sitting idle, a turn must still
+/// stream on the *original* connection (no reconnect happened).
+#[tokio::test]
+async fn idle_connector_does_not_spuriously_reconnect() {
+    let dir = TempDir::new().unwrap();
+    let signing_key = "deadbeef".repeat(8);
+    let path = dir.path().join("adelie.sock");
+    let server = ServerInstance::start(path.clone(), signing_key.clone());
+    wait_for_socket(&path).await;
+
+    let cfg = uds_config(path.clone(), mint_test_jwt(&signing_key, "dave"));
+    // A short stall window; the connection is healthy and open the whole time.
+    let stall = Duration::from_millis(150);
+    let connector = Connector::connect_with_stall_timeout(&cfg, stall)
+        .await
+        .expect("connector over uds");
+
+    // Register a tool, then sit idle WELL past the stall window. If an idle
+    // connection wrongly reconnected, the replay would re-run; more importantly,
+    // a spurious teardown would break the next turn.
+    connector
+        .register_client_tools(vec![desktop_assistant_api_model::ClientToolRegistration {
+            name: "noop".into(),
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+        }])
+        .await
+        .expect("register");
+    tokio::time::sleep(stall * 5).await;
+
+    // The tool is still registered on the SAME daemon (no restart happened);
+    // and a turn still streams on the original, never-dropped connection.
+    assert!(
+        server.coord.is_client_registered("noop").await,
+        "an idle connection must not have dropped/reconnected (tool would survive either way, \
+         but a teardown would break the turn below)"
+    );
+    drive_one_turn(&connector).await;
+
+    drop(server);
+}
+
 /// The real-path voice#49 assertion: a SendMessage carrying an idempotency key
 /// (the voice client's exact behaviour) driven through the REAL handler must
 /// stream Status + Delta + Completed events back to the connecting UDS client,

--- a/crates/client-common/tests/uds_streaming.rs
+++ b/crates/client-common/tests/uds_streaming.rs
@@ -174,7 +174,7 @@ async fn uds_streamed_response_is_correlatable_to_the_send() {
     wait_for_socket(&path).await;
 
     let cfg = uds_config(path, mint_test_jwt(&signing_key, "dave"));
-    let (client, mut signals) = connect_transport(&cfg).await.expect("connect over uds");
+    let (client, mut signals, _drop) = connect_transport(&cfg).await.expect("connect over uds");
 
     let returned_id = timeout(Duration::from_secs(2), client.send_prompt("conv-1", "hi"))
         .await

--- a/crates/client-common/tests/uds_transport.rs
+++ b/crates/client-common/tests/uds_transport.rs
@@ -130,7 +130,7 @@ async fn uds_transport_round_trips_commands() {
     wait_for_socket(&path).await;
 
     let config = uds_config(path, mint_test_jwt(&signing_key, "dave"));
-    let (client, _signals) = connect_transport(&config).await.expect("connect over uds");
+    let (client, _signals, _drop) = connect_transport(&config).await.expect("connect over uds");
 
     // Empty-list round-trip: confirms request/response correlation + framing.
     let conversations = timeout(Duration::from_secs(2), client.list_conversations())
@@ -164,7 +164,7 @@ async fn uds_transport_exposes_command_channel_via_as_commands() {
     wait_for_socket(&path).await;
 
     let config = uds_config(path, mint_test_jwt(&signing_key, "dave"));
-    let (client, _signals) = connect_transport(&config).await.expect("connect over uds");
+    let (client, _signals, _drop) = connect_transport(&config).await.expect("connect over uds");
 
     let commands = client
         .as_commands()
@@ -218,7 +218,7 @@ async fn uds_transport_rejects_invalid_jwt() {
     // connect time; the rejection surfaces as a failed command (the server
     // writes an error frame and closes).
     let config = uds_config(path, "not-a-real-jwt".to_string());
-    let (client, _signals) = connect_transport(&config)
+    let (client, _signals, _drop) = connect_transport(&config)
         .await
         .expect("socket connect itself succeeds");
 


### PR DESCRIPTION
Closes #246

## Problem
When the orchestrator daemon **restarts** (a binary redeploy — common here), every connected client is stranded on a dead socket. The shared `Connector` fan-out treats a closed upstream as terminal (by design from voice#49/#241), and there was no reconnect loop, so clients stayed dead until their own process was restarted. Config hot-reload (#222/#230) avoids restarts for config changes, but a binary redeploy still stranded voice/gtk/tui (all use the Connector via path-dep).

## What this does
On an actual transport close, the Connector transparently reconnects to the same endpoint:
1. **Capped exponential backoff + jitter** (~500ms → ~30s cap), single in-flight attempt, retrying indefinitely until reconnected or the Connector is dropped.
2. **Full handshake replay** — re-auth via the credential resolved from the stored `ConnectionConfig`, and the event stream resumes pumping to existing/new subscribers.
3. **Client-tool replay** — the Connector remembers the last `register_client_tools` payload and replays it after reconnect, so a daemon restart doesn't silently drop voice's `stop_listening`/`listen_for_more`/`say_this`.
4. Current waiters get a terminal `Disconnected` (the in-flight turn is genuinely lost on a server restart), but the Connector stays usable — subsequent `subscribe()` / `send_prompt` / commands work on the fresh transport.

No client-repo changes: this reaches voice/gtk/tui on rebuild via the path-dep.

## Design (where things live)
- **Reconnect lives *inside* the `TransportClient`**, not by swapping the client. Each socket client (UDS/WS) now holds its live writer behind a swappable `ConnState` cell, while the request-correlation map, the signal stream, and a new **drop-notifier** channel persist across reconnects. This keeps `Connector::client()` returning a stable `&TransportClient` — the path-dep clients pass it by reference (`f(conn.client())` where `f(&TransportClient)`), so returning anything else would have broken them.
- `connect_transport` now returns `Option<DropNotifier>` (`None` for D-Bus, which doesn't use the Connector). The Connector's **supervisor task** (`spawn_supervisor` in `connector.rs`) waits on it; one fire == one real socket close. It unsticks waiters, then loops `client.reconnect(&config)` with backoff, then replays tools.
- The backoff loop + `jittered_backoff` (capped, ~10% jitter via sub-second wall-clock nanos) live in `connector.rs`. New constants `RECONNECT_BACKOFF_INITIAL` / `RECONNECT_BACKOFF_MAX` in `timeouts.rs`.
- `TransportClient::reconnect` (in `transport.rs`) re-resolves the bearer token and calls the socket client's in-place `reconnect`; D-Bus returns an error.

## #241 idle/stall invariants preserved
Reconnect is triggered **only** by an actual close (the drop-notifier fires), never by a stall. The fan-out's stall/idle handling is unchanged and structurally separate from the drop-notifier: the socket reader no longer emits `Disconnected` on the persistent signal stream (that would read as a permanent end) — it fails pending requests and signals the supervisor via the drop channel. So an idle or stalled connection is never torn down or reconnected. Guarded by two integration tests (idle-no-reconnect, stall-no-reconnect).

## Command path during an outage
Fails fast ("writer/connection closed") or is bounded by the existing per-command dispatch timeout (#221) — never hangs. After reconnect, commands work normally.

## Auth on reconnect (v1 limitation)
The credential is re-resolved from `ConnectionConfig` on each attempt. A reconnect after an outage longer than the JWT's validity will fail auth; that error is surfaced and retried with backoff (no tight spin). A **token-refresh follow-up** could re-mint on auth failure.

## Tests
`crates/client-common/tests/uds_real_turn.rs`:
- `connector_reconnects_and_replays_tools_after_daemon_restart` — drops the server's whole runtime (closing the live connection, like a binary restart), re-binds the same socket with a fresh coordinator, and asserts the Connector reconnects, the registered tool is **replayed** to the new daemon, and a post-drop `send_prompt` streams its turn on the new connection.
- `idle_connector_does_not_spuriously_reconnect` — #241 idle guard.
- `per_turn_stall_does_not_trigger_a_reconnect` — #241 stall guard: a waiter on a silent connection gets the stall `Disconnected` but the transport is NOT closed/reconnected.
Plus connector unit tests for the capped/jittered backoff.

`just check` (fmt + `clippy --workspace --all-targets -D warnings` + build + full test) is **green, zero warnings**.

## Note for the upcoming system-ID handshake
The reconnect path re-runs the connect handshake via `TransportClient::reconnect` → `resolve_ws_bearer_token` + the socket client's `spawn_connection`. When the system-ID handshake adds a field to the connect handshake, it must be threaded through **both** the initial `connect` *and* `spawn_connection`/`reconnect` (and stored on `ConnectionConfig` if it's per-connection) so a reconnect re-sends it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)