### PR TITLE
Tool locality Phase 2: per-machine system-ID co-location handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -1133,9 +1133,94 @@ pub enum WsFrame {
     Event { event: Event },
 }
 
+/// The first frame on a UDS connection: the JWT plus, optionally, the client's
+/// per-machine **system id** and a friendly host label for tool-locality
+/// co-location (issue #248).
+///
+/// The UDS server has always read the JWT out of this frame's `jwt` field; the
+/// `system_id` / `host_label` fields are **optional additions** — older clients
+/// omit them and the server falls back to the transport heuristic (#243),
+/// unchanged. Both are `#[serde(default, skip_serializing_if = "Option::is_none")]`
+/// so the wire shape is byte-identical to the old `{"jwt": "…"}` when a client
+/// sends no id.
+///
+/// The system id is a **co-location/routing hint, not a trust boundary** (#248):
+/// it is self-reported and no privilege is gated on it (auth remains the JWT).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct UdsHandshake {
+    /// Bearer JWT the server validates. Optional in the *type* (so a handshake
+    /// frame missing it still parses and the server can reply with the same
+    /// explicit "missing jwt" auth error it always has — rather than a generic
+    /// deserialize failure); the server rejects a `None`/blank jwt. The client
+    /// always sets it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jwt: Option<String>,
+    /// The client's per-machine system id (#248). `None`/absent for older
+    /// clients ⇒ the server falls back to the transport heuristic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_id: Option<String>,
+    /// A friendly host label for the remote tool note (#248), e.g. the client's
+    /// hostname. Optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_label: Option<String>,
+}
+
+/// HTTP header carrying the client's per-machine **system id** on the WebSocket
+/// upgrade (issue #248). The WS transport authenticates via the `Authorization`
+/// bearer header at upgrade time (not an in-band frame), so the system id rides
+/// a custom header alongside it. Optional — older clients omit it and the server
+/// falls back to the transport heuristic.
+pub const WS_SYSTEM_ID_HEADER: &str = "x-adelie-system-id";
+
+/// HTTP header carrying the client's friendly host label on the WebSocket
+/// upgrade (issue #248). Optional companion to [`WS_SYSTEM_ID_HEADER`].
+pub const WS_HOST_LABEL_HEADER: &str = "x-adelie-host-label";
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn uds_handshake_without_system_id_is_wire_compatible() {
+        // Older shape: a bare `{"jwt": "…"}`. The optional fields must be
+        // skipped on serialize so the wire bytes match the pre-#248 handshake,
+        // and a legacy `{"jwt": "…"}` must still deserialize.
+        let h = UdsHandshake {
+            jwt: Some("tok".into()),
+            system_id: None,
+            host_label: None,
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, r#"{"jwt":"tok"}"#, "absent fields must not appear");
+
+        let legacy: UdsHandshake = serde_json::from_str(r#"{"jwt": "tok"}"#).unwrap();
+        assert_eq!(legacy.jwt.as_deref(), Some("tok"));
+        assert_eq!(legacy.system_id, None);
+        assert_eq!(legacy.host_label, None);
+    }
+
+    #[test]
+    fn uds_handshake_missing_jwt_still_parses() {
+        // A frame with no `jwt` must still deserialize (so the server can return
+        // its explicit "missing jwt" auth error rather than a generic parse
+        // failure). `jwt` is `None`.
+        let h: UdsHandshake = serde_json::from_str(r#"{"hello":"world"}"#).unwrap();
+        assert_eq!(h.jwt, None);
+    }
+
+    #[test]
+    fn uds_handshake_with_system_id_roundtrips() {
+        let h = UdsHandshake {
+            jwt: Some("tok".into()),
+            system_id: Some("machine-abc".into()),
+            host_label: Some("laptop".into()),
+        };
+        let json = serde_json::to_string(&h).unwrap();
+        let back: UdsHandshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, h);
+        assert!(json.contains("machine-abc"));
+        assert!(json.contains("laptop"));
+    }
 
     #[test]
     fn command_json_roundtrip_ping() {

--- a/crates/client-common/src/config.rs
+++ b/crates/client-common/src/config.rs
@@ -52,6 +52,18 @@ pub struct ConnectionConfig {
     /// `transport_mode == TransportMode::Uds`; `None` resolves to
     /// [`default_desktop_socket_path`].
     pub socket_path: Option<PathBuf>,
+    /// The client's per-machine **system id** for tool-locality co-location
+    /// (#248), sent in the connect handshake on every transport. Stored on the
+    /// config so the Connector's reconnect path re-sends it (the supervisor
+    /// re-reads the config on each reconnect). `None` ⇒ no id reported and the
+    /// daemon falls back to the transport heuristic. The Connector fills this in
+    /// from `system_id::local_system_id()` when it connects; callers normally
+    /// leave it `None`.
+    pub system_id: Option<String>,
+    /// An optional friendly host label sent alongside [`Self::system_id`] (#248)
+    /// to make the remote tool note nicer (e.g. the client's hostname). Stored
+    /// on the config for the same reconnect reason.
+    pub host_label: Option<String>,
 }
 
 impl Default for ConnectionConfig {
@@ -65,6 +77,8 @@ impl Default for ConnectionConfig {
             ws_subject: DEFAULT_WS_SUBJECT.to_string(),
             tls_ca_cert: Some(default_ca_cert_path()),
             socket_path: None,
+            system_id: None,
+            host_label: None,
         }
     }
 }

--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -179,6 +179,42 @@ fn jittered_backoff(current: Duration) -> Duration {
     base + Duration::from_millis(jitter)
 }
 
+/// Best-effort local hostname for the friendly tool-note host label (#248).
+/// Dependency-free: the Linux kernel hostname, then `/etc/hostname`, then the
+/// `HOSTNAME` env var. `None` when none resolve — the label is purely cosmetic,
+/// so omitting it is fine (the daemon shows the generic "your device").
+fn local_hostname() -> Option<String> {
+    let from_file = |path: &str| {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+    from_file("/proc/sys/kernel/hostname")
+        .or_else(|| from_file("/etc/hostname"))
+        .or_else(|| {
+            std::env::var("HOSTNAME")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+}
+
+/// Fill in the per-machine system id and host label on `config` for the connect
+/// handshake (#248), unless the caller already set them (respected so tests can
+/// inject a specific id). Reads the local id once (cached). Returns the
+/// (possibly) updated config — stored by the Connector and re-read by the
+/// reconnect supervisor, so the id rides both connect AND reconnect.
+fn stamp_system_id(mut config: ConnectionConfig) -> ConnectionConfig {
+    if config.system_id.is_none() {
+        config.system_id = crate::system_id::local_system_id();
+    }
+    if config.host_label.is_none() {
+        config.host_label = local_hostname();
+    }
+    config
+}
+
 /// The reconnect supervisor (#246). Waits on the transport's drop-notifier; on a
 /// socket close it unsticks the current waiters and reconnects the *same*
 /// `TransportClient` in place with capped exponential backoff + jitter,
@@ -288,10 +324,18 @@ impl Connector {
         config: &ConnectionConfig,
         stall_timeout: Duration,
     ) -> Result<Self> {
+        // Stamp the per-machine system id (+ host label) onto the config so the
+        // connect handshake carries it on EVERY transport (#248), and — because
+        // the reconnect supervisor re-reads this same stored config — it is
+        // re-sent on every reconnect too (#246/#247). A caller that already set
+        // an id (e.g. a test) is respected; otherwise we read the local one. The
+        // id is a co-location HINT, not a trust boundary — see `system_id`.
+        let config = stamp_system_id(config.clone());
+
         // The initial connect is awaited (and may fail) so the caller gets a
         // clear error if the daemon isn't up at all; only *subsequent* drops
         // trigger the background reconnect loop.
-        let (client, signal_rx, drop_rx) = connect_transport(config).await?;
+        let (client, signal_rx, drop_rx) = connect_transport(&config).await?;
         let client = Arc::new(client);
         let subscribers = spawn_fanout_with_stall_timeout(signal_rx, stall_timeout);
         let tools: RememberedTools = Arc::new(Mutex::new(None));
@@ -308,11 +352,12 @@ impl Connector {
             )
         });
 
+        let label = transport_label(&config);
         Ok(Self {
             client,
             subscribers,
             tools,
-            label: transport_label(config),
+            label,
             supervisor,
         })
     }

--- a/crates/client-common/src/lib.rs
+++ b/crates/client-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod connector;
 #[cfg(feature = "dbus")]
 pub mod dbus_client;
 pub mod signal;
+pub mod system_id;
 pub mod timeouts;
 pub mod transport;
 pub mod types;

--- a/crates/client-common/src/system_id.rs
+++ b/crates/client-common/src/system_id.rs
@@ -1,0 +1,133 @@
+//! Client-side read of the stable per-machine **system id** for tool-locality
+//! co-location (issue #248).
+//!
+//! The [`Connector`](crate::Connector) includes this id in the connect
+//! handshake so the daemon can compare it to its own and decide co-location
+//! exactly — same machine ⇒ co-located, **even over WebSocket** — instead of
+//! relying on the coarse transport heuristic (#243). All clients (voice/gtk/tui)
+//! go through the Connector, so they get this for free with no client-repo
+//! changes.
+//!
+//! The resolution strategy is intentionally the **same** as the daemon's
+//! `desktop_assistant_core::system_id`: prefer Linux `/etc/machine-id`, else a
+//! UUID generated once and persisted under `$XDG_DATA_HOME/adelie/system-id`.
+//! Keeping the two in lockstep is what makes the daemon-vs-client comparison
+//! meaningful on a single machine. It is duplicated here (rather than depending
+//! on `core`) for the same reason `uds_client` re-implements the wire framing:
+//! so a client binary doesn't link the daemon/domain stack just to read ~30
+//! lines. The logic is small and stable.
+//!
+//! The id is a **co-location/routing hint, not a trust boundary** (#248): the
+//! daemon never gates privilege on it (auth remains the JWT). See the daemon-side
+//! module docs for the full security rationale.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// The canonical Linux per-host machine id.
+const ETC_MACHINE_ID: &str = "/etc/machine-id";
+
+/// Process-wide cache: the id is stable for the life of the host, so resolve it
+/// at most once.
+static CACHED_ID: OnceLock<Option<String>> = OnceLock::new();
+
+fn normalize(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// `$XDG_DATA_HOME/adelie`, falling back to `$HOME/.local/share/adelie` — the
+/// machine-local directory the generated fallback id is persisted in.
+fn fallback_dir() -> Option<PathBuf> {
+    let data_home = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local").join("share"))
+        })?;
+    Some(data_home.join("adelie"))
+}
+
+/// Read the persisted fallback id from `dir/system-id`, or generate + persist a
+/// fresh UUID when absent/empty, reusing it thereafter. `dir` is explicit so
+/// tests can drive both branches against a temp dir.
+fn read_or_create_fallback_id(dir: &Path) -> std::io::Result<String> {
+    let path = dir.join("system-id");
+    if let Ok(contents) = std::fs::read_to_string(&path)
+        && let Some(id) = normalize(&contents)
+    {
+        return Ok(id);
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(&path, &id)?;
+    Ok(id)
+}
+
+fn resolve_system_id() -> Option<String> {
+    if let Ok(contents) = std::fs::read_to_string(ETC_MACHINE_ID)
+        && let Some(id) = normalize(&contents)
+    {
+        return Some(id);
+    }
+    let dir = fallback_dir()?;
+    match read_or_create_fallback_id(&dir) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                dir = %dir.display(),
+                "failed to read/create the fallback system-id; the daemon will fall back to the \
+                 transport co-location heuristic"
+            );
+            None
+        }
+    }
+}
+
+/// The local machine's stable system id, resolved once and cached (issue #248).
+/// `None` when neither `/etc/machine-id` nor a writable data dir is available —
+/// the handshake then omits the id and the daemon falls back to the transport
+/// heuristic.
+pub fn local_system_id() -> Option<String> {
+    CACHED_ID.get_or_init(resolve_system_id).clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_trims_and_rejects_empty() {
+        assert_eq!(normalize("abc\n").as_deref(), Some("abc"));
+        assert_eq!(normalize("   "), None);
+    }
+
+    #[test]
+    fn fallback_reads_existing_file() {
+        let dir = std::env::temp_dir().join(format!("adelie-cc-sysid-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("system-id"), "fixed-id-42\n").unwrap();
+        assert_eq!(read_or_create_fallback_id(&dir).unwrap(), "fixed-id-42");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn fallback_generates_persists_and_reuses() {
+        let dir = std::env::temp_dir().join(format!("adelie-cc-sysid-{}", uuid::Uuid::new_v4()));
+        let first = read_or_create_fallback_id(&dir).unwrap();
+        assert!(!first.is_empty());
+        assert!(dir.join("system-id").exists());
+        let second = read_or_create_fallback_id(&dir).unwrap();
+        assert_eq!(first, second, "persisted id must be reused");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn local_system_id_is_stable() {
+        assert_eq!(local_system_id(), local_system_id());
+    }
+}

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -101,8 +101,17 @@ impl TransportClient {
             )),
             Self::Ws(client) => {
                 let token = resolve_ws_bearer_token(config).await?;
+                // Re-send the #248 system id + host label from the stored config
+                // so co-location survives a reconnect (the supervisor re-reads
+                // this same config).
                 client
-                    .reconnect(&config.ws_url, &token, config.tls_ca_cert.as_deref())
+                    .reconnect(
+                        &config.ws_url,
+                        &token,
+                        config.tls_ca_cert.as_deref(),
+                        config.system_id.as_deref(),
+                        config.host_label.as_deref(),
+                    )
                     .await
             }
             Self::Uds(client) => {
@@ -116,7 +125,14 @@ impl TransportClient {
                             "no UDS socket path: set ConnectionConfig.socket_path or XDG_RUNTIME_DIR"
                         )
                     })?;
-                client.reconnect(&path, &token).await
+                client
+                    .reconnect(
+                        &path,
+                        &token,
+                        config.system_id.as_deref(),
+                        config.host_label.as_deref(),
+                    )
+                    .await
             }
         }
     }
@@ -358,8 +374,16 @@ pub async fn connect_transport(
         )),
         TransportMode::Ws => {
             let token = resolve_ws_bearer_token(config).await?;
-            let (client, signal_rx, drop_rx) =
-                WsClient::connect(&config.ws_url, &token, config.tls_ca_cert.as_deref()).await?;
+            // Carry the #248 system id + host label from the config into the
+            // handshake (custom upgrade headers); the Connector stamps them on.
+            let (client, signal_rx, drop_rx) = WsClient::connect(
+                &config.ws_url,
+                &token,
+                config.tls_ca_cert.as_deref(),
+                config.system_id.as_deref(),
+                config.host_label.as_deref(),
+            )
+            .await?;
             Ok((TransportClient::Ws(client), signal_rx, Some(drop_rx)))
         }
         TransportMode::Uds => {
@@ -375,7 +399,15 @@ pub async fn connect_transport(
                         "no UDS socket path: set ConnectionConfig.socket_path or XDG_RUNTIME_DIR"
                     )
                 })?;
-            let (client, signal_rx, drop_rx) = UdsClient::connect(&path, &token).await?;
+            // Carry the #248 system id + host label from the config into the
+            // JWT handshake frame; the Connector stamps them on.
+            let (client, signal_rx, drop_rx) = UdsClient::connect(
+                &path,
+                &token,
+                config.system_id.as_deref(),
+                config.host_label.as_deref(),
+            )
+            .await?;
             Ok((TransportClient::Uds(client), signal_rx, Some(drop_rx)))
         }
     }

--- a/crates/client-common/src/uds_client.rs
+++ b/crates/client-common/src/uds_client.rs
@@ -113,9 +113,15 @@ impl UdsClient {
     /// Connect a UDS transport. Returns the client, the persistent signal
     /// stream, and a drop-notifier receiver that fires once per underlying
     /// socket close (#246) — the Connector uses the latter to drive reconnect.
+    ///
+    /// `system_id` / `host_label` (#248) ride the JWT handshake frame so the
+    /// daemon can compute exact co-location; `None`/`None` reproduces the
+    /// pre-#248 `{"jwt": "…"}` handshake byte-for-byte.
     pub async fn connect(
         socket_path: &Path,
         bearer_token: &str,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
     ) -> Result<(
         Self,
         mpsc::UnboundedReceiver<SignalEvent>,
@@ -131,6 +137,8 @@ impl UdsClient {
         let outbound_tx = Self::spawn_connection(
             socket_path,
             bearer_token,
+            system_id,
+            host_label,
             Arc::clone(&pending),
             signal_tx.clone(),
             drop_tx.clone(),
@@ -157,6 +165,8 @@ impl UdsClient {
     async fn spawn_connection(
         socket_path: &Path,
         bearer_token: &str,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
         pending: Arc<Mutex<PendingState>>,
         signal_tx: mpsc::UnboundedSender<SignalEvent>,
         drop_tx: mpsc::UnboundedSender<()>,
@@ -166,11 +176,18 @@ impl UdsClient {
             .map_err(|e| anyhow!("failed to connect uds {}: {e}", socket_path.display()))?;
         let (mut read_half, mut write_half) = stream.into_split();
 
-        // Handshake: the first frame must be `{"jwt": "<token>"}`. On success
-        // the server sends nothing back and proceeds straight to the
-        // dispatcher; on failure it writes an error frame and closes, which
-        // the reader below turns into a connection-level failure.
-        let handshake = serde_json::to_vec(&serde_json::json!({ "jwt": bearer_token }))?;
+        // Handshake: the first frame carries the JWT plus, optionally, the
+        // client's per-machine system id + host label for co-location (#248).
+        // The optional fields are skipped when absent, so a no-id client sends
+        // the byte-identical pre-#248 `{"jwt": "…"}`. On success the server sends
+        // nothing back and proceeds straight to the dispatcher; on failure it
+        // writes an error frame and closes, which the reader below turns into a
+        // connection-level failure.
+        let handshake = serde_json::to_vec(&api::UdsHandshake {
+            jwt: Some(bearer_token.to_string()),
+            system_id: system_id.map(str::to_string),
+            host_label: host_label.map(str::to_string),
+        })?;
         write_frame(&mut write_half, &handshake)
             .await
             .map_err(|e| anyhow!("uds handshake write failed: {e}"))?;
@@ -245,10 +262,23 @@ impl UdsClient {
     /// channels, and swap in the new writer. On success the same
     /// `&TransportClient` resumes working; on failure the error is returned so
     /// the supervisor can back off and retry.
-    pub(crate) async fn reconnect(&self, socket_path: &Path, bearer_token: &str) -> Result<()> {
+    ///
+    /// The system id + host label (#248) are re-sent on every reconnect — the
+    /// caller (`TransportClient::reconnect`) re-reads them from the stored
+    /// `ConnectionConfig`, so a handshake field added in #248 survives a daemon
+    /// restart exactly like the bearer token does.
+    pub(crate) async fn reconnect(
+        &self,
+        socket_path: &Path,
+        bearer_token: &str,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
+    ) -> Result<()> {
         let outbound_tx = Self::spawn_connection(
             socket_path,
             bearer_token,
+            system_id,
+            host_label,
             Arc::clone(&self.pending),
             self.signal_tx.clone(),
             self.drop_tx.clone(),

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -67,10 +67,17 @@ impl WsClient {
     /// Connect a WebSocket transport. Returns the client, the persistent signal
     /// stream, and a drop-notifier receiver that fires once per underlying
     /// socket close (#246) — the Connector uses the latter to drive reconnect.
+    ///
+    /// `system_id` / `host_label` (#248) ride custom upgrade headers (WS
+    /// authenticates via the `Authorization` header at upgrade time, not an
+    /// in-band frame) so the daemon can compute exact co-location even over
+    /// WebSocket; `None`/`None` simply omits them.
     pub async fn connect(
         ws_url: &str,
         bearer_token: &str,
         tls_ca_cert: Option<&Path>,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
     ) -> Result<(
         Self,
         mpsc::UnboundedReceiver<SignalEvent>,
@@ -87,6 +94,8 @@ impl WsClient {
             ws_url,
             bearer_token,
             tls_ca_cert,
+            system_id,
+            host_label,
             Arc::clone(&pending),
             signal_tx.clone(),
             drop_tx.clone(),
@@ -110,19 +119,46 @@ impl WsClient {
     /// **persistent** `pending` / `signal_tx` / `drop_tx`, and return the new
     /// writer handle. Shared by [`connect`](Self::connect) and
     /// [`reconnect`](Self::reconnect) (#246).
+    // Each argument is a distinct connection input (endpoint, credential, TLS,
+    // the #248 id/label, and the three persistent channels); bundling them into
+    // a struct would just relocate the same fan-out without making it clearer.
+    #[allow(clippy::too_many_arguments)]
     async fn spawn_connection(
         ws_url: &str,
         bearer_token: &str,
         tls_ca_cert: Option<&Path>,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
         pending: Arc<Mutex<PendingState>>,
         signal_tx: mpsc::UnboundedSender<SignalEvent>,
         drop_tx: mpsc::UnboundedSender<()>,
     ) -> Result<mpsc::UnboundedSender<Message>> {
+        use tokio_tungstenite::tungstenite::http::HeaderName;
         let mut request = ws_url.into_client_request()?;
         request.headers_mut().insert(
             tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
             format!("Bearer {bearer_token}").parse()?,
         );
+        // System-id co-location handshake (#248): the daemon reads these custom
+        // headers and compares the id to its own. Optional — omitted when the
+        // client has no id, so the daemon falls back to the transport heuristic.
+        // A header value that won't parse (non-ASCII control bytes) is silently
+        // skipped — the id is a hint, not load-bearing, so we degrade rather
+        // than fail the connect.
+        if let Some(id) = system_id.filter(|s| !s.trim().is_empty())
+            && let Ok(value) = id.parse()
+        {
+            request
+                .headers_mut()
+                .insert(HeaderName::from_static(api::WS_SYSTEM_ID_HEADER), value);
+        }
+        if let Some(label) = host_label.filter(|s| !s.trim().is_empty())
+            && let Ok(value) = label.parse()
+        {
+            request
+                .headers_mut()
+                .insert(HeaderName::from_static(api::WS_HOST_LABEL_HEADER), value);
+        }
 
         let connector = if ws_url.starts_with("wss://") {
             Some(build_tls_connector(tls_ca_cert)?)
@@ -212,16 +248,25 @@ impl WsClient {
     /// spawn fresh writer/keepalive/reader tasks bound to the persistent
     /// channels, and swap in the new writer. On failure the error is returned so
     /// the supervisor can back off and retry.
+    ///
+    /// The system id + host label (#248) are re-sent on every reconnect — the
+    /// caller (`TransportClient::reconnect`) re-reads them from the stored
+    /// `ConnectionConfig`, so the co-location handshake field survives a daemon
+    /// restart exactly like the bearer token does.
     pub(crate) async fn reconnect(
         &self,
         ws_url: &str,
         bearer_token: &str,
         tls_ca_cert: Option<&Path>,
+        system_id: Option<&str>,
+        host_label: Option<&str>,
     ) -> Result<()> {
         let outbound_tx = Self::spawn_connection(
             ws_url,
             bearer_token,
             tls_ca_cert,
+            system_id,
+            host_label,
             Arc::clone(&self.pending),
             self.signal_tx.clone(),
             self.drop_tx.clone(),

--- a/crates/client-common/tests/system_id_handshake.rs
+++ b/crates/client-common/tests/system_id_handshake.rs
@@ -1,0 +1,146 @@
+//! System-id co-location handshake threading (#248).
+//!
+//! These tests assert the per-machine **system id** the Connector stamps onto
+//! the connection config is carried in the connect handshake AND re-sent on a
+//! reconnect (#246/#247) — the explicit requirement that any new handshake field
+//! survive a daemon restart.
+//!
+//! We hand-roll a minimal loopback UDS server (the same 4-byte little-endian
+//! length-prefixed framing the real server uses) that parses the first frame as
+//! an [`api::UdsHandshake`], reports it back over a channel, then **drops the
+//! connection** to force the Connector's reconnect supervisor to re-handshake.
+//! Driving the real daemon stack isn't needed to observe the handshake bytes.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::{ConnectionConfig, Connector, TransportMode};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+/// Read one 4-byte LE length-prefixed frame.
+async fn read_frame(stream: &mut UnixStream) -> std::io::Result<Vec<u8>> {
+    let mut len = [0u8; 4];
+    stream.read_exact(&mut len).await?;
+    let n = u32::from_le_bytes(len) as usize;
+    let mut body = vec![0u8; n];
+    if n > 0 {
+        stream.read_exact(&mut body).await?;
+    }
+    Ok(body)
+}
+
+/// A loopback server that, on each accepted connection, reads the handshake
+/// frame, parses it as a [`api::UdsHandshake`], sends it over `tx`, then shuts
+/// the socket down. The shutdown makes the client's reader see EOF, which fires
+/// the drop-notifier and drives the Connector's reconnect — so the next accepted
+/// connection re-handshakes and we capture a SECOND handshake.
+fn spawn_handshake_capture_server(path: PathBuf, tx: mpsc::UnboundedSender<api::UdsHandshake>) {
+    tokio::spawn(async move {
+        let listener = UnixListener::bind(&path).expect("bind capture uds");
+        while let Ok((mut stream, _addr)) = listener.accept().await {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                if let Ok(frame) = read_frame(&mut stream).await
+                    && let Ok(handshake) = serde_json::from_slice::<api::UdsHandshake>(&frame)
+                {
+                    let _ = tx.send(handshake);
+                }
+                // Drop the connection so the client reconnects (#246).
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+}
+
+async fn wait_for_socket(path: &std::path::Path) {
+    for _ in 0..100 {
+        if path.exists() && UnixStream::connect(path).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("capture uds socket {path:?} did not appear");
+}
+
+#[tokio::test]
+async fn system_id_is_sent_on_connect_and_resent_on_reconnect() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("capture.sock");
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    spawn_handshake_capture_server(path.clone(), tx);
+    wait_for_socket(&path).await;
+
+    // Inject a known system id + host label on the config. The Connector
+    // respects a pre-set id (it only fills one in when absent), so the test is
+    // hermetic — it doesn't depend on the host's /etc/machine-id.
+    let config = ConnectionConfig {
+        transport_mode: TransportMode::Uds,
+        socket_path: Some(path.clone()),
+        ws_jwt: Some("test-token".to_string()),
+        system_id: Some("machine-under-test".to_string()),
+        host_label: Some("test-laptop".to_string()),
+        ..ConnectionConfig::default()
+    };
+
+    // The first accepted connection is `wait_for_socket`'s probe (no handshake
+    // written — it connects and drops), so it never reaches the handshake
+    // parse. The Connector's real connect produces the first captured handshake;
+    // the forced drop produces the second on reconnect.
+    let _connector = Connector::connect(&config)
+        .await
+        .expect("connector connects");
+
+    // First handshake (initial connect) must carry the id + label.
+    let first = timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("first handshake captured")
+        .expect("handshake present");
+    assert_eq!(first.jwt.as_deref(), Some("test-token"));
+    assert_eq!(first.system_id.as_deref(), Some("machine-under-test"));
+    assert_eq!(first.host_label.as_deref(), Some("test-laptop"));
+
+    // Second handshake (after the forced drop → reconnect) must re-send the SAME
+    // id + label — the #248 field survives a reconnect (#246/#247).
+    let second = timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("reconnect handshake captured (id must be re-sent)")
+        .expect("handshake present");
+    assert_eq!(
+        second.system_id.as_deref(),
+        Some("machine-under-test"),
+        "the system id must be re-sent on reconnect, not dropped"
+    );
+    assert_eq!(second.host_label.as_deref(), Some("test-laptop"));
+}
+
+#[tokio::test]
+async fn no_system_id_yields_legacy_handshake_shape() {
+    // A config whose id is explicitly blank-out by a host with no /etc/machine-id
+    // would normally fall back to a generated id; to test the *no-id* wire shape
+    // deterministically we connect over the raw client with `None`/`None` and
+    // assert the captured frame is the bare `{"jwt": "…"}` an older client sends.
+    use desktop_assistant_client_common::uds_client::UdsClient;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("legacy.sock");
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    spawn_handshake_capture_server(path.clone(), tx);
+    wait_for_socket(&path).await;
+
+    let (_client, _signals, _drop) = UdsClient::connect(&path, "legacy-token", None, None)
+        .await
+        .expect("raw uds connect");
+
+    let frame = timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("handshake captured")
+        .expect("handshake present");
+    assert_eq!(frame.jwt.as_deref(), Some("legacy-token"));
+    assert_eq!(frame.system_id, None, "no-id client must omit system_id");
+    assert_eq!(frame.host_label, None);
+}

--- a/crates/client-common/tests/transport_command_channel.rs
+++ b/crates/client-common/tests/transport_command_channel.rs
@@ -41,7 +41,7 @@ async fn as_commands_returns_some_for_ws_transport() {
     // No TLS for plain `ws://`; the accept server ignores the bearer token.
     let (client, _signals, _drop) = timeout(
         Duration::from_secs(5),
-        WsClient::connect(&ws_url, "test-token", None),
+        WsClient::connect(&ws_url, "test-token", None, None, None),
     )
     .await
     .expect("ws connect did not complete in time")

--- a/crates/client-common/tests/transport_timeout.rs
+++ b/crates/client-common/tests/transport_timeout.rs
@@ -85,9 +85,10 @@ async fn uds_command_dispatch_times_out_on_a_silent_server() {
 
     // Connect at the raw-client level so we can shorten the dispatch deadline;
     // the production default is 30s, far too long for a unit test.
-    let (mut client, _signals, _drop) = UdsClient::connect(&path, "silent-server-no-validation")
-        .await
-        .expect("connect to silent uds");
+    let (mut client, _signals, _drop) =
+        UdsClient::connect(&path, "silent-server-no-validation", None, None)
+            .await
+            .expect("connect to silent uds");
     client.set_dispatch_timeout(Duration::from_millis(150));
 
     // The outer `timeout` is a test guard: if the dispatch timeout regressed,
@@ -113,9 +114,10 @@ async fn uds_pending_slot_is_reclaimed_after_a_timeout() {
     spawn_silent_server(path.clone()).await;
     wait_for_socket(&path).await;
 
-    let (mut client, _signals, _drop) = UdsClient::connect(&path, "silent-server-no-validation")
-        .await
-        .expect("connect to silent uds");
+    let (mut client, _signals, _drop) =
+        UdsClient::connect(&path, "silent-server-no-validation", None, None)
+            .await
+            .expect("connect to silent uds");
     client.set_dispatch_timeout(Duration::from_millis(100));
 
     for attempt in 0..2 {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 chrono.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tokio-util.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -271,25 +271,33 @@ pub(crate) fn llm_messages_for_turn(
     assembled
 }
 
-/// Per-turn tool execution-locality context (issue #243).
+/// Per-turn tool execution-locality context (issue #243, refined in #248).
 ///
 /// Bundles the inputs the tool-note builder needs to tag each tool with where
-/// it runs: the connection's [`TransportKind`] (the co-location signal), the
-/// daemon's self-identity `host` label, and the names of the tools registered
-/// as client-local for this turn. Cheap to build — the dispatch loop assembles
-/// it once per turn from the transport task-local, the handler's host label,
-/// and the client-tool port's definitions.
+/// it runs: the per-machine **system-id co-location** result (#248) with the
+/// connection's [`TransportKind`] as a fallback, the daemon's self-identity
+/// `host` label, and the names of the tools registered as client-local for this
+/// turn. Cheap to build — the dispatch loop assembles it once per turn from the
+/// transport + co-location task-locals, the handler's host label, and the
+/// client-tool port's definitions.
 #[derive(Debug, Clone)]
 pub(crate) struct ToolLocalityContext {
-    /// How the turn's connection reaches the daemon. Drives co-location:
+    /// Authoritative co-location result from the per-machine system-id
+    /// handshake (#248): `Some(true)` when the client's reported id equals the
+    /// daemon's own id (same machine — even over WebSocket), `Some(false)` when
+    /// the ids differ, and `None` when the client reported no id (an older
+    /// client). When `None`, co-location falls back to [`Self::transport`],
+    /// preserving the Phase-1 (#243) behaviour exactly.
+    pub co_located: Option<bool>,
+    /// How the turn's connection reaches the daemon. The **fallback**
+    /// co-location signal (#243) used only when [`Self::co_located`] is `None`:
     /// local transports collapse the server/client distinction.
     pub transport: TransportKind,
-    /// The daemon's self-identity label used for `Server { host }` (hostname
-    /// today; a stable machine-id in the follow-up phase).
+    /// The daemon's self-identity label used for `Server { host }` (the
+    /// hostname).
     pub host: String,
     /// Label shown for a client tool's machine in the remote tool note (e.g.
-    /// `your device`). A per-client device name arrives with the system-id
-    /// handshake in the follow-up phase.
+    /// `your device`, or a hostname the client reported in the handshake, #248).
     pub client_label: String,
     /// Names of the tools that run server-side (MCP / built-in) on the daemon
     /// host. A name in BOTH this set and [`Self::client_tool_names`] is a
@@ -302,8 +310,13 @@ pub(crate) struct ToolLocalityContext {
 
 impl ToolLocalityContext {
     /// Whether the connection is co-located with the daemon (same machine).
+    ///
+    /// Prefers the authoritative system-id match (#248) when the client
+    /// reported an id ([`Self::co_located`] is `Some`); otherwise falls back to
+    /// the transport heuristic (#243) for older clients that send no id.
     fn is_co_located(&self) -> bool {
-        self.transport.is_co_located()
+        self.co_located
+            .unwrap_or_else(|| self.transport.is_co_located())
     }
 
     fn is_server(&self, name: &str) -> bool {
@@ -2502,6 +2515,10 @@ mod tests {
 
     // --- Tool execution-locality (issue #243) ------------------------------
 
+    /// Build a context that relies on the **transport** co-location heuristic
+    /// (`co_located: None`), i.e. an older client that reported no system id.
+    /// This preserves the Phase-1 (#243) behaviour the existing assertions
+    /// cover.
     fn locality_ctx(
         transport: TransportKind,
         host: &str,
@@ -2509,6 +2526,28 @@ mod tests {
         client_names: &[&str],
     ) -> ToolLocalityContext {
         ToolLocalityContext {
+            co_located: None,
+            transport,
+            host: host.to_string(),
+            client_label: "your device".to_string(),
+            server_tool_names: server_names.iter().map(|s| s.to_string()).collect(),
+            client_tool_names: client_names.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Build a context with an authoritative system-id co-location result
+    /// (#248). `co_located` overrides the transport heuristic — used to assert
+    /// id-match co-locates even over WebSocket, and id-mismatch keeps localities
+    /// distinct even over a "local" transport.
+    fn locality_ctx_with_id(
+        co_located: bool,
+        transport: TransportKind,
+        host: &str,
+        server_names: &[&str],
+        client_names: &[&str],
+    ) -> ToolLocalityContext {
+        ToolLocalityContext {
+            co_located: Some(co_located),
             transport,
             host: host.to_string(),
             client_label: "your device".to_string(),
@@ -2573,6 +2612,91 @@ mod tests {
         assert!(
             !client.primary,
             "client side is the non-primary alternative"
+        );
+    }
+
+    #[test]
+    fn resolve_localities_id_match_co_locates_over_websocket() {
+        // #248: an authoritative system-id MATCH co-locates even on WebSocket —
+        // overriding the transport heuristic (which would treat WS as remote).
+        // The duplicate `terminal` collapses to the single server-side tool.
+        let ctx = locality_ctx_with_id(
+            true,
+            TransportKind::WebSocket,
+            "daemon-host",
+            &["terminal", "kb_search"],
+            &["terminal"],
+        );
+        let entries = resolve_tool_localities(&["terminal", "kb_search"], &ctx);
+        let terminal: Vec<_> = entries.iter().filter(|e| e.name == "terminal").collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "id-match must co-locate (collapse the duplicate) even over WebSocket"
+        );
+        assert!(terminal[0].locality.is_server());
+    }
+
+    #[test]
+    fn resolve_localities_id_mismatch_keeps_distinct_over_local_transport() {
+        // #248: an authoritative system-id MISMATCH keeps the localities
+        // distinct even on a nominally-local transport — overriding the
+        // transport heuristic (which would co-locate). Both `terminal` entries
+        // survive, server primary + client alternative.
+        let ctx = locality_ctx_with_id(
+            false,
+            TransportKind::Uds,
+            "daemon-host",
+            &["terminal"],
+            &["terminal"],
+        );
+        let entries = resolve_tool_localities(&["terminal"], &ctx);
+        let terminal: Vec<_> = entries.iter().filter(|e| e.name == "terminal").collect();
+        assert_eq!(
+            terminal.len(),
+            2,
+            "id-mismatch must keep both tools distinct even over a local transport"
+        );
+        assert!(terminal.iter().any(|e| e.locality.is_server() && e.primary));
+        assert!(
+            terminal
+                .iter()
+                .any(|e| e.locality.is_client() && !e.primary)
+        );
+    }
+
+    #[test]
+    fn resolve_localities_no_id_falls_back_to_transport() {
+        // #248: with no system id reported (`co_located: None`), co-location is
+        // the Phase-1 transport heuristic — WS remote (distinct), UDS local
+        // (collapsed). This is the backward-compat path for older clients.
+        let ws = locality_ctx(
+            TransportKind::WebSocket,
+            "daemon-host",
+            &["terminal"],
+            &["terminal"],
+        );
+        assert_eq!(
+            resolve_tool_localities(&["terminal"], &ws)
+                .iter()
+                .filter(|e| e.name == "terminal")
+                .count(),
+            2,
+            "no-id + WebSocket must stay remote (transport fallback, distinct tools)"
+        );
+        let uds = locality_ctx(
+            TransportKind::Uds,
+            "daemon-host",
+            &["terminal"],
+            &["terminal"],
+        );
+        assert_eq!(
+            resolve_tool_localities(&["terminal"], &uds)
+                .iter()
+                .filter(|e| e.name == "terminal")
+                .count(),
+            1,
+            "no-id + UDS must co-locate (transport fallback, collapsed)"
         );
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ports;
 pub mod prompts;
 pub mod sanitize;
 pub mod service;
+pub mod system_id;
 pub mod tools;
 
 use thiserror::Error;

--- a/crates/core/src/ports/transport.rs
+++ b/crates/core/src/ports/transport.rs
@@ -14,13 +14,26 @@
 //! the handler, and the dispatch loop reads it via [`current_transport_kind`]
 //! when it assembles the per-turn tool set.
 //!
+//! ## System-id co-location (#248)
+//!
+//! Phase 2 refines co-location with an exact per-machine **system id**: the
+//! daemon compares the client's reported id to its own and installs the
+//! authoritative result via [`with_co_location`] alongside the transport. The
+//! dispatch loop reads it via [`current_co_location`]; when the client reported
+//! no id (an older client) the slot holds `None` and co-location falls back to
+//! the transport heuristic, preserving Phase-1 behaviour. A client-supplied
+//! host label (for a friendlier tool note) rides the same path via
+//! [`with_client_label`] / [`current_client_label`].
+//!
 //! ## Default
 //!
 //! When no scope is installed — tests, dreaming jobs, and any caller that does
 //! not route through a transport adapter — [`current_transport_kind`] returns
 //! [`TransportKind::Uds`]. UDS is the live default transport and is co-located,
 //! so the safe, common-case behaviour (treat tools as same-machine) applies
-//! without every test having to install a scope.
+//! without every test having to install a scope. [`current_co_location`]
+//! defaults to `None` (no authoritative result ⇒ fall back to transport) and
+//! [`current_client_label`] to `None`.
 
 use crate::domain::TransportKind;
 
@@ -31,6 +44,20 @@ tokio::task_local! {
     /// which [`current_transport_kind`] reports as [`TransportKind::Uds`] (the
     /// co-located default).
     static TRANSPORT_KIND: TransportKind;
+
+    /// The authoritative per-machine system-id co-location result for the
+    /// current connection (#248): `Some(true)`/`Some(false)` when the client
+    /// reported an id the daemon could compare to its own, `None` for an older
+    /// client that sent none (⇒ fall back to the transport heuristic).
+    /// Installed by the transport adapter via [`with_co_location`]; read via
+    /// [`current_co_location`].
+    static CO_LOCATION: Option<bool>;
+
+    /// A client-supplied host label for the current connection (#248), used to
+    /// make the remote tool note friendlier (e.g. `your device 'laptop'`).
+    /// `None` when the client sent none. Installed via [`with_client_label`];
+    /// read via [`current_client_label`].
+    static CLIENT_LABEL: Option<String>;
 }
 
 /// Run `fut` with `kind` installed as the current task-local transport. All
@@ -56,6 +83,40 @@ pub fn current_transport_kind() -> TransportKind {
     TRANSPORT_KIND
         .try_with(|k| *k)
         .unwrap_or(TransportKind::Uds)
+}
+
+/// Run `fut` with `co_located` installed as the current authoritative
+/// system-id co-location result (#248). `Some(true)`/`Some(false)` overrides
+/// the transport heuristic; `None` defers to it. Like every task-local it does
+/// not cross `tokio::spawn` — re-install inside spawned turn bodies.
+pub async fn with_co_location<F, T>(co_located: Option<bool>, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CO_LOCATION.scope(co_located, fut).await
+}
+
+/// The current authoritative system-id co-location result (#248), or `None`
+/// when no scope is installed (⇒ the caller falls back to the transport
+/// heuristic). Never panics or blocks.
+pub fn current_co_location() -> Option<bool> {
+    CO_LOCATION.try_with(|c| *c).unwrap_or(None)
+}
+
+/// Run `fut` with `label` installed as the current client-supplied host label
+/// (#248). `None` means the client sent none. Like every task-local it does not
+/// cross `tokio::spawn` — re-install inside spawned turn bodies.
+pub async fn with_client_label<F, T>(label: Option<String>, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CLIENT_LABEL.scope(label, fut).await
+}
+
+/// The current client-supplied host label (#248), or `None` when no scope is
+/// installed or the client sent none. Never panics or blocks.
+pub fn current_client_label() -> Option<String> {
+    CLIENT_LABEL.try_with(|l| l.clone()).unwrap_or(None)
 }
 
 #[cfg(test)]
@@ -92,5 +153,29 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(observed, TransportKind::Uds);
+    }
+
+    #[tokio::test]
+    async fn current_co_location_defaults_to_none_outside_scope() {
+        assert_eq!(current_co_location(), None);
+    }
+
+    #[tokio::test]
+    async fn current_co_location_observes_installed_scope() {
+        let observed = with_co_location(Some(true), async { current_co_location() }).await;
+        assert_eq!(observed, Some(true));
+        let observed = with_co_location(Some(false), async { current_co_location() }).await;
+        assert_eq!(observed, Some(false));
+        // After the scope exits the slot is unset again (back to the default).
+        assert_eq!(current_co_location(), None);
+    }
+
+    #[tokio::test]
+    async fn current_client_label_defaults_to_none_and_observes_scope() {
+        assert_eq!(current_client_label(), None);
+        let observed =
+            with_client_label(Some("laptop".to_string()), async { current_client_label() }).await;
+        assert_eq!(observed.as_deref(), Some("laptop"));
+        assert_eq!(current_client_label(), None);
     }
 }

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -17,7 +17,7 @@ use crate::ports::llm::{
 use crate::ports::scratchpad::{SCRATCHPAD_GOAL_KEY, ScratchpadGetManyFn};
 use crate::ports::store::ConversationStore;
 use crate::ports::tools::ToolExecutor;
-use crate::ports::transport::current_transport_kind;
+use crate::ports::transport::{current_client_label, current_co_location, current_transport_kind};
 use crate::sanitize::{sanitize_assistant_text, sanitize_assistant_text_for_stream};
 use crate::tools::{
     NoopToolExecutor, categorize_tool_namespaces, tool_set_hash, tool_status_message,
@@ -474,14 +474,17 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             None => Vec::new(),
         };
 
-        // Tool execution-locality context (issue #243). Resolve the turn's
-        // co-location signal (the connection's transport: UDS/D-Bus ⇒ same
-        // machine, WebSocket ⇒ possibly remote) plus the daemon's host label,
-        // the server-side tool names, and the client-local tool names once. The
+        // Tool execution-locality context (issue #243, refined in #248).
+        // Resolve the turn's co-location signal once: the authoritative
+        // per-machine system-id match (#248) when the client reported an id, and
+        // the connection's transport (UDS/D-Bus ⇒ same machine, WebSocket ⇒
+        // possibly remote) as the fallback for older clients that sent none.
+        // Plus the daemon's host label, an optional client-reported host label,
+        // the server-side tool names, and the client-local tool names. The
         // tool-note builder uses it to tag each tool with where it runs and to
-        // route a capability that exists on both the server and a remote
-        // client. The server set is the full core set plus every namespaced
-        // tool — activated tools are always a subset of these (they come from
+        // route a capability that exists on both the server and a remote client.
+        // The server set is the full core set plus every namespaced tool —
+        // activated tools are always a subset of these (they come from
         // server-side search), so a tool that isn't in this set is client-only.
         let server_tool_names: Vec<String> = core_tools
             .iter()
@@ -492,10 +495,16 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     .flat_map(|ns| ns.tools.iter().map(|t| t.name.clone())),
             )
             .collect();
+        // Prefer a client-reported host label for the remote tool note; fall
+        // back to the generic "your device" when none was sent (#248).
+        let client_label = current_client_label()
+            .filter(|l| !l.trim().is_empty())
+            .unwrap_or_else(|| "your device".to_string());
         let tool_locality = ToolLocalityContext {
+            co_located: current_co_location(),
             transport: current_transport_kind(),
             host: self.host.clone(),
-            client_label: "your device".to_string(),
+            client_label,
             server_tool_names,
             client_tool_names: client_tool_defs.iter().map(|d| d.name.clone()).collect(),
         };

--- a/crates/core/src/system_id.rs
+++ b/crates/core/src/system_id.rs
@@ -1,0 +1,269 @@
+//! Stable per-machine **system id** for tool-locality co-location (issue #248).
+//!
+//! Phase 1 (#243/#245) inferred co-location from the connection's
+//! [`crate::domain::TransportKind`] (UDS/D-Bus ⇒ same machine, WebSocket ⇒
+//! possibly remote). That heuristic is coarse: a WebSocket connection that
+//! happens to terminate on the daemon's *own* machine is wrongly treated as
+//! remote.
+//!
+//! Phase 2 replaces the heuristic as the **primary** signal with an exact
+//! per-machine id that both the daemon and each client read. When the client's
+//! reported id equals the daemon's own id they are the same machine ⇒
+//! co-located, **even over WebSocket**. The transport heuristic stays as the
+//! fallback for clients that don't report an id (older clients), so Phase-1
+//! behaviour is preserved for them.
+//!
+//! ## What makes a good id
+//!
+//! - **Machine-local, not user-/network-scoped.** Two hosts must never share
+//!   it (that would falsely co-locate them); the same host must keep it stable
+//!   across reboots and processes (so co-location is consistent).
+//! - Linux **`/etc/machine-id`** fits exactly: a 128-bit hex id assigned at
+//!   install/first-boot, host-local, not synced across machines. It's the
+//!   preferred source.
+//! - When it's absent (non-systemd, containers without it, other platforms) we
+//!   **generate a UUID once and persist it** to a machine-local app path
+//!   (`$XDG_DATA_HOME/adelie/system-id`, falling back to `~/.local/share`),
+//!   reusing it thereafter. That file is per-machine by construction (it lives
+//!   on local storage, not a synced/home-roamed location in the common case).
+//!
+//! ## Security
+//!
+//! The id is a **co-location/routing hint, not a trust boundary** (#248). The
+//! client self-reports it; the daemon never gates privilege or access on it
+//! (auth remains the JWT). The worst a spoofed id can do is mislabel a tool's
+//! locality or make the daemon prefer its own server-side tools — no
+//! escalation, since server tools always run on the daemon and the client can
+//! still only call tools it is authorized for.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// The canonical Linux per-host machine id.
+const ETC_MACHINE_ID: &str = "/etc/machine-id";
+
+/// Process-wide cache of the resolved local system id. Resolved once (the id is
+/// stable for the life of the host), then reused — both the client read and the
+/// daemon's own read go through [`local_system_id`].
+static CACHED_ID: OnceLock<Option<String>> = OnceLock::new();
+
+/// Normalize a raw id read from a file or generated: trim surrounding
+/// whitespace/newlines and reject the empty string. `/etc/machine-id` is a
+/// single hex line with a trailing newline, so trimming is required.
+fn normalize(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Resolve the directory the generated fallback id is persisted in:
+/// `$XDG_DATA_HOME/adelie`, falling back to `$HOME/.local/share/adelie`. Kept
+/// machine-local on purpose (see module docs). Mirrors the client-side
+/// `default_ca_cert_path` resolution so the layout is consistent.
+fn fallback_dir() -> Option<PathBuf> {
+    let data_home = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local").join("share"))
+        })?;
+    Some(data_home.join("adelie"))
+}
+
+/// Read the persisted fallback id from `dir/system-id`, or generate + persist a
+/// fresh UUID when the file is absent/empty, reusing it on subsequent reads.
+///
+/// Split out from [`local_system_id`] with an explicit `dir` so tests can drive
+/// both branches (present file / generate-and-persist) against a temp dir
+/// without depending on the host's real data directory.
+fn read_or_create_fallback_id(dir: &Path) -> io::Result<String> {
+    let path = dir.join("system-id");
+
+    // Reuse the persisted id when present and non-empty.
+    if let Ok(contents) = std::fs::read_to_string(&path)
+        && let Some(id) = normalize(&contents)
+    {
+        return Ok(id);
+    }
+
+    // Generate a fresh UUID and persist it for next time.
+    let id = uuid::Uuid::new_v4().to_string();
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(&path, &id)?;
+    Ok(id)
+}
+
+/// Resolve the local machine's system id without the process-wide cache.
+///
+/// Resolution order:
+///   1. `/etc/machine-id` (preferred — the canonical per-host id).
+///   2. A UUID generated once and persisted to `$XDG_DATA_HOME/adelie/system-id`
+///      (or `~/.local/share/adelie/system-id`), reused thereafter.
+///   3. `None` when neither source is available (no `/etc/machine-id`, no home
+///      directory, and the fallback file can't be written) — the caller then
+///      falls back to the transport heuristic, preserving Phase-1 behaviour.
+fn resolve_system_id() -> Option<String> {
+    if let Ok(contents) = std::fs::read_to_string(ETC_MACHINE_ID)
+        && let Some(id) = normalize(&contents)
+    {
+        return Some(id);
+    }
+
+    let dir = fallback_dir()?;
+    match read_or_create_fallback_id(&dir) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                dir = %dir.display(),
+                "failed to read/create the fallback system-id; falling back to the transport \
+                 co-location heuristic"
+            );
+            None
+        }
+    }
+}
+
+/// The local machine's stable system id, resolved once and cached for the life
+/// of the process (issue #248).
+///
+/// Prefers `/etc/machine-id`; otherwise a generated UUID persisted under
+/// `$XDG_DATA_HOME/adelie/system-id`. Returns `None` only when neither source
+/// is available — co-location then falls back to the transport heuristic. Cheap
+/// and safe to call from anywhere (the work happens at most once).
+pub fn local_system_id() -> Option<String> {
+    CACHED_ID.get_or_init(resolve_system_id).clone()
+}
+
+/// Decide co-location from a pair of system ids (issue #248).
+///
+/// Returns:
+///   - `Some(true)`  when both ids are present (after trimming) and equal — the
+///     client is on the *same* machine as the daemon, **even over WebSocket**.
+///   - `Some(false)` when both are present and differ — distinct machines.
+///   - `None`        when either id is absent/blank — there is no authoritative
+///     result, so the caller falls back to the transport heuristic (the
+///     Phase-1, #243, behaviour for older clients).
+///
+/// This is a pure comparison (no I/O) so the daemon can call it per connection
+/// after reading its own id once. The id is a routing **hint**, not a trust
+/// boundary (#248) — see the module docs.
+pub fn co_location_from_ids(daemon_id: Option<&str>, client_id: Option<&str>) -> Option<bool> {
+    let daemon = daemon_id.map(str::trim).filter(|s| !s.is_empty())?;
+    let client = client_id.map(str::trim).filter(|s| !s.is_empty())?;
+    Some(daemon == client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_trims_and_rejects_empty() {
+        assert_eq!(normalize("abc123\n").as_deref(), Some("abc123"));
+        assert_eq!(normalize("  deadbeef  ").as_deref(), Some("deadbeef"));
+        assert_eq!(normalize(""), None);
+        assert_eq!(normalize("   \n\t "), None);
+    }
+
+    /// Fallback path, branch 1: an existing `system-id` file is read verbatim
+    /// (trimmed), not regenerated — so the id is stable across reads.
+    #[test]
+    fn fallback_reads_existing_file() {
+        let dir = std::env::temp_dir().join(format!("adelie-sysid-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("system-id"), "preexisting-id-9999\n").unwrap();
+
+        let id = read_or_create_fallback_id(&dir).unwrap();
+        assert_eq!(id, "preexisting-id-9999");
+
+        // A second read returns the same id and does not overwrite the file.
+        let again = read_or_create_fallback_id(&dir).unwrap();
+        assert_eq!(again, "preexisting-id-9999");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Fallback path, branch 2: no file yet ⇒ generate + persist, and a second
+    /// call reuses the persisted id rather than generating a new one.
+    #[test]
+    fn fallback_generates_and_persists_then_reuses() {
+        let dir = std::env::temp_dir().join(format!("adelie-sysid-test-{}", uuid::Uuid::new_v4()));
+        // Intentionally do NOT create the dir — the helper must create it.
+
+        let first = read_or_create_fallback_id(&dir).unwrap();
+        assert!(!first.is_empty(), "a fresh id must be generated");
+        assert!(
+            dir.join("system-id").exists(),
+            "the generated id must be persisted"
+        );
+
+        let second = read_or_create_fallback_id(&dir).unwrap();
+        assert_eq!(
+            first, second,
+            "the persisted id must be reused, not regenerated"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// An empty/whitespace-only persisted file is treated as absent and
+    /// regenerated, so a truncated write can't yield an empty id.
+    #[test]
+    fn fallback_regenerates_when_file_is_empty() {
+        let dir = std::env::temp_dir().join(format!("adelie-sysid-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("system-id"), "  \n").unwrap();
+
+        let id = read_or_create_fallback_id(&dir).unwrap();
+        assert!(
+            !id.is_empty(),
+            "empty file must be regenerated into a real id"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `local_system_id` resolves *something* on this host (it has
+    /// `/etc/machine-id` or a home dir) and is stable across calls (cached).
+    #[test]
+    fn local_system_id_is_stable() {
+        let a = local_system_id();
+        let b = local_system_id();
+        assert_eq!(a, b, "the cached id must be identical across calls");
+    }
+
+    #[test]
+    fn co_location_true_on_id_match() {
+        assert_eq!(
+            co_location_from_ids(Some("abc123"), Some("abc123")),
+            Some(true)
+        );
+        // Trimming makes a newline-suffixed /etc/machine-id match a clean id.
+        assert_eq!(
+            co_location_from_ids(Some("abc123\n"), Some("  abc123 ")),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn co_location_false_on_id_mismatch() {
+        assert_eq!(
+            co_location_from_ids(Some("daemon-id"), Some("client-id")),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn co_location_none_when_either_id_missing_or_blank() {
+        // Older client (no id) ⇒ no authoritative result ⇒ fall back to transport.
+        assert_eq!(co_location_from_ids(Some("daemon-id"), None), None);
+        assert_eq!(co_location_from_ids(Some("daemon-id"), Some("   ")), None);
+        // Daemon couldn't resolve its own id ⇒ also defer to the heuristic.
+        assert_eq!(co_location_from_ids(None, Some("client-id")), None);
+        assert_eq!(co_location_from_ids(None, None), None);
+    }
+}

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -215,11 +215,10 @@ fn env_bool(name: &str, default: bool) -> bool {
     parse_env_bool(std::env::var(name).ok().as_deref(), default)
 }
 
-/// The daemon's self-identity label for server-side tool localities (#243).
-///
-/// Hostname is the groundwork value; the follow-up phase replaces it with a
-/// stable per-machine system-id (e.g. `/etc/machine-id`) so a client can send
-/// its own id and the daemon can decide co-location precisely. Resolution is
+/// The daemon's self-identity **display label** for server-side tool localities
+/// (#243) — the human-readable `host` shown in the tool note (e.g.
+/// `terminal — server 'daemon-host'`). Co-location is decided separately by the
+/// per-machine system-id handshake (#248), not by this label. Resolution is
 /// dependency-free and best-effort: the Linux kernel hostname
 /// (`/proc/sys/kernel/hostname`), then `/etc/hostname`, then the `HOSTNAME`
 /// env var, falling back to `"this machine"` so the tool note is always
@@ -1644,9 +1643,9 @@ async fn main() -> Result<()> {
         Box::new(|| uuid::Uuid::now_v7().to_string()),
     )
     // Server-side tool localities (#243) are labelled with the daemon's host
-    // identity. Hostname is the groundwork value; the follow-up phase swaps in
-    // a stable per-machine system-id (e.g. /etc/machine-id) shared with clients
-    // for the co-location handshake.
+    // identity (the hostname — a human-readable display label for the tool
+    // note). Co-location itself is decided by the per-machine system-id
+    // handshake (#248, wired into the WS/UDS frontends below), not this label.
     .with_host(daemon_host_label());
 
     // Build the shared registry handle (#11): wraps the in-memory
@@ -1967,6 +1966,25 @@ async fn main() -> Result<()> {
         }
     };
 
+    // The daemon's own per-machine system id for the tool-locality co-location
+    // handshake (#248), read once at startup. Each client reports its id in the
+    // connect handshake (UDS frame field / WS upgrade header); when it equals
+    // this one they're the same machine ⇒ co-located, even over WebSocket. The
+    // id is a routing HINT, not a trust boundary — no privilege is gated on it
+    // (auth remains the JWT). `None` ⇒ co-location falls back to the transport
+    // heuristic for every connection (Phase-1, #243). Shared by both the WS and
+    // UDS frontends below.
+    let daemon_system_id = desktop_assistant_core::system_id::local_system_id();
+    match &daemon_system_id {
+        Some(id) => {
+            tracing::info!(system_id = %id, "tool-locality co-location: daemon system id resolved")
+        }
+        None => tracing::warn!(
+            "tool-locality co-location: could not resolve a daemon system id; \
+             falling back to the transport heuristic"
+        ),
+    }
+
     // Auth validator: OIDC-aware if configured, otherwise local-only. Built
     // unconditionally because the UDS frontend reuses it even when the
     // WebSocket listener is disabled.
@@ -2107,18 +2125,23 @@ async fn main() -> Result<()> {
         let ws_task = {
             let api_handler = Arc::clone(&api_handler);
             let ws_auth = Arc::clone(&ws_auth);
+            // The daemon system id (#248) so the WS upgrade handler can compare
+            // it to the client-reported header and co-locate same-machine WS
+            // connections.
+            let ws_daemon_system_id = daemon_system_id.clone();
             tokio::spawn(async move {
                 let shutdown = async {
                     let _ = ws_shutdown_rx.await;
                 };
                 let result = if let Some(acceptor) = tls_acceptor {
                     tracing::info!("WebSocket listening on wss://{ws_addr} (/ws, /auth/config)");
-                    ws::serve_full_tls(
+                    ws::serve_full_tls_with_system_id(
                         api_handler,
                         ws_auth,
                         ws_login_service,
                         auth_discovery,
                         allowed_origins,
+                        ws_daemon_system_id,
                         acceptor,
                         ws_addr,
                         shutdown,
@@ -2126,12 +2149,13 @@ async fn main() -> Result<()> {
                     .await
                 } else {
                     tracing::info!("WebSocket listening on ws://{ws_addr} (/ws, /auth/config)");
-                    ws::serve_full(
+                    ws::serve_full_with_system_id(
                         api_handler,
                         ws_auth,
                         ws_login_service,
                         auth_discovery,
                         allowed_origins,
+                        ws_daemon_system_id,
                         ws_addr,
                         shutdown,
                     )
@@ -2168,11 +2192,17 @@ async fn main() -> Result<()> {
         Some(path) => {
             let api_handler = Arc::clone(&api_handler);
             let ws_auth_for_uds = Arc::clone(&ws_auth);
+            // The daemon system id (#248) so the UDS handshake handler can
+            // compare it to the client-reported field. (A UDS client is already
+            // local, so this mostly refines the label; included for symmetry and
+            // so a mismatch — e.g. a namespaced peer — is honoured.)
+            let uds_daemon_system_id = daemon_system_id.clone();
             tracing::info!("UDS listening on {}", path.display());
             Some(tokio::spawn(async move {
                 let auth: Arc<dyn uds::UdsAuthValidator> =
                     Arc::new(WsAsUdsAuth::new(ws_auth_for_uds));
-                let config = uds::UdsServerConfig::new(path);
+                let config =
+                    uds::UdsServerConfig::new(path).with_daemon_system_id(uds_daemon_system_id);
                 let server = uds::UdsServer::new(api_handler, auth, config);
                 let shutdown = async {
                     let _ = uds_shutdown_rx.await;

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -24,7 +24,9 @@ use std::sync::Arc;
 use desktop_assistant_api_model as api;
 use desktop_assistant_application::{ApiError, AssistantApiHandler, EventSink};
 use desktop_assistant_core::ports::auth::{UserId, with_user_id};
-use desktop_assistant_core::ports::transport::with_transport_kind;
+use desktop_assistant_core::ports::transport::{
+    with_client_label, with_co_location, with_transport_kind,
+};
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use tokio::sync::mpsc;
@@ -40,35 +42,67 @@ const OUTBOUND_BUFFER: usize = 64;
 
 /// Pre-validated identity for the connection.
 ///
-/// Carries the JWT `sub` (`user_id`) and the connection's [`TransportKind`]
-/// so the dispatcher can scope per-user state (#105) and infer tool
-/// co-location (#243). Structured as a type so further per-connection fields
-/// can be added without changing the dispatcher signature.
+/// Carries the JWT `sub` (`user_id`), the connection's [`TransportKind`], and
+/// (issue #248) the authoritative per-machine **system-id co-location** result
+/// plus an optional client-reported host label. The dispatcher uses these to
+/// scope per-user state (#105) and tag tool co-location (#243/#248). Structured
+/// as a type so further per-connection fields can be added without changing the
+/// dispatcher signature.
 #[derive(Debug, Clone)]
 pub struct AuthContext {
     /// JWT `sub` claim.
     pub user_id: String,
-    /// How this connection reaches the daemon — drives tool co-location
-    /// (UDS/D-Bus ⇒ same machine, WebSocket ⇒ possibly remote) (#243).
+    /// How this connection reaches the daemon — the **fallback** co-location
+    /// signal (UDS/D-Bus ⇒ same machine, WebSocket ⇒ possibly remote), used only
+    /// when [`Self::co_located`] is `None` (#243).
     pub transport: TransportKind,
+    /// Authoritative co-location from the per-machine system-id handshake
+    /// (#248): `Some(true)` when the client's reported id equals the daemon's
+    /// own (same machine — even over WebSocket), `Some(false)` when they differ,
+    /// `None` when the client reported no id (an older client ⇒ fall back to
+    /// [`Self::transport`]).
+    pub co_located: Option<bool>,
+    /// A client-reported host label (#248) for a friendlier remote tool note
+    /// (e.g. `your device 'laptop'`); `None` when the client sent none.
+    pub client_label: Option<String>,
 }
 
 impl AuthContext {
-    /// Build a context for a connection on `transport`. Each transport adapter
-    /// passes its own kind so the per-turn tool note can tag tool localities.
+    /// Build a context for a connection on `transport`, with no system-id
+    /// co-location result (older-client / no-id path — co-location falls back to
+    /// the transport heuristic). Each transport adapter passes its own kind so
+    /// the per-turn tool note can tag tool localities.
     pub fn new(user_id: impl Into<String>, transport: TransportKind) -> Self {
         Self {
             user_id: user_id.into(),
             transport,
+            co_located: None,
+            client_label: None,
         }
     }
 
+    /// Attach the authoritative system-id co-location result (#248): `Some(true)`
+    /// / `Some(false)` when the client reported an id the daemon could compare,
+    /// `None` to defer to the transport heuristic.
+    pub fn with_co_location(mut self, co_located: Option<bool>) -> Self {
+        self.co_located = co_located;
+        self
+    }
+
+    /// Attach a client-reported host label (#248) for the remote tool note.
+    pub fn with_client_label(mut self, label: Option<String>) -> Self {
+        self.client_label = label.filter(|l| !l.trim().is_empty());
+        self
+    }
+
     /// Convenience for tests that don't need a real subject. Defaults to the
-    /// co-located UDS transport.
+    /// co-located UDS transport with no system-id result.
     pub fn anonymous() -> Self {
         Self {
             user_id: "anonymous".to_string(),
             transport: TransportKind::Uds,
+            co_located: None,
+            client_label: None,
         }
     }
 }
@@ -155,6 +189,11 @@ pub async fn dispatch_loop<R, W>(
     // `tokio::spawn`. Only the send-message paths run the LLM turn, so the
     // command/subscribe paths don't need it.
     let transport = auth.transport;
+    // The authoritative per-machine system-id co-location result and an
+    // optional client-reported host label (#248), installed alongside the
+    // transport so the turn loop prefers the id match over the heuristic.
+    let co_located = auth.co_located;
+    let client_label = auth.client_label.clone();
 
     // Per-connection state for `SubscribeBackgroundTasks` (#114).
     // At most one forwarder runs per connection — Subscribe is
@@ -197,18 +236,24 @@ pub async fn dispatch_loop<R, W>(
                 // streamed events are stamped with, so a socket client
                 // can correlate the response (voice#49); the legacy path
                 // simply leaves `task_id` empty.
-                let task_id = with_transport_kind(
-                    transport,
-                    with_user_id(
-                        user_id.clone(),
-                        handler.start_send_message(
-                            conversation_id.clone(),
-                            content.clone(),
-                            override_selection.clone(),
-                            system_refinement.clone(),
-                            request_id.clone(),
-                            idempotency_key.clone(),
-                            Arc::clone(&sink),
+                let task_id = with_co_location(
+                    co_located,
+                    with_client_label(
+                        client_label.clone(),
+                        with_transport_kind(
+                            transport,
+                            with_user_id(
+                                user_id.clone(),
+                                handler.start_send_message(
+                                    conversation_id.clone(),
+                                    content.clone(),
+                                    override_selection.clone(),
+                                    system_refinement.clone(),
+                                    request_id.clone(),
+                                    idempotency_key.clone(),
+                                    Arc::clone(&sink),
+                                ),
+                            ),
                         ),
                     ),
                 )
@@ -264,19 +309,30 @@ pub async fn dispatch_loop<R, W>(
                         let handler = Arc::clone(&handler);
                         let user_id_for_task = user_id.clone();
                         let transport_for_task = transport;
+                        // Re-install the #248 co-location result + client label
+                        // inside the spawn, like the transport, since task-locals
+                        // don't cross `tokio::spawn`.
+                        let co_located_for_task = co_located;
+                        let client_label_for_task = client_label.clone();
                         tokio::spawn(async move {
-                            let _ = with_transport_kind(
-                                transport_for_task,
-                                with_user_id(
-                                    user_id_for_task,
-                                    handler.handle_send_message_with_override(
-                                        conversation_id,
-                                        content,
-                                        override_selection,
-                                        system_refinement,
-                                        request_id,
-                                        idempotency_key,
-                                        sink,
+                            let _ = with_co_location(
+                                co_located_for_task,
+                                with_client_label(
+                                    client_label_for_task,
+                                    with_transport_kind(
+                                        transport_for_task,
+                                        with_user_id(
+                                            user_id_for_task,
+                                            handler.handle_send_message_with_override(
+                                                conversation_id,
+                                                content,
+                                                override_selection,
+                                                system_refinement,
+                                                request_id,
+                                                idempotency_key,
+                                                sink,
+                                            ),
+                                        ),
                                     ),
                                 ),
                             )
@@ -525,4 +581,38 @@ pub async fn dispatch_loop<R, W>(
     // returns `false` — the cancellation signal core relies on.
     drop(out_tx);
     let _ = writer.await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_context_defaults_have_no_co_location_result() {
+        // #248: a plain `new`/`anonymous` context carries no authoritative
+        // system-id result, so co-location falls back to the transport
+        // heuristic (the Phase-1, #243, behaviour for older clients).
+        let a = AuthContext::new("dave", TransportKind::WebSocket);
+        assert_eq!(a.co_located, None);
+        assert_eq!(a.client_label, None);
+        assert_eq!(AuthContext::anonymous().co_located, None);
+    }
+
+    #[test]
+    fn auth_context_builders_attach_co_location_and_label() {
+        let a = AuthContext::new("dave", TransportKind::WebSocket)
+            .with_co_location(Some(true))
+            .with_client_label(Some("laptop".to_string()));
+        assert_eq!(a.co_located, Some(true));
+        assert_eq!(a.client_label.as_deref(), Some("laptop"));
+    }
+
+    #[test]
+    fn auth_context_blank_label_is_dropped() {
+        // A blank/whitespace label is treated as absent so it never produces a
+        // `your device ''` in the tool note.
+        let a =
+            AuthContext::new("dave", TransportKind::Uds).with_client_label(Some("   ".to_string()));
+        assert_eq!(a.client_label, None);
+    }
 }

--- a/crates/uds-interface/Cargo.toml
+++ b/crates/uds-interface/Cargo.toml
@@ -17,9 +17,10 @@ tokio-util = "0.7"
 desktop-assistant-api-model = { path = "../api-model" }
 desktop-assistant-application = { path = "../application" }
 desktop-assistant-transport-dispatch = { path = "../transport-dispatch" }
+# System-id co-location comparison (#248).
+desktop-assistant-core = { path = "../core" }
 
 [dev-dependencies]
-desktop-assistant-core = { path = "../core" }
 desktop-assistant-auth-jwt.workspace = true
 desktop-assistant-transport-dispatch = { path = "../transport-dispatch" }
 tempfile = "3"

--- a/crates/uds-interface/src/lib.rs
+++ b/crates/uds-interface/src/lib.rs
@@ -132,13 +132,25 @@ pub struct UdsServerConfig {
     /// Filesystem path the listener binds. Existing files at this
     /// path are unlinked before bind.
     pub socket_path: PathBuf,
+    /// The daemon's own per-machine system id (#248), read once at startup.
+    /// Compared against each client's reported id in the handshake to decide
+    /// co-location exactly. `None` ⇒ the daemon couldn't resolve its own id, so
+    /// co-location falls back to the transport heuristic (UDS ⇒ co-located).
+    pub daemon_system_id: Option<String>,
 }
 
 impl UdsServerConfig {
     pub fn new(socket_path: impl Into<PathBuf>) -> Self {
         Self {
             socket_path: socket_path.into(),
+            daemon_system_id: None,
         }
+    }
+
+    /// Set the daemon's own system id for the #248 co-location handshake.
+    pub fn with_daemon_system_id(mut self, id: Option<String>) -> Self {
+        self.daemon_system_id = id;
+        self
     }
 }
 
@@ -239,14 +251,20 @@ impl UdsServer {
 
         let handler = Arc::clone(&self.handler);
         let auth = Arc::clone(&self.auth);
+        // The daemon's own system id (#248), shared by every connection's
+        // co-location comparison. `Arc` so the spawn per connection is cheap.
+        let daemon_system_id = Arc::new(self.config.daemon_system_id.clone());
         let accept_loop = async {
             loop {
                 match listener.accept().await {
                     Ok((stream, _addr)) => {
                         let handler = Arc::clone(&handler);
                         let auth = Arc::clone(&auth);
+                        let daemon_system_id = Arc::clone(&daemon_system_id);
                         tokio::spawn(async move {
-                            if let Err(e) = handle_connection(stream, handler, auth).await {
+                            if let Err(e) =
+                                handle_connection(stream, handler, auth, daemon_system_id).await
+                            {
                                 debug!("uds connection ended: {e}");
                             }
                         });
@@ -291,15 +309,18 @@ async fn handle_connection(
     stream: UnixStream,
     handler: Arc<dyn AssistantApiHandler>,
     auth: Arc<dyn UdsAuthValidator>,
+    daemon_system_id: Arc<Option<String>>,
 ) -> anyhow::Result<()> {
     let (mut read_half, mut write_half) = stream.into_split();
 
-    // Handshake: first frame must be `{"jwt": "<token>"}`. Anything
-    // else (including non-JSON, an empty body, or a missing/blank
-    // field) is rejected with an explicit error frame so clients can
-    // tell auth from framing problems.
+    // Handshake: first frame is the JWT plus, optionally, the client's
+    // per-machine system id + host label for co-location (#248). Anything that
+    // isn't valid JSON, or has a missing/blank `jwt`, is rejected with an
+    // explicit error frame so clients can tell auth from framing problems. An
+    // older client sends the bare `{"jwt": "<token>"}`, which still parses (the
+    // id fields default to absent).
     let handshake_raw = read_frame(&mut read_half).await?;
-    let handshake_json: serde_json::Value = match serde_json::from_slice(&handshake_raw) {
+    let handshake: api::UdsHandshake = match serde_json::from_slice(&handshake_raw) {
         Ok(v) => v,
         Err(e) => {
             // Surface the parse error to the client before closing so a
@@ -309,9 +330,8 @@ async fn handle_connection(
         }
     };
 
-    let token = handshake_json
-        .get("jwt")
-        .and_then(|v| v.as_str())
+    let token = handshake
+        .jwt
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
 
@@ -322,6 +342,16 @@ async fn handle_connection(
             return Ok(());
         }
     };
+
+    // System-id co-location (#248): compare the client's reported id to the
+    // daemon's own. `None` (older client / unresolved daemon id) defers to the
+    // transport heuristic. The id is a routing HINT, not a trust boundary — it
+    // is self-reported and no privilege is gated on it (auth is the JWT above).
+    let co_located = desktop_assistant_core::system_id::co_location_from_ids(
+        daemon_system_id.as_deref(),
+        handshake.system_id.as_deref(),
+    );
+    let client_label = handshake.host_label;
 
     if !auth.validate_bearer_token(&token).await {
         write_error(&mut write_half, "", "auth: invalid jwt").await?;
@@ -393,9 +423,12 @@ async fn handle_connection(
     // Per-connection identity resolved above (#105). The dispatcher
     // installs this into the `with_user_id` task-local around each
     // command so storage queries scope to the right partition. A UDS
-    // connection can only come from the daemon's own machine, so its tools
-    // are co-located with the server-side ones (#243).
-    let auth_ctx = AuthContext::new(user_id.into_inner(), TransportKind::Uds);
+    // connection is local, so the transport heuristic already treats its tools
+    // as co-located (#243); when the client also reported a system id we attach
+    // the authoritative match result + an optional host label (#248).
+    let auth_ctx = AuthContext::new(user_id.into_inner(), TransportKind::Uds)
+        .with_co_location(co_located)
+        .with_client_label(client_label);
 
     dispatch_loop(handler, auth_ctx, inbound, sink).await;
 

--- a/crates/ws-interface/Cargo.toml
+++ b/crates/ws-interface/Cargo.toml
@@ -14,6 +14,8 @@ serde_json.workspace = true
 desktop-assistant-api-model = { path = "../api-model" }
 desktop-assistant-application = { path = "../application" }
 desktop-assistant-transport-dispatch = { path = "../transport-dispatch" }
+# System-id co-location comparison (#248).
+desktop-assistant-core = { path = "../core" }
 
 # Async + WS
 futures = "0.3"
@@ -34,7 +36,6 @@ default = []
 tls = ["dep:tokio-rustls", "dep:hyper", "dep:hyper-util"]
 
 [dev-dependencies]
-desktop-assistant-core = { path = "../core" }
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
 tokio.workspace = true

--- a/crates/ws-interface/src/lib.rs
+++ b/crates/ws-interface/src/lib.rs
@@ -41,6 +41,12 @@ pub struct WsServerState {
     login_service: Option<Arc<dyn WsLoginService>>,
     auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
     allowed_origins: Arc<Vec<String>>,
+    /// The daemon's own per-machine system id (#248), read once at startup.
+    /// Compared against the client's `x-adelie-system-id` upgrade header to
+    /// decide co-location exactly — same machine ⇒ co-located even over
+    /// WebSocket. `None` ⇒ co-location falls back to the transport heuristic
+    /// (WS ⇒ remote), preserving Phase-1 behaviour.
+    daemon_system_id: Arc<Option<String>>,
 }
 
 #[async_trait::async_trait]
@@ -116,12 +122,38 @@ pub fn router_full(
     auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
     allowed_origins: Vec<String>,
 ) -> Router {
+    router_full_with_system_id(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        allowed_origins,
+        None,
+    )
+}
+
+/// Like [`router_full`] but also wires the daemon's own per-machine system id
+/// (#248) so the `/ws` handler can compute exact tool-locality co-location from
+/// the client's `x-adelie-system-id` upgrade header. `None` reproduces the
+/// transport-heuristic-only behaviour of [`router_full`].
+// One distinct collaborator per argument; a config struct would be an
+// out-of-scope refactor of the public router API.
+#[allow(clippy::too_many_arguments)]
+pub fn router_full_with_system_id(
+    handler: Arc<dyn AssistantApiHandler>,
+    auth_validator: Arc<dyn WsAuthValidator>,
+    login_service: Option<Arc<dyn WsLoginService>>,
+    auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
+    allowed_origins: Vec<String>,
+    daemon_system_id: Option<String>,
+) -> Router {
     let state = WsServerState {
         handler,
         auth_validator,
         login_service,
         auth_discovery,
         allowed_origins: Arc::new(allowed_origins),
+        daemon_system_id: Arc::new(daemon_system_id),
     };
 
     Router::new()
@@ -178,6 +210,17 @@ fn extract_basic_credentials(headers: &HeaderMap) -> Option<(String, String)> {
     Some((username.to_string(), password.to_string()))
 }
 
+/// Read a header value as a trimmed, non-empty `String`, or `None` if absent /
+/// non-ASCII / blank. Used for the #248 system-id + host-label upgrade headers.
+fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)?
+        .to_str()
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<WsServerState>,
@@ -207,9 +250,23 @@ async fn ws_handler(
         .await
         .unwrap_or_default();
 
+    // System-id co-location (#248): the client reports its per-machine id (and
+    // optionally a host label) in custom upgrade headers. Compare it to the
+    // daemon's own id; a match co-locates even over WebSocket. `None` (no header
+    // or unresolved daemon id) defers to the transport heuristic (WS ⇒ remote),
+    // preserving Phase-1 behaviour. The id is a routing HINT, not a trust
+    // boundary — it is self-reported and no privilege is gated on it (auth is
+    // the bearer token validated above).
+    let client_system_id = header_string(&headers, api::WS_SYSTEM_ID_HEADER);
+    let client_label = header_string(&headers, api::WS_HOST_LABEL_HEADER);
+    let co_located = desktop_assistant_core::system_id::co_location_from_ids(
+        state.daemon_system_id.as_deref(),
+        client_system_id.as_deref(),
+    );
+
     ws.max_message_size(MAX_WS_MESSAGE_BYTES)
         .max_frame_size(MAX_WS_MESSAGE_BYTES)
-        .on_upgrade(move |socket| handle_socket(socket, state, user_id))
+        .on_upgrade(move |socket| handle_socket(socket, state, user_id, co_located, client_label))
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -274,7 +331,13 @@ async fn auth_config_handler(State(state): State<WsServerState>) -> impl IntoRes
 /// `WsFrame` values into `Message::Text`. A `tokio_util::PollSender`
 /// gives us a `Sink<WsFrame>` over the mpsc so the dispatcher's
 /// generic bound is satisfied without a hand-rolled adapter.
-async fn handle_socket(socket: WebSocket, state: WsServerState, user_id: UserId) {
+async fn handle_socket(
+    socket: WebSocket,
+    state: WsServerState,
+    user_id: UserId,
+    co_located: Option<bool>,
+    client_label: Option<String>,
+) {
     use axum::extract::ws::CloseFrame;
     use futures::stream::StreamExt;
     use tokio::sync::mpsc;
@@ -391,10 +454,14 @@ async fn handle_socket(socket: WebSocket, state: WsServerState, user_id: UserId)
     // the schema sentinel for single-tenant fallback. The dispatcher
     // installs this into the per-task task-local on every dispatched
     // command so storage queries scope correctly.
-    // A WebSocket connection may terminate on a different host, so its
-    // client-registered tools are treated as remote — distinct from the
-    // daemon's server-side tools (#243).
-    let auth = AuthContext::new(user_id.into_inner(), TransportKind::WebSocket);
+    // A WebSocket connection may terminate on a different host, so by the
+    // transport heuristic its client-registered tools are treated as remote
+    // (#243). When the client reported a system id that matches the daemon's,
+    // the #248 co-location result overrides that — co-located even over WS — and
+    // an optional client host label makes the remote tool note friendlier.
+    let auth = AuthContext::new(user_id.into_inner(), TransportKind::WebSocket)
+        .with_co_location(co_located)
+        .with_client_label(client_label);
 
     dispatch_loop(Arc::clone(&state.handler), auth, inbound, sink).await;
 
@@ -483,12 +550,44 @@ pub async fn serve_full<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let app = router_full(
+    serve_full_with_system_id(
         handler,
         auth_validator,
         login_service,
         auth_discovery,
         allowed_origins,
+        None,
+        bind,
+        shutdown,
+    )
+    .await
+}
+
+/// Like [`serve_full`] but also wires the daemon's own per-machine system id
+/// (#248) so co-location can be computed from the client's upgrade header.
+// One distinct collaborator per argument; a config struct would be an
+// out-of-scope refactor of the public serve API.
+#[allow(clippy::too_many_arguments)]
+pub async fn serve_full_with_system_id<F>(
+    handler: Arc<dyn AssistantApiHandler>,
+    auth_validator: Arc<dyn WsAuthValidator>,
+    login_service: Option<Arc<dyn WsLoginService>>,
+    auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
+    allowed_origins: Vec<String>,
+    daemon_system_id: Option<String>,
+    bind: SocketAddr,
+    shutdown: F,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let app = router_full_with_system_id(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        allowed_origins,
+        daemon_system_id,
     );
     let listener = tokio::net::TcpListener::bind(bind).await?;
     axum::serve(listener, app)
@@ -516,16 +615,51 @@ pub async fn serve_full_tls<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    use hyper_util::rt::{TokioExecutor, TokioIo};
-    use hyper_util::server::conn::auto::Builder as ConnBuilder;
-    use hyper_util::service::TowerToHyperService;
-
-    let app = router_full(
+    serve_full_tls_with_system_id(
         handler,
         auth_validator,
         login_service,
         auth_discovery,
         allowed_origins,
+        None,
+        tls_acceptor,
+        bind,
+        shutdown,
+    )
+    .await
+}
+
+/// Like [`serve_full_tls`] but also wires the daemon's own per-machine system id
+/// (#248) for co-location from the client's upgrade header.
+// One distinct collaborator per argument; a config struct would be an
+// out-of-scope refactor of the public serve API.
+#[allow(clippy::too_many_arguments)]
+#[cfg(feature = "tls")]
+pub async fn serve_full_tls_with_system_id<F>(
+    handler: Arc<dyn AssistantApiHandler>,
+    auth_validator: Arc<dyn WsAuthValidator>,
+    login_service: Option<Arc<dyn WsLoginService>>,
+    auth_discovery: Option<Arc<dyn WsAuthDiscovery>>,
+    allowed_origins: Vec<String>,
+    daemon_system_id: Option<String>,
+    tls_acceptor: tokio_rustls::TlsAcceptor,
+    bind: SocketAddr,
+    shutdown: F,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto::Builder as ConnBuilder;
+    use hyper_util::service::TowerToHyperService;
+
+    let app = router_full_with_system_id(
+        handler,
+        auth_validator,
+        login_service,
+        auth_discovery,
+        allowed_origins,
+        daemon_system_id,
     );
     let listener = tokio::net::TcpListener::bind(bind).await?;
 


### PR DESCRIPTION
## What

Phase 2 of the tool execution-locality work (follows #243/#245 Phase 1 and #246/#247 Connector auto-reconnect). Replaces the coarse **transport heuristic** as the *primary* co-location signal with an exact per-machine **system-ID handshake**, keeping the transport heuristic as the **fallback** for older clients that report no id — so Phase-1 behaviour is unchanged for them.

When the client's reported id equals the daemon's own id, they're the same machine ⇒ co-located, **even over WebSocket** (the case the heuristic got wrong).

## How

- **`core::system_id`** — read a stable per-machine id: prefer Linux `/etc/machine-id`, else a UUID generated once and persisted under `$XDG_DATA_HOME/adelie/system-id` (reused thereafter); cached. `co_location_from_ids(daemon, client)` is the pure comparison: `Some(true)`/`Some(false)` when both ids present, `None` (⇒ transport fallback) when either is absent.
- **Client (`client-common`)** — the shared `Connector` stamps the local id (+ hostname label) onto `ConnectionConfig` at connect and the transport carries it in the handshake on **every transport**: the UDS handshake frame (`api::UdsHandshake`, optional fields skipped when absent ⇒ byte-identical legacy `{"jwt":…}`) and WS upgrade headers (`x-adelie-system-id` / `x-adelie-host-label`). Threaded through **both connect AND reconnect** (#246/#247) — the supervisor re-reads the stored config, so the id is re-sent after a daemon restart. All clients (voice/gtk/tui) inherit this via the Connector with **no client-repo changes**.
- **Daemon** — reads its own id once at startup, passes it to the UDS/WS frontends; each connection compares the client-reported id to its own and sets an authoritative co-location result (+ optional client label) on `AuthContext`, installed task-local for the turn alongside `transport` (#245).
- **Locality resolution (`core::context`)** — `resolve_tool_localities` now prioritizes the id match and falls back to the transport heuristic only when the client sent no id.

## Security

The system id is **self-reported by the client** → a co-location/routing **hint, not a trust boundary**. No privilege/access is gated on it (auth remains the JWT). A spoofed id can at worst mislabel a tool's locality or make the daemon prefer its own server-side tools — **no escalation**: server tools always run on the daemon, and the client can still only call tools it's authorized for. The UDS `jwt` field is still required (a missing/blank token is rejected with the same explicit auth error as before).

## Tests

- machine-id read: `/etc/machine-id` path + the generated-file fallback (temp-dir injected, host-independent), empty-file regeneration.
- `co_location_from_ids`: match / mismatch / no-id (either side) → fallback.
- handshake carries the id through **connect AND reconnect** — loopback capture server asserts the id is re-sent after a forced drop.
- `resolve_tool_localities`: id-match co-locates over WebSocket; id-mismatch stays distinct over a local transport; no-id uses the transport heuristic (WS remote / UDS local, unchanged).
- `AuthContext` builders + task-local install; api-model handshake wire-compat (legacy `{"jwt":…}` unchanged) + roundtrip.

`just check` (fmt + `clippy --workspace --all-targets -D warnings` + build + full test) is green, zero warnings.

## Scope

desktop-assistant only (api-model + client-common + daemon interfaces + core). No client-repo changes.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)