### PR TITLE
Surface live task activity: progress hints + tool/MCP call feed

### DIFF
--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -15,6 +15,7 @@ pub use desktop_assistant_auth_jwt::UserId;
 use desktop_assistant_core::domain::{DEFAULT_NOTE_TYPE, KnowledgeEntry, ScratchpadNote};
 use desktop_assistant_core::ports::auth::with_user_id;
 use desktop_assistant_core::ports::client_tools::with_client_tools;
+use desktop_assistant_core::ports::tool_observer::{ToolEvent, ToolObserver, with_tool_observer};
 use desktop_assistant_core::ports::inbound::{
     AssistantService, ConnectionAvailability, ConnectionConfigPayload, ConnectionsService,
     ConversationModelSelection, ConversationService, DispatchWarning, KnowledgeService,
@@ -29,7 +30,7 @@ use desktop_assistant_core::ports::transport::{current_transport_kind, with_tran
 use thiserror::Error;
 use tracing::warn;
 
-use crate::background_tasks::{BackgroundTaskRegistry, TaskError};
+use crate::background_tasks::{BackgroundTaskRegistry, TaskContext, TaskError};
 use crate::client_tools::{
     ClientToolCoordinator, ClientToolResolutionError, CoordinatorClientToolPort,
     register_client_tools, resolve_client_tool_result,
@@ -1744,6 +1745,7 @@ where
                 sink,
                 tokio_util::sync::CancellationToken::new(),
                 None,
+                None,
             )
             .await
             .map_err(Self::map_core_err)
@@ -1921,6 +1923,7 @@ where
                         turn_sink,
                         ctx.token.clone(),
                         client_tool_port,
+                        Some(ctx.clone()),
                     ),
                 ),
             )
@@ -2045,6 +2048,7 @@ where
                         sink_for_body,
                         ctx.token.clone(),
                         client_tool_port,
+                        Some(ctx.clone()),
                     ),
                 ),
             )
@@ -2131,6 +2135,40 @@ pub(crate) struct AgentConversationSpec {
     pub result_sink: Option<AgentResultSink>,
 }
 
+/// Build a [`ToolObserver`] that mirrors the core loop's tool/MCP calls into a
+/// background task's log ring. Installed around the dispatch (via
+/// [`with_tool_observer`]) so the task panel shows a live feed of what the turn
+/// is doing — each call's name + arguments, then its outcome — instead of an
+/// empty log. The one-line `progress_hint` (driven separately by `on_status`)
+/// still shows the latest humanized activity; this is the detailed timeline.
+fn task_tool_observer(ctx: TaskContext) -> ToolObserver {
+    Arc::new(move |event: ToolEvent| match event {
+        ToolEvent::Started { name, args } => {
+            let message = if args.is_empty() {
+                name
+            } else {
+                format!("{name}  {args}")
+            };
+            ctx.logs
+                .append(api::LogLevel::Info, api::LogCategory::ToolCall, message, None);
+        }
+        ToolEvent::Finished { name, ok, output } => {
+            let (level, message) = if ok {
+                let msg = if output.is_empty() {
+                    format!("{name} ✓")
+                } else {
+                    format!("{name} ✓ {output}")
+                };
+                (api::LogLevel::Info, msg)
+            } else {
+                (api::LogLevel::Warn, format!("{name} ✗ {output}"))
+            };
+            ctx.logs
+                .append(level, api::LogCategory::ToolResult, message, None);
+        }
+    })
+}
+
 pub(crate) fn spawn_agent_conversation<C>(
     registry: Arc<BackgroundTaskRegistry>,
     conversations: Arc<C>,
@@ -2168,13 +2206,16 @@ where
             effort: o.effort,
         });
 
-        // Drop callbacks — standalone / subagent runs emit progress
-        // through the registry's per-task log ring and broadcast
-        // channel, not through the streaming `SendMessage` chunk path.
-        // The chunk and status callbacks are required by the trait, so
-        // we wire no-op closures.
+        // Drop the chunk callback — standalone / subagent runs emit their
+        // final text through the registry, not the streaming `SendMessage`
+        // chunk path. The status callback, however, drives the task's
+        // `progress_hint` so the task list shows what the agent is doing right
+        // now (e.g. the current tool/MCP call) instead of just its title.
         let on_chunk: desktop_assistant_core::ports::llm::ChunkCallback = Box::new(|_chunk| true);
-        let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(|_msg| {});
+        let progress_ctx = ctx.clone();
+        let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(move |msg| {
+            progress_ctx.set_progress_hint(Some(msg));
+        });
 
         // Install the tool allowlist (if any) and the requesting user's
         // identity so the inner `send_prompt_with_override` call (and
@@ -2182,7 +2223,9 @@ where
         // foreground send path uses.
         let conv_id_for_send = conversation_id.clone();
         let token = ctx.token.clone();
-        let inner = async move {
+        // Mirror this agent's tool/MCP calls into its task log so the panel
+        // shows what the agent is doing, same as the foreground send path.
+        let inner = with_tool_observer(task_tool_observer(ctx.clone()), async move {
             conversations
                 .send_prompt_with_override(
                     &desktop_assistant_core::domain::ConversationId::from(
@@ -2199,7 +2242,7 @@ where
                     token,
                 )
                 .await
-        };
+        });
         let result = if let Some(tools) = tools {
             desktop_assistant_core::ports::auth::with_user_id(
                 user_id.clone(),
@@ -2209,6 +2252,10 @@ where
         } else {
             desktop_assistant_core::ports::auth::with_user_id(user_id.clone(), inner).await
         };
+
+        // The run is over — clear the "currently doing" hint so a finished
+        // agent that lingers in the list doesn't show a stale tool action.
+        ctx.set_progress_hint(None);
 
         match result {
             Ok(outcome) => {
@@ -2285,6 +2332,12 @@ async fn run_send_turn<C>(
     sink: Arc<dyn EventSink>,
     cancellation: tokio_util::sync::CancellationToken,
     client_tool_port: Option<Arc<dyn desktop_assistant_core::ports::client_tools::ClientToolPort>>,
+    // When this turn runs inside a registry task, the context lets us mirror
+    // the core loop's status messages onto the task's `progress_hint` so the
+    // task list shows what the turn is doing right now — e.g. the current
+    // tool/MCP call (#223 status strings, surfaced per-task). `None` on the
+    // no-registry direct path, which has no task to annotate.
+    task_ctx: Option<TaskContext>,
 ) -> Result<(), desktop_assistant_core::CoreError>
 where
     C: ConversationService + Send + Sync + 'static,
@@ -2312,11 +2365,20 @@ where
         .is_ok()
     });
 
-    // Bridge status updates from core callback -> canonical events.
+    // Bridge status updates from core callback -> canonical events, and mirror
+    // them onto the registry task's `progress_hint` so the task list shows the
+    // current activity (e.g. "Checking your calendar events") rather than just
+    // the static title.
     let status_tx = sink.clone();
     let conv_id_for_status = conversation_id.clone();
     let req_id_for_status = request_id.clone();
+    let progress_ctx = task_ctx.clone();
     let on_status: desktop_assistant_core::ports::llm::StatusCallback = Box::new(move |message| {
+        // `set_progress_hint` is cheap and synchronous (lock + broadcast), so
+        // update the hint inline before the fire-and-forget event emit.
+        if let Some(ctx) = &progress_ctx {
+            ctx.set_progress_hint(Some(message.clone()));
+        }
         let sink = Arc::clone(&status_tx);
         let conv_id = conv_id_for_status.clone();
         let req_id = req_id_for_status.clone();
@@ -2349,17 +2411,31 @@ where
         cancellation,
     );
 
-    // Install the per-turn client-tool port (#234) as a task-local around the
-    // dispatch so the core loop can offer the connection's client-local tools
-    // and suspend on a call. No port → the loop is server-side only, exactly
-    // as before.
-    let outcome = match client_tool_port {
-        Some(port) => with_client_tools(port, dispatch).await,
-        None => dispatch.await,
+    // Layer the per-turn task-locals around the dispatch. Innermost: the
+    // client-tool port (#234) so the core loop can offer the connection's
+    // client-local tools and suspend on a call. Outermost: a tool observer
+    // (when this turn is a tracked task) so the loop's tool/MCP calls land in
+    // the task's log ring for the panel's activity feed.
+    let dispatched = async move {
+        match client_tool_port {
+            Some(port) => with_client_tools(port, dispatch).await,
+            None => dispatch.await,
+        }
+    };
+    let outcome = match task_ctx.clone().map(task_tool_observer) {
+        Some(observer) => with_tool_observer(observer, dispatched).await,
+        None => dispatched.await,
     };
 
     if let Err(e) = forwarder.await {
         warn!("stream forwarder task failed: {e}");
+    }
+
+    // The turn is fully drained — nothing is "happening" anymore, so clear the
+    // hint. Matters for tasks that linger in the list after finishing (e.g. a
+    // fire-and-forget standalone agent) where a stale tool hint would mislead.
+    if let Some(ctx) = &task_ctx {
+        ctx.set_progress_hint(None);
     }
 
     match outcome {

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -51,6 +51,12 @@ pub mod conversation_ctx;
 /// turn on a client-tool call (#107 / #234).
 pub mod client_tools;
 
+/// Request-scoped tool-activity observer — task-local sink the turn loop
+/// notifies of each tool/MCP call and its outcome, so a caller can surface a
+/// live activity feed (e.g. the background-task panel) without threading a
+/// sink through the `send_prompt` trait surface.
+pub mod tool_observer;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/core/src/ports/tool_observer.rs
+++ b/crates/core/src/ports/tool_observer.rs
@@ -1,0 +1,134 @@
+//! Request-scoped tool-activity observer.
+//!
+//! The service dispatch loop calls tools deep inside a turn; an observer — the
+//! background-task panel, a tracer, anything that wants a live feed of what a
+//! turn is *doing* — needs to see each tool/MCP call and its outcome. Rather
+//! than thread a sink through [`crate::ports::inbound::ConversationService`]
+//! (and every implementor and test mock of the central `send_prompt` family),
+//! we expose a task-local observer the caller installs around the dispatch via
+//! [`with_tool_observer`] and the loop notifies via [`notify_tool_event`].
+//!
+//! ## Why a task-local
+//!
+//! This mirrors the way the dispatch loop already receives its other
+//! cross-cutting tool concerns: the client-tool port ([`current_client_tools`]),
+//! the conversation id ([`with_conversation_id`]), and the tool allowlist
+//! ([`with_tool_allowlist`]) all reach the loop as task-locals, not as
+//! parameters on `send_prompt`. A tool observer is the same family — per-turn
+//! context consumed deep in the loop — so it belongs alongside them rather than
+//! bloating the trait surface that every implementor and fixture must satisfy.
+//! See AGENTS.md ("cross-cutting context propagates via `tokio::task_local!`").
+//!
+//! When the slot is unset (tests, background workers, any caller that doesn't
+//! care), [`notify_tool_event`] is a no-op — the loop reports activity
+//! unconditionally and the absence of an observer simply drops it.
+//!
+//! [`current_client_tools`]: crate::ports::client_tools::current_client_tools
+//! [`with_conversation_id`]: crate::ports::conversation_ctx::with_conversation_id
+//! [`with_tool_allowlist`]: crate::ports::llm::with_tool_allowlist
+
+use std::sync::Arc;
+
+/// One observed step in a turn's tool activity. The string fields are short,
+/// already-truncated summaries produced at the dispatch site — an observer is
+/// a UI/telemetry sink, not a place to re-parse arguments or results.
+#[derive(Clone, Debug)]
+pub enum ToolEvent {
+    /// A tool is about to execute. `args` is a compact rendering of the call
+    /// arguments (may be empty when there are none).
+    Started { name: String, args: String },
+    /// A tool finished. `ok` is false when the executor returned an error;
+    /// `output` is a compact rendering of the result (or error) text.
+    Finished {
+        name: String,
+        ok: bool,
+        output: String,
+    },
+}
+
+/// Sink for [`ToolEvent`]s. Cheap to clone; invoked synchronously from the
+/// dispatch loop, so an implementation must not block (append-to-ring +
+/// broadcast is fine; awaiting I/O is not).
+pub type ToolObserver = Arc<dyn Fn(ToolEvent) + Send + Sync>;
+
+tokio::task_local! {
+    /// The observer for the current turn. Installed by the send-turn body via
+    /// [`with_tool_observer`] around the dispatch; read by the service loop via
+    /// [`notify_tool_event`] at each tool call.
+    static TOOL_OBSERVER: ToolObserver;
+}
+
+/// Run `fut` with `observer` installed as the current tool observer. All
+/// [`notify_tool_event`] calls inside the future are delivered to `observer`.
+pub async fn with_tool_observer<F, T>(observer: ToolObserver, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    TOOL_OBSERVER.scope(observer, fut).await
+}
+
+/// Deliver `event` to the installed observer, if any. No-op when no scope is
+/// installed. Safe to call from any async context — never panics, never blocks.
+pub fn notify_tool_event(event: ToolEvent) {
+    let _ = TOOL_OBSERVER.try_with(|obs| obs(event));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[tokio::test]
+    async fn notify_outside_scope_is_a_silent_noop() {
+        // Must not panic when no observer is installed.
+        notify_tool_event(ToolEvent::Started {
+            name: "x".into(),
+            args: String::new(),
+        });
+    }
+
+    #[tokio::test]
+    async fn installed_observer_receives_events_in_order() {
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = {
+            let seen = Arc::clone(&seen);
+            Arc::new(move |e: ToolEvent| match e {
+                ToolEvent::Started { name, .. } => seen.lock().unwrap().push(format!("start:{name}")),
+                ToolEvent::Finished { name, ok, .. } => {
+                    seen.lock().unwrap().push(format!("done:{name}:{ok}"))
+                }
+            }) as ToolObserver
+        };
+        with_tool_observer(sink, async {
+            notify_tool_event(ToolEvent::Started {
+                name: "search".into(),
+                args: "{}".into(),
+            });
+            notify_tool_event(ToolEvent::Finished {
+                name: "search".into(),
+                ok: true,
+                output: "hits".into(),
+            });
+        })
+        .await;
+        assert_eq!(*seen.lock().unwrap(), vec!["start:search", "done:search:true"]);
+    }
+
+    #[tokio::test]
+    async fn slot_does_not_cross_spawn() {
+        let sink = Arc::new(|_e: ToolEvent| {}) as ToolObserver;
+        with_tool_observer(sink, async {
+            // A spawned task does not inherit the task-local; notifying there
+            // must be a no-op rather than reaching the parent's observer.
+            tokio::spawn(async {
+                notify_tool_event(ToolEvent::Started {
+                    name: "x".into(),
+                    args: String::new(),
+                });
+            })
+            .await
+            .unwrap();
+        })
+        .await;
+    }
+}

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -13,6 +13,7 @@ use crate::planning::{self, StepStack};
 use crate::ports::client_tools::current_client_tools;
 use crate::ports::conversation_ctx::with_conversation_id;
 use crate::ports::inbound::ConversationService;
+use crate::ports::tool_observer::{ToolEvent, notify_tool_event};
 use crate::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, StatusCallback, current_cancellation_token,
     current_context_budget, current_system_refinement,
@@ -26,7 +27,8 @@ use crate::ports::tools::ToolExecutor;
 use crate::ports::transport::{current_client_label, current_co_location, current_transport_kind};
 use crate::sanitize::{sanitize_assistant_text, sanitize_assistant_text_for_stream};
 use crate::tools::{
-    NoopToolExecutor, categorize_tool_namespaces, tool_set_hash, tool_status_message,
+    NoopToolExecutor, categorize_tool_namespaces, summarize_tool_text, summarize_tool_value,
+    tool_set_hash, tool_status_message,
 };
 use chrono::{Duration, Local};
 use tokio_util::sync::CancellationToken;
@@ -1139,6 +1141,15 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     continue;
                 }
 
+                // Report the call to any installed tool observer (the task
+                // panel's activity feed). Emitted here — after the step-control
+                // fast path, before either execution branch — so it covers real
+                // tool work (server-side and client-local alike) exactly once.
+                notify_tool_event(ToolEvent::Started {
+                    name: tool_call.name.clone(),
+                    args: summarize_tool_value(&arguments),
+                });
+
                 // Route client-local tools to the client (#107 / #234): if a
                 // per-turn client-tool port is installed and the called name is
                 // registered for this user, suspend the turn and await the
@@ -1152,14 +1163,17 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     _ => None,
                 };
 
-                let result = if let Some(port) = client_exec {
+                // `tool_ok` is tracked alongside the result so the observer can
+                // distinguish a successful call from an error the loop folds
+                // into the tool result (and keeps looping on).
+                let (result, tool_ok) = if let Some(port) = client_exec {
                     match port
                         .execute(&tool_call.id, &tool_call.name, arguments)
                         .await
                     {
                         Ok(output) => {
                             tracing::debug!(tool = %tool_call.name, output = %output, "client tool result");
-                            output
+                            (output, true)
                         }
                         // Cancellation while a client tool was suspended (e.g.
                         // the user pressed Cancel) must abort the turn, not be
@@ -1168,7 +1182,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                         Err(CoreError::Cancelled) => return Err(CoreError::Cancelled),
                         Err(e) => {
                             tracing::warn!(tool = %tool_call.name, error = %e, "client tool execution failed");
-                            format!("Error: {e}")
+                            (format!("Error: {e}"), false)
                         }
                     }
                 } else {
@@ -1180,14 +1194,20 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     match with_conversation_id(conversation_id.clone(), exec).await {
                         Ok(output) => {
                             tracing::debug!(tool = %tool_call.name, output = %output, "tool result");
-                            output
+                            (output, true)
                         }
                         Err(e) => {
                             tracing::warn!(tool = %tool_call.name, error = %e, "tool execution failed");
-                            format!("Error: {e}")
+                            (format!("Error: {e}"), false)
                         }
                     }
                 };
+
+                notify_tool_event(ToolEvent::Finished {
+                    name: tool_call.name.clone(),
+                    ok: tool_ok,
+                    output: summarize_tool_text(&result),
+                });
 
                 // Dynamic activation: if tool_search returned results,
                 // activate the discovered tools for subsequent rounds.

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -116,6 +116,58 @@ fn verb_phrase(verb: &str) -> Option<&'static str> {
     Some(phrase)
 }
 
+/// Max characters of a tool's arguments/result surfaced to a tool-activity
+/// observer. Long enough to be informative in a log line, short enough to keep
+/// the per-task log ring cheap and each entry single-line.
+const TOOL_EVENT_SUMMARY_MAX: usize = 200;
+
+/// Compact, single-line rendering of a tool call's JSON arguments for an
+/// activity feed. Objects render as `key=value` pairs (the common, readable
+/// case); other shapes fall back to compact JSON. Empty for no-argument calls.
+/// Truncated to [`TOOL_EVENT_SUMMARY_MAX`] characters.
+pub(crate) fn summarize_tool_value(args: &serde_json::Value) -> String {
+    let rendered = match args {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Object(map) if map.is_empty() => String::new(),
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(k, v)| format!("{k}={}", compact_scalar(v)))
+            .collect::<Vec<_>>()
+            .join(", "),
+        other => other.to_string(),
+    };
+    truncate_single_line(&rendered, TOOL_EVENT_SUMMARY_MAX)
+}
+
+/// Compact, single-line rendering of a tool result (or error) string for an
+/// activity feed. Truncated to [`TOOL_EVENT_SUMMARY_MAX`] characters.
+pub(crate) fn summarize_tool_text(text: &str) -> String {
+    truncate_single_line(text, TOOL_EVENT_SUMMARY_MAX)
+}
+
+/// Render a single JSON value compactly: strings unquoted (so `path=/tmp/x`
+/// rather than `path="/tmp/x"`), everything else as compact JSON so a nested
+/// argument can't expand the summary's structure.
+fn compact_scalar(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Collapse internal whitespace runs to single spaces and cap the length,
+/// appending an ellipsis when truncated. Keeps activity-feed lines tidy and
+/// bounded regardless of how a tool formats its output.
+fn truncate_single_line(s: &str, max: usize) -> String {
+    let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= max {
+        collapsed
+    } else {
+        let kept: String = collapsed.chars().take(max).collect();
+        format!("{kept}…")
+    }
+}
+
 /// Use the LLM to semantically categorize tools into descriptive namespaces.
 ///
 /// Takes the raw tool namespaces (typically grouped by MCP server) and asks


### PR DESCRIPTION
Populates background tasks' `progress_hint` and per-task log ring so clients can show what a turn is doing, not just a static title.

## Changes
- Mirror the core loop's humanized status messages onto `progress_hint` on both the foreground chat path (`run_send_turn`) and the standalone/subagent path (`spawn_agent_conversation`); clear the hint when the turn ends.
- Add a request-scoped task-local `ToolObserver` (`crates/core/src/ports/tool_observer.rs`) that the dispatch loop notifies on each tool call start/finish. Chosen over a new `ConversationService::send_prompt_with_override` parameter to match the adjacent tool-loop concerns (`with_client_tools`, `with_conversation_id`, `with_tool_allowlist`), which are all task-locals, and to keep the central trait surface stable.
- The application builds an observer per tracked task that writes `ToolCall`/`ToolResult` entries into the task log ring — a live feed of tool/MCP calls and outcomes.

Client side (independent window that renders this feed): adelie-ai/adele-gtk#74.

## Testing
- `cargo build` (workspace), `cargo clippy` (core + application) clean.
- `cargo test` core + application green, incl. new `tool_observer` unit tests.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)