### PR TITLE
Add AGPL NOTICE and fill missing license fields

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+Adelie Desktop Assistant
+Copyright (C) 2026 David Spadea
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -2,6 +2,7 @@
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 edition = "2024"
+license = "AGPL-3.0-or-later"
 
 [dependencies]
 desktop-assistant-core.workspace = true

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -2,6 +2,7 @@
 name = "desktop-assistant-application"
 version = "0.1.0"
 edition = "2024"
+license = "AGPL-3.0-or-later"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ws-interface/Cargo.toml
+++ b/crates/ws-interface/Cargo.toml
@@ -2,6 +2,7 @@
 name = "desktop-assistant-ws"
 version = "0.1.0"
 edition = "2024"
+license = "AGPL-3.0-or-later"
 
 [dependencies]
 async-trait.workspace = true


### PR DESCRIPTION
Desktop Assistant is already licensed **AGPL-3.0-or-later** (LICENSE file + GitHub detection + nearly every crate's Cargo manifest), but two small gaps remained:

- **No `NOTICE` file** — added one crediting the author with the standard AGPL notice block.
- **Three crates didn't declare the license field** — `api-model`, `application`, and `ws-interface` now set `license = "AGPL-3.0-or-later"`, matching every other workspace member.

No code changes; manifests + NOTICE only. Opened as a PR because `main` is branch-protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)