### PR TITLE
feat(core): narrate logical steps, not turn-start filler or every tool

### DIFF
--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -28,7 +28,7 @@ use crate::ports::transport::{current_client_label, current_co_location, current
 use crate::sanitize::{sanitize_assistant_text, sanitize_assistant_text_for_stream};
 use crate::tools::{
     NoopToolExecutor, categorize_tool_namespaces, summarize_tool_text, summarize_tool_value,
-    tool_set_hash, tool_status_message,
+    tool_set_hash,
 };
 use chrono::{Duration, Local};
 use tokio_util::sync::CancellationToken;
@@ -59,11 +59,6 @@ fn cancellation_token_or_default() -> CancellationToken {
 
 /// Maximum number of tool-calling rounds before giving up.
 const MAX_TOOL_ROUNDS: usize = 200;
-
-/// Turn-start liveness status (issue #223), emitted via `on_status` before the
-/// first LLM token so clients (voice) get an immediate heartbeat. Terse and
-/// speakable; the voice client decides whether/how to narrate it.
-const TURN_START_STATUS: &str = "Working on it";
 
 fn now_timestamp() -> String {
     Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
@@ -682,12 +677,12 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
         // Track whether hosted search has been demoted to local fallback.
         let mut hosted_search_demoted = false;
 
-        // Turn-start liveness status (issue #223): emit a brief "working on it"
-        // as soon as the turn is set up, before the first LLM token. This gives
-        // clients (voice) an immediate heartbeat — without it a multi-round tool
-        // turn is silent until the final answer streams. Per-tool-round statuses
-        // follow from the dispatch loop below.
-        on_status(TURN_START_STATUS.to_string());
+        // No turn-start filler. A quick/direct answer narrates nothing and just
+        // streams its reply. Progress is narrated only when the model declares a
+        // logical step (`begin_step`, in the dispatch loop below) — a step spans
+        // multiple tool calls, so we narrate the step, not the turn start or each
+        // tool. A slow turn that declares no step is covered by the voice
+        // client's delayed-liveness safety net, not an unconditional status here.
 
         // Client-side tool execution (#107 / #234). When the connection
         // registered client-local tools, the application installs a per-turn
@@ -1112,7 +1107,6 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
 
                 let arguments: serde_json::Value =
                     serde_json::from_str(&tool_call.arguments).unwrap_or_default();
-                on_status(tool_status_message(&tool_call.name, &arguments));
                 tracing::info!(tool = %tool_call.name, %arguments, "executing tool");
 
                 // Step-planning + compaction control (#240) is handled here in
@@ -1127,6 +1121,19 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                     && (tool_call.name == planning::BEGIN_STEP_TOOL
                         || tool_call.name == planning::COMPLETE_STEP_TOOL)
                 {
+                    // Step-level narration: announce the logical step the model
+                    // just declared, once, as its goal. This is the only progress
+                    // narration now (turn-start filler and per-tool chatter were
+                    // removed); a step spans multiple tool calls. complete_step
+                    // stays silent.
+                    if tool_call.name == planning::BEGIN_STEP_TOOL
+                        && let Some(goal) = arguments.get("goal").and_then(|v| v.as_str())
+                    {
+                        let goal = goal.trim();
+                        if !goal.is_empty() {
+                            on_status(goal.to_string());
+                        }
+                    }
                     let ack = self
                         .handle_step_control(
                             &mut conv,
@@ -2097,10 +2104,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_emits_turn_start_then_per_tool_status() {
-        // Issue #223: a turn must emit a turn-start liveness status before the
-        // first LLM token, and one status per tool call from the dispatch loop,
-        // so clients get a heartbeat + narratable progress between rounds.
+    async fn tool_calls_without_steps_emit_no_status() {
+        // New narration model: no turn-start filler and no per-tool chatter. A
+        // turn that calls tools but declares no plan steps narrates nothing —
+        // progress is reserved for logical steps (`begin_step`).
         let tools = vec![
             ToolDefinition::new("calendar_list", "List calendar", serde_json::json!({})),
             ToolDefinition::new("notes_search", "Search notes", serde_json::json!({})),
@@ -2130,20 +2137,54 @@ mod tests {
         assert_eq!(result, "All set");
 
         let statuses = status_log.lock().unwrap().clone();
-        // First status is the turn-start heartbeat, before any tool round.
+        assert!(
+            statuses.is_empty(),
+            "tool calls without declared steps must emit no status; got {statuses:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn begin_step_narrates_its_goal() {
+        // A declared logical step IS narrated — once, as its goal — so clients
+        // (text + voice) get meaningful progress on multi-step work.
+        let llm = PlanContextCapturingLlm {
+            responses: Mutex::new(vec![
+                LlmResponse::with_tool_calls(
+                    "",
+                    vec![ToolCall::new("b1", "begin_step", r#"{"goal":"map the plan"}"#)],
+                ),
+                LlmResponse::text("done"),
+            ]),
+            captured: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        let (write, list, _sp) = in_memory_scratchpad();
+        let handler = ConversationHandler::with_tools(
+            MockStore::new(),
+            llm,
+            MockToolExecutor::new(vec![], HashMap::new()),
+            id_gen(),
+        )
+        .with_scratchpad_write(write)
+        .with_scratchpad_list(list);
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        let (status_cb, status_log) = recording_status();
+        handler
+            .send_prompt(
+                &conv.id,
+                "do a multi-step thing".into(),
+                noop_callback(),
+                status_cb,
+            )
+            .await
+            .unwrap();
+
+        let statuses = status_log.lock().unwrap().clone();
         assert_eq!(
-            statuses.first().map(String::as_str),
-            Some(TURN_START_STATUS),
-            "expected turn-start status first; got {statuses:?}"
-        );
-        // Each tool call emits a human-labelled status.
-        assert!(
-            statuses.contains(&"Checking your calendar".to_string()),
-            "expected a calendar status; got {statuses:?}"
-        );
-        assert!(
-            statuses.contains(&"Searching your notes".to_string()),
-            "expected a notes status; got {statuses:?}"
+            statuses,
+            vec!["map the plan".to_string()],
+            "the begin_step goal must be narrated once; got {statuses:?}"
         );
     }
 
@@ -2490,9 +2531,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_with_no_tools_still_emits_turn_start_status() {
-        // Even a plain text turn (no tool rounds) must emit the turn-start
-        // heartbeat so the client knows the assistant is working.
+    async fn turn_with_no_tools_emits_no_status() {
+        // A plain text turn (no tools, no steps) is a "quick answer": it
+        // narrates nothing and just streams its reply.
         let handler = make_handler(vec!["Hello there"]);
         let conv = handler.create_conversation("Test".into()).await.unwrap();
 
@@ -2503,7 +2544,10 @@ mod tests {
             .unwrap();
 
         let statuses = status_log.lock().unwrap().clone();
-        assert_eq!(statuses, vec![TURN_START_STATUS.to_string()]);
+        assert!(
+            statuses.is_empty(),
+            "a no-tool quick answer must emit no status; got {statuses:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -29,6 +29,12 @@ use crate::ports::tools::ToolExecutor;
 const FULL_LISTING_FIT_RATIO: f64 = 0.10;
 
 /// Generate a short, human-readable status message for a tool call.
+///
+/// No longer wired into the turn loop: per-tool status narration was replaced
+/// by step-level narration (`begin_step`). Retained (and still tested) for
+/// possible reuse; the whole cluster (`humanize_mcp_tool_status`/`verb_phrase`)
+/// is safe to delete if it stays unused.
+#[allow(dead_code)]
 pub(crate) fn tool_status_message(tool_name: &str, arguments: &serde_json::Value) -> String {
     match tool_name {
         "builtin_knowledge_base_search" => {
@@ -63,6 +69,7 @@ pub(crate) fn tool_status_message(tool_name: &str, arguments: &serde_json::Value
 /// events", `notes_search` → "Searching your notes"). Names use `_` or `.`
 /// separators (`calendar.list` ≡ `calendar_list`). Falls back to
 /// "Running <words>" when no verb is recognized.
+#[allow(dead_code)]
 fn humanize_mcp_tool_status(name: &str) -> String {
     // Normalize separators so `a.b.c` and `a_b_c` both split into words.
     let words: Vec<&str> = name.split(['_', '.']).filter(|w| !w.is_empty()).collect();
@@ -101,6 +108,7 @@ fn humanize_mcp_tool_status(name: &str) -> String {
 /// placeholder for the resource (e.g. "your calendar"). Returns `None` for
 /// unrecognized verbs so the caller can fall back. Synonyms collapse onto the
 /// same phrasing so a wide range of MCP naming conventions read naturally.
+#[allow(dead_code)]
 fn verb_phrase(verb: &str) -> Option<&'static str> {
     let phrase = match verb {
         "list" | "get" | "read" | "fetch" | "show" | "view" | "describe" | "check" => "Checking {}",


### PR DESCRIPTION
## What

Reworks progress narration so the assistant **answers directly when it's quick, and narrates only when it's genuinely multi-step** — instead of saying "Working on it" on every turn and a status on every tool call.

- **Removed** the unconditional turn-start `"Working on it"` (#223). A quick/direct answer now narrates nothing and just streams its reply.
- **Removed** the per-tool-call status — no more narrating every tool use.
- **Added** step-level narration: when the model calls `begin_step` (#240), its **goal** is emitted as the status. `begin_step` already fires only on genuine multi-step work (its prompt: *"For small one-shot tasks, don't use steps at all"*), and a step spans multiple tool calls — so we narrate the logical step, not each tool.

Statuses reach **text chat and voice** both (a good thing — just not constantly).

## Why

The always-on `"Working on it"` is stilted and repetitive in voice output, and per-tool chatter is noise. "Multi-step" is a logical concept (a step may use several tools), which maps exactly onto the existing `begin_step` planning abstraction.

## Follow-ups (separate)
- **Voice**: a delayed-liveness safety net so a slow turn that declares *no* step isn't dead-silent (voice is the only place silence matters; text clients have spinners). These should land together before the next deploy.
- The unwired per-tool status helper (`tool_status_message`/`humanize_mcp_tool_status`/`verb_phrase`) is kept `#[allow(dead_code)]` (still tested); deletable in a follow-up.

## Test
- 339 core tests pass; clippy clean. Rewrote the two tests that encoded the old behavior; added `begin_step_narrates_its_goal` and `tool_calls_without_steps_emit_no_status`.
- The UDS integration test uses its own stub (`on_status("thinking")`), so it's unaffected.

⚠️ **fmt note:** not `cargo fmt`'d. The local `1.96.0` rustfmt build (`1.9.0-stable`, 2026-05-25) reformats untouched `main` files, so running it would pollute the diff with unrelated churn. New code matches surrounding style; normalize with a `cargo fmt` on a correctly-pinned toolchain if desired.

Closes #265