### PR TITLE
Review 2026-06-09: bound three in-memory leaks (DA-14 + DT-12)

### DIFF
--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -538,8 +538,18 @@ impl BackgroundTaskRegistry {
     /// Subscribe to `Event::Task*` events for `user_id`. Slow consumers
     /// drop oldest events (broadcast semantics) — the registry never
     /// applies back-pressure to task bodies.
+    ///
+    /// Doubles as the prune point for dead senders (DT-12 / #300): a user who
+    /// subscribed then disconnected leaves a sender with no receivers, which
+    /// would otherwise live forever and slowly leak on a multi-user host. Each
+    /// subscribe sweeps out every other channel whose `receiver_count()` has
+    /// fallen to zero before handing back the (re)created live receiver.
     pub fn subscribe(&self, user_id: &UserId) -> broadcast::Receiver<api::Event> {
         let mut channels = self.inner.user_channels.lock().expect("channels poisoned");
+        // Prune channels that no longer have any live receiver. The entry for
+        // `user_id` is recreated just below, so dropping a stale one here is
+        // safe.
+        channels.retain(|_, sender| sender.receiver_count() > 0);
         let sender = channels
             .entry(user_id.clone())
             .or_insert_with(|| broadcast::channel(self.inner.config.broadcast_capacity).0);
@@ -887,10 +897,18 @@ struct Inner {
 impl Inner {
     /// Best-effort broadcast: a `SendError` (no live receivers) is normal
     /// and ignored — events that nobody is listening for are dropped.
+    ///
+    /// A failed send also means the sender has no receivers, so this prunes the
+    /// now-dead channel (DT-12 / #300): broadcasting to a user who has since
+    /// disconnected is the natural moment to reclaim their sender, complementing
+    /// the prune-on-subscribe sweep.
     fn broadcast(&self, user_id: &UserId, event: api::Event) {
-        let channels = self.user_channels.lock().expect("channels poisoned");
-        if let Some(sender) = channels.get(user_id) {
-            let _ = sender.send(event);
+        let mut channels = self.user_channels.lock().expect("channels poisoned");
+        if let Some(sender) = channels.get(user_id)
+            && sender.send(event).is_err()
+        {
+            // No live receivers — reclaim the sender.
+            channels.remove(user_id);
         }
     }
 

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -239,6 +239,18 @@ impl BackgroundTaskRegistry {
         Self::with_config(RegistryConfig::default())
     }
 
+    /// Number of per-user broadcast senders currently retained. Test-only:
+    /// lets the pruning test (DT-12 / #300) assert dead channels don't
+    /// accumulate on a multi-user host.
+    #[cfg(test)]
+    fn channel_count(&self) -> usize {
+        self.inner
+            .user_channels
+            .lock()
+            .expect("channels poisoned")
+            .len()
+    }
+
     /// Build a registry with the supplied configuration.
     pub fn with_config(config: RegistryConfig) -> Self {
         Self {
@@ -1114,6 +1126,62 @@ mod tests {
             }
             other => panic!("expected ScratchpadChanged, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn dead_broadcast_senders_are_pruned() {
+        // DT-12 (#300): a user who subscribes then disconnects (drops the
+        // receiver) must not leave an immortal sender behind. After every
+        // receiver for a user is gone, the registry prunes that user's channel
+        // so the map doesn't grow without bound on a multi-user host.
+        let registry = BackgroundTaskRegistry::new();
+
+        // Churn through many short-lived per-user subscriptions.
+        for i in 0..50 {
+            let user = UserId::new(format!("user-{i}"));
+            let rx = registry.subscribe(&user);
+            drop(rx); // disconnect immediately
+        }
+
+        // A subsequent subscribe (the natural prune trigger) plus broadcast
+        // activity must not leave 51 senders pinned forever.
+        let live = UserId::new("live");
+        let _live_rx = registry.subscribe(&live);
+        for i in 0..50 {
+            // Broadcasting to the dead users is the other prune opportunity.
+            registry.notify_scratchpad_changed(&UserId::new(format!("user-{i}")), "c");
+        }
+
+        assert!(
+            registry.channel_count() <= 1,
+            "dead senders must be pruned; only the live subscriber's channel should remain, got {}",
+            registry.channel_count()
+        );
+    }
+
+    #[tokio::test]
+    async fn pruning_does_not_drop_a_live_subscribers_channel() {
+        // Pruning must never evict a channel that still has a live receiver.
+        let registry = BackgroundTaskRegistry::new();
+        let alice = UserId::new("alice");
+        let mut alice_rx = registry.subscribe(&alice);
+
+        // Churn dead subscriptions for other users to trigger pruning.
+        for i in 0..20 {
+            drop(registry.subscribe(&UserId::new(format!("dead-{i}"))));
+        }
+        // Force a subscribe (prune trigger).
+        drop(registry.subscribe(&UserId::new("trigger")));
+
+        // Alice's channel must still deliver.
+        registry.notify_scratchpad_changed(&alice, "conv-1");
+        assert!(
+            matches!(
+                tokio::time::timeout(std::time::Duration::from_secs(5), alice_rx.recv()).await,
+                Ok(Ok(api::Event::ScratchpadChanged { .. }))
+            ),
+            "a live subscriber's channel must survive pruning"
+        );
     }
 
     #[tokio::test]

--- a/crates/application/src/client_tools.rs
+++ b/crates/application/src/client_tools.rs
@@ -601,6 +601,13 @@ impl InMemoryTurnStateStore {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Number of rows currently retained. Test-only: lets the eviction test
+    /// assert that terminal rows don't accumulate over the daemon's lifetime.
+    #[cfg(test)]
+    fn row_count(&self) -> usize {
+        self.rows.lock().unwrap().len()
+    }
 }
 
 #[async_trait::async_trait]
@@ -677,5 +684,106 @@ impl ClientToolPort for CoordinatorClientToolPort {
             },
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn turn_row(id: &str, status: TurnStatus) -> TurnRow {
+        TurnRow {
+            id: id.to_string(),
+            user_id: "u".to_string(),
+            conversation_id: "c".to_string(),
+            status,
+            state: TurnStateJson::default(),
+            last_error: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_transition_evicts_the_turn_row() {
+        // DA-14 (#300): a turn driven to a terminal status must not linger in
+        // the in-memory map — otherwise the store grows unbounded over the
+        // daemon's lifetime (mirror of the background-task eviction in #158).
+        let store = InMemoryTurnStateStore::new();
+        store
+            .create_turn(turn_row("t1", TurnStatus::PendingLlm))
+            .await
+            .unwrap();
+        assert_eq!(store.row_count(), 1);
+
+        store
+            .update_turn("t1", TurnStatus::Complete, &TurnStateJson::default(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.row_count(),
+            0,
+            "a Complete turn must be evicted from the map"
+        );
+        assert!(
+            store.get_turn("t1").await.unwrap().is_none(),
+            "the evicted row is gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_transition_also_evicts() {
+        let store = InMemoryTurnStateStore::new();
+        store
+            .create_turn(turn_row("t1", TurnStatus::PendingClientTool))
+            .await
+            .unwrap();
+        store
+            .update_turn(
+                "t1",
+                TurnStatus::Failed,
+                &TurnStateJson::default(),
+                Some("cancelled"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.row_count(), 0, "a Failed turn must be evicted too");
+    }
+
+    #[tokio::test]
+    async fn non_terminal_transition_keeps_the_row() {
+        // A mid-turn transition (e.g. suspending on a client tool) must keep
+        // the row so the suspend/resolve dance has its backing record.
+        let store = InMemoryTurnStateStore::new();
+        store
+            .create_turn(turn_row("t1", TurnStatus::PendingLlm))
+            .await
+            .unwrap();
+        store
+            .update_turn(
+                "t1",
+                TurnStatus::PendingClientTool,
+                &TurnStateJson::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.row_count(), 1, "a non-terminal turn row stays");
+        let row = store.get_turn("t1").await.unwrap().unwrap();
+        assert_eq!(row.status, TurnStatus::PendingClientTool);
+    }
+
+    #[tokio::test]
+    async fn updating_a_missing_turn_still_errors() {
+        // Eviction must not turn a genuinely-missing turn into a silent success.
+        let store = InMemoryTurnStateStore::new();
+        let err = store
+            .update_turn(
+                "ghost",
+                TurnStatus::Complete,
+                &TurnStateJson::default(),
+                None,
+            )
+            .await;
+        assert!(err.is_err(), "updating an unknown turn id must still error");
     }
 }

--- a/crates/application/src/client_tools.rs
+++ b/crates/application/src/client_tools.rs
@@ -639,6 +639,14 @@ impl TurnStateStore for InMemoryTurnStateStore {
         row.status = status;
         row.state = state.clone();
         row.last_error = last_error.map(String::from);
+        // A turn driven to a terminal state is done: nothing in this process
+        // reads its row again (the suspend/resolve dance has resolved, and the
+        // startup sweep only cares about *non*-terminal rows). Evict it so the
+        // map doesn't grow unbounded over the daemon's lifetime — the mirror of
+        // the background-task eviction in #158 (DA-14 / #300).
+        if status.is_terminal() {
+            rows.remove(id);
+        }
         Ok(())
     }
 

--- a/crates/application/src/inflight.rs
+++ b/crates/application/src/inflight.rs
@@ -68,6 +68,11 @@ impl InFlightTurn {
         let rx = self.tx.subscribe();
         (buffer.clone(), rx)
     }
+
+    #[cfg(test)]
+    async fn buffer_len(&self) -> usize {
+        self.buffer.lock().await.len()
+    }
 }
 
 /// `EventSink` that mirrors a turn's events to the original caller's sink
@@ -318,6 +323,43 @@ mod tests {
             vec!["x", "y"],
             "x via replay, y via live — exactly once each"
         );
+    }
+
+    #[tokio::test]
+    async fn buffer_is_capped_to_avoid_unbounded_growth() {
+        // DA-14 (#300): a long keyed turn that emits thousands of deltas must
+        // not buffer every one forever — the replay buffer is bounded. A late
+        // re-attacher may miss the oldest deltas but still gets the rest plus
+        // the terminal AssistantCompleted (which carries the full reply).
+        let turn = InFlightTurn::new();
+        for i in 0..(INFLIGHT_BROADCAST_CAP * 4) {
+            turn.emit_event(delta(&format!("chunk-{i}"))).await;
+        }
+        assert!(
+            turn.buffer_len().await <= INFLIGHT_BROADCAST_CAP,
+            "replay buffer must stay bounded, got {}",
+            turn.buffer_len().await
+        );
+    }
+
+    #[tokio::test]
+    async fn capped_buffer_keeps_the_most_recent_events() {
+        // The bound drops the OLDEST events, so the latest one — typically the
+        // terminal event for a late re-attacher — is always retained.
+        let turn = InFlightTurn::new();
+        for i in 0..(INFLIGHT_BROADCAST_CAP * 2) {
+            turn.emit_event(delta(&format!("chunk-{i}"))).await;
+        }
+        let (replay, _rx) = turn.snapshot_and_subscribe().await;
+        let last = replay.last().expect("buffer not empty");
+        match last {
+            api::Event::AssistantDelta { chunk, .. } => assert_eq!(
+                chunk,
+                &format!("chunk-{}", INFLIGHT_BROADCAST_CAP * 2 - 1),
+                "the newest event must be retained"
+            ),
+            other => panic!("unexpected last event: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/application/src/inflight.rs
+++ b/crates/application/src/inflight.rs
@@ -14,7 +14,7 @@
 //! conversation_id, idempotency_key)`; a turn registers when it starts and
 //! removes itself when it ends.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -30,12 +30,22 @@ use crate::EventSink;
 /// even a lagging re-attacher ends with the complete answer.
 const INFLIGHT_BROADCAST_CAP: usize = 256;
 
-/// A single live turn's fan-out hub: an append-only event buffer plus a live
-/// broadcast. Buffer-append and broadcast happen under one lock so a
+/// Cap on the replay buffer: a re-attacher that joins gets at most this many of
+/// the most-recent buffered events. Matches [`INFLIGHT_BROADCAST_CAP`] so a
+/// re-attacher's replay and its live subscription have the same depth. A long
+/// agentic turn can emit thousands of deltas; without a cap the buffer would
+/// grow with the turn (DA-14 / #300). Dropping the *oldest* deltas is safe: a
+/// late re-attacher loses early chunks but still gets the rest live, and the
+/// terminal `AssistantCompleted` (always the newest event when present) carries
+/// the full reply text.
+const INFLIGHT_BUFFER_CAP: usize = INFLIGHT_BROADCAST_CAP;
+
+/// A single live turn's fan-out hub: a bounded most-recent event buffer plus a
+/// live broadcast. Buffer-append and broadcast happen under one lock so a
 /// re-attacher can snapshot the buffer and subscribe atomically — no event is
 /// duplicated or dropped at the snapshot/subscribe boundary.
 pub(crate) struct InFlightTurn {
-    buffer: AsyncMutex<Vec<api::Event>>,
+    buffer: AsyncMutex<VecDeque<api::Event>>,
     tx: broadcast::Sender<api::Event>,
 }
 
@@ -43,17 +53,22 @@ impl InFlightTurn {
     fn new() -> Arc<Self> {
         let (tx, _rx) = broadcast::channel(INFLIGHT_BROADCAST_CAP);
         Arc::new(Self {
-            buffer: AsyncMutex::new(Vec::new()),
+            buffer: AsyncMutex::new(VecDeque::new()),
             tx,
         })
     }
 
     /// Record + fan out one event. `Err` from `send` just means there are no
     /// live subscribers right now; the buffer still keeps the event for a
-    /// future re-attacher.
+    /// future re-attacher. The buffer is bounded to the most-recent
+    /// [`INFLIGHT_BUFFER_CAP`] events (oldest dropped) so it can't grow with a
+    /// long turn.
     async fn emit_event(&self, event: api::Event) {
         let mut buffer = self.buffer.lock().await;
-        buffer.push(event.clone());
+        buffer.push_back(event.clone());
+        while buffer.len() > INFLIGHT_BUFFER_CAP {
+            buffer.pop_front();
+        }
         let _ = self.tx.send(event);
     }
 
@@ -66,7 +81,7 @@ impl InFlightTurn {
     ) -> (Vec<api::Event>, broadcast::Receiver<api::Event>) {
         let buffer = self.buffer.lock().await;
         let rx = self.tx.subscribe();
-        (buffer.clone(), rx)
+        (buffer.iter().cloned().collect(), rx)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Contained unbounded-growth fixes from the 2026-06-09 review (Tier 1). All three live in the `application` crate.

## DA-14a — `InMemoryTurnStateStore` never deletes terminal rows (#300)
`update_turn` now evicts the row once the turn reaches a terminal status (`Complete`/`Failed`). Nothing in-process reads a terminal turn again — the suspend/resolve dance has resolved and the startup sweep only scans *non*-terminal rows — so the row is dead weight that otherwise accumulates for the daemon's lifetime. Mirrors the background-task eviction in #158. (The turn-state integration tests use their own non-evicting double, so they're unaffected.)

## DA-14b — `InFlightTurn.buffer` buffers every delta unbounded (#300)
The replay buffer is now a `VecDeque` bounded to `INFLIGHT_BUFFER_CAP` (= `INFLIGHT_BROADCAST_CAP`, 256) most-recent events, oldest dropped (O(1) front-drop). A long agentic keyed turn no longer grows the buffer with the turn. A late re-attacher may miss the earliest chunks but still gets the rest via the live broadcast, and the terminal `AssistantCompleted` (the newest event when present) carries the full reply.

## DT-12 — per-user broadcast senders never pruned (#300)
Senders are reclaimed when `receiver_count() == 0`: `subscribe()` sweeps stale channels before (re)creating, and a failed `broadcast` send removes the now-dead sender. Stops the slow leak on a multi-user host.

## Tests (TDD — failing tests committed first)
- `terminal_transition_evicts_the_turn_row`, `failed_transition_also_evicts`, `non_terminal_transition_keeps_the_row`, `updating_a_missing_turn_still_errors`
- `buffer_is_capped_to_avoid_unbounded_growth`, `capped_buffer_keeps_the_most_recent_events`
- `dead_broadcast_senders_are_pruned`, `pruning_does_not_drop_a_live_subscribers_channel`

## Gates
`cargo fmt --check`, `cargo clippy -p desktop-assistant-application --all-targets` (zero warnings), `cargo test -p desktop-assistant-core -p desktop-assistant-application` all green; daemon builds.

Scope: `crates/application` only.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)