### PR TITLE
DT-3: 1h default WS JWT TTL + jti revocation (#269)

### DIFF
--- a/crates/daemon/src/config/jwt.rs
+++ b/crates/daemon/src/config/jwt.rs
@@ -34,8 +34,16 @@ pub(super) fn default_ws_jwt_audience() -> &'static str {
     "desktop-assistant-ws"
 }
 
-fn default_ws_jwt_ttl_seconds() -> u64 {
-    60 * 60 * 24 * 30
+/// Default lifetime of a daemon-minted WS JWT.
+///
+/// DT-3 (#269): dropped from 30 days to 1 hour to match the jwt-minter's own
+/// default (`dbus-bridge`'s `token_ttl_seconds`). A leaked token is now a
+/// one-hour exposure, not a month, and clients re-mint transparently on
+/// expiry (the `Connector` already reconnects and replays). Existing configs
+/// that explicitly request a longer TTL via the minter keep working — this is
+/// only the default applied when no TTL is supplied.
+pub(super) fn default_ws_jwt_ttl_seconds() -> u64 {
+    60 * 60
 }
 
 pub fn current_username() -> String {
@@ -70,7 +78,23 @@ pub(super) fn encode_ws_jwt(claims: &WsJwtClaims) -> anyhow::Result<String> {
     auth_jwt::encode(claims, &signing_key)
 }
 
+/// Decode and verify `token`, then reject it if its `jti` is on the
+/// revocation deny-list (DT-3 #269). This is the single chokepoint that both
+/// [`validate_ws_jwt`] and [`ws_jwt_sub`] route through, so a revoked token is
+/// rejected on every auth path.
 pub(super) fn decode_ws_jwt_claims(token: &str) -> anyhow::Result<WsJwtClaims> {
+    let claims = decode_ws_jwt_claims_ignoring_revocation(token)?;
+    if is_jti_revoked(&claims.jti) {
+        return Err(anyhow!("ws jwt has been revoked"));
+    }
+    Ok(claims)
+}
+
+/// Decode and verify `token` (signature, issuer, audience, exp/nbf) WITHOUT
+/// consulting the revocation list. Used internally so revocation can be added
+/// on top, and by [`revoke_ws_jwt`] to read a token's `jti`/`exp` before
+/// denying it.
+pub(super) fn decode_ws_jwt_claims_ignoring_revocation(token: &str) -> anyhow::Result<WsJwtClaims> {
     let signing_key = auth_jwt::read_signing_key_at(&signing_key_path())
         .ok_or_else(|| anyhow!("ws jwt signing key is not initialized"))?;
     auth_jwt::decode(
@@ -126,4 +150,112 @@ pub fn ws_jwt_sub(token: &str) -> Option<String> {
         return None;
     }
     decode_ws_jwt_claims(token).ok().map(|claims| claims.sub)
+}
+
+// ── DT-3 (#269): jti revocation deny-list ────────────────────────────────────
+//
+// Tokens are short-lived (1h default), so a revoked `jti` only needs to be
+// remembered until its own `exp` passes — after that the token is rejected by
+// the `exp` check anyway and the entry is pruned. The list is a JSON map of
+// `jti -> exp` persisted next to the signing key. All access is serialised
+// through a process-wide mutex so concurrent revokes/validations can't race on
+// the file; the lock is cheap because the file is tiny (it only holds
+// not-yet-expired revoked jtis).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+fn revocation_list_path() -> PathBuf {
+    super::default_secret_store_dir().join("ws_jwt_revocations.json")
+}
+
+fn revocation_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Read the persisted deny-list (`jti -> exp`). Missing/corrupt file → empty.
+fn read_revocations() -> HashMap<String, u64> {
+    let path = revocation_list_path();
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return HashMap::new();
+    };
+    serde_json::from_str(&raw).unwrap_or_else(|error| {
+        tracing::warn!(
+            path = %path.display(),
+            %error,
+            "ws jwt revocation list is corrupt; treating as empty"
+        );
+        HashMap::new()
+    })
+}
+
+/// Atomically persist the deny-list with the same 0600/0700 tightening the
+/// signing key gets (reuse `auth_jwt`'s atomic writer).
+fn write_revocations(map: &HashMap<String, u64>) -> anyhow::Result<()> {
+    let json = serde_json::to_string(map).map_err(|e| anyhow!("serialize revocations: {e}"))?;
+    auth_jwt::write_signing_key_at(&revocation_list_path(), &json)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// True if `jti` is on the (non-expired) deny-list.
+pub(super) fn is_jti_revoked(jti: &str) -> bool {
+    let _guard = revocation_lock().lock().unwrap_or_else(|e| e.into_inner());
+    match read_revocations().get(jti) {
+        Some(&exp) => exp > now_secs(),
+        None => false,
+    }
+}
+
+/// Drop deny-list entries whose `exp` has already passed (they're rejected by
+/// the `exp` check regardless), keeping the file from growing without bound.
+pub fn prune_revocations() {
+    let _guard = revocation_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let now = now_secs();
+    let mut map = read_revocations();
+    let before = map.len();
+    map.retain(|_, &mut exp| exp > now);
+    if map.len() != before
+        && let Err(error) = write_revocations(&map)
+    {
+        tracing::warn!(%error, "failed to persist pruned ws jwt revocation list");
+    }
+}
+
+/// Revoke a WS JWT by its `jti`.
+///
+/// The token must currently decode (valid signature/issuer/audience) so an
+/// operator can't accidentally poison the list with garbage; `exp` is read
+/// from the token so the entry self-expires. Idempotent: re-revoking is fine.
+/// Returns an error for a missing/malformed/expired token rather than silently
+/// succeeding, so callers know nothing was added.
+pub fn revoke_ws_jwt(token: &str) -> anyhow::Result<()> {
+    let token = token.trim();
+    if token.is_empty() {
+        return Err(anyhow!("cannot revoke an empty token"));
+    }
+    // Decode ignoring revocation (a token already revoked must still be
+    // re-revocable / inspectable) but still requiring a valid signature+exp.
+    let claims = decode_ws_jwt_claims_ignoring_revocation(token)?;
+
+    let _guard = revocation_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let now = now_secs();
+    let mut map = read_revocations();
+    map.retain(|_, &mut exp| exp > now); // opportunistic prune
+    map.insert(claims.jti, claims.exp);
+    write_revocations(&map)
+}
+
+#[cfg(test)]
+pub(super) fn record_revocation_for_test(jti: &str, exp: u64) {
+    let _guard = revocation_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let mut map = read_revocations();
+    map.insert(jti.to_string(), exp);
+    write_revocations(&map).expect("write test revocation");
 }

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -1890,6 +1890,152 @@ y = 2
     }
 
     // ─────────────────────────────────────────────────────────────────────
+    // DT-3 (#269): saner default TTL + jti revocation
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Run `body` with `XDG_DATA_HOME` pointed at a fresh unique temp dir so
+    /// the signing key and revocation list live in isolation. Serialised
+    /// against the other JWT tests via `ws_jwt_env_lock`.
+    fn with_isolated_jwt_store<F: FnOnce()>(tag: &str, body: F) {
+        let _guard = ws_jwt_env_lock();
+        let test_dir =
+            std::env::temp_dir().join(format!("da-test-ws-jwt-{tag}-{}", uuid::Uuid::new_v4()));
+        let data_home = test_dir.join("data");
+        std::fs::create_dir_all(&data_home).unwrap();
+        // SAFETY: serialised against other JWT tests via `ws_jwt_env_lock`;
+        // the temp dir is unique per run (UUID-suffixed).
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", &data_home);
+        }
+        body();
+        // SAFETY: same scope as the matching `set_var` above.
+        unsafe {
+            std::env::remove_var("XDG_DATA_HOME");
+        }
+        std::fs::remove_dir_all(&test_dir).ok();
+    }
+
+    #[test]
+    fn default_ws_jwt_ttl_is_one_hour() {
+        // DT-3: the daemon default must align with the minter's 1h, not the
+        // old 30-day window. Clients re-mint on expiry.
+        assert_eq!(
+            jwt::default_ws_jwt_ttl_seconds(),
+            60 * 60,
+            "default WS JWT TTL must be 1 hour"
+        );
+    }
+
+    #[test]
+    fn valid_token_is_accepted() {
+        with_isolated_jwt_store("valid", || {
+            let token = generate_ws_jwt(Some("tui".to_string())).expect("generate jwt");
+            assert!(validate_ws_jwt(&token).expect("validate"));
+            assert_eq!(ws_jwt_sub(&token).as_deref(), Some("tui"));
+        });
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        with_isolated_jwt_store("expired", || {
+            // Forge a token whose exp is in the past (re-signed with the real
+            // key so only the clock, not the signature, rejects it).
+            let token = generate_ws_jwt(Some("tui".to_string())).expect("generate jwt");
+            let mut claims = jwt::decode_ws_jwt_claims(&token).expect("decode");
+            claims.exp = claims.iat.saturating_sub(3600);
+            let expired = jwt::encode_ws_jwt(&claims).expect("re-encode expired");
+
+            assert!(!validate_ws_jwt(&expired).expect("validate expired"));
+            assert!(ws_jwt_sub(&expired).is_none());
+        });
+    }
+
+    #[test]
+    fn revoked_token_is_rejected() {
+        with_isolated_jwt_store("revoked", || {
+            let token = generate_ws_jwt(Some("tui".to_string())).expect("generate jwt");
+            // Valid before revocation.
+            assert!(validate_ws_jwt(&token).expect("validate pre-revoke"));
+
+            revoke_ws_jwt(&token).expect("revoke token");
+
+            // Rejected by BOTH chokepoints after revocation.
+            assert!(
+                !validate_ws_jwt(&token).expect("validate post-revoke"),
+                "revoked token must not validate"
+            );
+            assert!(
+                ws_jwt_sub(&token).is_none(),
+                "revoked token must not yield a sub"
+            );
+        });
+    }
+
+    #[test]
+    fn revoking_one_token_does_not_affect_another() {
+        with_isolated_jwt_store("revoke-isolation", || {
+            let a = generate_ws_jwt(Some("tui".to_string())).expect("token a");
+            let b = generate_ws_jwt(Some("plasmoid".to_string())).expect("token b");
+
+            revoke_ws_jwt(&a).expect("revoke a");
+
+            assert!(!validate_ws_jwt(&a).expect("a rejected"));
+            assert!(validate_ws_jwt(&b).expect("b still valid"));
+        });
+    }
+
+    #[test]
+    fn revocation_survives_a_fresh_decode_path() {
+        // The deny-list must be persisted, not just held in memory: a second
+        // logical "process" (a fresh read of the list from disk) still
+        // rejects the revoked jti.
+        with_isolated_jwt_store("revoke-persist", || {
+            let token = generate_ws_jwt(Some("tui".to_string())).expect("generate jwt");
+            revoke_ws_jwt(&token).expect("revoke");
+
+            // Read the revocation file straight from disk and confirm the jti
+            // is recorded (persistence, not just a cached set).
+            let claims = jwt::decode_ws_jwt_claims_ignoring_revocation(&token)
+                .expect("decode for jti");
+            assert!(
+                jwt::is_jti_revoked(&claims.jti),
+                "revoked jti must be readable from the persisted list"
+            );
+        });
+    }
+
+    #[test]
+    fn revoking_unparseable_token_is_an_error_not_a_silent_noop() {
+        // Unhappy path: revoking garbage must surface an error so an operator
+        // isn't lulled into thinking a bad token id was revoked.
+        with_isolated_jwt_store("revoke-malformed", || {
+            assert!(revoke_ws_jwt("not-a-jwt").is_err());
+            assert!(revoke_ws_jwt("").is_err());
+        });
+    }
+
+    #[test]
+    fn expired_revocation_entries_are_pruned() {
+        // The deny-list must self-prune: an entry whose exp has passed is
+        // dropped so the file can't grow without bound. We revoke a token,
+        // then prove a manually-aged entry is gone after a prune cycle.
+        with_isolated_jwt_store("revoke-prune", || {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            // Record a long-dead jti directly, then prune.
+            jwt::record_revocation_for_test("dead-jti", now.saturating_sub(10_000));
+            jwt::record_revocation_for_test("live-jti", now + 10_000);
+
+            jwt::prune_revocations();
+
+            assert!(!jwt::is_jti_revoked("dead-jti"), "expired entry pruned");
+            assert!(jwt::is_jti_revoked("live-jti"), "live entry retained");
+        });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
     // Purpose-aware LLM config resolution
     // ─────────────────────────────────────────────────────────────────────
 

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -34,7 +34,10 @@ pub use views::{
 // Re-export the JWT + OIDC public API at the `config::` path so existing
 // callers (`config::generate_ws_jwt`, `config::OidcValidator`, etc.)
 // keep working unchanged.
-pub use jwt::{current_username, generate_ws_jwt, validate_ws_jwt, ws_jwt_sub};
+pub use jwt::{
+    current_username, generate_ws_jwt, prune_revocations, revoke_ws_jwt, validate_ws_jwt,
+    ws_jwt_sub,
+};
 pub use oidc::OidcValidator;
 
 // Resolution helpers — public API stays at `config::` for callers in
@@ -1995,8 +1998,8 @@ y = 2
 
             // Read the revocation file straight from disk and confirm the jti
             // is recorded (persistence, not just a cached set).
-            let claims = jwt::decode_ws_jwt_claims_ignoring_revocation(&token)
-                .expect("decode for jti");
+            let claims =
+                jwt::decode_ws_jwt_claims_ignoring_revocation(&token).expect("decode for jti");
             assert!(
                 jwt::is_jti_revoked(&claims.jti),
                 "revoked jti must be readable from the persisted list"

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -765,6 +765,25 @@ async fn main() -> Result<()> {
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 
+    // DT-3 (#269): operator escape hatch. `desktop-assistant --revoke-token
+    // <jwt>` adds the token's `jti` to the WS JWT revocation deny-list and
+    // exits without starting the daemon, so a leaked short-lived token can be
+    // killed before its 1h expiry. The token must still be a valid,
+    // unexpired, daemon-signed JWT (we read its jti/exp); garbage is rejected.
+    {
+        let args: Vec<String> = std::env::args().collect();
+        if let Some(pos) = args.iter().position(|a| a == "--revoke-token") {
+            let token = args
+                .get(pos + 1)
+                .ok_or_else(|| anyhow::anyhow!("--revoke-token requires a JWT argument"))?;
+            config::revoke_ws_jwt(token)
+                .map_err(|e| anyhow::anyhow!("failed to revoke token: {e}"))?;
+            tracing::info!("ws jwt revoked");
+            println!("token revoked");
+            return Ok(());
+        }
+    }
+
     tracing::info!("desktop-assistant starting");
 
     // Install the rustls crypto provider for TLS support. Returns Err if a
@@ -799,6 +818,11 @@ async fn main() -> Result<()> {
             tracing::warn!("Secret Service store init task failed: {error}");
         }
     }
+
+    // DT-3 (#269): drop WS JWT revocation entries whose own `exp` has already
+    // passed (they're rejected by the exp check anyway), so the deny-list file
+    // can't grow without bound across restarts.
+    config::prune_revocations();
 
     // Build the LLM client from daemon.toml + KWallet (fallback to env)
     let config_path = config::default_daemon_config_path();


### PR DESCRIPTION
## Problem

The daemon (`config/jwt.rs`) minted WS bearer tokens with a **30-day default TTL** and, although a `jti` was generated, nothing tracked it — so there was **no revocation**. One leaked token meant a month of full assistant access (including terminal/fileio tools). The jwt-minter's own default is 1h; that is the intended posture (DT-3, code review §2, HIGH).

## Fix

**Shorter default TTL.** Dropped the daemon default from 30 days to **1 hour** to match `dbus-bridge`'s `token_ttl_seconds`. Clients re-mint transparently on expiry (the `Connector` already reconnects and replays). Configs that explicitly request a longer TTL via the minter keep working — this only changes the default applied when no TTL is supplied.

**Revocation deny-list.** A JSON `jti -> exp` map persisted next to the signing key (`ws_jwt_revocations.json`), guarded by a process-wide mutex and written atomically (0600). The check lives in `decode_ws_jwt_claims` — the single chokepoint both `validate_ws_jwt` and `ws_jwt_sub` route through — so a revoked token is rejected on **every** auth path. Because tokens are short-lived, entries only need to outlive their own `exp`; they self-prune at daemon startup and opportunistically on each revoke, so the file can't grow without bound.

**Real call sites, no trait ripple.** Rather than thread a new method through the 13-impl `SystemService` port, revocation is a daemon-`config` capability with two production callers:
- `desktop-assistant --revoke-token <jwt>` adds the token's `jti` to the deny-list and exits (the operator escape hatch). The token must be a valid, unexpired, daemon-signed JWT, so garbage can't poison the list.
- Daemon startup calls `prune_revocations()`.

A corrupt revocation file **fails open** (logged) rather than locking every client out — a deliberate availability choice given a tiny, self-pruning file.

## Tests (`crates/daemon/src/config/mod.rs`)

- `default_ws_jwt_ttl_is_one_hour`
- `valid_token_is_accepted`
- `expired_token_is_rejected`
- `revoked_token_is_rejected`
- `revoking_one_token_does_not_affect_another`
- `revocation_survives_a_fresh_decode_path` (persistence, not just in-memory)
- `revoking_unparseable_token_is_an_error_not_a_silent_noop` (malformed/empty)
- `expired_revocation_entries_are_pruned`

All 271 daemon tests pass; `cargo fmt` + `cargo clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #269