### PR TITLE
Enforce subagent tool allowlist + recursion depth cap (DA-6)

### DIFF
--- a/crates/application/src/subagent_tools.rs
+++ b/crates/application/src/subagent_tools.rs
@@ -69,6 +69,16 @@ pub const TOOL_SPAWN_SUBAGENT: &str = "spawn_subagent";
 /// Tool name (LLM-visible) for polling a previously-spawned subagent.
 pub const TOOL_GET_SUBAGENT_STATUS: &str = "get_subagent_status";
 
+/// Maximum subagent recursion depth (issue #291). Depth is the number of
+/// `Subagent` ancestors a task would have: a top-level conversation
+/// spawning a subagent produces depth 1, that subagent spawning another
+/// produces depth 2, and so on. A `spawn_subagent` whose resulting child
+/// would exceed this cap is rejected with a recoverable error, bounding
+/// recursive fan-out (a "restricted" subagent could otherwise spawn
+/// subagents — including itself — without limit). 8 is generous enough for
+/// legitimate multi-level delegation while preventing runaway recursion.
+pub const MAX_SUBAGENT_DEPTH: usize = 8;
+
 /// Generic-over-`ConversationService` wrapper that publishes the two
 /// builtin tools and dispatches them. Cheap to `Clone` — only holds
 /// `Arc`s.
@@ -195,6 +205,34 @@ impl<C: ConversationService + Send + Sync + 'static> SubagentTools<C> {
         }
     }
 
+    /// Count how many `Subagent` tasks are on the chain from `task_id` up
+    /// to the root (inclusive of `task_id` itself when it is a subagent).
+    /// This is the number of subagent levels already nested above the child
+    /// a spawn would create. A defensive cap on the walk length guards
+    /// against a corrupted/cyclic parent chain so this can never loop
+    /// unboundedly — a cycle would itself be treated as "too deep".
+    fn subagent_depth(
+        &self,
+        user_id: &desktop_assistant_auth_jwt::UserId,
+        task_id: &api::TaskId,
+    ) -> usize {
+        let mut depth = 0usize;
+        let mut current = Some(task_id.clone());
+        // Walk at most MAX_SUBAGENT_DEPTH + 1 hops; past that we already know
+        // the child would exceed the cap, so the exact count no longer matters.
+        for _ in 0..=MAX_SUBAGENT_DEPTH {
+            let Some(id) = current else { break };
+            let Some(view) = self.registry.get(user_id, &id) else {
+                break;
+            };
+            if matches!(view.kind, api::TaskKind::Subagent { .. }) {
+                depth += 1;
+            }
+            current = view.parent;
+        }
+        depth
+    }
+
     async fn spawn(&self, arguments: serde_json::Value) -> Result<String, CoreError> {
         let name = required_string(&arguments, "name")?;
         let prompt = required_string(&arguments, "prompt")?;
@@ -217,6 +255,21 @@ impl<C: ConversationService + Send + Sync + 'static> SubagentTools<C> {
                     .to_string(),
             )
         })?;
+
+        // Recursion depth limit (issue #291). Walk the parent chain to count
+        // how many `Subagent` ancestors the about-to-be-spawned child would
+        // have; the child's own depth is that count + 1. Reject the spawn when
+        // it would exceed `MAX_SUBAGENT_DEPTH` so a subagent cannot recurse
+        // (or self-spawn) unboundedly. Done before any side effects (no child
+        // conversation is created) so a rejected spawn leaves no orphan state.
+        let child_depth = self.subagent_depth(&user_id, &parent_task_id) + 1;
+        if child_depth > MAX_SUBAGENT_DEPTH {
+            return Err(CoreError::ToolExecution(format!(
+                "spawn_subagent rejected: subagent recursion depth limit ({MAX_SUBAGENT_DEPTH}) \
+                 reached. This subagent is already nested too deeply to spawn another. Complete \
+                 the work directly instead of delegating further."
+            )));
+        }
 
         // Create the child conversation. The title doubles as the
         // subagent label so the UI can show it without destructuring

--- a/crates/application/tests/spawn_subagent.rs
+++ b/crates/application/tests/spawn_subagent.rs
@@ -1207,3 +1207,214 @@ async fn current_task_id_outside_registry_is_none_inside_is_some() {
         .expect("wait() must resolve once the task finalizes, not hang");
     assert!(seen.load(Ordering::SeqCst));
 }
+
+// --------------------------------------------------------------------
+// 14. recursion depth limit (issue #291)
+// --------------------------------------------------------------------
+
+/// Register a chain of nested `Subagent` tasks `depth` levels deep
+/// (level 0's parent is a `Conversation` task) and run `body` inside the
+/// deepest one, where `current_task_id()` resolves to that level's id and
+/// the registry holds the full parent chain. Returns the body's value.
+///
+/// Used by the depth-limit tests: they drive `tools.spawn(..)` from deep
+/// inside a real Subagent chain so the dispatch-time depth check has a
+/// genuine ancestry to walk.
+async fn under_subagent_chain<F, Fut, T>(
+    registry: &Arc<BackgroundTaskRegistry>,
+    user: UserId,
+    depth: usize,
+    body: F,
+) -> T
+where
+    F: FnOnce(api::TaskId) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    // First register the root Conversation parent so the chain hangs off
+    // a real ancestor.
+    let result_slot: Arc<Mutex<Option<T>>> = Arc::new(Mutex::new(None));
+    let result_for_body = Arc::clone(&result_slot);
+    let registry_outer = Arc::clone(registry);
+    let user_outer = user.clone();
+
+    let root_id = registry.spawn(
+        user.clone(),
+        api::TaskKind::Conversation {
+            conversation_id: "root-conv".into(),
+        },
+        "root".into(),
+        move |ctx| {
+            let registry = registry_outer;
+            let user = user_outer;
+            let result_for_body = result_for_body;
+            async move {
+                with_user_id(user.clone(), async move {
+                    let token = ctx.token.clone();
+                    desktop_assistant_core::ports::llm::with_cancellation_token(
+                        token,
+                        async move {
+                            let parent = ctx.task_id.clone();
+                            let value = spawn_nested(&registry, user, parent, depth, body).await;
+                            *result_for_body.lock().unwrap() = Some(value);
+                        },
+                    )
+                    .await;
+                    Ok(())
+                })
+                .await
+            }
+        },
+    );
+    timeout(Duration::from_secs(10), registry.wait(&root_id))
+        .await
+        .expect("subagent chain must finish, not hang");
+    result_slot
+        .lock()
+        .unwrap()
+        .take()
+        .expect("chain body produced a value")
+}
+
+/// Spawn one more `Subagent` level under `parent`; recurse until
+/// `remaining == 0`, then run `body` inside the deepest body.
+fn spawn_nested<F, Fut, T>(
+    registry: &Arc<BackgroundTaskRegistry>,
+    user: UserId,
+    parent: api::TaskId,
+    remaining: usize,
+    body: F,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send>>
+where
+    F: FnOnce(api::TaskId) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let registry = Arc::clone(registry);
+    Box::pin(async move {
+        let result_slot: Arc<Mutex<Option<T>>> = Arc::new(Mutex::new(None));
+        let result_for_body = Arc::clone(&result_slot);
+        let registry_inner = Arc::clone(&registry);
+        let user_inner = user.clone();
+        let parent_for_kind = parent.clone();
+        let child_id = registry.spawn(
+            user.clone(),
+            api::TaskKind::Subagent {
+                parent_task_id: parent_for_kind,
+                conversation_id: format!("sub-conv-{remaining}"),
+                name: format!("level-{remaining}"),
+            },
+            format!("level-{remaining}"),
+            move |ctx| {
+                let registry = registry_inner;
+                let user = user_inner;
+                let result_for_body = result_for_body;
+                async move {
+                    with_user_id(user.clone(), async move {
+                        let token = ctx.token.clone();
+                        desktop_assistant_core::ports::llm::with_cancellation_token(
+                            token,
+                            async move {
+                                let me = ctx.task_id.clone();
+                                let value = if remaining <= 1 {
+                                    body(me).await
+                                } else {
+                                    spawn_nested(&registry, user, me, remaining - 1, body).await
+                                };
+                                *result_for_body.lock().unwrap() = Some(value);
+                            },
+                        )
+                        .await;
+                        Ok(())
+                    })
+                    .await
+                }
+            },
+        );
+        timeout(Duration::from_secs(10), registry.wait(&child_id))
+            .await
+            .expect("nested subagent level must finish, not hang");
+        result_slot
+            .lock()
+            .unwrap()
+            .take()
+            .expect("nested body produced a value")
+    })
+}
+
+#[tokio::test]
+async fn spawn_subagent_rejected_past_recursion_depth_limit() {
+    use desktop_assistant_application::subagent_tools::MAX_SUBAGENT_DEPTH;
+
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let conversations = Arc::new(FakeConversations::new("child text"));
+    let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
+    let user = unique_user("deep");
+
+    // Run from inside a Subagent chain already at MAX_SUBAGENT_DEPTH
+    // Subagent ancestors. Spawning one more would exceed the cap, so the
+    // tool must refuse with a recoverable error and create no child task.
+    let tools_for_body = tools.clone();
+    let result: Result<String, CoreError> = under_subagent_chain(
+        &registry,
+        user.clone(),
+        MAX_SUBAGENT_DEPTH,
+        move |_deepest| async move {
+            tools_for_body
+                .execute_tool(
+                    TOOL_SPAWN_SUBAGENT,
+                    serde_json::json!({
+                        "name": "too-deep",
+                        "prompt": "go deeper",
+                        "wait": true,
+                    }),
+                )
+                .await
+        },
+    )
+    .await;
+
+    let err = result.expect_err("spawn past the depth cap must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("depth"),
+        "rejection should mention the depth limit, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn spawn_subagent_allowed_within_recursion_depth_limit() {
+    use desktop_assistant_application::subagent_tools::MAX_SUBAGENT_DEPTH;
+
+    let registry = Arc::new(BackgroundTaskRegistry::new());
+    let conversations = Arc::new(FakeConversations::new("child text"));
+    let tools = SubagentTools::new(Arc::clone(&registry), Arc::clone(&conversations));
+    let user = unique_user("shallow");
+
+    // One level below the cap: a spawn here is still permitted, proving
+    // the limit doesn't fire prematurely.
+    let tools_for_body = tools.clone();
+    let result: Result<String, CoreError> = under_subagent_chain(
+        &registry,
+        user.clone(),
+        MAX_SUBAGENT_DEPTH - 1,
+        move |_deepest| async move {
+            tools_for_body
+                .execute_tool(
+                    TOOL_SPAWN_SUBAGENT,
+                    serde_json::json!({
+                        "name": "still-ok",
+                        "prompt": "one more",
+                        "wait": true,
+                    }),
+                )
+                .await
+        },
+    )
+    .await;
+
+    assert_eq!(
+        result.expect("a spawn within the depth limit must succeed"),
+        "child text"
+    );
+}

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -1921,6 +1921,187 @@ mod tests {
         );
     }
 
+    // --- TOOL_ALLOWLIST dispatch enforcement (issue #291 / #133) --------
+    //
+    // The `TOOL_ALLOWLIST` task-local (#113) is read at the dispatch
+    // chokepoint: a tool call whose name is NOT on the allowlist is
+    // rejected with a recoverable tool_result error and the executor is
+    // never invoked. `None` means "no restriction"; an empty allowlist
+    // means "no tools".
+
+    #[tokio::test]
+    async fn dispatch_rejects_tool_not_on_allowlist() {
+        // A subagent is given `tools: ["read_file"]` but the LLM tries to
+        // call `delete_file`. The call must be rejected with a recoverable
+        // error folded into the tool_result, and the executor must NOT run
+        // the disallowed tool (it would have returned "boom" if it had).
+        let read_def = ToolDefinition::new(
+            "read_file",
+            "Read a file",
+            serde_json::json!({"type": "object"}),
+        );
+        let delete_def = ToolDefinition::new(
+            "delete_file",
+            "Delete a file",
+            serde_json::json!({"type": "object"}),
+        );
+        let bad_call = ToolCall::new("call-1", "delete_file", r#"{"path": "/etc/passwd"}"#);
+
+        let responses = vec![
+            LlmResponse::with_tool_calls("", vec![bad_call]),
+            LlmResponse::text("done"),
+        ];
+        let mut tool_results = HashMap::new();
+        // If dispatch wrongly executes the disallowed tool, this is what it
+        // would return — its absence from the history proves enforcement.
+        tool_results.insert("delete_file".to_string(), "boom".to_string());
+
+        let handler = make_tool_handler(responses, vec![read_def, delete_def], tool_results);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let result = crate::ports::llm::with_tool_allowlist(
+            vec!["read_file".to_string()],
+            handler.send_prompt(
+                &conv.id,
+                "delete the file".into(),
+                noop_callback(),
+                noop_status(),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, "done");
+
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let tool_msg = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .expect("a tool_result must be recorded for the rejected call");
+        assert!(
+            tool_msg.content.contains("not permitted")
+                || tool_msg.content.to_lowercase().contains("not allowed"),
+            "rejection text should explain the tool is not on the allowlist, got: {}",
+            tool_msg.content
+        );
+        assert!(
+            tool_msg.content.contains("delete_file"),
+            "rejection should name the disallowed tool, got: {}",
+            tool_msg.content
+        );
+        assert!(
+            !tool_msg.content.contains("boom"),
+            "the disallowed tool must NOT have executed, got: {}",
+            tool_msg.content
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_allows_tool_on_allowlist() {
+        // Baseline: an allowed tool dispatches normally under an allowlist.
+        let read_def = ToolDefinition::new(
+            "read_file",
+            "Read a file",
+            serde_json::json!({"type": "object"}),
+        );
+        let good_call = ToolCall::new("call-1", "read_file", r#"{"path": "/tmp/ok"}"#);
+        let responses = vec![
+            LlmResponse::with_tool_calls("", vec![good_call]),
+            LlmResponse::text("read it"),
+        ];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("read_file".to_string(), "hello world".to_string());
+
+        let handler = make_tool_handler(responses, vec![read_def], tool_results);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let result = crate::ports::llm::with_tool_allowlist(
+            vec!["read_file".to_string()],
+            handler.send_prompt(&conv.id, "read it".into(), noop_callback(), noop_status()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, "read it");
+
+        let updated = handler.get_conversation(&conv.id).await.unwrap();
+        let tool_msg = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .expect("a tool_result must be recorded");
+        assert_eq!(
+            tool_msg.content, "hello world",
+            "an allowlisted tool must execute normally"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_empty_allowlist_rejects_every_tool() {
+        // An empty allowlist (distinct from None) means "no tools": every
+        // tool call is rejected.
+        let read_def = ToolDefinition::new(
+            "read_file",
+            "Read a file",
+            serde_json::json!({"type": "object"}),
+        );
+        let call = ToolCall::new("call-1", "read_file", r#"{"path": "/tmp/ok"}"#);
+        let responses = vec![
+            LlmResponse::with_tool_calls("", vec![call]),
+            LlmResponse::text("done"),
+        ];
+        let mut tool_results = HashMap::new();
+        tool_results.insert("read_file".to_string(), "hello world".to_string());
+
+        let handler = make_tool_handler(responses, vec![read_def], tool_results);
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        handler
+            .send_prompt(&conv.id, "go".into(), noop_callback(), noop_status())
+            .await
+            .unwrap();
+        // Re-run under an empty allowlist via a fresh conversation/handler so
+        // the assertion is unambiguous.
+        let read_def2 = ToolDefinition::new(
+            "read_file",
+            "Read a file",
+            serde_json::json!({"type": "object"}),
+        );
+        let call2 = ToolCall::new("call-1", "read_file", r#"{"path": "/tmp/ok"}"#);
+        let responses2 = vec![
+            LlmResponse::with_tool_calls("", vec![call2]),
+            LlmResponse::text("done"),
+        ];
+        let mut tr2 = HashMap::new();
+        tr2.insert("read_file".to_string(), "hello world".to_string());
+        let handler2 = make_tool_handler(responses2, vec![read_def2], tr2);
+        let conv2 = handler2.create_conversation("Test".into()).await.unwrap();
+
+        crate::ports::llm::with_tool_allowlist(
+            Vec::new(),
+            handler2.send_prompt(&conv2.id, "go".into(), noop_callback(), noop_status()),
+        )
+        .await
+        .unwrap();
+
+        let updated = handler2.get_conversation(&conv2.id).await.unwrap();
+        let tool_msg = updated
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .expect("a tool_result must be recorded for the rejected call");
+        assert!(
+            !tool_msg.content.contains("hello world"),
+            "an empty allowlist must reject every tool, got: {}",
+            tool_msg.content
+        );
+        assert!(
+            tool_msg.content.contains("not permitted")
+                || tool_msg.content.to_lowercase().contains("not allowed"),
+            "rejection text expected, got: {}",
+            tool_msg.content
+        );
+    }
+
     #[tokio::test]
     async fn final_answer_streams_after_a_tool_round() {
         // DA-9: the user-facing chunk callback must keep streaming after the

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -15,7 +15,7 @@ use crate::ports::conversation_ctx::with_conversation_id;
 use crate::ports::inbound::ConversationService;
 use crate::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, StatusCallback, current_cancellation_token,
-    current_context_budget, current_system_refinement,
+    current_context_budget, current_system_refinement, current_tool_allowlist,
 };
 use crate::ports::scratchpad::{
     MAX_NOTE_BYTES, NewScratchpadNote, SCRATCHPAD_GOAL_KEY, ScratchpadGetManyFn, ScratchpadListFn,
@@ -818,6 +818,20 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 tool_defs.push(planning::complete_step_tool());
             }
 
+            // Restrict the advertised tool set to the caller's allowlist
+            // (issues #291 / #133) so a restricted subagent's LLM only ever
+            // sees the tools it may use. `None` ⇒ no restriction; an empty
+            // allowlist ⇒ no tools. The core-loop step-planning tools are
+            // exempt — they're the loop's own control surface, not delegable
+            // capabilities, and dispatch also re-checks the allowlist below.
+            if let Some(allowed) = current_tool_allowlist() {
+                tool_defs.retain(|t| {
+                    t.name == planning::BEGIN_STEP_TOOL
+                        || t.name == planning::COMPLETE_STEP_TOOL
+                        || allowed.iter().any(|a| a == &t.name)
+                });
+            }
+
             let deferred_ns: &[ToolNamespace] = if !hosted_search_demoted {
                 &namespaces
             } else {
@@ -1201,6 +1215,45 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                         .await;
                     conv.messages
                         .push(Message::tool_result(&tool_call.id, &ack));
+                    continue;
+                }
+
+                // Tool allowlist enforcement (issues #291 / #133). A subagent
+                // (or any caller) may install a `TOOL_ALLOWLIST` task-local
+                // restricting which tools it can invoke. The allowlist is also
+                // applied at advertisement time below (the LLM only sees the
+                // permitted set), but enforce it here at the dispatch
+                // chokepoint too: a call to a non-allowlisted name — whether the
+                // model hallucinated it or it leaked in from history — is
+                // rejected with a recoverable error folded into the tool_result,
+                // and no executor runs. `None` means "no restriction"; an empty
+                // allowlist means "no tools". The core-loop step-planning tools
+                // handled above are intentionally exempt (they aren't real tool
+                // work and were never advertised through the allowlist).
+                if let Some(allowed) = current_tool_allowlist()
+                    && !allowed.iter().any(|t| t == &tool_call.name)
+                {
+                    tracing::warn!(
+                        tool = %tool_call.name,
+                        "tool call rejected: not on the subagent's allowlist"
+                    );
+                    let rejection = format!(
+                        "Error: the tool '{}' is not permitted for this subagent — it is not \
+                         on the configured tool allowlist. Choose a tool from your available \
+                         set, or answer without it.",
+                        tool_call.name
+                    );
+                    notify_tool_event(ToolEvent::Started {
+                        name: tool_call.name.clone(),
+                        args: summarize_tool_value(&arguments),
+                    });
+                    notify_tool_event(ToolEvent::Finished {
+                        name: tool_call.name.clone(),
+                        ok: false,
+                        output: "rejected: not on allowlist".to_string(),
+                    });
+                    conv.messages
+                        .push(Message::tool_result(&tool_call.id, &rejection));
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

DA-6 (Tier-2 security): the subagent `tools` allowlist was **advertised** (declared in the `spawn_subagent` schema, stashed into the `TOOL_ALLOWLIST` task-local) but **never enforced** — `current_tool_allowlist()` was read by nobody in the dispatch path. A "restricted" subagent therefore received the full tool set, including `spawn_subagent` itself, with **no recursion depth limit**, so unbounded recursive spawning was possible.

## Fix

Enforcement now happens in two layers in `crates/core/src/service.rs`, plus a depth cap in `crates/application/src/subagent_tools.rs`:

1. **Advertisement filtering** — the per-round tool set is filtered by `current_tool_allowlist()` when `Some` (`None` = unrestricted; empty = no tools). The restricted subagent's LLM only ever sees its permitted tools. The core-loop step-planning tools (`begin_step`/`complete_step`) are exempt.
2. **Dispatch chokepoint** — in the per-tool-call loop, a call to a non-allowlisted name is rejected with a recoverable error folded into the `tool_result`; **no executor runs**. This catches a hallucinated or history-leaked name even if it bypassed advertisement.
3. **Recursion depth cap** — `spawn_subagent` walks the `Subagent` parent chain and rejects a spawn whose child would exceed `MAX_SUBAGENT_DEPTH` (**8**), *before any side effects* (no orphan child conversation).

## Tests (TDD — failing first, in their own commit)

Core dispatch (`crates/core/src/service.rs`):
- `dispatch_rejects_tool_not_on_allowlist`
- `dispatch_allows_tool_on_allowlist`
- `dispatch_empty_allowlist_rejects_every_tool`

Recursion depth (`crates/application/tests/spawn_subagent.rs`):
- `spawn_subagent_rejected_past_recursion_depth_limit`
- `spawn_subagent_allowed_within_recursion_depth_limit`

## Relationship to #133 / #134

- **#133** (dispatch-side `TOOL_ALLOWLIST` enforcement) overlaps this PR's dispatch+advertisement work. Left **open** — it specifies additional named tests (`allowlist_persists_across_tool_rounds_within_a_turn`, etc.) that aren't all covered here.
- **#134** (compose `SubagentTools` into the daemon's `McpToolExecutor`) is **untouched** — separate wiring concern.

## Verification

`cargo fmt`, `cargo clippy -p desktop-assistant-core -p desktop-assistant-application --all-targets -- -D warnings` clean; full `desktop-assistant-core` + `desktop-assistant-application` test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #291