### PR TITLE
DS-5: diff-and-write conversation update (no full rewrite per turn)

### DIFF
--- a/crates/storage/src/conversation.rs
+++ b/crates/storage/src/conversation.rs
@@ -366,18 +366,56 @@ impl ConversationStore for PgConversationStore {
             return Err(CoreError::ConversationNotFound(conv.id.0.clone()));
         }
 
-        // Replace all messages: delete existing, re-insert. Scoped by
-        // user_id as defense-in-depth — the UPDATE above already
-        // proved the conversation belongs to this user.
-        sqlx::query("DELETE FROM messages WHERE user_id = $1 AND conversation_id = $2")
+        // Structural diff-and-write (DS-5): load the existing rows in this
+        // same transaction (which already proved ownership) and write only
+        // what actually changed, keeping row ids stable per (conversation,
+        // ordinal) slot. The dominant cases — append-only turns and
+        // compaction stamping `summary_id` — touch no prior rows, so their
+        // tsvectors are not regenerated. Every statement stays scoped by
+        // user_id as defense-in-depth.
+        let existing: Vec<ExistingMsgRow> = sqlx::query_as(
+            "SELECT ordinal, role, content, tool_calls, tool_call_id, summary_id \
+             FROM messages \
+             WHERE user_id = $1 AND conversation_id = $2 \
+             ORDER BY ordinal",
+        )
+        .bind(user_id.as_str())
+        .bind(&conv.id.0)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        for (ordinal, msg) in conv.messages.iter().enumerate() {
+            match existing.get(ordinal) {
+                // Row at this slot is structurally identical — no write at
+                // all, so its id and tsvector are untouched.
+                Some(row) if row.matches(msg) => {}
+                // Row exists but differs (e.g. summary_id stamped, or
+                // content shifted up by a mid-history removal): UPDATE in
+                // place, preserving the row id.
+                Some(_) => {
+                    update_message(&mut tx, user_id.as_str(), &conv.id.0, ordinal, msg).await?;
+                }
+                // No row at this slot — a genuinely new (appended) message.
+                None => {
+                    insert_message(&mut tx, user_id.as_str(), &conv.id.0, ordinal, msg).await?;
+                }
+            }
+        }
+
+        // Tail truncation: drop any persisted rows past the new length in a
+        // single ranged DELETE.
+        if existing.len() > conv.messages.len() {
+            sqlx::query(
+                "DELETE FROM messages \
+                 WHERE user_id = $1 AND conversation_id = $2 AND ordinal >= $3",
+            )
             .bind(user_id.as_str())
             .bind(&conv.id.0)
+            .bind(conv.messages.len() as i32)
             .execute(&mut *tx)
             .await
             .map_err(|e| CoreError::Storage(e.to_string()))?;
-
-        for (ordinal, msg) in conv.messages.iter().enumerate() {
-            insert_message(&mut tx, user_id.as_str(), &conv.id.0, ordinal, msg).await?;
         }
 
         tx.commit()
@@ -512,6 +550,17 @@ impl ConversationStore for PgConversationStore {
     }
 }
 
+/// JSONB representation of a message's tool calls. Empty tool calls map to
+/// SQL `NULL` (the historical `insert_message` behavior), so the unchanged-row
+/// comparison in `ExistingMsgRow::matches` stays consistent.
+fn tool_calls_json(msg: &Message) -> Option<serde_json::Value> {
+    if msg.tool_calls.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_value(&msg.tool_calls).unwrap_or_default())
+    }
+}
+
 async fn insert_message(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     user_id: &str,
@@ -519,11 +568,7 @@ async fn insert_message(
     ordinal: usize,
     msg: &Message,
 ) -> Result<(), CoreError> {
-    let tool_calls_json = if msg.tool_calls.is_empty() {
-        None
-    } else {
-        Some(serde_json::to_value(&msg.tool_calls).unwrap_or_default())
-    };
+    let tool_calls_json = tool_calls_json(msg);
 
     sqlx::query(
         "INSERT INTO messages \
@@ -532,6 +577,40 @@ async fn insert_message(
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     )
     .bind(uuid::Uuid::now_v7().to_string())
+    .bind(user_id)
+    .bind(conversation_id)
+    .bind(ordinal as i32)
+    .bind(role_to_str(&msg.role))
+    .bind(&msg.content)
+    .bind(tool_calls_json)
+    .bind(&msg.tool_call_id)
+    .bind(&msg.summary_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+/// In-place UPDATE of the message occupying `(conversation_id, ordinal)`,
+/// preserving its row id (and so its primary-key identity). Only called when
+/// the slot's content differs from what's persisted, so the regenerated
+/// tsvector cost is paid only for genuinely changed rows.
+async fn update_message(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: &str,
+    conversation_id: &str,
+    ordinal: usize,
+    msg: &Message,
+) -> Result<(), CoreError> {
+    let tool_calls_json = tool_calls_json(msg);
+
+    sqlx::query(
+        "UPDATE messages \
+         SET role = $4, content = $5, tool_calls = $6, \
+             tool_call_id = $7, summary_id = $8 \
+         WHERE user_id = $1 AND conversation_id = $2 AND ordinal = $3",
+    )
     .bind(user_id)
     .bind(conversation_id)
     .bind(ordinal as i32)
@@ -608,4 +687,34 @@ struct MsgRow {
 struct SummaryRow {
     id: String,
     summary: String,
+}
+
+/// An existing persisted message row, loaded inside `update`'s transaction to
+/// drive the structural diff. Carries exactly the columns `insert_message`
+/// writes (minus the id, which is what we are preserving) so a row can be
+/// compared structurally against an in-memory `Message`.
+#[derive(sqlx::FromRow)]
+struct ExistingMsgRow {
+    #[allow(dead_code)]
+    ordinal: i32,
+    role: String,
+    content: String,
+    tool_calls: Option<serde_json::Value>,
+    tool_call_id: Option<String>,
+    summary_id: Option<String>,
+}
+
+impl ExistingMsgRow {
+    /// Whether this persisted row is structurally identical to `msg`, i.e. a
+    /// re-insert would produce the same data. `tool_calls` is compared as a
+    /// `serde_json::Value` so JSONB key-order normalization cannot cause a
+    /// false mismatch; empty tool calls are stored as SQL `NULL` on both sides
+    /// (see `tool_calls_json`).
+    fn matches(&self, msg: &Message) -> bool {
+        self.role == role_to_str(&msg.role)
+            && self.content == msg.content
+            && self.tool_call_id == msg.tool_call_id
+            && self.summary_id == msg.summary_id
+            && self.tool_calls == tool_calls_json(msg)
+    }
 }

--- a/crates/storage/tests/conversation_persistence.rs
+++ b/crates/storage/tests/conversation_persistence.rs
@@ -71,7 +71,9 @@ impl Fixture {
             .await
             .expect("connect per-test pool");
 
-        run_migrations(&pool).await.expect("run_migrations succeeds");
+        run_migrations(&pool)
+            .await
+            .expect("run_migrations succeeds");
 
         Some(Self {
             pool,
@@ -116,8 +118,13 @@ fn conversation_with_messages(id: &str, count: usize) -> Conversation {
     conv.created_at = "2026-01-01 00:00:00".to_string();
     conv.updated_at = "2026-01-01 00:00:00".to_string();
     for i in 0..count {
-        let role = if i % 2 == 0 { Role::User } else { Role::Assistant };
-        conv.messages.push(Message::new(role, format!("message {i}")));
+        let role = if i % 2 == 0 {
+            Role::User
+        } else {
+            Role::Assistant
+        };
+        conv.messages
+            .push(Message::new(role, format!("message {i}")));
     }
     conv
 }
@@ -125,13 +132,12 @@ fn conversation_with_messages(id: &str, count: usize) -> Conversation {
 /// Row ids in ordinal order, fetched directly so the assertion is on the
 /// actual persisted rows.
 async fn message_ids(pool: &PgPool, conversation_id: &str) -> Vec<String> {
-    let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT id FROM messages WHERE conversation_id = $1 ORDER BY ordinal",
-    )
-    .bind(conversation_id)
-    .fetch_all(pool)
-    .await
-    .expect("fetch message ids");
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT id FROM messages WHERE conversation_id = $1 ORDER BY ordinal")
+            .bind(conversation_id)
+            .fetch_all(pool)
+            .await
+            .expect("fetch message ids");
     rows.into_iter().map(|(id,)| id).collect()
 }
 
@@ -215,51 +221,54 @@ async fn noop_update_keeps_all_ids() {
 
 #[tokio::test]
 async fn summary_assignment_updates_rows_in_place() {
-    with_fixture("summary_assignment_updates_rows_in_place", |fx| async move {
-        let store = PgConversationStore::new(fx.pool.clone());
-        let mut conv = conversation_with_messages("conv-summary", 10);
+    with_fixture(
+        "summary_assignment_updates_rows_in_place",
+        |fx| async move {
+            let store = PgConversationStore::new(fx.pool.clone());
+            let mut conv = conversation_with_messages("conv-summary", 10);
 
-        with_user_id(UserId::new("u1"), async {
-            store.create(conv.clone()).await.expect("create");
-        })
-        .await;
-        let before = message_ids(&fx.pool, "conv-summary").await;
+            with_user_id(UserId::new("u1"), async {
+                store.create(conv.clone()).await.expect("create");
+            })
+            .await;
+            let before = message_ids(&fx.pool, "conv-summary").await;
 
-        // Simulate compaction assigning a summary id to the first 4 messages
-        // through the normal whole-conversation update path. (The summary row
-        // itself isn't needed for the messages-table assertion.)
-        for msg in conv.messages.iter_mut().take(4) {
-            msg.summary_id = Some("summary-1".to_string());
-        }
-        // messages.summary_id has an FK to message_summaries — create the row.
-        sqlx::query(
-            "INSERT INTO message_summaries \
+            // Simulate compaction assigning a summary id to the first 4 messages
+            // through the normal whole-conversation update path. (The summary row
+            // itself isn't needed for the messages-table assertion.)
+            for msg in conv.messages.iter_mut().take(4) {
+                msg.summary_id = Some("summary-1".to_string());
+            }
+            // messages.summary_id has an FK to message_summaries — create the row.
+            sqlx::query(
+                "INSERT INTO message_summaries \
                 (id, user_id, conversation_id, summary, start_ordinal, end_ordinal) \
              VALUES ('summary-1', 'u1', 'conv-summary', 's', 0, 3)",
-        )
-        .execute(&fx.pool)
-        .await
-        .expect("insert summary row");
+            )
+            .execute(&fx.pool)
+            .await
+            .expect("insert summary row");
 
-        with_user_id(UserId::new("u1"), async {
-            store.update(conv.clone()).await.expect("update");
-        })
-        .await;
+            with_user_id(UserId::new("u1"), async {
+                store.update(conv.clone()).await.expect("update");
+            })
+            .await;
 
-        let after = message_ids(&fx.pool, "conv-summary").await;
-        assert_eq!(before, after, "metadata-only change must keep all row ids");
+            let after = message_ids(&fx.pool, "conv-summary").await;
+            assert_eq!(before, after, "metadata-only change must keep all row ids");
 
-        let summary_col = summary_ids_column(&fx.pool, "conv-summary").await;
-        assert!(
-            summary_col[..4]
-                .iter()
-                .all(|s| s.as_deref() == Some("summary-1")),
-            "summary_id must be persisted on the first 4 rows: {summary_col:?}"
-        );
-        assert!(summary_col[4..].iter().all(|s| s.is_none()));
+            let summary_col = summary_ids_column(&fx.pool, "conv-summary").await;
+            assert!(
+                summary_col[..4]
+                    .iter()
+                    .all(|s| s.as_deref() == Some("summary-1")),
+                "summary_id must be persisted on the first 4 rows: {summary_col:?}"
+            );
+            assert!(summary_col[4..].iter().all(|s| s.is_none()));
 
-        fx
-    })
+            fx
+        },
+    )
     .await;
 }
 
@@ -337,9 +346,12 @@ async fn update_round_trips_tool_calls_and_tool_results() {
         |fx| async move {
             let store = PgConversationStore::new(fx.pool.clone());
             let mut conv = conversation_with_messages("conv-tools", 2);
-            conv.messages.push(Message::assistant_with_tool_calls(vec![
-                ToolCall::new("call-1", "read_file", r#"{"path":"/tmp/x"}"#),
-            ]));
+            conv.messages
+                .push(Message::assistant_with_tool_calls(vec![ToolCall::new(
+                    "call-1",
+                    "read_file",
+                    r#"{"path":"/tmp/x"}"#,
+                )]));
             conv.messages
                 .push(Message::tool_result("call-1", "file contents"));
 

--- a/crates/storage/tests/conversation_persistence.rs
+++ b/crates/storage/tests/conversation_persistence.rs
@@ -1,0 +1,412 @@
+//! Persistence-model tests for `ConversationStore::update` (review finding
+//! DS-5): updates must diff-and-write instead of delete-all + re-insert.
+//!
+//! The observable contract under test:
+//! - appending one message to an N-message conversation INSERTs exactly one
+//!   row (proven via row-id stability: regenerated rows would get fresh
+//!   `now_v7()` ids);
+//! - unchanged messages keep their row ids across updates;
+//! - metadata-only changes (summary_id) update rows in place;
+//! - truncation deletes only the removed tail;
+//! - user scoping is not weakened.
+//!
+//! ## Running locally
+//!
+//! Same harness as `user_id_scoping.rs`:
+//!
+//! ```sh
+//! podman run -d --name pg-test -e POSTGRES_PASSWORD=test -p 15432:5432 \
+//!     docker.io/pgvector/pgvector:pg17
+//! TEST_DATABASE_URL="postgres://postgres:test@localhost:15432/postgres" \
+//!     cargo test -p desktop-assistant-storage --test conversation_persistence
+//! ```
+//!
+//! When `TEST_DATABASE_URL` is unset every test pass-skips.
+
+use std::sync::Arc;
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::domain::{Conversation, ConversationId, Message, Role, ToolCall};
+use desktop_assistant_core::ports::store::ConversationStore;
+use desktop_assistant_storage::{PgConversationStore, UserId, run_migrations, with_user_id};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+/// RAII fixture: private schema, pool pinned to it, migrations applied.
+struct Fixture {
+    pool: PgPool,
+    schema: String,
+    admin_url: String,
+}
+
+impl Fixture {
+    async fn try_new() -> Option<Self> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let schema = format!("ds5_{}", Uuid::now_v7().simple());
+
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
+            .execute(&admin)
+            .await
+            .expect("create test schema");
+        admin.close().await;
+
+        let schema_for_hook = Arc::new(schema.clone());
+        let pool = PgPoolOptions::new()
+            .max_connections(8)
+            .after_connect(move |conn, _| {
+                let schema = Arc::clone(&schema_for_hook);
+                Box::pin(async move {
+                    let sql = format!("SET search_path TO \"{schema}\", public");
+                    sqlx::query(sqlx::AssertSqlSafe(sql)).execute(conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect per-test pool");
+
+        run_migrations(&pool).await.expect("run_migrations succeeds");
+
+        Some(Self {
+            pool,
+            schema,
+            admin_url: url,
+        })
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        if let Ok(admin) = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&self.admin_url)
+            .await
+        {
+            let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+                "DROP SCHEMA \"{}\" CASCADE",
+                self.schema
+            )))
+            .execute(&admin)
+            .await;
+            admin.close().await;
+        }
+    }
+}
+
+async fn with_fixture<F, Fut>(name: &str, body: F)
+where
+    F: FnOnce(Fixture) -> Fut,
+    Fut: std::future::Future<Output = Fixture>,
+{
+    let Some(fx) = Fixture::try_new().await else {
+        eprintln!("skip: TEST_DATABASE_URL not set; {name} pass-skipped");
+        return;
+    };
+    let fx = body(fx).await;
+    fx.cleanup().await;
+}
+
+fn conversation_with_messages(id: &str, count: usize) -> Conversation {
+    let mut conv = Conversation::new(id, "persistence test");
+    conv.created_at = "2026-01-01 00:00:00".to_string();
+    conv.updated_at = "2026-01-01 00:00:00".to_string();
+    for i in 0..count {
+        let role = if i % 2 == 0 { Role::User } else { Role::Assistant };
+        conv.messages.push(Message::new(role, format!("message {i}")));
+    }
+    conv
+}
+
+/// Row ids in ordinal order, fetched directly so the assertion is on the
+/// actual persisted rows.
+async fn message_ids(pool: &PgPool, conversation_id: &str) -> Vec<String> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT id FROM messages WHERE conversation_id = $1 ORDER BY ordinal",
+    )
+    .bind(conversation_id)
+    .fetch_all(pool)
+    .await
+    .expect("fetch message ids");
+    rows.into_iter().map(|(id,)| id).collect()
+}
+
+async fn summary_ids_column(pool: &PgPool, conversation_id: &str) -> Vec<Option<String>> {
+    let rows: Vec<(Option<String>,)> = sqlx::query_as(
+        "SELECT summary_id FROM messages WHERE conversation_id = $1 ORDER BY ordinal",
+    )
+    .bind(conversation_id)
+    .fetch_all(pool)
+    .await
+    .expect("fetch summary ids");
+    rows.into_iter().map(|(s,)| s).collect()
+}
+
+// --- DS-5 acceptance criteria -------------------------------------------------
+
+#[tokio::test]
+async fn append_one_message_inserts_exactly_one_row_and_keeps_ids() {
+    with_fixture(
+        "append_one_message_inserts_exactly_one_row_and_keeps_ids",
+        |fx| async move {
+            let store = PgConversationStore::new(fx.pool.clone());
+            let mut conv = conversation_with_messages("conv-append", 200);
+
+            with_user_id(UserId::new("u1"), async {
+                store.create(conv.clone()).await.expect("create");
+            })
+            .await;
+
+            let before = message_ids(&fx.pool, "conv-append").await;
+            assert_eq!(before.len(), 200);
+
+            conv.messages
+                .push(Message::new(Role::User, "the 201st message"));
+            with_user_id(UserId::new("u1"), async {
+                store.update(conv.clone()).await.expect("update");
+            })
+            .await;
+
+            let after = message_ids(&fx.pool, "conv-append").await;
+            assert_eq!(after.len(), 201, "exactly one row added");
+            assert_eq!(
+                &after[..200],
+                &before[..],
+                "the 200 pre-existing rows must keep their ids (no delete-all rewrite)"
+            );
+            assert!(
+                !before.contains(&after[200]),
+                "the appended row must be a new id"
+            );
+
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn noop_update_keeps_all_ids() {
+    with_fixture("noop_update_keeps_all_ids", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+        let conv = conversation_with_messages("conv-noop", 20);
+
+        with_user_id(UserId::new("u1"), async {
+            store.create(conv.clone()).await.expect("create");
+        })
+        .await;
+        let before = message_ids(&fx.pool, "conv-noop").await;
+
+        with_user_id(UserId::new("u1"), async {
+            store.update(conv.clone()).await.expect("update");
+        })
+        .await;
+        let after = message_ids(&fx.pool, "conv-noop").await;
+
+        assert_eq!(before, after, "no-op update must not rewrite any row");
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn summary_assignment_updates_rows_in_place() {
+    with_fixture("summary_assignment_updates_rows_in_place", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+        let mut conv = conversation_with_messages("conv-summary", 10);
+
+        with_user_id(UserId::new("u1"), async {
+            store.create(conv.clone()).await.expect("create");
+        })
+        .await;
+        let before = message_ids(&fx.pool, "conv-summary").await;
+
+        // Simulate compaction assigning a summary id to the first 4 messages
+        // through the normal whole-conversation update path. (The summary row
+        // itself isn't needed for the messages-table assertion.)
+        for msg in conv.messages.iter_mut().take(4) {
+            msg.summary_id = Some("summary-1".to_string());
+        }
+        // messages.summary_id has an FK to message_summaries — create the row.
+        sqlx::query(
+            "INSERT INTO message_summaries \
+                (id, user_id, conversation_id, summary, start_ordinal, end_ordinal) \
+             VALUES ('summary-1', 'u1', 'conv-summary', 's', 0, 3)",
+        )
+        .execute(&fx.pool)
+        .await
+        .expect("insert summary row");
+
+        with_user_id(UserId::new("u1"), async {
+            store.update(conv.clone()).await.expect("update");
+        })
+        .await;
+
+        let after = message_ids(&fx.pool, "conv-summary").await;
+        assert_eq!(before, after, "metadata-only change must keep all row ids");
+
+        let summary_col = summary_ids_column(&fx.pool, "conv-summary").await;
+        assert!(
+            summary_col[..4]
+                .iter()
+                .all(|s| s.as_deref() == Some("summary-1")),
+            "summary_id must be persisted on the first 4 rows: {summary_col:?}"
+        );
+        assert!(summary_col[4..].iter().all(|s| s.is_none()));
+
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn tail_truncation_deletes_only_the_tail() {
+    with_fixture("tail_truncation_deletes_only_the_tail", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+        let mut conv = conversation_with_messages("conv-trunc", 10);
+
+        with_user_id(UserId::new("u1"), async {
+            store.create(conv.clone()).await.expect("create");
+        })
+        .await;
+        let before = message_ids(&fx.pool, "conv-trunc").await;
+
+        conv.messages.truncate(6);
+        with_user_id(UserId::new("u1"), async {
+            store.update(conv.clone()).await.expect("update");
+        })
+        .await;
+
+        let after = message_ids(&fx.pool, "conv-trunc").await;
+        assert_eq!(after.len(), 6);
+        assert_eq!(after[..], before[..6], "surviving rows keep their ids");
+
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn mid_history_removal_round_trips() {
+    with_fixture("mid_history_removal_round_trips", |fx| async move {
+        let store = PgConversationStore::new(fx.pool.clone());
+        let mut conv = conversation_with_messages("conv-mid", 8);
+
+        with_user_id(UserId::new("u1"), async {
+            store.create(conv.clone()).await.expect("create");
+        })
+        .await;
+        let before = message_ids(&fx.pool, "conv-mid").await;
+
+        // Remove a message from the middle (compaction's trim_tool_pairs shape).
+        conv.messages.remove(3);
+        with_user_id(UserId::new("u1"), async {
+            store.update(conv.clone()).await.expect("update");
+        })
+        .await;
+
+        let after = message_ids(&fx.pool, "conv-mid").await;
+        assert_eq!(after.len(), 7);
+        assert_eq!(after[..3], before[..3], "prefix rows keep their ids");
+
+        // Read-back must equal the in-memory conversation.
+        let loaded = with_user_id(UserId::new("u1"), async {
+            store.get(&ConversationId::from("conv-mid")).await
+        })
+        .await
+        .expect("get");
+        assert_eq!(loaded.messages.len(), 7);
+        for (i, (got, want)) in loaded.messages.iter().zip(&conv.messages).enumerate() {
+            assert_eq!(got.content, want.content, "content mismatch at index {i}");
+            assert_eq!(got.role, want.role, "role mismatch at index {i}");
+        }
+
+        fx
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_round_trips_tool_calls_and_tool_results() {
+    with_fixture(
+        "update_round_trips_tool_calls_and_tool_results",
+        |fx| async move {
+            let store = PgConversationStore::new(fx.pool.clone());
+            let mut conv = conversation_with_messages("conv-tools", 2);
+            conv.messages.push(Message::assistant_with_tool_calls(vec![
+                ToolCall::new("call-1", "read_file", r#"{"path":"/tmp/x"}"#),
+            ]));
+            conv.messages
+                .push(Message::tool_result("call-1", "file contents"));
+
+            with_user_id(UserId::new("u1"), async {
+                store.create(conv.clone()).await.expect("create");
+            })
+            .await;
+            let before = message_ids(&fx.pool, "conv-tools").await;
+
+            conv.messages
+                .push(Message::new(Role::Assistant, "done reading"));
+            with_user_id(UserId::new("u1"), async {
+                store.update(conv.clone()).await.expect("update");
+            })
+            .await;
+
+            let after = message_ids(&fx.pool, "conv-tools").await;
+            assert_eq!(after.len(), 5);
+            assert_eq!(after[..4], before[..], "existing rows keep their ids");
+
+            let loaded = with_user_id(UserId::new("u1"), async {
+                store.get(&ConversationId::from("conv-tools")).await
+            })
+            .await
+            .expect("get");
+            assert_eq!(loaded.messages.len(), 5);
+            assert_eq!(loaded.messages[2].tool_calls.len(), 1);
+            assert_eq!(loaded.messages[2].tool_calls[0].id, "call-1");
+            assert_eq!(loaded.messages[2].tool_calls[0].name, "read_file");
+            assert_eq!(loaded.messages[3].tool_call_id.as_deref(), Some("call-1"));
+            assert_eq!(loaded.messages[3].content, "file contents");
+
+            fx
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn cross_user_update_is_not_found_and_writes_nothing() {
+    with_fixture(
+        "cross_user_update_is_not_found_and_writes_nothing",
+        |fx| async move {
+            let store = PgConversationStore::new(fx.pool.clone());
+            let mut conv = conversation_with_messages("conv-owned", 3);
+
+            with_user_id(UserId::new("alice"), async {
+                store.create(conv.clone()).await.expect("create");
+            })
+            .await;
+            let before = message_ids(&fx.pool, "conv-owned").await;
+
+            conv.messages.push(Message::new(Role::User, "bob was here"));
+            let result = with_user_id(UserId::new("bob"), async {
+                store.update(conv.clone()).await
+            })
+            .await;
+            assert!(
+                matches!(result, Err(CoreError::ConversationNotFound(_))),
+                "cross-user update must be NotFound, got {result:?}"
+            );
+
+            let after = message_ids(&fx.pool, "conv-owned").await;
+            assert_eq!(before, after, "bob's update must not touch alice's rows");
+
+            fx
+        },
+    )
+    .await;
+}


### PR DESCRIPTION
## What

`PgConversationStore::update` previously delete-all'd and re-inserted **every** message with a fresh `now_v7()` id on **every** turn (O(n) writes + full FTS tsvector reindex per turn → O(n²) per session). This replaces that with an in-transaction **structural diff** that writes only what changed, with **slot-stable message ids**.

Implements the approved Tier-3 design in #294.

## How

Inside the same transaction that proves user ownership (the conversations UPDATE), `update` loads the existing message rows `(ordinal, role, content, tool_calls, tool_call_id, summary_id)` ordered by ordinal and walks `conv.messages`, diffing per `(conversation, ordinal)` slot:

- **unchanged** (`ExistingMsgRow::matches`: role/content/tool_call_id/summary_id direct, `tool_calls` compared as `serde_json::Value` so JSONB key-order can't false-mismatch; empty tool_calls ≡ NULL) → **no write** (id + tsvector untouched);
- **changed** → in-place `UPDATE ... WHERE ordinal = i`, preserving the row id;
- **new slot** → `INSERT` with a fresh `now_v7()` id (genuinely appended);
- **tail past len** → one ranged `DELETE ... WHERE ordinal >= len`.

tsvector regeneration now happens only for rows actually inserted/updated. Every statement remains `user_id`-scoped (defense-in-depth); a cross-user update still returns `ConversationNotFound` with zero writes. The final state is a gapless `0..len` ordinal sequence — identical to what delete-all+reinsert produced — so the loader and all window arithmetic see identical data.

### Id stability
Stable **per (conversation, ordinal) slot**. Append-only turns and compaction stamping `summary_id` on prefix messages preserve every pre-existing id; a mid-history removal shifts content across slots, so those slots are UPDATEd in place (ids stay with slots, not content). Strictly stronger than the status-quo fresh-ids-every-turn; nothing keys long-lived references on these ids today.

### No migration
Schema unchanged; the `(user_id, conversation_id, ordinal)` access path already exists.

### Concurrency
Assumes DA-1 (#282) per-conversation serialization above the store, so the read-then-diff is race-free.

## Tests

Adopted the 7 failing-first tests from the pre-existing `fix/ds-5-conversation-append` branch (committed red first, against the old delete-all impl), now green:

- `append_one_message_inserts_exactly_one_row_and_keeps_ids` (200 → 201, prior 200 ids unchanged)
- `noop_update_keeps_all_ids`
- `summary_assignment_updates_rows_in_place`
- `tail_truncation_deletes_only_the_tail`
- `mid_history_removal_round_trips`
- `update_round_trips_tool_calls_and_tool_results`
- `cross_user_update_is_not_found_and_writes_nothing`

Full `desktop-assistant-storage` suite green against pgvector:pg17 (run `--test-threads=1` to avoid the known shared-DB parallel-migration race in the harness). `cargo fmt` + `cargo clippy --all-targets -D warnings` clean.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)