### PR TITLE
fix(core): repair main — test mocks vs new ConversationStore::list signature

### DIFF
--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -5460,8 +5460,14 @@ mod concurrency_tests {
                 .ok_or_else(|| CoreError::ConversationNotFound(id.0.clone()))
         }
 
-        async fn list(&self) -> Result<Vec<Conversation>, CoreError> {
-            Ok(self.data.lock().unwrap().values().cloned().collect())
+        async fn list(&self) -> Result<Vec<ConversationSummary>, CoreError> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .values()
+                .map(ConversationSummary::from)
+                .collect())
         }
 
         async fn update(&self, conv: Conversation) -> Result<(), CoreError> {
@@ -5599,7 +5605,7 @@ mod concurrency_tests {
         async fn get(&self, id: &ConversationId) -> Result<Conversation, CoreError> {
             self.inner.get(id).await
         }
-        async fn list(&self) -> Result<Vec<Conversation>, CoreError> {
+        async fn list(&self) -> Result<Vec<ConversationSummary>, CoreError> {
             self.inner.list().await
         }
         async fn update(&self, conv: Conversation) -> Result<(), CoreError> {


### PR DESCRIPTION
**Build-fix for `main`.** A logical merge conflict from the 2026-06-09 review batch: DS-6 (#321) changed `ConversationStore::list` → `Vec<ConversationSummary>`; DA-1 (#325) and DA-6 (#324) each landed a test mock in `crates/core/src/service.rs` still returning `Vec<Conversation>`. Each PR was green against its own base, but combined on `main` the core lib-test target failed to compile (E0271 ×2).

Fix maps both mocks to the projection via the existing `From<&Conversation> for ConversationSummary`.

- `cargo check --workspace --tests` clean
- `cargo clippy -p desktop-assistant-core --all-targets -- -D warnings` clean
- `cargo test -p desktop-assistant-core --lib` → 372 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)