### PR TITLE
refactor(client-common): adopt shared length-prefixed frame codec (#280)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "desktop-assistant-application",
  "desktop-assistant-auth-jwt",
  "desktop-assistant-core",
+ "desktop-assistant-frame-codec",
  "desktop-assistant-uds",
  "futures",
  "reqwest",
@@ -1384,6 +1385,13 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "zbus",
+]
+
+[[package]]
+name = "desktop-assistant-frame-codec"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/api-model",
     "crates/application",
+    "crates/frame-codec",
     "crates/auth-jwt",
     "crates/ws-interface",
     "crates/core",
@@ -47,6 +48,7 @@ desktop-assistant-storage = { path = "crates/storage" }
 desktop-assistant-client-common = { path = "crates/client-common" }
 desktop-assistant-transport-dispatch = { path = "crates/transport-dispatch" }
 desktop-assistant-uds = { path = "crates/uds-interface" }
+desktop-assistant-frame-codec = { path = "crates/frame-codec" }
 serde_json = "1"
 toml = "1"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }

--- a/crates/client-common/Cargo.toml
+++ b/crates/client-common/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap = { version = "4", features = ["derive"], optional = true }
 desktop-assistant-api-model = { path = "../api-model" }
+desktop-assistant-frame-codec = { workspace = true }
 futures = "0.3"
 reqwest = { version = "0.13", features = ["json"] }
 serde_json.workspace = true

--- a/crates/client-common/src/uds_client.rs
+++ b/crates/client-common/src/uds_client.rs
@@ -7,11 +7,11 @@
 //! request/response multiplexing and shares every typed command via
 //! [`AssistantCommands`]; only the connect step and the framing differ.
 //!
-//! The framing functions below are a deliberate re-implementation of the
-//! server's `read_frame`/`write_frame` (identical wire format — see
-//! `crates/uds-interface/src/lib.rs`). Depending on that crate would drag the
-//! entire daemon stack into every client binary, so the ~20 lines are
-//! duplicated on purpose.
+//! The framing is shared with the server via the dependency-light
+//! [`desktop_assistant_frame_codec`] crate (`read_frame`/`write_frame`), so the
+//! frame cap and framing rules can never drift between client and server.
+//! That crate carries only the `tokio` async I/O traits, so it doesn't drag
+//! the daemon stack into client binaries.
 //!
 //! ## Reconnect (#246)
 //!
@@ -25,7 +25,6 @@
 //! the event stream.
 
 use std::collections::HashMap;
-use std::io;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,7 +33,7 @@ use anyhow::{Result, anyhow};
 use api::{WsFrame, WsRequest};
 use async_trait::async_trait;
 use desktop_assistant_api_model as api;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use desktop_assistant_frame_codec::{read_frame, write_frame};
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, mpsc, oneshot};
 
@@ -42,10 +41,6 @@ use crate::commands::{AssistantCommands, PendingResult};
 use crate::signal::SignalEvent;
 use crate::timeouts::DISPATCH_TIMEOUT;
 use crate::ws_client::map_event_to_signal;
-
-/// 4 MB cap, matching the server. Keeps a buggy/hostile peer from claiming a
-/// multi-GB frame length and forcing an allocation blow-up.
-const MAX_FRAME_LEN: u32 = 4 * 1024 * 1024;
 
 /// In-flight requests plus a terminal "closed" marker, behind a single mutex.
 ///
@@ -332,38 +327,4 @@ impl AssistantCommands for UdsClient {
             }
         }
     }
-}
-
-/// Read one length-prefixed frame: a 4-byte little-endian `u32` length followed
-/// by that many body bytes. A 0-length frame signals a clean close.
-async fn read_frame<R>(read_half: &mut R) -> io::Result<Vec<u8>>
-where
-    R: AsyncReadExt + Unpin,
-{
-    let mut len_buf = [0u8; 4];
-    read_half.read_exact(&mut len_buf).await?;
-    let len = u32::from_le_bytes(len_buf);
-    if len > MAX_FRAME_LEN {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("frame length {len} exceeds cap {MAX_FRAME_LEN}"),
-        ));
-    }
-    let mut body = vec![0u8; len as usize];
-    if len > 0 {
-        read_half.read_exact(&mut body).await?;
-    }
-    Ok(body)
-}
-
-/// Write one length-prefixed frame.
-async fn write_frame<W>(write_half: &mut W, body: &[u8]) -> io::Result<()>
-where
-    W: AsyncWriteExt + Unpin,
-{
-    let len = body.len() as u32;
-    write_half.write_all(&len.to_le_bytes()).await?;
-    write_half.write_all(body).await?;
-    write_half.flush().await?;
-    Ok(())
 }

--- a/crates/frame-codec/Cargo.toml
+++ b/crates/frame-codec/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "desktop-assistant-frame-codec"
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-or-later"
+
+[dependencies]
+tokio.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "io-util"] }

--- a/crates/frame-codec/src/lib.rs
+++ b/crates/frame-codec/src/lib.rs
@@ -1,0 +1,129 @@
+//! Length-prefixed frame codec shared by every local transport.
+//!
+//! The wire format is a 4-byte little-endian `u32` length followed by that
+//! many body bytes. A 0-length frame carries an empty body (used as a clean
+//! close marker by some peers). The header is read with `read_exact`, the
+//! body is then allocated and read with `read_exact`.
+//!
+//! The [`MAX_FRAME_LEN`] cap keeps a buggy or hostile peer from claiming a
+//! multi-GB length and forcing an allocation blow-up.
+//!
+//! This crate is intentionally tiny and dependency-light (only `tokio` for
+//! the async read/write traits) so both the server transports
+//! (`uds-interface`, `dbus-bridge`) and the client transports
+//! (`client-common`) can share one definition. Before this crate, the codec
+//! was copy-pasted verbatim into all three, so the frame cap and framing
+//! rules could silently drift between client and server.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Maximum accepted frame body size (4 MB).
+///
+/// Reads that announce a larger length are rejected with
+/// [`std::io::ErrorKind::InvalidData`] before any allocation happens.
+pub const MAX_FRAME_LEN: u32 = 4 * 1024 * 1024;
+
+/// Read one length-prefixed frame.
+///
+/// The header is a 4-byte little-endian `u32` length. We `read_exact` the
+/// header, validate it against [`MAX_FRAME_LEN`], allocate the body, then
+/// `read_exact` the body. A 0-length frame yields an empty `Vec`.
+pub async fn read_frame<R>(reader: &mut R) -> std::io::Result<Vec<u8>>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf);
+    if len > MAX_FRAME_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame length {len} exceeds cap {MAX_FRAME_LEN}"),
+        ));
+    }
+    let mut body = vec![0u8; len as usize];
+    if len > 0 {
+        reader.read_exact(&mut body).await?;
+    }
+    Ok(body)
+}
+
+/// Write one length-prefixed frame and flush.
+pub async fn write_frame<W>(writer: &mut W, body: &[u8]) -> std::io::Result<()>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let len = body.len() as u32;
+    writer.write_all(&len.to_le_bytes()).await?;
+    writer.write_all(body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn round_trips_a_frame() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, b"hello world").await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let body = read_frame(&mut cursor).await.unwrap();
+        assert_eq!(body, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn round_trips_an_empty_frame() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, b"").await.unwrap();
+        // 4-byte header, zero body.
+        assert_eq!(buf, vec![0, 0, 0, 0]);
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let body = read_frame(&mut cursor).await.unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn round_trips_back_to_back_frames() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, b"one").await.unwrap();
+        write_frame(&mut buf, b"two").await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), b"one");
+        assert_eq!(read_frame(&mut cursor).await.unwrap(), b"two");
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_length_without_allocating() {
+        // Header claims MAX_FRAME_LEN + 1, no body follows.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(MAX_FRAME_LEN + 1).to_le_bytes());
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let err = read_frame(&mut cursor).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn accepts_exactly_max_len_header() {
+        // A header of exactly MAX_FRAME_LEN must not be rejected by the cap
+        // check; it fails on the truncated body instead (UnexpectedEof).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&MAX_FRAME_LEN.to_le_bytes());
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let err = read_frame(&mut cursor).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn truncated_header_is_eof() {
+        let mut cursor = std::io::Cursor::new(vec![0u8, 0u8]);
+        let err = read_frame(&mut cursor).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+}


### PR DESCRIPTION
## Summary
`client-common` carried a **third verbatim copy** of the length-prefixed frame codec, alongside `uds-interface` and `dbus-bridge/src/transport.rs`. One drifting copy means one transport with a different frame cap.

This PR extracts the codec into a new dependency-light crate **`desktop-assistant-frame-codec`** (`crates/frame-codec`) — it carries only the `tokio` async I/O traits, so it does **not** drag the daemon stack into client binaries (the original reason client-common kept its own copy). `client-common`'s UDS transport now uses the shared `read_frame`/`write_frame` + `MAX_FRAME_LEN`.

The frame cap and framing rules can now never drift between client and server.

## Behavior
Unchanged: same 4-byte little-endian `u32` header, same 4 MB cap, same 0-length-frame handling. Pure dedup.

## Relationship to #279
The shared crate created here is also the server-side dedup target for the transports batch (**#279**), which is based on this branch and points `uds-interface` + `dbus-bridge` at the same crate.

## Tests
- New `frame-codec` unit tests: round-trip, empty frame, back-to-back frames, oversized-length rejection (no allocation), exactly-`MAX_FRAME_LEN` header, truncated header.
- `client-common` lib + `uds_client_tools` tests green. (The `uds_real_turn` reconnect tests fail only against a live local daemon — known main-is-red GOTCHA #313, unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #280