### PR TITLE
Refactor: shared curated-model + live-endpoint merge resolver (#304)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "desktop-assistant-core",
+ "desktop-assistant-llm-http",
  "eventsource-stream",
  "httpmock",
  "reqwest",

--- a/crates/llm-anthropic/Cargo.toml
+++ b/crates/llm-anthropic/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 async-trait.workspace = true
 desktop-assistant-core.workspace = true
+desktop-assistant-llm-http.workspace = true
 eventsource-stream = "0.2"
 reqwest = { version = "0.13", features = ["stream", "json"] }
 serde.workspace = true

--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -678,10 +678,15 @@ impl AnthropicClient {
 /// Anthropic does offer a `GET /v1/models` endpoint, but it returns raw
 /// model IDs without capability metadata (context window, vision/tool
 /// support, reasoning) so the picker still needs a curated source of
-/// truth. Keeping the list hand-maintained here is intentional until we
-/// add a hybrid resolver that merges the API response with this table.
-// TODO(#7): hit `/v1/models` and merge with this curated table so newly
-// released models appear automatically.
+/// truth. Keeping the list hand-maintained here is intentional.
+///
+/// `list_models` routes this table through the shared
+/// [`merge_curated_with_live`](desktop_assistant_llm_http::merge_curated_with_live)
+/// resolver (issue #304). Today it passes an empty live list, so the curated
+/// table is returned unchanged; when we start fetching `GET /v1/models` the
+/// live ids slot in as the resolver's `live` argument — curated metadata wins
+/// on overlap, unknown live ids are appended — with no merge policy to
+/// re-derive here.
 fn curated_anthropic_models() -> Vec<ModelInfo> {
     let claude_caps = ModelCapabilities {
         reasoning: false,
@@ -753,7 +758,13 @@ impl LlmClient for AnthropicClient {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
-        Ok(curated_anthropic_models())
+        // No live `/v1/models` fetch yet; the empty live list returns the
+        // curated table unchanged. Routing through the shared resolver keeps
+        // the merge policy in one place for when a live fetch lands (#304).
+        Ok(desktop_assistant_llm_http::merge_curated_with_live(
+            curated_anthropic_models(),
+            Vec::new(),
+        ))
     }
 
     async fn stream_completion(
@@ -1508,6 +1519,15 @@ mod tests {
             !json.contains("thinking"),
             "thinking field must be omitted when reasoning is off; got: {json}"
         );
+    }
+
+    /// The shared-resolver path with an empty live list must return exactly
+    /// the curated table — proves the #304 refactor is behavior-preserving.
+    #[tokio::test]
+    async fn list_models_matches_curated_table_via_resolver() {
+        let client = AnthropicClient::new("key".into());
+        let models = client.list_models().await.unwrap();
+        assert_eq!(models, curated_anthropic_models());
     }
 
     #[tokio::test]

--- a/crates/llm-http/src/lib.rs
+++ b/crates/llm-http/src/lib.rs
@@ -12,6 +12,10 @@
 //! (`ContextOverflow`, `RateLimited`, `QuotaExceeded`, `ModelLoading`,
 //! `ToolsUnsupported`) and aren't worth shoehorning into one helper.
 
+mod models;
+
+pub use models::merge_curated_with_live;
+
 use desktop_assistant_core::CoreError;
 use reqwest::Response;
 

--- a/crates/llm-http/src/models.rs
+++ b/crates/llm-http/src/models.rs
@@ -1,0 +1,139 @@
+//! Shared curated-model / live-endpoint merge resolver.
+//!
+//! Issue #304. Before this, the connectors with a hand-maintained curated
+//! model table (`llm-anthropic`, `llm-openai`) each carried the same
+//! `TODO(#7)` about merging the static curated list with the provider's live
+//! `/v1/models` endpoint, and would have hand-rolled the merge independently —
+//! letting the "curated wins, unknown live appended" policy drift per provider.
+//!
+//! [`merge_curated_with_live`] is the single place that policy lives:
+//!
+//! * the curated entries are emitted first, in their original order, and their
+//!   metadata (display name, context window, capability flags) wins on any id
+//!   overlap with the live list — the live `/v1/models` response typically
+//!   carries only bare ids with no capability metadata, so the curated table
+//!   remains the source of truth for models we know about;
+//! * live models whose id is not in the curated table are appended afterwards,
+//!   in the order the endpoint returned them, so freshly released models still
+//!   surface in the picker without a code change.
+//!
+//! Connectors that fetch a live list pass it in; connectors that don't yet hit
+//! their list endpoint pass an empty `live` slice and get their curated table
+//! back unchanged, ready to grow a live fetch later without re-deriving the
+//! merge policy.
+
+use desktop_assistant_core::ports::llm::ModelInfo;
+
+/// Merge a curated model table with a live endpoint listing.
+///
+/// Curated entries come first (preserving their order) and win on any id
+/// overlap; live entries with an id not already present are appended in the
+/// order given. The result is duplicate-free by id.
+///
+/// Passing an empty `live` returns `curated` unchanged; passing an empty
+/// `curated` returns `live` de-duplicated by id (first occurrence wins).
+pub fn merge_curated_with_live(curated: Vec<ModelInfo>, live: Vec<ModelInfo>) -> Vec<ModelInfo> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut merged: Vec<ModelInfo> = Vec::with_capacity(curated.len() + live.len());
+
+    for model in curated.into_iter().chain(live) {
+        if seen.insert(model.id.clone()) {
+            merged.push(model);
+        }
+    }
+
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_core::ports::llm::{ModelCapabilities, ModelInfo};
+
+    fn model(id: &str, ctx: u64, reasoning: bool) -> ModelInfo {
+        ModelInfo::new(id)
+            .with_display_name(format!("display:{id}"))
+            .with_context_limit(ctx)
+            .with_capabilities(ModelCapabilities {
+                reasoning,
+                vision: true,
+                tools: true,
+                embedding: false,
+            })
+    }
+
+    /// Bare live entry: just an id, no metadata — mirrors what a provider's
+    /// `/v1/models` endpoint returns.
+    fn bare(id: &str) -> ModelInfo {
+        ModelInfo::new(id)
+    }
+
+    #[test]
+    fn empty_live_returns_curated_unchanged() {
+        let curated = vec![model("a", 100, true), model("b", 200, false)];
+        let merged = merge_curated_with_live(curated.clone(), vec![]);
+        assert_eq!(merged, curated);
+    }
+
+    #[test]
+    fn empty_curated_returns_live_deduped() {
+        let live = vec![bare("x"), bare("y"), bare("x")];
+        let merged = merge_curated_with_live(vec![], live);
+        let ids: Vec<&str> = merged.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["x", "y"]);
+    }
+
+    #[test]
+    fn curated_metadata_wins_on_overlap() {
+        // Curated "a" has rich metadata; the live endpoint reports the same id
+        // with nothing useful. The merged "a" must keep the curated metadata.
+        let curated = vec![model("a", 400_000, true)];
+        let live = vec![bare("a")];
+        let merged = merge_curated_with_live(curated, live);
+        assert_eq!(merged.len(), 1, "id overlap must not duplicate");
+        assert_eq!(merged[0].context_limit, Some(400_000));
+        assert!(merged[0].capabilities.reasoning);
+        assert_eq!(merged[0].display_name, "display:a");
+    }
+
+    #[test]
+    fn unknown_live_models_appended_after_curated() {
+        let curated = vec![model("a", 100, false), model("b", 200, false)];
+        let live = vec![bare("a"), bare("z"), bare("c")];
+        let merged = merge_curated_with_live(curated, live);
+        let ids: Vec<&str> = merged.iter().map(|m| m.id.as_str()).collect();
+        // Curated order first (a, b), then the unknown live ids in endpoint
+        // order (z, c). The overlapping "a" stays in its curated slot.
+        assert_eq!(ids, ["a", "b", "z", "c"]);
+    }
+
+    #[test]
+    fn ordering_is_stable_curated_then_live() {
+        let curated = vec![model("m1", 1, false), model("m2", 2, false)];
+        let live = vec![bare("m3"), bare("m4")];
+        let merged = merge_curated_with_live(curated, live);
+        let ids: Vec<&str> = merged.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["m1", "m2", "m3", "m4"]);
+    }
+
+    #[test]
+    fn duplicate_live_ids_keep_first_occurrence() {
+        let live = vec![
+            model("dup", 10, true),
+            model("dup", 20, false),
+            bare("other"),
+        ];
+        let merged = merge_curated_with_live(vec![], live);
+        let ids: Vec<&str> = merged.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["dup", "other"]);
+        // First occurrence's metadata is the one retained.
+        assert_eq!(merged[0].context_limit, Some(10));
+        assert!(merged[0].capabilities.reasoning);
+    }
+
+    #[test]
+    fn both_empty_returns_empty() {
+        let merged = merge_curated_with_live(vec![], vec![]);
+        assert!(merged.is_empty());
+    }
+}

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -815,15 +815,19 @@ fn parse_openai_context_length_message(message: &str) -> (Option<u64>, Option<u6
 /// Curated list of OpenAI models exposed through this connector.
 ///
 /// OpenAI's `/v1/models` endpoint returns a firehose of model IDs
-/// (including retired and fine-tune variants) with no capability metadata.
-/// Until we ship a resolver that merges the live list with this curated
-/// table, we hand-maintain the set that the model picker should offer.
+/// (including retired and fine-tune variants) with no capability metadata,
+/// so this hand-maintained table is the set the model picker should offer.
+///
+/// `list_models` routes this table through the shared
+/// [`merge_curated_with_live`](desktop_assistant_llm_http::merge_curated_with_live)
+/// resolver (issue #304). Today it passes an empty live list, so the curated
+/// table is returned unchanged; when we start fetching `/v1/models` the live
+/// ids slot in as the resolver's `live` argument — curated metadata wins on
+/// overlap, unknown live ids are appended.
 ///
 /// To extend: append a `ModelInfo` entry here with the right
 /// `ModelCapabilities` flags. `reasoning: true` belongs on the o-series
 /// (o1, o3, o4) and any GPT-5 variant that exposes reasoning traces.
-// TODO(#7): fetch `/v1/models` and merge with this table so newly
-// released models surface automatically.
 /// True when `model` is one of the curated OpenAI models flagged as
 /// reasoning-capable. Used to gate the `reasoning.effort` field on
 /// requests — sending it for non-reasoning models (e.g. `gpt-4o`) is a
@@ -952,7 +956,13 @@ impl LlmClient for OpenAiClient {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
-        Ok(curated_openai_models())
+        // No live `/v1/models` fetch yet; the empty live list returns the
+        // curated table unchanged. Routing through the shared resolver keeps
+        // the merge policy in one place for when a live fetch lands (#304).
+        Ok(desktop_assistant_llm_http::merge_curated_with_live(
+            curated_openai_models(),
+            Vec::new(),
+        ))
     }
 
     async fn stream_completion(
@@ -1513,6 +1523,15 @@ mod tests {
         unsafe { std::env::remove_var("OPENAI_API_KEY") };
         let result = OpenAiClient::from_env();
         assert!(matches!(result, Err(CoreError::Llm(_))));
+    }
+
+    /// The shared-resolver path with an empty live list must return exactly
+    /// the curated table — proves the #304 refactor is behavior-preserving.
+    #[tokio::test]
+    async fn list_models_matches_curated_table_via_resolver() {
+        let client = OpenAiClient::new("key".into());
+        let models = client.list_models().await.unwrap();
+        assert_eq!(models, curated_openai_models());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Extracts the curated-model merge policy that the curated-table connectors (`llm-anthropic`, `llm-openai`) each carried a `TODO(#7)` to hand-roll, into a single shared resolver in `llm-http`.

- **New:** `desktop_assistant_llm_http::merge_curated_with_live(curated, live) -> Vec<ModelInfo>` (in `crates/llm-http/src/models.rs`). Curated entries come first preserving order and win on any id overlap; live ids not already present are appended in endpoint order; result is duplicate-free by id. Empty `live` returns `curated` unchanged.
- **Adopted in** `llm-anthropic` and `llm-openai`: `list_models()` now returns its curated table via the resolver with an empty live list. Output is byte-identical (asserted by new `list_models_matches_curated_table_via_resolver` tests). The duplicated `TODO(#7)` is retired; a future live `/v1/models` fetch just passes its result as the `live` argument.

## Behavior-preserving

Tier-4 refactor. The pre-existing `list_models_returns_curated_*` tests still pass unchanged, and each provider gains an equality test proving the resolver path equals the raw curated table.

## Scope note

Bedrock and Ollama are **not** routed through the resolver: neither has a curated table, and Bedrock's existing live-source merge (foundation + inference profiles) sorts-then-dedupes by id, so reusing the insertion-order resolver would change its ordering — out of scope for a behavior-preserving change.

## Tests

`cargo test` green for `llm-http` (9, incl. 7 new resolver tests), `llm-anthropic`, `llm-openai`. `cargo clippy --all-targets -D warnings` clean on all three; `cargo fmt --check` clean.

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)