### PR TITLE
refactor(storage): dead-field removal + String→CoreError in dreaming/tag_registry (#303)

### DIFF
--- a/crates/storage/src/database.rs
+++ b/crates/storage/src/database.rs
@@ -71,22 +71,13 @@ const PERSONAL_DATA_TABLES: &[&str] = &[
     "scratchpads",
 ];
 
-/// Output of `prepare_select_for_user` — the rewritten SELECT plus the
-/// caller's user_id ready to bind as `$1` when grafting added a
-/// `user_id = $1` predicate. When no personal-data table was
-/// referenced (e.g. `SELECT now()` or a query over
-/// `information_schema`), `bound_user_id` is `None` and the SQL is
+/// Output of `prepare_select_for_user` — the rewritten SELECT (with
+/// `user_id = '<user_id>'` predicates grafted onto every personal-data
+/// table reference). When no personal-data table was referenced (e.g.
+/// `SELECT now()` or a query over `information_schema`), the SQL is
 /// returned essentially unchanged.
 pub(crate) struct PreparedSelect {
     pub sql: String,
-    /// `Some(user_id)` when the rewriter grafted at least one
-    /// `user_id = '<user_id>'` predicate; `None` when the query did
-    /// not reference any personal-data table. Currently informational
-    /// (the value is inlined as a SQL literal so there's no bind to
-    /// perform), but exposed so a future migration to parameter-
-    /// rebinding can use it.
-    #[allow(dead_code)]
-    pub bound_user_id: Option<String>,
     /// True when the parsed query already carries a `LIMIT` clause, so the
     /// read path must not wrap it in an auto-LIMIT subquery (DS-7). Derived
     /// from the AST (`Query.limit_clause`), not a substring scan, so a string
@@ -134,7 +125,6 @@ pub(crate) fn prepare_select_for_user(
 
     Ok(PreparedSelect {
         sql: sql_out,
-        bound_user_id: grafter.bound.then(|| user_id.to_string()),
         has_limit,
     })
 }
@@ -414,17 +404,11 @@ impl PersonalDataTableFinder {
 /// scoping.
 struct UserIdGrafter<'a> {
     user_id: &'a str,
-    /// Tracks whether at least one graft happened — when true, the
-    /// resulting `PreparedSelect.bound_user_id` is `Some(user_id)`.
-    bound: bool,
 }
 
 impl<'a> UserIdGrafter<'a> {
     fn new(user_id: &'a str) -> Self {
-        Self {
-            user_id,
-            bound: false,
-        }
+        Self { user_id }
     }
 
     fn visit_query(&mut self, q: &mut Query) {
@@ -476,7 +460,6 @@ impl<'a> UserIdGrafter<'a> {
                 },
                 None => predicate,
             });
-            self.bound = true;
         }
     }
 

--- a/crates/storage/src/dreaming/archival.rs
+++ b/crates/storage/src/dreaming/archival.rs
@@ -16,6 +16,7 @@
 use sqlx::PgPool;
 
 use desktop_assistant_auth_jwt::DEFAULT_USER_ID;
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::ports::auth::current_user_id;
 
 /// Archive conversations not touched in `days` days. Returns rows archived.
@@ -25,7 +26,7 @@ use desktop_assistant_core::ports::auth::current_user_id;
 /// single-tenant deploys, IS the whole table. In multi-tenant deploys
 /// archival is normally driven from inside a per-user consolidation
 /// cycle, so the scope picks the right partition automatically.
-pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, String> {
+pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, CoreError> {
     let user_id = current_user_id();
     if user_id.as_str() == DEFAULT_USER_ID {
         // Audit-allowlisted: when no per-user scope is installed (e.g.
@@ -41,7 +42,7 @@ pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, Strin
         .bind(days as i32)
         .execute(pool)
         .await
-        .map_err(|e| format!("dreaming: archival query failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: archival query failed: {e}")))?;
         Ok(result.rows_affected() as usize)
     } else {
         let result = sqlx::query(
@@ -55,7 +56,7 @@ pub async fn run_archival_phase(pool: &PgPool, days: u32) -> Result<usize, Strin
         .bind(user_id.as_str())
         .execute(pool)
         .await
-        .map_err(|e| format!("dreaming: archival query failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: archival query failed: {e}")))?;
         Ok(result.rows_affected() as usize)
     }
 }

--- a/crates/storage/src/dreaming/common.rs
+++ b/crates/storage/src/dreaming/common.rs
@@ -21,6 +21,7 @@
 use sqlx::PgPool;
 
 use super::types::{MAX_CONVERSATIONS_PER_SCAN, MAX_MESSAGE_CHARS};
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::ports::auth::current_user_id;
 
 /// Conversations that have messages beyond their watermark, with their
@@ -33,7 +34,7 @@ use desktop_assistant_core::ports::auth::current_user_id;
 /// allowlist.
 pub async fn find_conversations_with_new_messages(
     pool: &PgPool,
-) -> Result<Vec<(String, String, i32, String)>, String> {
+) -> Result<Vec<(String, String, i32, String)>, CoreError> {
     // Audit-allowlisted: cross-user scan in the dreaming background
     // worker. The returned `user_id` column is consumed by the worker
     // to install a per-user scope before any subsequent query runs.
@@ -57,7 +58,7 @@ pub async fn find_conversations_with_new_messages(
     .bind(MAX_CONVERSATIONS_PER_SCAN)
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: failed to find conversations: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: failed to find conversations: {e}")))?;
 
     Ok(rows)
 }
@@ -69,7 +70,7 @@ pub async fn load_new_transcript(
     pool: &PgPool,
     conversation_id: &str,
     from_ordinal: i32,
-) -> Result<String, String> {
+) -> Result<String, CoreError> {
     let user_id = current_user_id();
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT role, content FROM messages \
@@ -82,7 +83,7 @@ pub async fn load_new_transcript(
     .bind(from_ordinal)
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: failed to load transcript: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: failed to load transcript: {e}")))?;
 
     let mut transcript = String::new();
     for (role, content) in rows {
@@ -104,7 +105,10 @@ pub async fn load_new_transcript(
 /// Returns an empty string if the conversation has been hard-deleted —
 /// callers must handle that case (consolidation falls through to KB-only
 /// judgment). Scoped to the task-local user id.
-pub async fn load_full_transcript(pool: &PgPool, conversation_id: &str) -> Result<String, String> {
+pub async fn load_full_transcript(
+    pool: &PgPool,
+    conversation_id: &str,
+) -> Result<String, CoreError> {
     let user_id = current_user_id();
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT role, content FROM messages \
@@ -116,7 +120,7 @@ pub async fn load_full_transcript(pool: &PgPool, conversation_id: &str) -> Resul
     .bind(conversation_id)
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: failed to load full transcript: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: failed to load full transcript: {e}")))?;
 
     let mut transcript = String::new();
     for (role, content) in rows {
@@ -133,7 +137,7 @@ pub async fn load_full_transcript(pool: &PgPool, conversation_id: &str) -> Resul
 
 /// Get the maximum message ordinal for a conversation. Scoped to the
 /// task-local user id.
-pub async fn get_max_ordinal(pool: &PgPool, conversation_id: &str) -> Result<i32, String> {
+pub async fn get_max_ordinal(pool: &PgPool, conversation_id: &str) -> Result<i32, CoreError> {
     let user_id = current_user_id();
     let row: (Option<i32>,) = sqlx::query_as(
         "SELECT MAX(ordinal) FROM messages \
@@ -143,7 +147,7 @@ pub async fn get_max_ordinal(pool: &PgPool, conversation_id: &str) -> Result<i32
     .bind(conversation_id)
     .fetch_one(pool)
     .await
-    .map_err(|e| format!("dreaming: failed to get max ordinal: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: failed to get max ordinal: {e}")))?;
 
     Ok(row.0.unwrap_or(0))
 }
@@ -155,7 +159,7 @@ pub async fn update_watermark(
     pool: &PgPool,
     conversation_id: &str,
     ordinal: i32,
-) -> Result<(), String> {
+) -> Result<(), CoreError> {
     let user_id = current_user_id();
     sqlx::query(
         "INSERT INTO dreaming_watermarks \
@@ -171,7 +175,7 @@ pub async fn update_watermark(
     .bind(ordinal)
     .execute(pool)
     .await
-    .map_err(|e| format!("dreaming: failed to update watermark: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: failed to update watermark: {e}")))?;
 
     Ok(())
 }

--- a/crates/storage/src/dreaming/consolidation.rs
+++ b/crates/storage/src/dreaming/consolidation.rs
@@ -20,6 +20,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::ports::auth::{UserId, current_user_id, with_user_id};
 use pgvector::Vector;
 use sqlx::PgPool;
@@ -48,7 +49,7 @@ pub async fn run_consolidation_phase(
     llm_fn: &DreamingLlmFn,
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
-) -> Result<ConsolidationStats, String> {
+) -> Result<ConsolidationStats, CoreError> {
     // Load focals across all users, grouped by user. The cross-user
     // scan is audit-allowlisted (background-worker entry point); from
     // here on every per-user batch installs a `with_user_id` scope so
@@ -92,7 +93,7 @@ async fn consolidate_user_focals(
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
     focals: Vec<KbRow>,
-) -> Result<ConsolidationStats, String> {
+) -> Result<ConsolidationStats, CoreError> {
     let mut buffer = OpBuffer::new();
 
     for focal in &focals {
@@ -167,7 +168,7 @@ async fn consolidate_user_focals(
 
 async fn load_entries_needing_review_by_user(
     pool: &PgPool,
-) -> Result<Vec<(String, Vec<KbRow>)>, String> {
+) -> Result<Vec<(String, Vec<KbRow>)>, CoreError> {
     // Audit-allowlisted: cross-user scan in the dreaming background
     // worker. The caller groups by user_id and installs a per-user
     // task-local scope before doing anything else with each row.
@@ -184,7 +185,7 @@ async fn load_entries_needing_review_by_user(
     .bind(MAX_REVIEWS_PER_CYCLE)
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: load focals failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: load focals failed: {e}")))?;
 
     let mut grouped: BTreeMap<String, Vec<KbRow>> = BTreeMap::new();
     for (user_id, id, content, tags, metadata_json) in rows {
@@ -203,7 +204,7 @@ async fn load_entries_needing_review_by_user(
 /// the same factory shape.
 #[cfg(test)]
 #[allow(dead_code)]
-async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String> {
+async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, CoreError> {
     let user_id = current_user_id();
     let rows: Vec<(String, String, Vec<String>, serde_json::Value)> = sqlx::query_as(
         "SELECT id, content, tags, metadata \
@@ -220,7 +221,7 @@ async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String
     .bind(MAX_REVIEWS_PER_CYCLE)
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: load focals failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: load focals failed: {e}")))?;
 
     Ok(rows
         .into_iter()
@@ -234,7 +235,7 @@ async fn load_entries_needing_review(pool: &PgPool) -> Result<Vec<KbRow>, String
         .collect())
 }
 
-async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>, String> {
+async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>, CoreError> {
     let user_id = current_user_id();
     // Pull the focal's first embedding chunk to use as the similarity probe.
     let focal_chunk: Option<(Vec<Vector>,)> =
@@ -243,7 +244,9 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
             .bind(&focal.id)
             .fetch_optional(pool)
             .await
-            .map_err(|e| format!("dreaming: load focal embedding failed: {e}"))?;
+            .map_err(|e| {
+                CoreError::Storage(format!("dreaming: load focal embedding failed: {e}"))
+            })?;
 
     let probe = match focal_chunk.and_then(|(v,)| v.into_iter().next()) {
         Some(v) => v,
@@ -278,7 +281,7 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
         .bind(user_id.as_str())
         .fetch_all(pool)
         .await
-        .map_err(|e| format!("dreaming: tag-overlap retrieve failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: tag-overlap retrieve failed: {e}")))?;
 
         for (id, content, tags, metadata_json, distance) in tag_rows {
             by_id.insert(
@@ -315,7 +318,7 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
     .bind(user_id.as_str())
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: embedding retrieve failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: embedding retrieve failed: {e}")))?;
 
     for (id, content, tags, metadata_json, distance) in emb_rows {
         let entry = KbRow {
@@ -345,7 +348,7 @@ async fn retrieve_candidates(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>,
     Ok(combined)
 }
 
-async fn retrieve_by_tags_only(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>, String> {
+async fn retrieve_by_tags_only(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow>, CoreError> {
     if focal.tags.is_empty() {
         return Ok(Vec::new());
     }
@@ -364,7 +367,7 @@ async fn retrieve_by_tags_only(pool: &PgPool, focal: &KbRow) -> Result<Vec<KbRow
     .bind(user_id.as_str())
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("dreaming: tag-only retrieve failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: tag-only retrieve failed: {e}")))?;
 
     Ok(rows
         .into_iter()
@@ -420,11 +423,13 @@ async fn review_focal(
     focal: &KbRow,
     candidates: &[KbRow],
     transcript_included: bool,
-) -> Result<Vec<ReviewAction>, String> {
+) -> Result<Vec<ReviewAction>, CoreError> {
     let system_prompt = build_review_system_prompt();
     let user_prompt = build_review_user_prompt(focal, candidates, None);
 
-    let response = llm_fn(system_prompt.clone(), user_prompt).await?;
+    let response = llm_fn(system_prompt.clone(), user_prompt)
+        .await
+        .map_err(CoreError::Storage)?;
     let actions = parse_review_response(&response);
 
     // If the LLM asked for the source and we haven't already provided it,
@@ -455,7 +460,9 @@ async fn review_focal(
 
         let user_prompt_with_source =
             build_review_user_prompt(focal, candidates, Some(&transcript));
-        let response = llm_fn(system_prompt, user_prompt_with_source).await?;
+        let response = llm_fn(system_prompt, user_prompt_with_source)
+            .await
+            .map_err(CoreError::Storage)?;
         return Ok(parse_review_response(&response)
             .into_iter()
             .filter(|a| !matches!(a, ReviewAction::FetchSource))
@@ -761,15 +768,17 @@ async fn synthesize_cluster(
     llm_fn: &DreamingLlmFn,
     cluster: &BTreeSet<String>,
     id_to_focal: &HashMap<String, &KbRow>,
-) -> Result<SynthesizedMerge, String> {
+) -> Result<SynthesizedMerge, CoreError> {
     let members = load_cluster_members(pool, cluster, id_to_focal).await;
     if members.len() < 2 {
-        return Err("synthesize: fewer than 2 members".to_string());
+        return Err(CoreError::Storage(
+            "synthesize: fewer than 2 members".to_string(),
+        ));
     }
 
     let canonical_id = OpBuffer::canonical_of(cluster)
         .cloned()
-        .ok_or_else(|| "synthesize: empty cluster".to_string())?;
+        .ok_or_else(|| CoreError::Storage("synthesize: empty cluster".to_string()))?;
 
     let mut user = String::from(
         "Merge the following entries into a single unified knowledge-base \
@@ -797,18 +806,18 @@ async fn synthesize_cluster(
         phrasing; keep the entry self-contained and concise.",
     );
 
-    let response = llm_fn(system, user).await?;
+    let response = llm_fn(system, user).await.map_err(CoreError::Storage)?;
     let payload = extract_json_payload(response.trim());
     let parsed: serde_json::Value = serde_json::from_str(&payload)
-        .map_err(|e| format!("synthesize: response not JSON: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("synthesize: response not JSON: {e}")))?;
 
     let new_content = parsed
         .get("content")
         .and_then(|v| v.as_str())
         .map(|s| s.trim().to_string())
-        .ok_or_else(|| "synthesize: missing content".to_string())?;
+        .ok_or_else(|| CoreError::Storage("synthesize: missing content".to_string()))?;
     if new_content.is_empty() {
-        return Err("synthesize: empty content".to_string());
+        return Err(CoreError::Storage("synthesize: empty content".to_string()));
     }
 
     let new_scope = match parsed.get("scope") {

--- a/crates/storage/src/dreaming/extraction.rs
+++ b/crates/storage/src/dreaming/extraction.rs
@@ -17,6 +17,7 @@
 
 use std::collections::BTreeSet;
 
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::chunking::{CHUNK_MAX_CHARS, CHUNK_OVERLAP, chunk_text};
 use desktop_assistant_core::ports::auth::{UserId, current_user_id, with_user_id};
 use pgvector::Vector;
@@ -36,7 +37,7 @@ pub async fn run_extraction_phase(
     llm_fn: &DreamingLlmFn,
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
-) -> Result<usize, String> {
+) -> Result<usize, CoreError> {
     let conversations = find_conversations_with_new_messages(pool).await?;
     if conversations.is_empty() {
         tracing::debug!("dreaming: no conversations with new messages");
@@ -96,7 +97,7 @@ async fn process_one_conversation_for_extraction(
     conv_id: &str,
     watermark: i32,
     context_summary: &str,
-) -> Result<usize, String> {
+) -> Result<usize, CoreError> {
     // Tag registry is per-user (#102 PK is `(user_id, name)`); the
     // task-local scope already picks the right partition.
     let registry = tag_registry::list_active_tags(pool).await?;
@@ -278,7 +279,7 @@ async fn write_extracted_fact(
     source_conversation_id: &str,
     proposal: ExtractedFactProposal,
     registry_names: &BTreeSet<String>,
-) -> Result<bool, String> {
+) -> Result<bool, CoreError> {
     let mut final_tags: BTreeSet<String> = BTreeSet::new();
 
     // Existing tags: keep only those present in the active registry.
@@ -323,9 +324,11 @@ async fn write_extracted_fact(
 
     // Embed content for the row's `embedding` array.
     let chunks = chunk_text(&proposal.content, CHUNK_MAX_CHARS, CHUNK_OVERLAP);
-    let embeddings = embed_fn(chunks).await?;
+    let embeddings = embed_fn(chunks).await.map_err(CoreError::Storage)?;
     if embeddings.is_empty() {
-        return Err("dreaming: embedding returned no vectors".to_string());
+        return Err(CoreError::Storage(
+            "dreaming: embedding returned no vectors".to_string(),
+        ));
     }
     let embedding_vecs: Vec<Vector> = embeddings.into_iter().map(Vector::from).collect();
 
@@ -347,7 +350,7 @@ async fn write_extracted_fact(
     .bind(embedding_model)
     .execute(pool)
     .await
-    .map_err(|e| format!("dreaming: insert fact failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: insert fact failed: {e}")))?;
 
     tracing::info!(
         "dreaming: wrote fact id={id} (scope={:?}): {}",

--- a/crates/storage/src/dreaming/mod.rs
+++ b/crates/storage/src/dreaming/mod.rs
@@ -22,6 +22,7 @@ mod extraction;
 mod reconcile;
 mod types;
 
+use desktop_assistant_core::CoreError;
 use sqlx::PgPool;
 
 pub use types::{BackfillEmbedFn, ConsolidationStats, DreamingLlmFn};
@@ -35,7 +36,7 @@ pub async fn run_dreaming_scan(
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
     archive_after_days: u32,
-) -> Result<usize, String> {
+) -> Result<usize, CoreError> {
     tracing::info!("dreaming: phase 1/3 extraction");
     let new_facts =
         extraction::run_extraction_phase(pool, llm_fn, embed_fn, embedding_model).await?;

--- a/crates/storage/src/dreaming/reconcile.rs
+++ b/crates/storage/src/dreaming/reconcile.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::chunking::{CHUNK_MAX_CHARS, CHUNK_OVERLAP, chunk_text};
 use desktop_assistant_core::ports::auth::current_user_id;
 use pgvector::Vector;
@@ -184,14 +185,14 @@ pub async fn apply_ops(
     buffer: &OpBuffer,
     synthesized: &[SynthesizedMerge],
     soft_delete_ttl_days: i32,
-) -> Result<ConsolidationStats, String> {
+) -> Result<ConsolidationStats, CoreError> {
     let user_id = current_user_id();
     let mut stats = ConsolidationStats::default();
 
     let mut tx = pool
         .begin()
         .await
-        .map_err(|e| format!("dreaming: begin tx failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: begin tx failed: {e}")))?;
 
     // First, reap any soft-deleted entries past their TTL. Cheap, and
     // happens in the same tx so a single cycle stays atomic. Scoped to
@@ -207,12 +208,12 @@ pub async fn apply_ops(
     .bind(user_id.as_str())
     .execute(&mut *tx)
     .await
-    .map_err(|e| format!("dreaming: TTL reap failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("dreaming: TTL reap failed: {e}")))?;
 
     // Apply merges: update canonical row, soft-delete cluster members.
     for merge in synthesized {
         let chunks = chunk_text(&merge.new_content, CHUNK_MAX_CHARS, CHUNK_OVERLAP);
-        let embeddings = embed_fn(chunks).await?;
+        let embeddings = embed_fn(chunks).await.map_err(CoreError::Storage)?;
         if embeddings.is_empty() {
             tracing::warn!(
                 "dreaming: synthesis embedding empty for cluster canonical {}",
@@ -230,7 +231,7 @@ pub async fn apply_ops(
                 .bind(&merge.canonical_id)
                 .fetch_optional(&mut *tx)
                 .await
-                .map_err(|e| format!("dreaming: metadata fetch failed: {e}"))?;
+                .map_err(|e| CoreError::Storage(format!("dreaming: metadata fetch failed: {e}")))?;
 
         let mut metadata = existing_metadata
             .map(|(v,)| KbMetadata::from_json(&v))
@@ -254,7 +255,7 @@ pub async fn apply_ops(
         .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
-        .map_err(|e| format!("dreaming: merge canonical update failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: merge canonical update failed: {e}")))?;
 
         // Soft-delete the rest of the cluster.
         let to_delete: Vec<String> = merge
@@ -273,7 +274,9 @@ pub async fn apply_ops(
             .bind(user_id.as_str())
             .execute(&mut *tx)
             .await
-            .map_err(|e| format!("dreaming: cluster soft-delete failed: {e}"))?;
+            .map_err(|e| {
+                CoreError::Storage(format!("dreaming: cluster soft-delete failed: {e}"))
+            })?;
             stats.soft_deleted += to_delete.len();
         }
 
@@ -283,7 +286,7 @@ pub async fn apply_ops(
     // Standalone updates (not in any merge cluster).
     for (id, new_content) in buffer.standalone_updates() {
         let chunks = chunk_text(&new_content, CHUNK_MAX_CHARS, CHUNK_OVERLAP);
-        let embeddings = embed_fn(chunks).await?;
+        let embeddings = embed_fn(chunks).await.map_err(CoreError::Storage)?;
         if embeddings.is_empty() {
             continue;
         }
@@ -305,7 +308,7 @@ pub async fn apply_ops(
         .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
-        .map_err(|e| format!("dreaming: update failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: update failed: {e}")))?;
         stats.updated += 1;
     }
 
@@ -317,7 +320,9 @@ pub async fn apply_ops(
                 .bind(&id)
                 .fetch_optional(&mut *tx)
                 .await
-                .map_err(|e| format!("dreaming: scope-add metadata fetch failed: {e}"))?;
+                .map_err(|e| {
+                    CoreError::Storage(format!("dreaming: scope-add metadata fetch failed: {e}"))
+                })?;
 
         if let Some((value,)) = existing {
             let mut metadata = KbMetadata::from_json(&value);
@@ -332,7 +337,7 @@ pub async fn apply_ops(
             .bind(user_id.as_str())
             .execute(&mut *tx)
             .await
-            .map_err(|e| format!("dreaming: scope-add update failed: {e}"))?;
+            .map_err(|e| CoreError::Storage(format!("dreaming: scope-add update failed: {e}")))?;
             stats.scope_added += 1;
         }
     }
@@ -348,7 +353,7 @@ pub async fn apply_ops(
         .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
-        .map_err(|e| format!("dreaming: soft-delete failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: soft-delete failed: {e}")))?;
         stats.soft_deleted += 1;
     }
 
@@ -365,13 +370,13 @@ pub async fn apply_ops(
         .bind(user_id.as_str())
         .execute(&mut *tx)
         .await
-        .map_err(|e| format!("dreaming: reviewed_at update failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: reviewed_at update failed: {e}")))?;
         stats.reviewed = touched.len();
     }
 
     tx.commit()
         .await
-        .map_err(|e| format!("dreaming: commit failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("dreaming: commit failed: {e}")))?;
 
     Ok(stats)
 }

--- a/crates/storage/src/knowledge.rs
+++ b/crates/storage/src/knowledge.rs
@@ -119,7 +119,7 @@ impl KnowledgeBaseStore for PgKnowledgeBaseStore {
                 FROM vector_ranked v
                 FULL OUTER JOIN text_ranked t ON v.id = t.id
             )
-            SELECT id, content, tags, metadata, created_at, updated_at, rrf_score
+            SELECT id, content, tags, metadata, created_at, updated_at
             FROM fused ORDER BY rrf_score DESC LIMIT $5",
         )
         .bind(embedding_vec)
@@ -251,8 +251,6 @@ struct KbSearchRow {
     metadata: serde_json::Value,
     created_at: chrono::DateTime<chrono::Utc>,
     updated_at: chrono::DateTime<chrono::Utc>,
-    #[allow(dead_code)]
-    rrf_score: Option<f64>,
 }
 
 impl KbSearchRow {

--- a/crates/storage/src/tag_registry.rs
+++ b/crates/storage/src/tag_registry.rs
@@ -12,6 +12,7 @@
 //! `name + description` for similarity dedup, and a `deprecated_for_tag`
 //! chain so a retired tag can point at its replacement.
 
+use desktop_assistant_core::CoreError;
 use desktop_assistant_core::ports::auth::current_user_id;
 use pgvector::Vector;
 use sqlx::PgPool;
@@ -60,7 +61,7 @@ pub enum CreateTagOutcome {
 /// the primary consumer, runs per conversation and inherits each
 /// conversation's `user_id` via [`with_user_id`] — see #105 for the
 /// threading contract.
-pub async fn list_active_tags(pool: &PgPool) -> Result<Vec<TagRecord>, String> {
+pub async fn list_active_tags(pool: &PgPool) -> Result<Vec<TagRecord>, CoreError> {
     let user_id = current_user_id();
     let rows: Vec<(String, String, serde_json::Value, Vec<String>)> = sqlx::query_as(
         "SELECT name, description, examples, distinguish_from \
@@ -71,14 +72,14 @@ pub async fn list_active_tags(pool: &PgPool) -> Result<Vec<TagRecord>, String> {
     .bind(user_id.as_str())
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("tag_registry: list failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("tag_registry: list failed: {e}")))?;
 
     Ok(rows.into_iter().map(row_to_record).collect())
 }
 
 /// Look up a single tag by name (active or deprecated). Scoped to the
 /// current task-local user.
-pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, String> {
+pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, CoreError> {
     let user_id = current_user_id();
     let row: Option<(String, String, serde_json::Value, Vec<String>)> = sqlx::query_as(
         "SELECT name, description, examples, distinguish_from \
@@ -88,7 +89,7 @@ pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, Str
     .bind(name)
     .fetch_optional(pool)
     .await
-    .map_err(|e| format!("tag_registry: get failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("tag_registry: get failed: {e}")))?;
 
     Ok(row.map(row_to_record))
 }
@@ -99,7 +100,7 @@ pub async fn get_tag(pool: &PgPool, name: &str) -> Result<Option<TagRecord>, Str
 /// terminates at a missing tag (shouldn't happen given the FK, but graceful).
 /// The chain is followed within a single user's tag partition; cross-user
 /// pointers are forbidden by the FK in #102's migration.
-pub async fn resolve_active_name(pool: &PgPool, name: &str) -> Result<Option<String>, String> {
+pub async fn resolve_active_name(pool: &PgPool, name: &str) -> Result<Option<String>, CoreError> {
     let user_id = current_user_id();
     let mut current = name.to_string();
     for _ in 0..16 {
@@ -111,14 +112,16 @@ pub async fn resolve_active_name(pool: &PgPool, name: &str) -> Result<Option<Str
         .bind(&current)
         .fetch_optional(pool)
         .await
-        .map_err(|e| format!("tag_registry: resolve failed: {e}"))?;
+        .map_err(|e| CoreError::Storage(format!("tag_registry: resolve failed: {e}")))?;
         match row {
             None => return Ok(None),
             Some((None,)) => return Ok(Some(current)),
             Some((Some(next),)) => current = next,
         }
     }
-    Err("tag_registry: deprecation chain too deep (cycle?)".to_string())
+    Err(CoreError::Storage(
+        "tag_registry: deprecation chain too deep (cycle?)".to_string(),
+    ))
 }
 
 /// Create a new tag, or redirect to an existing similar one.
@@ -135,7 +138,7 @@ pub async fn create_or_match_tag(
     embed_fn: &BackfillEmbedFn,
     embedding_model: &str,
     proposal: TagProposal,
-) -> Result<CreateTagOutcome, String> {
+) -> Result<CreateTagOutcome, CoreError> {
     let user_id = current_user_id();
     let normalized = normalize_tag_name(&proposal.name);
 
@@ -148,11 +151,13 @@ pub async fn create_or_match_tag(
     }
 
     let embed_text = format!("{}: {}", normalized, proposal.description);
-    let embeddings = embed_fn(vec![embed_text]).await?;
+    let embeddings = embed_fn(vec![embed_text])
+        .await
+        .map_err(CoreError::Storage)?;
     let vector = embeddings
         .into_iter()
         .next()
-        .ok_or_else(|| "tag_registry: embed returned no vectors".to_string())?;
+        .ok_or_else(|| CoreError::Storage("tag_registry: embed returned no vectors".to_string()))?;
     let query_vec = Vector::from(vector);
 
     let nearest: Option<(String, String, serde_json::Value, Vec<String>, f64)> = sqlx::query_as(
@@ -166,7 +171,7 @@ pub async fn create_or_match_tag(
     .bind(user_id.as_str())
     .fetch_optional(pool)
     .await
-    .map_err(|e| format!("tag_registry: nearest search failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("tag_registry: nearest search failed: {e}")))?;
 
     if let Some((name, description, examples, distinguish_from, distance)) = nearest
         && distance < TAG_DEDUP_DISTANCE_THRESHOLD
@@ -200,7 +205,7 @@ pub async fn create_or_match_tag(
     .bind(embedding_model)
     .execute(pool)
     .await
-    .map_err(|e| format!("tag_registry: insert failed: {e}"))?;
+    .map_err(|e| CoreError::Storage(format!("tag_registry: insert failed: {e}")))?;
 
     Ok(CreateTagOutcome::Created(TagRecord {
         name: normalized,


### PR DESCRIPTION
Storage cleanup batch from the 2026-06-09 code review (§3, Refactoring 3-5). Tier-4 refactor, behavior-preserving.

## What changed

### Dead/quasi-dead fields removed (`#[allow(dead_code)]` crutches)
- **`PreparedSelect.bound_user_id`** (`database.rs`): never read by any caller — the grafter inlines the user_id as a SQL literal, so there was no bind to perform. Removing it also let the internal `UserIdGrafter.bound` tracking flag go.
- **`KbSearchRow.rrf_score`** (`knowledge.rs`): the hybrid-search RRF score is only needed for `ORDER BY rrf_score DESC` inside SQL; the Rust struct never read it. Removed from the struct and from the outer `SELECT` projection (the `fused` CTE still computes it, so ordering is unchanged).

### `String` → `CoreError` in `dreaming/*` + `tag_registry.rs`
- `dreaming/{mod,common,archival,extraction,consolidation,reconcile}.rs` and `tag_registry.rs` returned bare `String` errors; the rest of the storage stores use `CoreError::Storage`. All `Result<T, String>` storage functions now return `Result<T, CoreError>`.
- **Error messages are unchanged** — same `format!` text, now wrapped in `CoreError::Storage`, so log output is byte-for-byte identical.
- The plugin-boundary callback types `DreamingLlmFn` (`types.rs`) and `BackfillEmbedFn` (`embedding_backfill.rs`, out of scope) keep `Result<_, String>` — they're daemon-supplied inputs, not storage errors. Their `String` errors are converted at each storage-side await via `.map_err(CoreError::Storage)`.
- `run_dreaming_scan` now returns `Result<usize, CoreError>`; the sole caller (daemon) only formats it via `Display`, which `CoreError` implements.

### Load-block dedup — already subsumed
The issue's first item (extract the shared messages+summaries loading block in `get`/`list`) was flagged as *"Partially subsumed by DS-6 if `list` stops loading bodies."* DS-6 (#295) has since merged: `list` now uses a single `LEFT JOIN … GROUP BY` aggregate and loads no bodies. The duplicated block exists in only `get` now, so there is nothing left to dedup. Left as-is (extracting a one-call-site helper would add indirection without removing duplication).

## Tests
- Full `desktop-assistant-storage` suite green against Postgres (pgvector:pg17), run serial (`--test-threads=1`): lib 60, + all integration binaries (database_query_user_id_scoping 10, user_id_scoping 18, multi_tenant_schema 14, conversation_persistence 7, scratchpad 9, …). The `database_query_user_id_scoping` and `knowledge_search_*` tests directly exercise the touched grafter and hybrid-search SQL — behavior unchanged.
- `cargo fmt --all --check` clean; `cargo clippy -p desktop-assistant-storage -p desktop-assistant-daemon --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #303