### PR TITLE
Refactor: extract the shared LLM streaming scaffold into llm-http (#302)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "desktop-assistant-core",
+ "desktop-assistant-llm-http",
  "serde",
  "serde_json",
  "tokio",
@@ -1446,7 +1447,10 @@ dependencies = [
  "desktop-assistant-core",
  "httpmock",
  "reqwest",
+ "serde_json",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/llm-anthropic/src/lib.rs
+++ b/crates/llm-anthropic/src/lib.rs
@@ -8,53 +8,19 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
 };
+use desktop_assistant_llm_http::{
+    STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT, StreamStep, build_response, next_step,
+    parse_retry_after_header,
+};
 use eventsource_stream::Eventsource;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tokio_stream::StreamExt;
 
-/// Maximum time to wait for the HTTP connection handshake (response headers)
-/// before failing the turn. Mirrors the Bedrock connector (#214/#220).
-const ANTHROPIC_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-/// Maximum gap allowed between two streamed SSE events. Each received event
-/// resets the clock (the heartbeat), so this only fires when the stream goes
-/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
-const ANTHROPIC_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-
-/// Outcome of racing a stream's next item against cancellation and a stall
-/// timeout. Extracted so the timeout behaviour is unit-testable with a short
-/// duration instead of the production 60s constant (#220).
-enum StreamStep<T> {
-    /// The stream yielded an item.
-    Item(T),
-    /// The stream ended (no more items).
-    Done,
-    /// The cancellation token tripped.
-    Cancelled,
-    /// No item arrived within the stall timeout.
-    Stalled,
-}
-
-/// Await the next item from `stream`, racing it against `cancellation` and a
-/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
-/// so the stall window resets each time a caller consumes an item.
-async fn next_step<S>(
-    stream: &mut S,
-    cancellation: &tokio_util::sync::CancellationToken,
-    timeout: std::time::Duration,
-) -> StreamStep<S::Item>
-where
-    S: tokio_stream::Stream + Unpin,
-{
-    tokio::select! {
-        _ = cancellation.cancelled() => StreamStep::Cancelled,
-        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
-        next = stream.next() => match next {
-            Some(item) => StreamStep::Item(item),
-            None => StreamStep::Done,
-        },
-    }
-}
+/// Connection-handshake / per-event stall budgets shared with the other
+/// connectors (#214/#220/#302). Kept as local aliases so the streaming loop
+/// reads naturally.
+const ANTHROPIC_CONNECT_TIMEOUT: std::time::Duration = STREAM_CONNECT_TIMEOUT;
+const ANTHROPIC_EVENT_TIMEOUT: std::time::Duration = STREAM_EVENT_TIMEOUT;
 
 /// Return the prompt-token context window for a known Anthropic model id.
 ///
@@ -664,12 +630,9 @@ impl AnthropicClient {
 
         let tool_calls = tool_acc.into_tool_calls();
         let usage = to_token_usage(&accumulated_usage);
-        let resp = if tool_calls.is_empty() {
-            LlmResponse::text(full_response)
-        } else {
-            LlmResponse::with_tool_calls(full_response, tool_calls)
-        };
-        Ok(resp.with_usage(usage))
+        // Anthropic always reports usage, so `Some(usage)` here is equivalent
+        // to the prior unconditional `.with_usage(usage)`.
+        Ok(build_response(full_response, tool_calls, Some(usage)))
     }
 }
 
@@ -1000,85 +963,13 @@ fn parse_prompt_too_long(message: &str) -> (Option<u64>, Option<u64>) {
     }
 }
 
-/// Read the `Retry-After` HTTP header and parse it as a delay.
-///
-/// Supports the integer-seconds form (e.g. `Retry-After: 30`); the HTTP-
-/// date form is rare on JSON APIs and not parsed here. Returns `None`
-/// when the header is absent or unparseable so the caller treats it as
-/// "no hint" rather than substituting a default.
-fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<std::time::Duration> {
-    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
-    raw.trim()
-        .parse::<u64>()
-        .ok()
-        .map(std::time::Duration::from_secs)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Stream that yields `n` items then stays `Pending` forever, simulating a
-    /// mid-stream stall (#220).
-    struct StallingStream {
-        remaining: usize,
-    }
-
-    impl tokio_stream::Stream for StallingStream {
-        type Item = u32;
-
-        fn poll_next(
-            mut self: std::pin::Pin<&mut Self>,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Self::Item>> {
-            if self.remaining > 0 {
-                self.remaining -= 1;
-                std::task::Poll::Ready(Some(0))
-            } else {
-                std::task::Poll::Pending
-            }
-        }
-    }
-
-    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
-        match step {
-            StreamStep::Item(_) => "Item",
-            StreamStep::Done => "Done",
-            StreamStep::Cancelled => "Cancelled",
-            StreamStep::Stalled => "Stalled",
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_fires_stall_timeout_after_silence() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        let mut stream = StallingStream { remaining: 1 };
-        let timeout = std::time::Duration::from_millis(50);
-
-        // First item arrives immediately (the heartbeat).
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Item(_) => {}
-            other => panic!("expected first item, got {}", step_name(&other)),
-        }
-
-        // Stream now silent: the per-event timeout must fire rather than hang.
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Stalled => {}
-            other => panic!("expected stall, got {}", step_name(&other)),
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_prefers_cancellation_over_stall() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        cancellation.cancel();
-        let mut stream = StallingStream { remaining: 0 };
-        let timeout = std::time::Duration::from_millis(50);
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Cancelled => {}
-            other => panic!("expected cancelled, got {}", step_name(&other)),
-        }
-    }
+    // The stall-loop primitive (`StreamStep` / `next_step`) and its
+    // `StallingStream` harness now live in `desktop-assistant-llm-http` and are
+    // tested there (#302).
 
     #[test]
     fn client_builder() {
@@ -1862,36 +1753,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn parse_retry_after_integer_seconds() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::RETRY_AFTER,
-            reqwest::header::HeaderValue::from_static("45"),
-        );
-        assert_eq!(
-            parse_retry_after_header(&headers),
-            Some(std::time::Duration::from_secs(45))
-        );
-    }
-
-    #[test]
-    fn parse_retry_after_missing() {
-        let headers = reqwest::header::HeaderMap::new();
-        assert_eq!(parse_retry_after_header(&headers), None);
-    }
-
-    #[test]
-    fn parse_retry_after_http_date_unparseable() {
-        // HTTP-date form is uncommon on JSON APIs and intentionally
-        // unsupported; treat it as "no hint" rather than guessing.
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::RETRY_AFTER,
-            reqwest::header::HeaderValue::from_static("Wed, 21 Oct 2026 07:28:00 GMT"),
-        );
-        assert_eq!(parse_retry_after_header(&headers), None);
-    }
+    // `parse_retry_after_header` now lives in `desktop-assistant-llm-http`
+    // and is tested there (#302).
 
     // --- Cancellation (issue #109) ---------------------------------------
 

--- a/crates/llm-bedrock/Cargo.toml
+++ b/crates/llm-bedrock/Cargo.toml
@@ -12,6 +12,7 @@ aws-sdk-bedrock = "1"
 aws-sdk-bedrockruntime = "1"
 aws-smithy-types = "1"
 desktop-assistant-core.workspace = true
+desktop-assistant-llm-http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/llm-bedrock/src/lib.rs
+++ b/crates/llm-bedrock/src/lib.rs
@@ -19,6 +19,7 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
 };
+use desktop_assistant_llm_http::{STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -1268,8 +1269,11 @@ impl BedrockClient {
         // of hanging forever (#214). `stream.recv()` and `send()` have no
         // built-in timeout; gpt-oss on Bedrock was observed accepting a
         // tool-history follow-up request and then never emitting an event.
-        const BEDROCK_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-        const BEDROCK_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+        // The budgets are shared with the reqwest connectors (#302); Bedrock's
+        // AWS-SDK stream can't reuse the `tokio_stream`-typed `next_step`, but
+        // it keeps the same constants so the timeouts can't drift apart.
+        const BEDROCK_CONNECT_TIMEOUT: std::time::Duration = STREAM_CONNECT_TIMEOUT;
+        const BEDROCK_EVENT_TIMEOUT: std::time::Duration = STREAM_EVENT_TIMEOUT;
 
         // Race connection establishment against cancellation and a timeout. If
         // the user cancels mid-handshake we drop the in-flight request (the

--- a/crates/llm-http/Cargo.toml
+++ b/crates/llm-http/Cargo.toml
@@ -7,8 +7,18 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 desktop-assistant-core.workspace = true
 reqwest = { version = "0.13", default-features = false }
+tokio = { workspace = true }
+tokio-stream = "0.1"
+tokio-util.workspace = true
+
+[features]
+# Shared test harnesses (`StallingStream`, `step_name`) for the connector
+# crates' stall-loop tests. Off by default; providers enable it as a
+# dev-dependency feature.
+test-util = []
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 httpmock = "0.8"
 reqwest = { version = "0.13" }
+serde_json = "1"

--- a/crates/llm-http/src/lib.rs
+++ b/crates/llm-http/src/lib.rs
@@ -13,8 +13,13 @@
 //! `ToolsUnsupported`) and aren't worth shoehorning into one helper.
 
 mod models;
+pub mod streaming;
 
 pub use models::merge_curated_with_live;
+pub use streaming::{
+    STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT, StreamStep, build_response, next_step,
+    parse_retry_after_header,
+};
 
 use desktop_assistant_core::CoreError;
 use reqwest::Response;

--- a/crates/llm-http/src/streaming.rs
+++ b/crates/llm-http/src/streaming.rs
@@ -1,0 +1,233 @@
+//! Shared streaming scaffold for the LLM connector crates.
+//!
+//! Issue #302. The reqwest-based connectors (`llm-anthropic`, `llm-openai`,
+//! `llm-ollama`) — and, for the constants, `llm-bedrock` — each carried a
+//! byte-identical copy of the streaming plumbing introduced by #214/#220:
+//! the connect/stall timeout constants, the [`StreamStep`] / [`next_step`]
+//! stall-loop primitive, the `Retry-After` header parser, the response
+//! envelope builder, and a `StallingStream` test harness. Copy-pasted fixes
+//! are a demonstrated failure mode in this codebase, so this module is the
+//! single home for all of it.
+//!
+//! What stays provider-specific: the request construction, the connect race
+//! (`tokio::select!` of `send()` against cancellation — the future and the
+//! error mapping differ per provider), the SSE/NDJSON event parsing, and
+//! Bedrock's AWS-SDK stream which can't share the `tokio_stream`-typed
+//! [`next_step`] but does share the timeout constants.
+
+use desktop_assistant_core::domain::ToolCall;
+use desktop_assistant_core::ports::llm::{LlmResponse, TokenUsage};
+use std::time::Duration;
+use tokio_stream::StreamExt;
+
+/// Maximum time to wait for the HTTP connection handshake (response headers)
+/// before failing the turn (#214/#220).
+pub const STREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum gap allowed between two streamed events/chunks. Each received item
+/// resets the clock (the heartbeat), so this only fires when the stream goes
+/// silent mid-response (#214/#220).
+pub const STREAM_EVENT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Outcome of racing a stream's next item against cancellation and a stall
+/// timeout. Extracted so the timeout behaviour is unit-testable with a short
+/// duration instead of the production [`STREAM_EVENT_TIMEOUT`] (#220).
+pub enum StreamStep<T> {
+    /// The stream yielded an item.
+    Item(T),
+    /// The stream ended (no more items).
+    Done,
+    /// The cancellation token tripped.
+    Cancelled,
+    /// No item arrived within the stall timeout.
+    Stalled,
+}
+
+/// Await the next item from `stream`, racing it against `cancellation` and a
+/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
+/// so the stall window resets each time a caller consumes an item.
+pub async fn next_step<S>(
+    stream: &mut S,
+    cancellation: &tokio_util::sync::CancellationToken,
+    timeout: Duration,
+) -> StreamStep<S::Item>
+where
+    S: tokio_stream::Stream + Unpin,
+{
+    tokio::select! {
+        _ = cancellation.cancelled() => StreamStep::Cancelled,
+        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
+        next = stream.next() => match next {
+            Some(item) => StreamStep::Item(item),
+            None => StreamStep::Done,
+        },
+    }
+}
+
+/// Parse a `Retry-After` response header expressed as an integer number of
+/// seconds. The HTTP-date form is uncommon on JSON APIs and intentionally
+/// unsupported — it returns `None` ("no hint") rather than guessing.
+pub fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    raw.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Assemble an [`LlmResponse`] from accumulated streaming output: text, any
+/// tool calls, and optional token usage. Every provider built this envelope
+/// the same way at the end of its stream loop.
+pub fn build_response(
+    text: String,
+    tool_calls: Vec<ToolCall>,
+    usage: Option<TokenUsage>,
+) -> LlmResponse {
+    let response = if tool_calls.is_empty() {
+        LlmResponse::text(text)
+    } else {
+        LlmResponse::with_tool_calls(text, tool_calls)
+    };
+    match usage {
+        Some(u) => response.with_usage(u),
+        None => response,
+    }
+}
+
+/// Test-only stream harnesses shared across the connector crates' stall-loop
+/// tests. Gated behind the `test-util` feature so it ships only as a
+/// dev-dependency of the providers.
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_util {
+    /// Stream that yields `n` items then stays `Pending` forever, simulating a
+    /// mid-stream stall (#220). Goes silent: never wakes, never ends.
+    pub struct StallingStream {
+        /// Number of items to yield before stalling.
+        pub remaining: usize,
+    }
+
+    impl tokio_stream::Stream for StallingStream {
+        type Item = u32;
+
+        fn poll_next(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            if self.remaining > 0 {
+                self.remaining -= 1;
+                std::task::Poll::Ready(Some(0))
+            } else {
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    /// Short label for a [`super::StreamStep`] variant, for test panic
+    /// messages.
+    pub fn step_name<T>(step: &super::StreamStep<T>) -> &'static str {
+        match step {
+            super::StreamStep::Item(_) => "Item",
+            super::StreamStep::Done => "Done",
+            super::StreamStep::Cancelled => "Cancelled",
+            super::StreamStep::Stalled => "Stalled",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_util::{StallingStream, step_name};
+    use super::*;
+    use desktop_assistant_core::domain::ToolCall;
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_fires_stall_timeout_after_silence() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut stream = StallingStream { remaining: 1 };
+        let timeout = Duration::from_millis(50);
+
+        // First item arrives immediately (the heartbeat).
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Item(_) => {}
+            other => panic!("expected first item, got {}", step_name(&other)),
+        }
+
+        // Stream now silent: the per-event timeout must fire rather than hang.
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Stalled => {}
+            other => panic!("expected stall, got {}", step_name(&other)),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_step_prefers_cancellation_over_stall() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut stream = StallingStream { remaining: 0 };
+        let timeout = Duration::from_millis(50);
+        match next_step(&mut stream, &cancellation, timeout).await {
+            StreamStep::Cancelled => {}
+            other => panic!("expected cancelled, got {}", step_name(&other)),
+        }
+    }
+
+    #[test]
+    fn parse_retry_after_integer_seconds() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_static("45"),
+        );
+        assert_eq!(
+            parse_retry_after_header(&headers),
+            Some(Duration::from_secs(45))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_missing() {
+        let headers = reqwest::header::HeaderMap::new();
+        assert_eq!(parse_retry_after_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_http_date_unparseable() {
+        // HTTP-date form is uncommon on JSON APIs and intentionally
+        // unsupported; treat it as "no hint" rather than guessing.
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            reqwest::header::HeaderValue::from_static("Wed, 21 Oct 2026 07:28:00 GMT"),
+        );
+        assert_eq!(parse_retry_after_header(&headers), None);
+    }
+
+    #[test]
+    fn build_response_text_only() {
+        let resp = build_response("hello".into(), vec![], None);
+        assert_eq!(resp.text, "hello");
+        assert!(resp.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn build_response_with_tool_calls() {
+        let calls = vec![ToolCall::new("call_1", "do_thing", "{}")];
+        let resp = build_response(String::new(), calls, None);
+        assert_eq!(resp.tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn build_response_attaches_usage() {
+        let usage = TokenUsage {
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        };
+        let resp = build_response("hi".into(), vec![], Some(usage));
+        assert_eq!(resp.usage.as_ref().and_then(|u| u.input_tokens), Some(10));
+    }
+
+    #[test]
+    fn shared_timeout_constants_match_legacy_values() {
+        assert_eq!(STREAM_CONNECT_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(STREAM_EVENT_TIMEOUT, Duration::from_secs(60));
+    }
+}

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -10,54 +10,18 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
 };
+use desktop_assistant_llm_http::{
+    STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT, StreamStep, build_response, next_step,
+};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
-use tokio_stream::StreamExt;
 
-/// Maximum time to wait for the HTTP connection handshake (response headers)
-/// before failing the turn. Mirrors the Bedrock connector (#214/#220): a
-/// stalled connect must not hang the turn forever.
-const OLLAMA_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-/// Maximum gap allowed between two streamed NDJSON chunks. Each received chunk
-/// resets the clock (the heartbeat), so this only fires when the stream goes
-/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
-const OLLAMA_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-
-/// Outcome of racing a stream's next item against cancellation and a stall
-/// timeout. Extracted so the timeout behaviour is unit-testable with a short
-/// duration instead of the production 60s constant (#220).
-enum StreamStep<T> {
-    /// The stream yielded an item.
-    Item(T),
-    /// The stream ended (no more items).
-    Done,
-    /// The cancellation token tripped.
-    Cancelled,
-    /// No item arrived within the stall timeout.
-    Stalled,
-}
-
-/// Await the next item from `stream`, racing it against `cancellation` and a
-/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
-/// so the stall window resets each time a caller consumes an item.
-async fn next_step<S>(
-    stream: &mut S,
-    cancellation: &tokio_util::sync::CancellationToken,
-    timeout: std::time::Duration,
-) -> StreamStep<S::Item>
-where
-    S: tokio_stream::Stream + Unpin,
-{
-    tokio::select! {
-        _ = cancellation.cancelled() => StreamStep::Cancelled,
-        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
-        next = stream.next() => match next {
-            Some(item) => StreamStep::Item(item),
-            None => StreamStep::Done,
-        },
-    }
-}
+/// Connection-handshake / per-chunk stall budgets shared with the other
+/// connectors (#214/#220/#302). Kept as local aliases so the streaming loop
+/// reads naturally.
+const OLLAMA_CONNECT_TIMEOUT: std::time::Duration = STREAM_CONNECT_TIMEOUT;
+const OLLAMA_EVENT_TIMEOUT: std::time::Duration = STREAM_EVENT_TIMEOUT;
 
 /// Ollama LLM client that streams completions via the native `/api/chat` endpoint.
 ///
@@ -960,90 +924,15 @@ fn detect_ollama_tools_unsupported(body: &str) -> bool {
     body.to_ascii_lowercase().contains("does not support tools")
 }
 
-fn build_response(
-    text: String,
-    tool_calls: Vec<ToolCall>,
-    usage: Option<TokenUsage>,
-) -> LlmResponse {
-    let response = if tool_calls.is_empty() {
-        LlmResponse::text(text)
-    } else {
-        LlmResponse::with_tool_calls(text, tool_calls)
-    };
-    match usage {
-        Some(u) => response.with_usage(u),
-        None => response,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use httpmock::Method::{GET, POST};
     use httpmock::MockServer;
 
-    /// Stream that yields `n` items then stays `Pending` forever, simulating a
-    /// mid-stream stall (#220).
-    struct StallingStream {
-        remaining: usize,
-    }
-
-    impl tokio_stream::Stream for StallingStream {
-        type Item = u32;
-
-        fn poll_next(
-            mut self: std::pin::Pin<&mut Self>,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Self::Item>> {
-            if self.remaining > 0 {
-                self.remaining -= 1;
-                std::task::Poll::Ready(Some(0))
-            } else {
-                // Go silent: never wake, never end.
-                std::task::Poll::Pending
-            }
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_fires_stall_timeout_after_silence() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        let mut stream = StallingStream { remaining: 1 };
-        let timeout = std::time::Duration::from_millis(50);
-
-        // First item arrives immediately (the heartbeat).
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Item(_) => {}
-            other => panic!("expected first item, got {}", step_name(&other)),
-        }
-
-        // Stream now silent: the per-event timeout must fire rather than hang.
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Stalled => {}
-            other => panic!("expected stall, got {}", step_name(&other)),
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_prefers_cancellation_over_stall() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        cancellation.cancel();
-        let mut stream = StallingStream { remaining: 0 };
-        let timeout = std::time::Duration::from_millis(50);
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Cancelled => {}
-            other => panic!("expected cancelled, got {}", step_name(&other)),
-        }
-    }
-
-    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
-        match step {
-            StreamStep::Item(_) => "Item",
-            StreamStep::Done => "Done",
-            StreamStep::Cancelled => "Cancelled",
-            StreamStep::Stalled => "Stalled",
-        }
-    }
+    // The stall-loop primitive (`StreamStep` / `next_step`) and its
+    // `StallingStream` harness, and the `build_response` envelope builder, now
+    // live in `desktop-assistant-llm-http` and are tested there (#302).
 
     #[test]
     fn chat_message_from_user() {

--- a/crates/llm-openai/src/lib.rs
+++ b/crates/llm-openai/src/lib.rs
@@ -8,53 +8,19 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
     TokenUsage, current_model_override,
 };
+use desktop_assistant_llm_http::{
+    STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT, StreamStep, build_response, next_step,
+    parse_retry_after_header,
+};
 use eventsource_stream::Eventsource;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tokio_stream::StreamExt;
 
-/// Maximum time to wait for the HTTP connection handshake (response headers)
-/// before failing the turn. Mirrors the Bedrock connector (#214/#220).
-const OPENAI_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-/// Maximum gap allowed between two streamed SSE events. Each received event
-/// resets the clock (the heartbeat), so this only fires when the stream goes
-/// silent mid-response. Matches the Bedrock per-event timeout (#214/#220).
-const OPENAI_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-
-/// Outcome of racing a stream's next item against cancellation and a stall
-/// timeout. Extracted so the timeout behaviour is unit-testable with a short
-/// duration instead of the production 60s constant (#220).
-enum StreamStep<T> {
-    /// The stream yielded an item.
-    Item(T),
-    /// The stream ended (no more items).
-    Done,
-    /// The cancellation token tripped.
-    Cancelled,
-    /// No item arrived within the stall timeout.
-    Stalled,
-}
-
-/// Await the next item from `stream`, racing it against `cancellation` and a
-/// `timeout`. A fresh `tokio::time::sleep(timeout)` is created on every call,
-/// so the stall window resets each time a caller consumes an item.
-async fn next_step<S>(
-    stream: &mut S,
-    cancellation: &tokio_util::sync::CancellationToken,
-    timeout: std::time::Duration,
-) -> StreamStep<S::Item>
-where
-    S: tokio_stream::Stream + Unpin,
-{
-    tokio::select! {
-        _ = cancellation.cancelled() => StreamStep::Cancelled,
-        _ = tokio::time::sleep(timeout) => StreamStep::Stalled,
-        next = stream.next() => match next {
-            Some(item) => StreamStep::Item(item),
-            None => StreamStep::Done,
-        },
-    }
-}
+/// Connection-handshake / per-event stall budgets shared with the other
+/// connectors (#214/#220/#302). Kept as local aliases so the streaming loop
+/// reads naturally.
+const OPENAI_CONNECT_TIMEOUT: std::time::Duration = STREAM_CONNECT_TIMEOUT;
+const OPENAI_EVENT_TIMEOUT: std::time::Duration = STREAM_EVENT_TIMEOUT;
 
 /// Return the prompt-token context window for a known OpenAI model id.
 ///
@@ -704,15 +670,7 @@ impl OpenAiClient {
             tool_call_count = tool_calls.len(),
             "OpenAI response parsed"
         );
-        let mut resp = if tool_calls.is_empty() {
-            LlmResponse::text(full_response)
-        } else {
-            LlmResponse::with_tool_calls(full_response, tool_calls)
-        };
-        if let Some(usage) = token_usage {
-            resp = resp.with_usage(usage);
-        }
-        Ok(resp)
+        Ok(build_response(full_response, tool_calls, token_usage))
     }
 }
 
@@ -775,20 +733,6 @@ fn detect_openai_insufficient_quota(body: &str) -> bool {
     };
     envelope.error.code.as_deref() == Some("insufficient_quota")
         || envelope.error.error_type.as_deref() == Some("insufficient_quota")
-}
-
-/// Read the `Retry-After` HTTP header and parse it as a delay.
-///
-/// Supports the integer-seconds form (e.g. `Retry-After: 30`); the HTTP-
-/// date form is rare on JSON APIs and not parsed here. Returns `None`
-/// when the header is absent or unparseable so the caller treats it as
-/// "no hint" rather than substituting a default.
-fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<std::time::Duration> {
-    let raw = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
-    raw.trim()
-        .parse::<u64>()
-        .ok()
-        .map(std::time::Duration::from_secs)
 }
 
 /// Parse OpenAI's `"This model's maximum context length is 128000
@@ -1081,67 +1025,9 @@ mod tests {
     use super::*;
     use desktop_assistant_core::ports::llm::ReasoningLevel;
 
-    /// Stream that yields `n` items then stays `Pending` forever, simulating a
-    /// mid-stream stall (#220).
-    struct StallingStream {
-        remaining: usize,
-    }
-
-    impl tokio_stream::Stream for StallingStream {
-        type Item = u32;
-
-        fn poll_next(
-            mut self: std::pin::Pin<&mut Self>,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Self::Item>> {
-            if self.remaining > 0 {
-                self.remaining -= 1;
-                std::task::Poll::Ready(Some(0))
-            } else {
-                std::task::Poll::Pending
-            }
-        }
-    }
-
-    fn step_name<T>(step: &StreamStep<T>) -> &'static str {
-        match step {
-            StreamStep::Item(_) => "Item",
-            StreamStep::Done => "Done",
-            StreamStep::Cancelled => "Cancelled",
-            StreamStep::Stalled => "Stalled",
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_fires_stall_timeout_after_silence() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        let mut stream = StallingStream { remaining: 1 };
-        let timeout = std::time::Duration::from_millis(50);
-
-        // First item arrives immediately (the heartbeat).
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Item(_) => {}
-            other => panic!("expected first item, got {}", step_name(&other)),
-        }
-
-        // Stream now silent: the per-event timeout must fire rather than hang.
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Stalled => {}
-            other => panic!("expected stall, got {}", step_name(&other)),
-        }
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn next_step_prefers_cancellation_over_stall() {
-        let cancellation = tokio_util::sync::CancellationToken::new();
-        cancellation.cancel();
-        let mut stream = StallingStream { remaining: 0 };
-        let timeout = std::time::Duration::from_millis(50);
-        match next_step(&mut stream, &cancellation, timeout).await {
-            StreamStep::Cancelled => {}
-            other => panic!("expected cancelled, got {}", step_name(&other)),
-        }
-    }
+    // The stall-loop primitive (`StreamStep` / `next_step`) and its
+    // `StallingStream` harness now live in `desktop-assistant-llm-http` and are
+    // tested there (#302).
 
     // --- convert_messages tests ---
 
@@ -1910,18 +1796,8 @@ mod tests {
         assert!(!detect_openai_insufficient_quota("not json at all"));
     }
 
-    #[test]
-    fn parse_retry_after_integer_seconds() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::RETRY_AFTER,
-            reqwest::header::HeaderValue::from_static("60"),
-        );
-        assert_eq!(
-            parse_retry_after_header(&headers),
-            Some(std::time::Duration::from_secs(60))
-        );
-    }
+    // `parse_retry_after_header` now lives in `desktop-assistant-llm-http`
+    // and is tested there (#302).
 
     // --- Cancellation (issue #109) ---------------------------------------
 


### PR DESCRIPTION
## Summary

Extracts the streaming scaffold that was copy-pasted ~byte-for-byte across the reqwest connectors into `desktop-assistant-llm-http` (new `crates/llm-http/src/streaming.rs`), then migrates all four providers onto it.

### New shared API (`llm-http`)
- `STREAM_CONNECT_TIMEOUT` (30s) / `STREAM_EVENT_TIMEOUT` (60s) constants.
- `StreamStep<T>` + `next_step()` — the cancellation/stall-timeout race primitive (#220).
- `parse_retry_after_header()` — integer-seconds `Retry-After` parser (was byte-identical in anthropic/openai).
- `build_response()` — the `text` / `tool_calls` / optional-`usage` `LlmResponse` envelope (was ollama's helper, inlined in the others).
- `test-util` feature exposing the `StallingStream` harness + `step_name`.

All tests for these move to `llm-http` (single copy).

### Provider migrations
- **anthropic / openai / ollama:** drop their local `StreamStep`/`next_step`, timeout constants, `parse_retry_after_header`, ollama's `build_response`, and the duplicated `StallingStream`/`step_name`/`next_step`/`parse-retry` unit tests — all now imported. Constants kept as thin local aliases (`OPENAI_CONNECT_TIMEOUT = STREAM_CONNECT_TIMEOUT`, …) so the stream loops read naturally.
- **bedrock:** its AWS-SDK stream (`stream.recv()`) isn't a `tokio_stream::Stream`, so it can't reuse `next_step`; its connect/event timeout constants now alias the shared ones so the budgets can't drift from the reqwest connectors.

## Behavior-preserving

Tier-4 refactor. Each connector's streaming integration tests (cancellation, stall-timeout) and HTTP error-classification tests pass unchanged. Anthropic's always-present usage maps to `build_response(.., Some(usage))`, equivalent to the prior unconditional `.with_usage(usage)`.

## Tests

`cargo test` green for `llm-http` (18), `llm-anthropic` (72 incl. integration), `llm-openai`, `llm-ollama`, `llm-bedrock`. `cargo clippy --all-targets -D warnings` clean on all five; `cargo fmt --check` clean; full `cargo build --workspace` green.

## Note on base

Based on **`issue-304-curated-model-resolver`** (PR #331), not `origin/main`: both PRs touch `crates/llm-http/src/lib.rs` (module wiring / re-exports) and the provider import blocks, so they'd textually conflict. This PR's diff shows only the #302 changes; please merge #304 first (GitHub will retarget this PR to `main` automatically).

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)