### PR TITLE
fix(test): assert client-tool replay across sessions (repair red main from #263)

### DIFF
--- a/crates/application/src/client_tools.rs
+++ b/crates/application/src/client_tools.rs
@@ -229,6 +229,19 @@ impl ClientToolCoordinator {
             .unwrap_or(false)
     }
 
+    /// Test/diagnostic helper: true iff `name` is registered in **any**
+    /// `(user, session)` bucket. Production code must use
+    /// [`is_client_registered`], which is correctly scoped to the calling
+    /// connection's session (#261). This exists for out-of-band callers
+    /// (integration tests, diagnostics) that need to assert a registration
+    /// landed without knowing the server-minted `session_id` of the
+    /// connection that registered it — a session id that is never visible to
+    /// a caller outside that connection's request scope.
+    pub async fn is_registered_in_any_session(&self, name: &str) -> bool {
+        let regs = self.registrations.lock().unwrap();
+        regs.values().any(|set| set.contains_key(name))
+    }
+
     /// The tool definitions registered as client-local for the current
     /// connection's session, in the shape the LLM tool list expects (#234).
     /// Maps each [`api::ClientToolRegistration`] to a core [`ToolDefinition`]

--- a/crates/client-common/tests/uds_real_turn.rs
+++ b/crates/client-common/tests/uds_real_turn.rs
@@ -578,7 +578,10 @@ async fn connector_reconnects_and_replays_tools_after_daemon_restart() {
     // replays the registration. Poll until the reconnect+replay lands.
     let replayed = wait_until(Duration::from_secs(10), || {
         let coord = Arc::clone(&server2.coord);
-        async move { coord.is_client_registered("stop_listening").await }
+        // The replay lands under the reconnected connection's server-minted
+        // `(user, session_id)` bucket (#261), which the test can't name from
+        // out here; assert across all sessions instead.
+        async move { coord.is_registered_in_any_session("stop_listening").await }
     })
     .await;
     assert!(
@@ -773,7 +776,10 @@ async fn idle_connector_does_not_spuriously_reconnect() {
     // The tool is still registered on the SAME daemon (no restart happened);
     // and a turn still streams on the original, never-dropped connection.
     assert!(
-        server.coord.is_client_registered("noop").await,
+        // Registered under the connection's server-minted `(user, session_id)`
+        // bucket (#261); the test can't name that session from out here, so
+        // assert across all sessions.
+        server.coord.is_registered_in_any_session("noop").await,
         "an idle connection must not have dropped/reconnected (tool would survive either way, \
          but a teardown would break the turn below)"
     );


### PR DESCRIPTION
## Problem

`main`'s pre-push gate (`just check`) has been **red since 2026-06-08**, failing two `client-common` integration tests:

- `connector_reconnects_and_replays_tools_after_daemon_restart`
- `idle_connector_does_not_spuriously_reconnect`

Bisect pins the regression to **2fa2d92 (#263, "Scope client-tool registry to the login session")**: the commit immediately before it (c2d0a4b) is green in 2.5s; #263 and every commit after fail at the 10s timeout. This was previously mis-attributed to a live-daemon socket collision (#313) and routed around with `--no-verify`, but these tests use a `TempDir` socket and never touch the live daemon — the redness was real.

## Root cause (test-only)

#263 re-keyed `ClientToolCoordinator` on the composite `(user_id, session_id)`. Both tests peek at the coordinator **directly from the test task** via `coord.is_client_registered(name)`, which resolves the *default* sentinel session bucket — but the real over-the-wire registration lands under the connection's server-minted `sess-N`. The lookup never matched; the tests spun their 10s wait loops and failed.

**The product was always correct.** Registration and the turn loop's `registered_definitions()` both run inside the same connection's session scope, so voice's `say_this`/`stop_listening` tools are replayed and offered after an orchestrator restart (#246). Only the out-of-band test assertion was stale.

## Fix

Add `ClientToolCoordinator::is_registered_in_any_session(name)` — a diagnostic/test helper that scans every `(user, session)` bucket — and use it at the two cross-scope assertion sites (the test can't name the server-minted session id from outside the connection). It still fails if replay genuinely doesn't happen, so it can't mask a real regression.

## Verification

- `cargo test -p desktop-assistant-client-common --test uds_real_turn` — 5/5 pass (2.5s), daemon up **and** down, parallel and single-threaded.
- Full `just check` green with the live daemon running — **`--no-verify` no longer needed on `main`**.