### PR TITLE
Fix backend-reinstall build: --locked + pin time below broken 0.3.48

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -50,7 +50,11 @@ rcgen.workspace = true
 rustls.workspace = true
 rustls-pki-types.workspace = true
 tokio-rustls.workspace = true
-time = "0.3"
+# 0.3.48 emits conflicting `From` impls that break coherence (E0119) against any
+# blanket `impl<T> From<T>` (e.g. aws-smithy-types CanDisable, rcgen DnValue).
+# cargo unifies `time` to one version graph-wide, so this bound guards all crates.
+# Re-widen once a fixed release (>=0.3.49) is out.
+time = ">=0.3, <0.3.48"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/justfile
+++ b/justfile
@@ -133,7 +133,7 @@ backend-restart:
 
 # Rebuild + reinstall daemon binary used by systemd service, then restart it
 backend-reinstall:
-    cargo install --path crates/daemon --force
+    cargo install --path crates/daemon --force --locked
     systemctl --user restart {{service_name}}
     systemctl --user is-active {{service_name}}
 


### PR DESCRIPTION
## Problem
`just backend-reinstall` fails to build with E0119 "conflicting implementations of trait `From<…HourBase>`", surfacing in `aws-smithy-types` (or `rcgen`, depending on the build).

## Root cause
The error always points back to the **`time` crate**. The freshly-published **`time` 0.3.48** emits an impl that the compiler treats as conflicting with any blanket `impl<T> From<T> for …` (smithy's `CanDisable<T>`, rcgen's `DnValue`). The AWS crates are innocent.

`just backend-reinstall` ran `cargo install --path crates/daemon --force` **without `--locked`**, so it ignored the (good) committed `Cargo.lock` and re-resolved to the broken `time` 0.3.48.

## Fix
1. `backend-reinstall` now passes `--locked` so installs honor the tested lockfile.
2. Pin `time = ">=0.3, <0.3.48"` in `crates/daemon` (cargo unifies `time` graph-wide) so a deliberate `cargo update` can't re-pull 0.3.48 either. Re-widen once a fixed release lands.

## Verification
- `cargo build --locked -p desktop-assistant-daemon` ✅
- With the pin, a full `cargo update` keeps `time` at 0.3.47 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)