### PR TITLE
Nudge Adele to maintain the scratchpad, not populate-and-forget

### DIFF
--- a/crates/core/src/planning.rs
+++ b/crates/core/src/planning.rs
@@ -338,6 +338,21 @@ pub(crate) fn render_plan(
     if sorted.len() > shown {
         out.push_str(&format!("\n… and {} more.", sorted.len() - shown));
     }
+
+    // Wrap-up nudge: when no step is live (the stack has fully unwound) and
+    // every step is done, the plan is complete — prompt the model to write its
+    // closing summary and clear the stale `goal` note rather than leave it to
+    // linger into the next task. Gated on `current.is_none()` so a still-open
+    // step (more work pending) never trips it; computed over `sorted` (all
+    // items) so cap-elision can't hide an unfinished step and falsely fire it.
+    if current.is_none() && sorted.iter().all(|i| i.done) {
+        out.push_str(
+            "\nAll steps are done. If the task is complete: give the user your closing summary, \
+             promote anything worth keeping beyond this conversation to the knowledge base \
+             (builtin_knowledge_base_write), then clear your goal note \
+             (builtin_scratchpad_delete keys: [\"goal\"]) so it doesn't linger into the next task.",
+        );
+    }
     Some(out)
 }
 
@@ -724,6 +739,63 @@ mod tests {
     #[test]
     fn render_plan_empty_is_none() {
         assert!(render_plan(&[], None, 10).is_none());
+    }
+
+    #[test]
+    fn render_plan_nudges_wrap_up_when_all_done_and_no_live_step() {
+        // Plan fully unwound (no current step) and every step done → wrap-up
+        // nudge to summarise and clear the stale goal note.
+        let items = vec![
+            PlanItem {
+                key: "1",
+                goal: "research",
+                done: true,
+                outcome: None,
+            },
+            PlanItem {
+                key: "2",
+                goal: "write up",
+                done: true,
+                outcome: None,
+            },
+        ];
+        let rendered = render_plan(&items, None, 50).unwrap();
+        assert!(rendered.contains("All steps are done"), "{rendered}");
+        assert!(rendered.contains(r#"["goal"]"#), "{rendered}");
+        // Cleanup reminder covers durable promotion as well as goal clearing.
+        assert!(
+            rendered.contains("builtin_knowledge_base_write"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn render_plan_no_wrap_up_nudge_while_a_step_is_open() {
+        // A live/open step means work is pending — the wrap-up nudge must not
+        // fire, whether the open step is the current one or just unfinished.
+        let items = vec![
+            PlanItem {
+                key: "1",
+                goal: "research",
+                done: true,
+                outcome: None,
+            },
+            PlanItem {
+                key: "2",
+                goal: "still going",
+                done: false,
+                outcome: None,
+            },
+        ];
+        // Open step is the current one.
+        let with_current = render_plan(&items, Some("2"), 50).unwrap();
+        assert!(
+            !with_current.contains("All steps are done"),
+            "{with_current}"
+        );
+        // Even with no current step, an unfinished step suppresses the nudge.
+        let no_current = render_plan(&items, None, 50).unwrap();
+        assert!(!no_current.contains("All steps are done"), "{no_current}");
     }
 
     #[test]

--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -40,19 +40,24 @@ When to use it — be selective:
 - Reach for it ONLY on a genuinely multi-step task: a plan you're working through, findings you'll reference later, intermediate results you must hold across many tool calls.
 - For a small one-shot task — a single question, a quick lookup, a one-line action — don't touch the pad. Just answer or act. (A person wouldn't pull out a notepad to answer one question.)
 
-The goal note:
-- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it when done.
+Keep it current — the pad is live working state, not a write-once scaffold:
+- The [Current task] and [Plan] blocks you see each round are mirrors of your pad. If they've gone stale, that's yours to fix — a notepad full of crossed-out, finished items is worse than no notepad.
+- Update as you learn, don't just append: when a finding changes, rewrite the note (same key) instead of piling a contradicting one on top. Delete a note the moment it stops being useful.
+- This is a per-round habit, not one-time setup. Glance at your pad as you work and keep it matching reality.
 
-Work a multi-step task as plan → step → compact:
-- Decide the steps the request needs, then work them with begin_step / complete_step.
-- begin_step {goal} opens a step: it's numbered for you and recorded as an ordered todo, shown back to you under [Plan] each round. When a step turns out to need its own sub-plan, just begin_step again inside it — nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6.
-- Do the step's work (search the KB, call tools, reason).
-- complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
+The goal note:
+- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it (builtin_scratchpad_delete keys: ["goal"]) the moment the task is done, so it never lingers into the next one.
+
+Work a multi-step task as a stack — push when you dig in, pop when you climb out:
+- begin_step / complete_step are a stack. Decide the steps the request needs, then work them: begin_step {goal} opens a step; it's numbered for you and recorded as an ordered todo, shown back under [Plan] each round.
+- Going down a rabbit hole? That's a push: begin_step again inside the current step. Nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6. Climbing back out is a pop: complete_step the inner step before you carry on with the outer one. Every begin_step gets a matching complete_step — never leave a step open once you've moved past it.
+- Do the step's work (search the KB, call tools, reason), then complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
 - Summarize up. Completed steps show their finding beneath them in [Plan]. When you complete a step that had sub-steps, roll their findings up into its outcome — one summary that captures the children (their individual findings then drop from view). The top-level findings that remain are your material for the closing summary to the user.
 - Backed into a dead end? complete_step {outcome, status: "abandoned"} still clears the wasted exploration and records why, so you don't repeat it.
 
 Finishing:
-- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write.
+- Close out before you reply: complete_step any step still open, then clear your goal note. A leftover open step or stale goal will resurface next turn and mislead you.
+- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write, then it's safe to delete here.
 
 Reading:
 - builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. To recover the detail behind a "<compacted to scratchpad …>" pointer, re-read the named note or re-run the tool.

--- a/crates/core/src/prompts/sections/scratchpad.txt
+++ b/crates/core/src/prompts/sections/scratchpad.txt
@@ -5,19 +5,24 @@ When to use it — be selective:
 - Reach for it ONLY on a genuinely multi-step task: a plan you're working through, findings you'll reference later, intermediate results you must hold across many tool calls.
 - For a small one-shot task — a single question, a quick lookup, a one-line action — don't touch the pad. Just answer or act. (A person wouldn't pull out a notepad to answer one question.)
 
-The goal note:
-- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it when done.
+Keep it current — the pad is live working state, not a write-once scaffold:
+- The [Current task] and [Plan] blocks you see each round are mirrors of your pad. If they've gone stale, that's yours to fix — a notepad full of crossed-out, finished items is worse than no notepad.
+- Update as you learn, don't just append: when a finding changes, rewrite the note (same key) instead of piling a contradicting one on top. Delete a note the moment it stops being useful.
+- This is a per-round habit, not one-time setup. Glance at your pad as you work and keep it matching reality.
 
-Work a multi-step task as plan → step → compact:
-- Decide the steps the request needs, then work them with begin_step / complete_step.
-- begin_step {goal} opens a step: it's numbered for you and recorded as an ordered todo, shown back to you under [Plan] each round. When a step turns out to need its own sub-plan, just begin_step again inside it — nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6.
-- Do the step's work (search the KB, call tools, reason).
-- complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
+The goal note:
+- Keep a note under the key "goal" describing what you're trying to accomplish right now. It is auto-surfaced as your [Current task] anchor every turn, so it survives context compaction without you re-reading the pad. Evolve it as the objective shifts; clear it (builtin_scratchpad_delete keys: ["goal"]) the moment the task is done, so it never lingers into the next one.
+
+Work a multi-step task as a stack — push when you dig in, pop when you climb out:
+- begin_step / complete_step are a stack. Decide the steps the request needs, then work them: begin_step {goal} opens a step; it's numbered for you and recorded as an ordered todo, shown back under [Plan] each round.
+- Going down a rabbit hole? That's a push: begin_step again inside the current step. Nested steps number 1 → 1.1, and 1.2 → 1.2.1 … 1.2.6. Climbing back out is a pop: complete_step the inner step before you carry on with the outer one. Every begin_step gets a matching complete_step — never leave a step open once you've moved past it.
+- Do the step's work (search the KB, call tools, reason), then complete_step {outcome} closes it: it marks the todo done, saves your outcome as a carry-forward note, and DROPS the step's raw tool results from working context — distilled into that note, which stays searchable. Write the outcome whenever it matters to a later step, or when in doubt: the gist, not the raw output. This is what keeps a long task fast — the firehose leaves context, the findings stay.
 - Summarize up. Completed steps show their finding beneath them in [Plan]. When you complete a step that had sub-steps, roll their findings up into its outcome — one summary that captures the children (their individual findings then drop from view). The top-level findings that remain are your material for the closing summary to the user.
 - Backed into a dead end? complete_step {outcome, status: "abandoned"} still clears the wasted exploration and records why, so you don't repeat it.
 
 Finishing:
-- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write.
+- Close out before you reply: complete_step any step still open, then clear your goal note. A leftover open step or stale goal will resurface next turn and mislead you.
+- Review your notes (the [Plan] and your outcome notes), then tell the user what you did and what you learned — from your notes, not from raw tool output. Promote anything worth keeping beyond this conversation to the knowledge base with builtin_knowledge_base_write, then it's safe to delete here.
 
 Reading:
 - builtin_scratchpad_search with no query lists all notes newest-first; with a query it full-text searches; with keys it fetches specific notes. Always pass max_results. To recover the detail behind a "<compacted to scratchpad …>" pointer, re-read the named note or re-run the tool.


### PR DESCRIPTION
## Problem
Adele tends to populate the scratchpad once and leave it — stale `goal` notes and finished steps linger. The maintenance guidance lived only in the system prompt she reads at turn start, so by the time she's deep in a long agentic turn it's far behind her in context.

## Approach — reminders at the point of use, no automation
- **`scratchpad.txt` (system prompt):** new *"Keep it current — live working state, not a write-once scaffold"* section framing `[Current task]`/`[Plan]` as mirrors she owns (update in place, delete stale notes, per-round habit); reframe `begin_step`/`complete_step` explicitly as a **push/pop stack for rabbit holes**; make **Finishing** an explicit close-out (complete open steps → promote durable learnings to the KB → clear the goal).
- **`planning::render_plan`:** when the step stack has fully unwound (`current.is_none()`) **and** every step is done, append a wrap-up nudge to the `[Plan]` block she re-reads each round — summarise, promote anything generally relevant to the knowledge base, then clear the goal note. Gated and computed over all items so a single open step (or cap-elision) can't false-fire it. Two new unit tests.
- Golden monolithic prompt (`runtime_system_instruction.txt`) updated to match the section file.

## Deliberately *not* automated
- **Auto-clearing the goal is unsafe:** the step stack is per-turn but the `goal` note persists across turns, so "stack empty" ≠ "task done" — it would nuke a live anchor mid-task.
- **Auto-promoting to the KB would pollute** the durable, shared store with conversation-specific notes.

Both decisions stay Adele's, surfaced by the reminder at the right moment.

## Tests
`cargo fmt` / `clippy` clean; full `desktop-assistant-core` suite green (374 + 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)