### PR TITLE
Advertise free-form scratchpad note keys each round (#340)

### DIFF
--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -200,6 +200,7 @@ pub(crate) fn llm_messages_for_turn_with_plan(
     max_messages: usize,
     active_task: Option<&str>,
     plan: Option<&str>,
+    scratchpad_index: Option<&str>,
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
@@ -216,6 +217,7 @@ pub(crate) fn llm_messages_for_turn_with_plan(
         current_max,
         active_task,
         plan,
+        scratchpad_index,
         tool_rounds_since_anchor,
         system_refinement,
         budget,
@@ -273,6 +275,7 @@ pub(crate) fn llm_messages_for_turn_with_plan(
             current_max,
             active_task,
             plan,
+            scratchpad_index,
             tool_rounds_since_anchor,
             system_refinement,
             Some(budget),
@@ -524,6 +527,7 @@ pub(crate) fn llm_messages_for_turn(
         max_messages,
         active_task,
         None,
+        None,
         tool_rounds_since_anchor,
         system_refinement,
         budget,
@@ -699,6 +703,7 @@ fn assemble_messages_inner(
     max_messages: usize,
     active_task: Option<&str>,
     plan: Option<&str>,
+    scratchpad_index: Option<&str>,
     tool_rounds_since_anchor: u32,
     system_refinement: &str,
     budget: Option<ContextBudget>,
@@ -779,6 +784,12 @@ fn assemble_messages_inner(
     // tool results; an explicit `[Current task]` re-statement keeps the
     // assistant aligned with the original intent across compaction and
     // windowing events.
+    // Shared "context is starting to drop" signal used both by the
+    // `[Current task]` re-injection and the `[Scratchpad]` index (#340): once a
+    // long agentic loop has run past the round threshold, surfacing durable
+    // anchors again keeps the model on-task even if they're nominally visible.
+    let many_tool_rounds = tool_rounds_since_anchor > ACTIVE_TASK_ROUND_THRESHOLD;
+
     if let Some(task) = active_task.filter(|t| !t.is_empty()) {
         // Find a non-collapsed User message in the window whose content
         // matches the anchor. Messages with an active `summary_id` are
@@ -792,7 +803,6 @@ fn assemble_messages_inner(
                     .as_deref()
                     .is_some_and(|sid| active_summary_ids.contains(sid))
         });
-        let many_tool_rounds = tool_rounds_since_anchor > ACTIVE_TASK_ROUND_THRESHOLD;
 
         if !anchor_visible || many_tool_rounds {
             messages.push(Message::new(Role::System, format!("[Current task] {task}")));
@@ -806,6 +816,22 @@ fn assemble_messages_inner(
     // persisted to `conv.messages`.
     if let Some(plan) = plan.filter(|p| !p.is_empty()) {
         messages.push(Message::new(Role::System, format!("[Plan]\n{plan}")));
+    }
+
+    // Advertise the free-form scratchpad note keys (#340) right after the plan.
+    // These notes are durable in storage but otherwise invisible once the
+    // message that wrote them is windowed/compacted away — nothing re-surfaces a
+    // general note, so the model never thinks to `builtin_scratchpad_search` for
+    // it. The index lists the keys (recognition over recall), gated on the SAME
+    // "context is dropping" condition as `[Current task]`: windowing has begun
+    // (which also covers collapse-behind-summary, since summaries are only
+    // injected when windowed) OR the turn has run past the round threshold.
+    // Before that, the note content is usually still in the live conversation,
+    // so the index would only burn tokens.
+    if let Some(index) = scratchpad_index.filter(|s| !s.is_empty())
+        && (is_windowed || many_tool_rounds)
+    {
+        messages.push(Message::new(Role::System, format!("[Scratchpad] {index}")));
     }
 
     // Track which summaries have already been injected.
@@ -2403,6 +2429,139 @@ mod tests {
         assert!(result[2].content.contains(task));
         // Whatever comes next must not be a System message.
         assert_ne!(result[3].role, Role::System);
+    }
+
+    // --- Scratchpad index (#340) ---
+
+    fn scratchpad_index_text(result: &[Message]) -> Option<&str> {
+        result
+            .iter()
+            .find(|m| m.role == Role::System && m.content.starts_with("[Scratchpad]"))
+            .map(|m| m.content.as_str())
+    }
+
+    #[test]
+    fn scratchpad_index_not_shown_on_short_turn() {
+        // Anchor still visible, few tool rounds → context isn't dropping yet,
+        // so the live notes are still in view. The index would just burn tokens.
+        let msgs = vec![
+            Message::new(Role::User, "do a thing"),
+            Message::new(Role::Assistant, "on it"),
+        ];
+        let index = "Notes you've stashed (read with builtin_scratchpad_search): foo, bar.";
+        let result = llm_messages_for_turn_with_plan(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            Some("do a thing"),
+            None,
+            Some(index),
+            0,
+            "",
+            None,
+            None,
+            &default_estimate,
+        );
+        assert!(
+            scratchpad_index_text(&result).is_none(),
+            "scratchpad index must not appear on a short, fully-visible turn"
+        );
+    }
+
+    #[test]
+    fn scratchpad_index_shown_when_windowed() {
+        let total = MAX_CONTEXT_MESSAGES + 5;
+        let mut msgs: Vec<Message> = Vec::with_capacity(total);
+        msgs.push(Message::new(Role::User, "original task"));
+        for i in 1..total {
+            if i % 2 == 0 {
+                msgs.push(Message::new(Role::User, format!("u-{i}")));
+            } else {
+                msgs.push(Message::new(Role::Assistant, format!("a-{i}")));
+            }
+        }
+        let index = "Notes you've stashed (read with builtin_scratchpad_search): foo, bar.";
+        let result = llm_messages_for_turn_with_plan(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            None,
+            Some(index),
+            0,
+            "",
+            None,
+            None,
+            &default_estimate,
+        );
+        let text = scratchpad_index_text(&result)
+            .expect("scratchpad index must appear once windowing has dropped context");
+        assert!(text.contains(index));
+    }
+
+    #[test]
+    fn scratchpad_index_shown_after_many_tool_rounds() {
+        let msgs = vec![
+            Message::new(Role::User, "trace it"),
+            Message::assistant_with_tool_calls(vec![ToolCall::new("c1", "tool_a", "{}")]),
+            Message::tool_result("c1", "result"),
+        ];
+        let index = "Notes you've stashed (read with builtin_scratchpad_search): foo.";
+        let result = llm_messages_for_turn_with_plan(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            Some("trace it"),
+            None,
+            Some(index),
+            ACTIVE_TASK_ROUND_THRESHOLD + 1,
+            "",
+            None,
+            None,
+            &default_estimate,
+        );
+        assert!(
+            scratchpad_index_text(&result).is_some(),
+            "scratchpad index must appear after many tool rounds even when anchor is visible"
+        );
+    }
+
+    #[test]
+    fn scratchpad_index_omitted_when_empty() {
+        let total = MAX_CONTEXT_MESSAGES + 5;
+        let mut msgs: Vec<Message> = Vec::with_capacity(total);
+        for i in 0..total {
+            msgs.push(Message::new(Role::User, format!("m-{i}")));
+        }
+        let result = llm_messages_for_turn_with_plan(
+            &msgs,
+            &[],
+            &[],
+            &[],
+            "",
+            MAX_CONTEXT_MESSAGES,
+            None,
+            None,
+            None,
+            0,
+            "",
+            None,
+            None,
+            &default_estimate,
+        );
+        assert!(
+            scratchpad_index_text(&result).is_none(),
+            "no scratchpad index when there are no free-form notes"
+        );
     }
 
     // --- Message summary (collapsing) tests ---

--- a/crates/core/src/planning.rs
+++ b/crates/core/src/planning.rs
@@ -28,6 +28,7 @@
 //! dispatch loop; everything here is synchronous and unit-tested in isolation.
 
 use crate::domain::{Message, Role, ToolDefinition};
+use crate::ports::scratchpad::SCRATCHPAD_GOAL_KEY;
 
 /// Tool the model calls to begin a (possibly nested) step. Advertised in the
 /// per-turn tool set and intercepted by name in the dispatch loop.
@@ -411,6 +412,59 @@ fn select_plan_items<'a>(
         .enumerate()
         .filter_map(|(i, item)| keep[i].then_some(item))
         .collect()
+}
+
+/// Maximum free-form note keys named in the per-round `[Scratchpad]` index
+/// before the "… and N more" tail. Mirrors [`MAX_PLAN_ITEMS`] — the index is
+/// re-sent every round, so it stays cheap; recognition over recall means a
+/// generous-but-bounded list of keys is enough to remind the model what it has
+/// stashed.
+pub(crate) const MAX_SCRATCHPAD_INDEX_KEYS: usize = 40;
+
+/// Select the free-form notepad keys from a conversation's notes (#340).
+///
+/// "Free-form" = a `note`-typed note that is NOT already surfaced elsewhere:
+/// the `goal` note is the `[Current task]` anchor, and `outcome:<step>` notes
+/// plus `todo`-typed steps are rendered into `[Plan]`. Filtering by type alone
+/// is insufficient (both `goal` and `outcome:*` are `note`-typed), so this also
+/// excludes by key. The remaining set is the durable-but-otherwise-invisible
+/// notepad that the `[Scratchpad]` index advertises.
+pub(crate) fn freeform_note_keys<'a>(notes: &[RawNote<'a>]) -> Vec<&'a str> {
+    notes
+        .iter()
+        .filter(|n| {
+            n.note_type == OUTCOME_NOTE_TYPE
+                && n.key != SCRATCHPAD_GOAL_KEY
+                && !n.key.starts_with(OUTCOME_KEY_PREFIX)
+        })
+        .map(|n| n.key)
+        .collect()
+}
+
+/// Render the per-round `[Scratchpad]` index: a sorted, capped list of the
+/// free-form note keys, so a note the model stashed earlier survives windowing
+/// and compaction as *recognition* (it can `builtin_scratchpad_search` for the
+/// key) even after the message that wrote it is gone (#340). Keys only — no
+/// content previews. Returns `None` when there are no keys to advertise.
+pub(crate) fn render_scratchpad_index(keys: &[&str], max_items: usize) -> Option<String> {
+    let mut sorted: Vec<&str> = keys.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    if sorted.is_empty() {
+        return None;
+    }
+
+    let total = sorted.len();
+    let shown = max_items.min(total);
+    let listed = sorted[..shown].join(", ");
+
+    let mut out = format!("Notes you've stashed (read with builtin_scratchpad_search): {listed}");
+    if total > shown {
+        out.push_str(&format!(" … and {} more.", total - shown));
+    } else {
+        out.push('.');
+    }
+    Some(out)
 }
 
 /// A scratchpad note as the plan renderer needs it — just the fields it reads,
@@ -981,5 +1035,97 @@ mod tests {
     fn step_tools_have_stable_names() {
         assert_eq!(begin_step_tool().name, "begin_step");
         assert_eq!(complete_step_tool().name, "complete_step");
+    }
+
+    // --- Scratchpad index (#340) ---
+
+    #[test]
+    fn render_scratchpad_index_empty_is_none() {
+        assert!(render_scratchpad_index(&[], 5).is_none());
+    }
+
+    #[test]
+    fn render_scratchpad_index_sorts_keys() {
+        let keys = ["user-prefs", "api-quirks", "deploy-target"];
+        let rendered = render_scratchpad_index(&keys, 10).unwrap();
+        // Sorted, no "and N more" tail (under cap).
+        assert!(
+            rendered.contains("api-quirks, deploy-target, user-prefs"),
+            "keys must be rendered sorted: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("more"),
+            "no tail under cap: {rendered:?}"
+        );
+        // Advertises the read tool so the model knows how to recover content.
+        assert!(rendered.contains("builtin_scratchpad_search"));
+    }
+
+    #[test]
+    fn render_scratchpad_index_exactly_at_cap_has_no_tail() {
+        let keys = ["a", "b", "c"];
+        let rendered = render_scratchpad_index(&keys, 3).unwrap();
+        assert!(rendered.contains("a, b, c"));
+        assert!(
+            !rendered.contains("more"),
+            "exactly at cap must not show a tail: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn render_scratchpad_index_over_cap_shows_remainder_count() {
+        let keys = ["e", "d", "c", "b", "a"];
+        let rendered = render_scratchpad_index(&keys, 2).unwrap();
+        // First two in sort order are shown; the remaining 3 are summarised.
+        assert!(
+            rendered.contains("a, b"),
+            "shows capped sorted head: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("… and 3 more."),
+            "over-cap must show remainder count: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains(", c"),
+            "elided keys must not render: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn render_scratchpad_index_dedupes_and_sorts() {
+        // Duplicate keys collapse (a key is upsert-by-key in storage, but the
+        // renderer should be robust to a caller passing dups).
+        let keys = ["b", "a", "b"];
+        let rendered = render_scratchpad_index(&keys, 10).unwrap();
+        assert!(rendered.contains("a, b"));
+        assert!(
+            !rendered.contains("a, b, b"),
+            "dups must collapse: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn freeform_note_keys_filters_out_anchors_and_plan_notes() {
+        let notes = vec![
+            raw("goal", "the goal", "note", false), // excluded: [Current task]
+            raw("outcome:1", "finding", "note", false), // excluded: [Plan]
+            raw("outcome:1.2", "more", "note", false), // excluded: [Plan]
+            raw("1", "a step", "todo", false),      // excluded: [Plan] (todo)
+            raw("deploy-target", "prod", "note", false), // KEEP
+            raw("api-quirks", "rate limits", "note", false), // KEEP
+        ];
+        let mut keys = freeform_note_keys(&notes);
+        keys.sort();
+        assert_eq!(keys, vec!["api-quirks", "deploy-target"]);
+    }
+
+    #[test]
+    fn freeform_note_keys_empty_when_only_excluded() {
+        let notes = vec![
+            raw("goal", "g", "note", false),
+            raw("outcome:1", "f", "note", false),
+            raw("1", "s", "todo", true),
+        ];
+        assert!(freeform_note_keys(&notes).is_empty());
     }
 }

--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -42,6 +42,7 @@ When to use it — be selective:
 
 Keep it current — the pad is live working state, not a write-once scaffold:
 - The [Current task] and [Plan] blocks you see each round are mirrors of your pad. If they've gone stale, that's yours to fix — a notepad full of crossed-out, finished items is worse than no notepad.
+- Once context starts dropping you'll also see a [Scratchpad] line listing the keys of your other notes — your reminder that they exist after the message that wrote them has scrolled away. It shows keys only, so name notes descriptively (e.g. "deploy-target", "api-quirks") and builtin_scratchpad_search the key to read one back.
 - Update as you learn, don't just append: when a finding changes, rewrite the note (same key) instead of piling a contradicting one on top. Delete a note the moment it stops being useful.
 - This is a per-round habit, not one-time setup. Glance at your pad as you work and keep it matching reality.
 

--- a/crates/core/src/prompts/sections/scratchpad.txt
+++ b/crates/core/src/prompts/sections/scratchpad.txt
@@ -7,6 +7,7 @@ When to use it — be selective:
 
 Keep it current — the pad is live working state, not a write-once scaffold:
 - The [Current task] and [Plan] blocks you see each round are mirrors of your pad. If they've gone stale, that's yours to fix — a notepad full of crossed-out, finished items is worse than no notepad.
+- Once context starts dropping you'll also see a [Scratchpad] line listing the keys of your other notes — your reminder that they exist after the message that wrote them has scrolled away. It shows keys only, so name notes descriptively (e.g. "deploy-target", "api-quirks") and builtin_scratchpad_search the key to read one back.
 - Update as you learn, don't just append: when a finding changes, rewrite the note (same key) instead of piling a contradicting one on top. Delete a note the moment it stops being useful.
 - This is a per-round habit, not one-time setup. Glance at your pad as you work and keep it matching reality.
 

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -537,6 +537,42 @@ impl<S, L, T> ConversationHandler<S, L, T> {
         planning::render_plan_from_notes(&raw, current_key, planning::MAX_PLAN_ITEMS)
     }
 
+    /// Render the free-form scratchpad index (#340) for per-round surfacing: the
+    /// keys of `note`-typed notes that aren't already shown as `[Current task]`
+    /// (`goal`) or `[Plan]` (`outcome:*` findings and `todo` steps). These notes
+    /// are durable in storage but otherwise invisible once the message that wrote
+    /// them is windowed/compacted away, so the context builder advertises their
+    /// keys (gated on the same "context is dropping" trigger as `[Current task]`)
+    /// to remind the model what it can `builtin_scratchpad_search` for. Returns
+    /// `None` when no lister is wired or there are no free-form notes.
+    async fn render_current_scratchpad_index(
+        &self,
+        conversation_id: &ConversationId,
+    ) -> Option<String> {
+        let list = self.scratchpad_list.clone()?;
+        // No type filter — `goal` and `outcome:*` are also `note`-typed, so the
+        // free-form set is carved out by key in `freeform_note_keys`, not by a
+        // storage-side type filter.
+        let notes = list(
+            conversation_id.0.clone(),
+            None,
+            planning::MAX_SCRATCHPAD_INDEX_KEYS.saturating_mul(3),
+        )
+        .await
+        .ok()?;
+        let raw: Vec<planning::RawNote> = notes
+            .iter()
+            .map(|n| planning::RawNote {
+                key: n.key.as_str(),
+                content: n.content.as_str(),
+                note_type: n.note_type.as_str(),
+                done: n.done,
+            })
+            .collect();
+        let keys = planning::freeform_note_keys(&raw);
+        planning::render_scratchpad_index(&keys, planning::MAX_SCRATCHPAD_INDEX_KEYS)
+    }
+
     /// Build the per-turn [`StepStack`], seeding its top-level numbering from the
     /// conversation's existing `todo` notes (DA-7 / #292).
     ///
@@ -1006,6 +1042,12 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 .render_current_plan(conversation_id, current_step.as_deref())
                 .await;
 
+            // Advertise the free-form scratchpad note keys (#340) so a note the
+            // model stashed earlier survives windowing/compaction as recognition
+            // (it can search for the key) even after the writing message is gone.
+            // Gated context-builder-side on the same trigger as [Current task].
+            let scratchpad_index = self.render_current_scratchpad_index(conversation_id).await;
+
             // The estimator borrows `&self.llm` so the closure is built
             // each iteration; constructing it is cheap (no allocation).
             let estimate = |text: &str| self.llm.estimate_tokens(text);
@@ -1018,6 +1060,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                 target_window,
                 anchor,
                 plan.as_deref(),
+                scratchpad_index.as_deref(),
                 tool_rounds_since_anchor,
                 &system_refinement,
                 current_context_budget(),


### PR DESCRIPTION
Closes #340.

## What & why
The scratchpad is Adele's working memory, but only *structured* anchors survived windowing/compaction: the `goal` note re-surfaces as `[Current task]`, and `todo`/`outcome:*` notes re-render into `[Plan]`. Arbitrary **free-form** notes were durable on disk but functionally invisible — once the message that wrote a note scrolled out of the window, nothing pulled it back, so the model never thought to `builtin_scratchpad_search` for it.

This adds a cheap per-round `[Scratchpad]` index that advertises the free-form note **keys** (recognition over recall), mirroring how `[Plan]` advertises steps:

```
[Scratchpad] Notes you've stashed (read with builtin_scratchpad_search): api-quirks, deploy-target, user-prefs … and 13 more.
```

## Scoping (per the issue)
- **Free-form only.** Excludes `goal` (already `[Current task]`) and `outcome:*` (already `[Plan]`) — both are `note`-typed, so the filter excludes by key as well as type — and `todo` steps (already `[Plan]`).
- **Same gate as `[Current task]`**: only once context starts dropping (`is_windowed || tool_rounds_since_anchor > ACTIVE_TASK_ROUND_THRESHOLD`). Windowing subsumes collapse-behind-summary (summaries are only injected when windowed). Before that, the note content is still in the live conversation, so the index would only burn tokens.
- **Keys only**, no content previews. Cap **40** (`MAX_SCRATCHPAD_INDEX_KEYS`, mirrors `MAX_PLAN_ITEMS`), then a "… and N more" tail.

## Implementation
- `planning.rs`: pure `render_scratchpad_index(keys, max_items)` (sorts, dedupes, caps, tail) + `freeform_note_keys(notes)`.
- `service.rs`: `render_current_scratchpad_index` reads notes via the existing `scratchpad_list` closure and filters to free-form keys; passed into the context builder next to `plan`.
- `context/mod.rs`: thread `scratchpad_index` through the assembler; push `[Scratchpad]` right after `[Plan]` behind the shared gate.
- Prompt: a line under "Keep it current" in `scratchpad.txt`, mirrored verbatim into the golden `runtime_system_instruction.txt`.

## Testing
Unit (`planning.rs`):
- `render_scratchpad_index_empty_is_none`
- `render_scratchpad_index_sorts_keys`
- `render_scratchpad_index_exactly_at_cap_has_no_tail`
- `render_scratchpad_index_over_cap_shows_remainder_count`
- `render_scratchpad_index_dedupes_and_sorts`
- `freeform_note_keys_filters_out_anchors_and_plan_notes`
- `freeform_note_keys_empty_when_only_excluded`

Integration (`context/mod.rs`):
- `scratchpad_index_not_shown_on_short_turn`
- `scratchpad_index_shown_when_windowed`
- `scratchpad_index_shown_after_many_tool_rounds`
- `scratchpad_index_omitted_when_empty`

Plus the existing `prompts::tests::assembled_static_sections_match_original` golden still passes (prompt edit mirrored).

`just check` green (warnings-as-errors workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)