### PR TITLE
Resolve & set effective Ollama context window (num_ctx) so budget is accurate on local models

### DIFF
--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -2630,6 +2630,52 @@ y = 2
         assert_eq!(budget.max_input_tokens, 200_000);
     }
 
+    /// Integration (issue #342): a real Ollama connector with a small
+    /// configured window must drive a small resolved budget — NOT the 200K
+    /// universal fallback. Before #342 Ollama reported `None` here, so the
+    /// budget fell through to 200K, the 0.85 proactive-compaction trigger
+    /// never fired (170K vs. a real 8k window), and every turn landed in
+    /// reactive overflow-recovery. This proves the connector's effective
+    /// `num_ctx` reaches tier-2 budget resolution so compaction keys off the
+    /// real runtime window.
+    #[tokio::test]
+    async fn ollama_effective_window_drives_budget_not_200k_fallback() {
+        use desktop_assistant_core::ports::llm::LlmClient;
+        use httpmock::Method::POST;
+        use httpmock::MockServer;
+
+        let server = MockServer::start();
+        // Model's architecture ceiling is 32k; the configured num_ctx (4096)
+        // is smaller, so the effective runtime window is 4096.
+        server.mock(|when, then| {
+            when.method(POST).path("/api/show");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"model_info":{"qwen2.context_length":32768}}"#);
+        });
+
+        let client = desktop_assistant_llm_ollama::OllamaClient::new(server.url(""), "qwen2.5")
+            .with_num_ctx(Some(4_096));
+        client.warm_context_length().await;
+
+        // Tier-2 source: the connector's honest effective window.
+        let connector_max = client.max_context_tokens();
+        assert_eq!(connector_max, Some(4_096));
+
+        // No purpose override → tier 2 wins, NOT the 200K fallback.
+        let budget = resolve_context_budget(None, connector_max);
+        assert_eq!(budget.source, BudgetSource::ConnectorTable);
+        assert_eq!(budget.max_input_tokens, 4_096);
+        assert_ne!(budget.max_input_tokens, DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS);
+
+        // The 0.85 proactive-compaction trigger therefore fires at ~3481
+        // tokens — well below the real window — instead of at 170K, which
+        // the model could never reach. Sanity-check the trigger point sits
+        // inside the real window.
+        let trigger = (budget.max_input_tokens as f64 * 0.85) as u64;
+        assert!(trigger < 4_096 && trigger > 3_000);
+    }
+
     #[test]
     fn max_context_purpose_override_pulls_from_config() {
         // The `purpose_max_context_override` helper extracts the field

--- a/crates/daemon/src/routing_llm.rs
+++ b/crates/daemon/src/routing_llm.rs
@@ -475,11 +475,15 @@ mod tests {
         // `RoutingLlmClient::max_context_tokens` is plain delegation to
         // the resolved client — no overlay, no tier fallback (the
         // three-tier budget resolution lives in
-        // `config::resolve_context_budget`). Ollama returns `None`;
-        // the wrapper must too.
+        // `config::resolve_context_budget`). Post-#342 an un-warmed Ollama
+        // reports its configured-default effective `num_ctx` (never `None`),
+        // so the wrapper must surface that same value.
         let fallback = build_ollama_registry();
         let client = RoutingLlmClient::new(fallback);
-        assert_eq!(client.max_context_tokens(), None);
+        assert_eq!(
+            client.max_context_tokens(),
+            Some(desktop_assistant_llm_ollama::DEFAULT_OLLAMA_NUM_CTX)
+        );
     }
 
     // --- DynamicPurpose mode -------------------------------------------------

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -7,8 +7,8 @@ use desktop_assistant_core::CoreError;
 use desktop_assistant_core::domain::{Message, Role, ToolCall, ToolDefinition};
 use desktop_assistant_core::ports::embedding::EmbeddingClient;
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo, ReasoningConfig,
-    TokenUsage, current_model_override,
+    BudgetSource, ChunkCallback, LlmClient, LlmResponse, ModelCapabilities, ModelInfo,
+    ReasoningConfig, TokenUsage, current_context_budget, current_model_override,
 };
 use desktop_assistant_llm_http::{
     STREAM_CONNECT_TIMEOUT, STREAM_EVENT_TIMEOUT, StreamStep, build_response, next_step,
@@ -23,23 +23,56 @@ use tokio::sync::OnceCell;
 const OLLAMA_CONNECT_TIMEOUT: std::time::Duration = STREAM_CONNECT_TIMEOUT;
 const OLLAMA_EVENT_TIMEOUT: std::time::Duration = STREAM_EVENT_TIMEOUT;
 
+/// Default effective context window (`num_ctx`) the connector provisions
+/// when the user hasn't configured one (issue #342).
+///
+/// Ollama's own default is **2048**, independent of the model's real
+/// capability — a qwen2.5 that can do 32k–128k still runs at 2048 unless
+/// the daemon sets `num_ctx` explicitly. We pick a value comfortably above
+/// 2048 that any modern local chat model can hold and that consumer
+/// hardware can afford. Unlike hosted connectors we never guess
+/// *optimistically* high: Ollama silently truncates above the effective
+/// window with no error, so the window must be **provisioned** (set on the
+/// request) and **reported honestly** (`max_context_tokens`), then clamped
+/// down to the model's architecture ceiling from `/api/show`.
+pub const DEFAULT_OLLAMA_NUM_CTX: u64 = 8_192;
+
 /// Ollama LLM client that streams completions via the native `/api/chat` endpoint.
 ///
 /// Uses NDJSON streaming (one JSON object per line) and Ollama's native tool
 /// calling format. No authentication is required.
 ///
-/// Context windows are not curated — Ollama hosts arbitrary GGUF models, so
-/// we read the value from the per-model `POST /api/show` response. Because
-/// `LlmClient::max_context_tokens` is synchronous and the source is an HTTP
-/// call, the connector caches results per-model id in
-/// [`OllamaClient::context_length_cache`]. Callers should invoke
-/// [`OllamaClient::warm_context_length`] (fire-and-forget) shortly after
-/// construction to populate the cache for `self.model`; until then,
-/// `max_context_tokens()` returns `None` and the daemon's universal
-/// fallback applies. The cache is keyed by model id so per-turn model
-/// overrides (issue #34) can be warmed independently — but a cold lookup
-/// for an overridden model still returns `None` until that model has been
-/// warmed.
+/// # Effective context window (`num_ctx`) — issue #342
+///
+/// Ollama hosts arbitrary GGUF models, so we don't curate context windows.
+/// The model's *architecture* context length (the ceiling) is read from the
+/// per-model `POST /api/show` response and cached per-model in
+/// [`OllamaClient::context_length_cache`] (populated by
+/// [`OllamaClient::warm_context_length`], fire-and-forget at startup).
+///
+/// The *runtime* window is Ollama's `num_ctx`, which defaults to a measly
+/// 2048 regardless of what the model can do. We therefore:
+///
+/// 1. **Provision** an explicit `num_ctx` on every chat request, sized to a
+///    configurable default ([`DEFAULT_OLLAMA_NUM_CTX`], well above 2048) or
+///    a per-connection [`Self::with_num_ctx`] override, clamped down to the
+///    `/api/show` ceiling when known.
+/// 2. **Report** that same effective `num_ctx` from
+///    [`LlmClient::max_context_tokens`] (never `None`) so the daemon's
+///    budget resolution and the 0.85 proactive-compaction trigger key off
+///    the real runtime window instead of the 200K universal fallback.
+///
+/// When a per-turn [`ContextBudget`](desktop_assistant_core::ports::llm::ContextBudget)
+/// tagged `PurposeOverride` is installed (the user's
+/// `purposes.<kind>.max_context_tokens`), it wins over the configured
+/// default for the request `num_ctx` too — so the budget the daemon
+/// believes and the `num_ctx` actually sent agree (both clamped to the
+/// ceiling). A `ConnectorTable` budget is the connector's own value echoed
+/// back and is deliberately ignored to avoid circularity.
+///
+/// Degradation: if `/api/show` is unavailable/old, the ceiling is unknown
+/// and the configured `num_ctx` is used unclamped (logged once) — the
+/// network probe is never a hard dependency.
 pub struct OllamaClient {
     client: Client,
     model: String,
@@ -48,10 +81,14 @@ pub struct OllamaClient {
     temperature: Option<f64>,
     top_p: Option<f64>,
     max_tokens: Option<u32>,
-    /// Per-model cache of `/api/show`-derived context lengths. `None`
-    /// values are cached too (when `/api/show` declines to populate the
-    /// field) so we don't keep retrying. Populated by
-    /// [`Self::warm_context_length`] and [`Self::context_length_for`].
+    /// Configured effective context window. `None` means "use
+    /// [`DEFAULT_OLLAMA_NUM_CTX`]". Either way it is clamped to the
+    /// `/api/show` ceiling before being applied/reported.
+    num_ctx: Option<u64>,
+    /// Per-model cache of `/api/show`-derived *architecture ceiling* context
+    /// lengths. `None` values are cached too (when `/api/show` declines to
+    /// populate the field) so we don't keep retrying. Populated by
+    /// [`Self::warm_context_length`] and read by [`Self::cached_context_length`].
     context_length_cache: Mutex<HashMap<String, Option<u64>>>,
 }
 
@@ -73,6 +110,7 @@ impl OllamaClient {
             temperature: None,
             top_p: None,
             max_tokens: None,
+            num_ctx: None,
             context_length_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -103,6 +141,16 @@ impl OllamaClient {
 
     pub fn with_max_tokens(mut self, max_tokens: Option<u32>) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Configure the effective context window (`num_ctx`) the connector
+    /// provisions on chat requests and reports via
+    /// [`LlmClient::max_context_tokens`]. `None` (the default) uses
+    /// [`DEFAULT_OLLAMA_NUM_CTX`]. The value is always clamped to the model's
+    /// `/api/show` architecture ceiling when that is known (issue #342).
+    pub fn with_num_ctx(mut self, num_ctx: Option<u64>) -> Self {
+        self.num_ctx = num_ctx;
         self
     }
 
@@ -255,6 +303,10 @@ struct OllamaOptions {
     top_p: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     num_predict: Option<u32>,
+    /// Effective context window. Always set on chat requests (issue #342) so
+    /// Ollama doesn't silently fall back to its 2048 default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_ctx: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -566,6 +618,58 @@ impl OllamaClient {
             .ok()
             .and_then(|guard| guard.get(model).copied().flatten())
     }
+
+    /// The effective runtime context window (`num_ctx`) for `model` (issue
+    /// #342): the requested window clamped down to the model's `/api/show`
+    /// architecture ceiling when that ceiling is known.
+    ///
+    /// The requested window is:
+    /// - a per-turn [`ContextBudget`] tagged `PurposeOverride` (the user's
+    ///   `purposes.<kind>.max_context_tokens`), when one is installed for the
+    ///   current task — so the budget the daemon believes and the `num_ctx`
+    ///   sent on the wire agree; otherwise
+    /// - the connection's configured [`Self::num_ctx`]; otherwise
+    /// - [`DEFAULT_OLLAMA_NUM_CTX`].
+    ///
+    /// A `ConnectorTable` / `UniversalFallback` budget is ignored: the former
+    /// is this connector's own value echoed back (reading it would be
+    /// circular) and the latter is the 200K guess this method exists to
+    /// replace.
+    ///
+    /// Returns the same value `max_context_tokens()` reports and the same
+    /// value the chat request carries — the two must agree.
+    fn effective_num_ctx(&self, model: &str) -> u64 {
+        let requested = self
+            .purpose_override_window()
+            .or(self.num_ctx)
+            .unwrap_or(DEFAULT_OLLAMA_NUM_CTX);
+
+        match self.cached_context_length(model) {
+            Some(ceiling) => {
+                if requested > ceiling {
+                    tracing::debug!(
+                        model,
+                        requested,
+                        ceiling,
+                        "clamping requested num_ctx down to the model's architecture ceiling"
+                    );
+                }
+                requested.min(ceiling)
+            }
+            // Ceiling unknown (/api/show unavailable or old): degrade
+            // gracefully — provision the requested window unclamped rather
+            // than guessing high or returning None.
+            None => requested,
+        }
+    }
+
+    /// The per-turn purpose-override context window, if one is installed as a
+    /// `PurposeOverride` budget for the current task. `None` otherwise.
+    fn purpose_override_window(&self) -> Option<u64> {
+        current_context_budget()
+            .filter(|b| b.source == BudgetSource::PurposeOverride)
+            .map(|b| b.max_input_tokens)
+    }
 }
 
 #[async_trait::async_trait]
@@ -580,7 +684,11 @@ impl LlmClient for OllamaClient {
 
     fn max_context_tokens(&self) -> Option<u64> {
         let model = current_model_override().unwrap_or_else(|| self.model.clone());
-        self.cached_context_length(&model)
+        // Report the effective runtime window (configured/overridden num_ctx
+        // clamped to the ceiling), never `None` — see the type-level docs and
+        // issue #342. This is the value the daemon's budget resolution keys
+        // off, and it matches the `num_ctx` the chat request carries.
+        Some(self.effective_num_ctx(&model))
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, CoreError> {
@@ -624,16 +732,17 @@ impl LlmClient for OllamaClient {
 
         let chat_tools: Vec<ChatTool> = tools.iter().map(ChatTool::from).collect();
 
-        let options =
-            if self.temperature.is_some() || self.top_p.is_some() || self.max_tokens.is_some() {
-                Some(OllamaOptions {
-                    temperature: self.temperature,
-                    top_p: self.top_p,
-                    num_predict: self.max_tokens,
-                })
-            } else {
-                None
-            };
+        // Always provision an explicit num_ctx (issue #342): sized to the
+        // configured/overridden window, clamped to the model's ceiling. This
+        // matches what `max_context_tokens()` reports, so the budget the
+        // daemon believes and the window Ollama actually runs at agree.
+        let num_ctx = self.effective_num_ctx(&model);
+        let options = Some(OllamaOptions {
+            temperature: self.temperature,
+            top_p: self.top_p,
+            num_predict: self.max_tokens,
+            num_ctx: Some(num_ctx),
+        });
 
         let request = ChatRequest {
             model,
@@ -1420,9 +1529,16 @@ mod tests {
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
         });
 
-        let client = OllamaClient::new(server.url(""), "llama3.2");
+        // `warm_context_length` caches the /api/show *ceiling* (131_072).
+        // With a configured num_ctx at/above the ceiling, the reported
+        // effective window equals the ceiling (clamp is a no-op here).
+        let client = OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(200_000));
         let warmed = client.warm_context_length().await;
-        assert_eq!(warmed, Some(131_072));
+        assert_eq!(
+            warmed,
+            Some(131_072),
+            "warmup caches the architecture ceiling"
+        );
         assert_eq!(client.max_context_tokens(), Some(131_072));
         show.assert_calls(1);
     }
@@ -1495,8 +1611,8 @@ mod tests {
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
         });
 
-        let client =
-            OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(DEFAULT_OLLAMA_NUM_CTX));
+        let client = OllamaClient::new(server.url(""), "llama3.2")
+            .with_num_ctx(Some(DEFAULT_OLLAMA_NUM_CTX));
         let _ = client.warm_context_length().await;
 
         // Override targets a model whose ceiling hasn't been warmed: the
@@ -1838,10 +1954,9 @@ mod tests {
         // runtime window, well above Ollama's own 2048 default.
         let client = OllamaClient::new("http://localhost:11434", "llama3.2");
         assert_eq!(client.max_context_tokens(), Some(DEFAULT_OLLAMA_NUM_CTX));
-        assert!(
-            DEFAULT_OLLAMA_NUM_CTX > 2048,
-            "default num_ctx must exceed Ollama's 2048 default"
-        );
+        // The default must exceed Ollama's own 2048 default (compile-time
+        // checked, documenting the invariant the value upholds).
+        const _: () = assert!(DEFAULT_OLLAMA_NUM_CTX > 2048);
     }
 
     #[test]
@@ -1957,7 +2072,11 @@ mod tests {
         let client = OllamaClient::new(server.url(""), "clamped").with_num_ctx(Some(65_536));
         client.warm_context_length().await;
         let reported = client.max_context_tokens();
-        assert_eq!(reported, Some(4_096), "reported window is clamped to ceiling");
+        assert_eq!(
+            reported,
+            Some(4_096),
+            "reported window is clamped to ceiling"
+        );
 
         client
             .stream_completion(

--- a/crates/llm-ollama/src/lib.rs
+++ b/crates/llm-ollama/src/lib.rs
@@ -1400,9 +1400,12 @@ mod tests {
     // --- max_context_tokens / context-length cache tests ---
 
     #[test]
-    fn max_context_tokens_is_none_before_warmup() {
+    fn max_context_tokens_before_warmup_is_configured_default() {
+        // Pre-#342 this returned `None`; now an un-warmed connector reports
+        // its configured/default num_ctx so budget never falls through to the
+        // daemon's 200K universal fallback on a local model.
         let client = OllamaClient::new("http://localhost:11434", "llama3.2");
-        assert_eq!(client.max_context_tokens(), None);
+        assert_eq!(client.max_context_tokens(), Some(DEFAULT_OLLAMA_NUM_CTX));
     }
 
     #[tokio::test]
@@ -1434,8 +1437,11 @@ mod tests {
 
         let client = OllamaClient::new(server.url(""), "mystery");
         let warmed = client.warm_context_length().await;
+        // The /api/show *ceiling* probe failed → cached as None (no clamp).
         assert_eq!(warmed, None);
-        assert_eq!(client.max_context_tokens(), None);
+        // But the connector still reports its configured-default num_ctx
+        // (unclamped, since the ceiling is unknown) — never None (#342).
+        assert_eq!(client.max_context_tokens(), Some(DEFAULT_OLLAMA_NUM_CTX));
     }
 
     #[tokio::test]
@@ -1460,7 +1466,9 @@ mod tests {
                 .body(r#"{"model_info":{"qwen2.context_length":32768}}"#);
         });
 
-        let client = OllamaClient::new(server.url(""), "llama3.2");
+        // Configure a num_ctx above both ceilings so the per-model clamp
+        // surfaces each model's distinct ceiling as the reported window.
+        let client = OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(1_000_000));
 
         // Warm both models — `warm_context_length` defaults to `self.model`,
         // and `warm_context_length_for` covers the override target.
@@ -1487,14 +1495,18 @@ mod tests {
                 .body(r#"{"model_info":{"llama.context_length":131072}}"#);
         });
 
-        let client = OllamaClient::new(server.url(""), "llama3.2");
+        let client =
+            OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(DEFAULT_OLLAMA_NUM_CTX));
         let _ = client.warm_context_length().await;
 
-        // Override targets a model that hasn't been warmed: returns None
-        // (cache miss is the safe answer).
+        // Override targets a model whose ceiling hasn't been warmed: the
+        // ceiling is unknown so no clamp applies, and the connector reports its
+        // configured num_ctx unclamped (never None — #342). The safe answer is
+        // still bounded by the configured window, not the daemon's 200K
+        // fallback.
         let observed =
             with_model_override("never-warmed".into(), async { client.max_context_tokens() }).await;
-        assert_eq!(observed, None);
+        assert_eq!(observed, Some(DEFAULT_OLLAMA_NUM_CTX));
     }
 
     // --- Context-overflow detection (issue #59) --------------------------
@@ -1814,5 +1826,251 @@ mod tests {
             elapsed < Duration::from_secs(2),
             "stream should abort promptly on cancellation; took {elapsed:?}"
         );
+    }
+
+    // --- num_ctx / effective context window (issue #342) -----------------
+
+    #[test]
+    fn max_context_tokens_reports_configured_default_not_none() {
+        // Issue #342, cause 1: Ollama must never report `None` (which falls
+        // through to the daemon's 200K universal fallback). With no warmup and
+        // no explicit num_ctx, it reports the connector's sane default — a real
+        // runtime window, well above Ollama's own 2048 default.
+        let client = OllamaClient::new("http://localhost:11434", "llama3.2");
+        assert_eq!(client.max_context_tokens(), Some(DEFAULT_OLLAMA_NUM_CTX));
+        assert!(
+            DEFAULT_OLLAMA_NUM_CTX > 2048,
+            "default num_ctx must exceed Ollama's 2048 default"
+        );
+    }
+
+    #[test]
+    fn max_context_tokens_reports_explicit_num_ctx() {
+        let client =
+            OllamaClient::new("http://localhost:11434", "llama3.2").with_num_ctx(Some(16_384));
+        assert_eq!(client.max_context_tokens(), Some(16_384));
+    }
+
+    #[tokio::test]
+    async fn effective_num_ctx_clamps_configured_to_ceiling() {
+        // A configured num_ctx larger than the model's architecture ceiling
+        // (from /api/show) is clamped down to the ceiling — Ollama would
+        // silently truncate above it.
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/api/show").body_includes("tiny");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"model_info":{"llama.context_length":4096}}"#);
+        });
+
+        let client = OllamaClient::new(server.url(""), "tiny").with_num_ctx(Some(32_768));
+        client.warm_context_length().await;
+        // min(32_768 configured, 4096 ceiling) == 4096.
+        assert_eq!(client.max_context_tokens(), Some(4_096));
+    }
+
+    #[tokio::test]
+    async fn effective_num_ctx_keeps_configured_below_ceiling() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).path("/api/show").body_includes("big");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"model_info":{"llama.context_length":131072}}"#);
+        });
+
+        let client = OllamaClient::new(server.url(""), "big").with_num_ctx(Some(8_192));
+        client.warm_context_length().await;
+        // min(8_192 configured, 131_072 ceiling) == 8_192.
+        assert_eq!(client.max_context_tokens(), Some(8_192));
+    }
+
+    #[test]
+    fn effective_num_ctx_degrades_when_ceiling_unknown() {
+        // No /api/show warmup → ceiling unknown → use configured value
+        // unclamped rather than guessing or returning None.
+        let client =
+            OllamaClient::new("http://localhost:11434", "llama3.2").with_num_ctx(Some(24_000));
+        assert_eq!(client.max_context_tokens(), Some(24_000));
+    }
+
+    #[tokio::test]
+    async fn stream_completion_sends_num_ctx_in_options() {
+        // Issue #342, cause 2: the chat request must carry an explicit
+        // `num_ctx` in `options` so Ollama doesn't silently run at 2048.
+        let server = MockServer::start();
+        let _tags = server.mock(|when, then| {
+            when.method(GET).path("/api/tags");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models":[{"name":"llama3.2:latest"}]}"#);
+        });
+        let chat = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/chat")
+                .body_includes(r#""num_ctx":12345"#);
+            then.status(200)
+                .header("content-type", "application/x-ndjson")
+                .body("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+        });
+
+        let client = OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(12_345));
+        client
+            .stream_completion(
+                vec![Message::new(Role::User, "hi")],
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await
+            .expect("dispatch must succeed");
+        chat.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn num_ctx_in_request_matches_reported_max_context_tokens() {
+        // The two must agree: the num_ctx sent on the wire equals what
+        // max_context_tokens() reports (after the ceiling clamp).
+        let server = MockServer::start();
+        let _tags = server.mock(|when, then| {
+            when.method(GET).path("/api/tags");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models":[{"name":"clamped:latest"}]}"#);
+        });
+        let _show = server.mock(|when, then| {
+            when.method(POST).path("/api/show").body_includes("clamped");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"model_info":{"llama.context_length":4096}}"#);
+        });
+        let chat = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/chat")
+                .body_includes(r#""num_ctx":4096"#);
+            then.status(200)
+                .header("content-type", "application/x-ndjson")
+                .body("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+        });
+
+        let client = OllamaClient::new(server.url(""), "clamped").with_num_ctx(Some(65_536));
+        client.warm_context_length().await;
+        let reported = client.max_context_tokens();
+        assert_eq!(reported, Some(4_096), "reported window is clamped to ceiling");
+
+        client
+            .stream_completion(
+                vec![Message::new(Role::User, "hi")],
+                &[],
+                ReasoningConfig::default(),
+                Box::new(|_| true),
+            )
+            .await
+            .expect("dispatch must succeed");
+        // The request carried num_ctx == reported max_context_tokens.
+        chat.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn purpose_override_drives_num_ctx_via_context_budget() {
+        // Issue #342: a `purposes.<kind>.max_context_tokens` override installed
+        // as the per-turn ContextBudget must be applied as the request num_ctx
+        // (clamped to ceiling), not just used for budget accounting.
+        use desktop_assistant_core::ports::llm::{
+            BudgetSource, ContextBudget, with_context_budget,
+        };
+
+        let server = MockServer::start();
+        let _tags = server.mock(|when, then| {
+            when.method(GET).path("/api/tags");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models":[{"name":"llama3.2:latest"}]}"#);
+        });
+        let _show = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/show")
+                .body_includes("llama3.2");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"model_info":{"llama.context_length":131072}}"#);
+        });
+        let chat = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/chat")
+                .body_includes(r#""num_ctx":40000"#);
+            then.status(200)
+                .header("content-type", "application/x-ndjson")
+                .body("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+        });
+
+        // Connector default is small; the purpose override is larger and must win.
+        let client = OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(8_192));
+        client.warm_context_length().await;
+
+        let budget = ContextBudget {
+            max_input_tokens: 40_000,
+            source: BudgetSource::PurposeOverride,
+        };
+        with_context_budget(budget, async {
+            client
+                .stream_completion(
+                    vec![Message::new(Role::User, "hi")],
+                    &[],
+                    ReasoningConfig::default(),
+                    Box::new(|_| true),
+                )
+                .await
+                .expect("dispatch must succeed");
+        })
+        .await;
+        chat.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn connector_table_budget_does_not_override_num_ctx() {
+        // A ContextBudget tagged ConnectorTable is the connector's OWN reported
+        // value echoed back by the daemon — it must NOT be re-read as an
+        // override (that would be circular). num_ctx stays the connector's
+        // effective value.
+        use desktop_assistant_core::ports::llm::{
+            BudgetSource, ContextBudget, with_context_budget,
+        };
+
+        let server = MockServer::start();
+        let _tags = server.mock(|when, then| {
+            when.method(GET).path("/api/tags");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models":[{"name":"llama3.2:latest"}]}"#);
+        });
+        let chat = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/chat")
+                .body_includes(r#""num_ctx":8192"#);
+            then.status(200)
+                .header("content-type", "application/x-ndjson")
+                .body("{\"message\":{\"content\":\"ok\"},\"done\":true}\n");
+        });
+
+        let client = OllamaClient::new(server.url(""), "llama3.2").with_num_ctx(Some(8_192));
+        let budget = ContextBudget {
+            max_input_tokens: 999_999,
+            source: BudgetSource::ConnectorTable,
+        };
+        with_context_budget(budget, async {
+            client
+                .stream_completion(
+                    vec![Message::new(Role::User, "hi")],
+                    &[],
+                    ReasoningConfig::default(),
+                    Box::new(|_| true),
+                )
+                .await
+                .expect("dispatch must succeed");
+        })
+        .await;
+        chat.assert_calls(1);
     }
 }


### PR DESCRIPTION
Closes #342

## Problem

On local Ollama models the daemon believed it had **200K tokens** when the model was actually running at **2048**. Two compounding causes:

1. `LlmClient::max_context_tokens()` returned `None` for Ollama (before warmup), so per-turn budget fell through the three-tier resolution to the universal `DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS = 200_000` fallback. Even after warmup it reported the model's raw architecture *ceiling*, not the effective runtime window.
2. The connector never set `num_ctx` on its chat requests, so Ollama silently ran at its 2048 default regardless of the model's real capability.

Net effect: budget believed huge, real window tiny → the 0.85 proactive-compaction trigger never fired and every turn landed in reactive overflow-recovery (the worst mode).

## Fix (two-sided)

1. **Provision the window.** The Ollama connector now sets an explicit `num_ctx` on every `/api/chat` request, sized to a configurable default (`DEFAULT_OLLAMA_NUM_CTX = 8192`, well above 2048) or a per-connection `with_num_ctx` override, **clamped down to the model's `/api/show` architecture ceiling** when known.
2. **Report the truth.** `max_context_tokens()` returns that same effective `num_ctx` (never `None`), so budget resolution and the 0.85 trigger key off the real runtime window.

The `purposes.<kind>.max_context_tokens` override (tier-1 `ContextBudget`, tagged `PurposeOverride`) now flows through to the request `num_ctx` too — so the budget the daemon believes and the window actually sent **agree** (both clamped to the ceiling). A `ConnectorTable` budget is deliberately ignored to avoid circularity. When `/api/show` is unavailable the ceiling is unknown and the configured `num_ctx` is used unclamped (capability-based degradation — the probe is never a hard dependency).

## Scope

Only `crates/llm-ollama/src/lib.rs`, `crates/daemon/src/config/{resolution.rs via mod.rs tests}`, and one delegation test in `crates/daemon/src/routing_llm.rs`. No #340-owned files touched; clean rebase onto #340. No new dependencies (lockfile unchanged).

## Testing

Unit (`crates/llm-ollama`):
- `max_context_tokens_reports_configured_default_not_none` — never `None`, default > 2048
- `max_context_tokens_reports_explicit_num_ctx`
- `max_context_tokens_before_warmup_is_configured_default`
- `effective_num_ctx_clamps_configured_to_ceiling`
- `effective_num_ctx_keeps_configured_below_ceiling`
- `effective_num_ctx_degrades_when_ceiling_unknown`
- `stream_completion_sends_num_ctx_in_options`
- `num_ctx_in_request_matches_reported_max_context_tokens`
- `purpose_override_drives_num_ctx_via_context_budget`
- `connector_table_budget_does_not_override_num_ctx`
- updated: `warm_context_length_populates_cache`, `warm_context_length_caches_failures_as_none`, `max_context_tokens_consults_model_override`, `max_context_tokens_for_uncached_override_is_none`

Integration (`crates/daemon/config`):
- `ollama_effective_window_drives_budget_not_200k_fallback` — a warmed Ollama with a small configured window drives a small resolved `ContextBudget` (`ConnectorTable`, 4096), not the 200K fallback; asserts the 0.85 trigger point falls inside the real window.

Updated delegation test: `routing_llm::max_context_delegates_to_resolved_client`.

`just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)