### PR TITLE
Emit per-turn context-usage event for client context-fill indicators (#341)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -502,6 +502,26 @@ pub enum Event {
         message: String,
     },
 
+    /// Per-turn context-window fill report (issue #341). Emitted after each
+    /// LLM call once the provider reports input-token usage and the per-turn
+    /// budget is known, so clients can render a "used / budget (%)" indicator
+    /// and shift colour as the proactive-compaction line (0.85 of budget) is
+    /// approached. Carries token COUNTS only — never message content — and is
+    /// purely advisory: a client that does not understand it ignores it.
+    ContextUsage {
+        conversation_id: String,
+        request_id: String,
+        /// Prompt/input tokens the provider reported for this turn.
+        used_tokens: u64,
+        /// Resolved max input-token budget for this turn (three-tier
+        /// resolution: purpose override → connector table → fallback).
+        budget_tokens: u64,
+        /// `true` once the effective message window was shrunk and the
+        /// dropped range compacted on this turn (proactive compaction ran).
+        #[serde(default)]
+        compaction_active: bool,
+    },
+
     /// Streaming chunk for a content response.
     AssistantDelta {
         conversation_id: String,

--- a/crates/application/src/inflight.rs
+++ b/crates/application/src/inflight.rs
@@ -126,6 +126,7 @@ fn restamp_request_id(mut event: api::Event, request_id: &str) -> api::Event {
     match &mut event {
         api::Event::AssistantDelta { request_id: r, .. }
         | api::Event::AssistantStatus { request_id: r, .. }
+        | api::Event::ContextUsage { request_id: r, .. }
         | api::Event::AssistantCompleted { request_id: r, .. }
         | api::Event::AssistantError { request_id: r, .. } => {
             *r = request_id.to_string();

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -2441,6 +2441,9 @@ where
     C: ConversationService + Send + Sync + 'static,
 {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<api::Event>(STREAM_EVENT_BUFFER);
+    // Cloned before `tx` is moved into the chunk callback below; used by the
+    // context-usage sink (#341) installed around the dispatch.
+    let usage_tx = tx.clone();
 
     let sink_for_forwarder = Arc::clone(&sink);
     let forwarder = tokio::spawn(async move {
@@ -2516,12 +2519,34 @@ where
     // client-local tools and suspend on a call. Outermost: a tool observer
     // (when this turn is a tracked task) so the loop's tool/MCP calls land in
     // the task's log ring for the panel's activity feed.
+    // Context-usage sink (#341): the core dispatch loop reports each turn's
+    // fill (used / budget tokens + compaction flag) via this sink, which we
+    // forward as `Event::ContextUsage` on the same channel the chunk/status
+    // callbacks use. `try_send` is synchronous and non-blocking — usage is
+    // best-effort telemetry, so a full buffer simply drops the report rather
+    // than stalling the turn. Token COUNTS only; no message content crosses.
+    let conv_id_for_usage = conversation_id.clone();
+    let req_id_for_usage = request_id.clone();
+    let usage_sink: desktop_assistant_core::ports::llm::ContextUsageSink = Arc::new(
+        move |usage: desktop_assistant_core::ports::llm::ContextUsage| {
+            let _ = usage_tx.try_send(api::Event::ContextUsage {
+                conversation_id: conv_id_for_usage.clone(),
+                request_id: req_id_for_usage.clone(),
+                used_tokens: usage.used_tokens,
+                budget_tokens: usage.budget_tokens,
+                compaction_active: usage.compaction_active,
+            });
+        },
+    );
+
     let dispatched = async move {
         match client_tool_port {
             Some(port) => with_client_tools(port, dispatch).await,
             None => dispatch.await,
         }
     };
+    let dispatched =
+        desktop_assistant_core::ports::llm::with_context_usage_sink(usage_sink, dispatched);
     // Install this turn's task-tool observer when tracked by a registry task
     // (#256 — shared with the agent path). The companion `progress_hint` clear
     // lives in the registry's panic-safe `finalize` (#254), so there is no

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -19,6 +19,18 @@ pub enum SignalEvent {
         request_id: String,
         message: String,
     },
+    /// Per-turn context-window fill report (issue #341): `used_tokens` of
+    /// `budget_tokens` consumed this turn, plus whether proactive compaction
+    /// ran. Carries token COUNTS only — clients render a "used / budget (%)"
+    /// indicator and shift colour toward the 0.85 compaction line. Delivered
+    /// on the same stream as `Status`.
+    ContextUsage {
+        conversation_id: String,
+        request_id: String,
+        used_tokens: u64,
+        budget_tokens: u64,
+        compaction_active: bool,
+    },
     TitleChanged {
         conversation_id: String,
         title: String,

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -419,6 +419,19 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             request_id,
             message,
         }),
+        api::Event::ContextUsage {
+            conversation_id,
+            request_id,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        } => Some(SignalEvent::ContextUsage {
+            conversation_id,
+            request_id,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        }),
         api::Event::ConfigChanged { .. } => None,
         api::Event::ConversationWarningEmitted {
             conversation_id,
@@ -497,6 +510,35 @@ mod tests {
             error: "oops".to_string(),
         });
         assert!(matches!(error, Some(SignalEvent::Error { .. })));
+    }
+
+    #[test]
+    fn maps_context_usage_event() {
+        // Issue #341: the per-turn fill report crosses to the signal stream
+        // with its counts and flag intact so clients can render the indicator.
+        let signal = map_event_to_signal(api::Event::ContextUsage {
+            conversation_id: "c1".to_string(),
+            request_id: "r1".to_string(),
+            used_tokens: 12_000,
+            budget_tokens: 32_000,
+            compaction_active: true,
+        });
+        match signal {
+            Some(SignalEvent::ContextUsage {
+                conversation_id,
+                request_id,
+                used_tokens,
+                budget_tokens,
+                compaction_active,
+            }) => {
+                assert_eq!(conversation_id, "c1");
+                assert_eq!(request_id, "r1");
+                assert_eq!(used_tokens, 12_000);
+                assert_eq!(budget_tokens, 32_000);
+                assert!(compaction_active);
+            }
+            other => panic!("expected SignalEvent::ContextUsage, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -15,6 +15,29 @@ pub type ChunkCallback = Box<dyn FnMut(String) -> bool + Send>;
 /// (e.g. "Searching knowledge base...", "Querying timeclock sessions...").
 pub type StatusCallback = Box<dyn FnMut(String) + Send>;
 
+/// Per-turn context-window fill snapshot reported by the dispatch loop after
+/// each LLM call (issue #341). Carries token COUNTS only — never message
+/// content — so a client can render a "used / budget (%)" indicator and shift
+/// colour as the proactive-compaction line is approached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextUsage {
+    /// Prompt/input tokens the provider reported for this turn.
+    pub used_tokens: u64,
+    /// Resolved max input-token budget for this turn.
+    pub budget_tokens: u64,
+    /// `true` once the effective window was shrunk and the dropped range
+    /// compacted on this turn (proactive compaction ran).
+    pub compaction_active: bool,
+}
+
+/// Sink the dispatch loop calls with each turn's [`ContextUsage`]. Installed
+/// as a task-local by the daemon/application transport layer (which owns the
+/// event channel) via [`with_context_usage_sink`]; read in `send_prompt` via
+/// [`emit_context_usage`]. `Arc<dyn Fn>` so it is `Clone` for the task-local
+/// slot and may fan to the event sink from any concurrent turn. Unset outside
+/// the scope (tests, dreaming jobs), in which case emission is a no-op.
+pub type ContextUsageSink = std::sync::Arc<dyn Fn(ContextUsage) + Send + Sync>;
+
 tokio::task_local! {
     /// Per-turn reasoning configuration. Set by the daemon-side routing
     /// handler via [`with_reasoning_config`] before invoking `send_prompt`;
@@ -55,6 +78,16 @@ tokio::task_local! {
     /// in `service::ConversationHandler` doesn't need to know the daemon's
     /// resolution logic.
     static CONTEXT_BUDGET: ContextBudget;
+
+    /// Per-turn context-usage sink (issue #341). Installed by the transport
+    /// layer (which owns the client event channel) via
+    /// [`with_context_usage_sink`]; the dispatch loop reports each turn's fill
+    /// via [`emit_context_usage`]. Lives in core so the read site in
+    /// `service::ConversationHandler` need not know the transport's event
+    /// plumbing — same rationale as [`CONTEXT_BUDGET`]. Unset for callers that
+    /// don't route through the transport layer (tests, dreaming jobs), where
+    /// emission is a silent no-op.
+    static CONTEXT_USAGE_SINK: ContextUsageSink;
 
     /// Per-turn cancellation token for `send_prompt` (issue #109).
     ///
@@ -290,6 +323,24 @@ where
 /// from `max_context_tokens()`.
 pub fn current_context_budget() -> Option<ContextBudget> {
     CONTEXT_BUDGET.try_with(|b| *b).ok()
+}
+
+/// Run `fut` with `sink` installed as the per-turn context-usage sink.
+/// The dispatch loop reports each turn's [`ContextUsage`] via
+/// [`emit_context_usage`], which the transport layer forwards as an
+/// `Event::ContextUsage` on the client stream (issue #341).
+pub async fn with_context_usage_sink<F, T>(sink: ContextUsageSink, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    CONTEXT_USAGE_SINK.scope(sink, fut).await
+}
+
+/// Report this turn's context fill to the installed sink, if any. A silent
+/// no-op when no sink is installed (tests, dreaming jobs) — context usage is
+/// best-effort telemetry, never load-bearing for the turn's outcome.
+pub fn emit_context_usage(usage: ContextUsage) {
+    let _ = CONTEXT_USAGE_SINK.try_with(|sink| sink(usage));
 }
 
 /// Run `fut` with `token` installed as the per-turn cancellation token.
@@ -1597,6 +1648,68 @@ mod tests {
         })
         .await;
         assert_eq!(observed, Some(inner_budget));
+    }
+
+    // --- CONTEXT_USAGE_SINK tests (issue #341) --------------------------
+
+    #[tokio::test]
+    async fn emit_context_usage_is_noop_when_no_sink_installed() {
+        // No `with_context_usage_sink` wrapper — the foreground send path,
+        // a dreaming job, or a unit test. Emission must be a silent no-op,
+        // never a panic: context usage is best-effort telemetry.
+        emit_context_usage(ContextUsage {
+            used_tokens: 100,
+            budget_tokens: 1_000,
+            compaction_active: false,
+        });
+    }
+
+    #[tokio::test]
+    async fn emit_context_usage_invokes_installed_sink() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured_for_sink = std::sync::Arc::clone(&captured);
+        let sink: ContextUsageSink = std::sync::Arc::new(move |u: ContextUsage| {
+            captured_for_sink.lock().unwrap().push(u);
+        });
+
+        with_context_usage_sink(sink, async {
+            emit_context_usage(ContextUsage {
+                used_tokens: 12_000,
+                budget_tokens: 32_000,
+                compaction_active: false,
+            });
+            emit_context_usage(ContextUsage {
+                used_tokens: 30_000,
+                budget_tokens: 32_000,
+                compaction_active: true,
+            });
+        })
+        .await;
+
+        let got = captured.lock().unwrap().clone();
+        assert_eq!(
+            got,
+            vec![
+                ContextUsage {
+                    used_tokens: 12_000,
+                    budget_tokens: 32_000,
+                    compaction_active: false,
+                },
+                ContextUsage {
+                    used_tokens: 30_000,
+                    budget_tokens: 32_000,
+                    compaction_active: true,
+                },
+            ]
+        );
+
+        // After the scope exits the slot is unset again — emission no-ops.
+        emit_context_usage(ContextUsage {
+            used_tokens: 1,
+            budget_tokens: 2,
+            compaction_active: false,
+        });
+        assert_eq!(captured.lock().unwrap().len(), 2);
     }
 
     // --- TOOL_ALLOWLIST tests (issues #112 / #113) ----------------------

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -1208,6 +1208,11 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
             {
                 let max_tokens = budget.max_input_tokens;
                 let threshold = (max_tokens as f64 * COMPACTION_TOKEN_RATIO) as u64;
+                // Whether proactive compaction actually ran this turn — set
+                // only when we both crossed the threshold AND were able to
+                // shrink the window. Reported to clients so the indicator can
+                // show that summarization is active (#341).
+                let mut compaction_active = false;
                 if input_tokens > threshold {
                     let new_window = (target_window / 2).max(MIN_CONTEXT_MESSAGES);
                     if new_window < target_window {
@@ -1229,6 +1234,7 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                             conv.context_summary = summary;
                             conv.compacted_through = to;
                         }
+                        compaction_active = true;
                     } else {
                         tracing::debug!(
                             input_tokens,
@@ -1238,6 +1244,13 @@ impl<S: ConversationStore, L: LlmClient, T: ToolExecutor> ConversationService
                         );
                     }
                 }
+                // Surface the fill to subscribed clients (#341). Token counts
+                // only — no message content crosses this boundary.
+                crate::ports::llm::emit_context_usage(crate::ports::llm::ContextUsage {
+                    used_tokens: input_tokens,
+                    budget_tokens: max_tokens,
+                    compaction_active,
+                });
             }
 
             if !response.has_tool_calls() {
@@ -4432,6 +4445,159 @@ mod tests {
         assert_eq!(
             after.compacted_through, 0,
             "no compaction expected when token usage is below threshold"
+        );
+    }
+
+    // --- Context-usage emission tests (issue #341) ----------------------
+
+    /// Run one turn with a [`ContextUsage`](crate::ports::llm::ContextUsage)
+    /// sink + the given budget installed, returning every usage report the
+    /// dispatch loop emitted. `input_tokens` is what the mock LLM reports;
+    /// `prime_messages` seeds the conversation so the window-shrink path can
+    /// be exercised when desired.
+    async fn capture_context_usage(
+        input_tokens: u64,
+        max_context: u64,
+        prime_messages: usize,
+    ) -> Vec<crate::ports::llm::ContextUsage> {
+        use crate::ports::llm::{
+            BudgetSource, ContextBudget, ContextUsage, ContextUsageSink, with_context_budget,
+            with_context_usage_sink,
+        };
+
+        let handler = ConversationHandler::new(
+            MockStore::new(),
+            TokenReportingLlm {
+                text: "ok".into(),
+                input_tokens,
+                max_context: Some(max_context),
+            },
+            Box::new(|| "conv-1".to_string()),
+        );
+
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+        if prime_messages > 0 {
+            let mut stored = handler.get_conversation(&conv.id).await.unwrap();
+            for i in 0..prime_messages {
+                let role = if i % 2 == 0 {
+                    Role::User
+                } else {
+                    Role::Assistant
+                };
+                stored.messages.push(Message::new(role, format!("m-{i}")));
+            }
+            handler.store.update(stored).await.unwrap();
+        }
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured_for_sink = Arc::clone(&captured);
+        let sink: ContextUsageSink = Arc::new(move |u: ContextUsage| {
+            captured_for_sink.lock().unwrap().push(u);
+        });
+
+        let budget = ContextBudget {
+            max_input_tokens: max_context,
+            source: BudgetSource::ConnectorTable,
+        };
+        with_context_budget(budget, async {
+            with_context_usage_sink(sink, async {
+                handler
+                    .send_prompt(&conv.id, "next".into(), noop_callback(), noop_status())
+                    .await
+                    .unwrap();
+            })
+            .await
+        })
+        .await;
+
+        captured.lock().unwrap().clone()
+    }
+
+    #[tokio::test]
+    async fn emits_context_usage_with_correct_used_and_budget() {
+        // A modest fill well under the 0.85 line: report used/budget verbatim,
+        // compaction not active.
+        let reports = capture_context_usage(12_000, 32_000, 4).await;
+        assert_eq!(reports.len(), 1, "exactly one usage report per turn");
+        let r = reports[0];
+        assert_eq!(r.used_tokens, 12_000);
+        assert_eq!(r.budget_tokens, 32_000);
+        assert!(!r.compaction_active);
+    }
+
+    #[tokio::test]
+    async fn emits_context_usage_at_0_85_boundary_without_compaction() {
+        // Exactly at the threshold: the pressure branch uses `>` (strictly
+        // greater), so being *at* 0.85 does NOT trigger compaction. The
+        // 0.85 amber colour decision is the client's; the daemon only flags
+        // compaction when it actually ran. 27_200 == 0.85 * 32_000.
+        let reports = capture_context_usage(27_200, 32_000, 4).await;
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].used_tokens, 27_200);
+        assert_eq!(reports[0].budget_tokens, 32_000);
+        assert!(
+            !reports[0].compaction_active,
+            "at exactly 0.85 the strict `>` threshold must not flag compaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn emits_context_usage_flagging_compaction_when_window_shrinks() {
+        // Above the threshold with enough primed history that the window can
+        // actually shrink → compaction ran → flag set. used > budget here
+        // (overflow), which clients render red.
+        let reports = capture_context_usage(40_000, 32_000, MAX_CONTEXT_MESSAGES + 20).await;
+        assert_eq!(reports.len(), 1);
+        let r = reports[0];
+        assert_eq!(r.used_tokens, 40_000);
+        assert_eq!(r.budget_tokens, 32_000);
+        assert!(
+            r.used_tokens > r.budget_tokens,
+            "overflow case: used exceeds budget"
+        );
+        assert!(
+            r.compaction_active,
+            "above threshold with shrinkable window must flag compaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_context_usage_emitted_when_budget_unset() {
+        use crate::ports::llm::{ContextUsage, ContextUsageSink, with_context_usage_sink};
+
+        // No budget installed (foreground send / background job): the
+        // token-pressure branch is gated on `current_context_budget()`, so
+        // no usage is reported even though the LLM reported input tokens.
+        // This is the "used==0 at turn start / budget unknown" graceful case
+        // — clients simply never see a report and render nothing.
+        let handler = ConversationHandler::new(
+            MockStore::new(),
+            TokenReportingLlm {
+                text: "ok".into(),
+                input_tokens: 5_000,
+                max_context: Some(32_000),
+            },
+            Box::new(|| "conv-1".to_string()),
+        );
+        let conv = handler.create_conversation("Test".into()).await.unwrap();
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured_for_sink = Arc::clone(&captured);
+        let sink: ContextUsageSink = Arc::new(move |u: ContextUsage| {
+            captured_for_sink.lock().unwrap().push(u);
+        });
+        // Sink installed, but NO `with_context_budget` wrapper.
+        with_context_usage_sink(sink, async {
+            handler
+                .send_prompt(&conv.id, "next".into(), noop_callback(), noop_status())
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "no budget installed → no context-usage report"
         );
     }
 

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -137,6 +137,14 @@ pub fn translate(event: api::Event) -> ForwardAction {
         api::Event::AssistantStatus { .. } => ForwardAction::Ignored {
             kind: "assistant_status",
         },
+        // Context-usage fill (issue #341) is a UDS/WS-protocol concern — the
+        // clients that render the indicator (adele-tui, adele-gtk, KDE) all
+        // subscribe over UDS/WS. The sole D-Bus client (voice) does not show
+        // a context indicator, so there is no D-Bus signal for it. Recorded
+        // as a deliberate ignore rather than a missed translation.
+        api::Event::ContextUsage { .. } => ForwardAction::Ignored {
+            kind: "context_usage",
+        },
         api::Event::ConversationTitleChanged { .. } => ForwardAction::Ignored {
             kind: "conversation_title_changed",
         },

--- a/crates/dbus-bridge/tests/bridge.rs
+++ b/crates/dbus-bridge/tests/bridge.rs
@@ -464,6 +464,19 @@ async fn event_translator_marks_unhandled_variants_explicitly() {
             },
             "conversation_title_changed",
         ),
+        (
+            // Context-usage (issue #341) is a UDS/WS concern; the D-Bus
+            // client (voice) shows no context indicator, so it is a
+            // deliberate ignore here rather than a missed translation.
+            api::Event::ContextUsage {
+                conversation_id: "c".into(),
+                request_id: "r".into(),
+                used_tokens: 12_000,
+                budget_tokens: 32_000,
+                compaction_active: false,
+            },
+            "context_usage",
+        ),
     ];
     for (event, expected_kind) in cases {
         match translate(event) {


### PR DESCRIPTION
## What

Daemon side of issue #341 — emit the context-window fill each turn so clients (tui/gtk/KDE) can render a `used / budget (%)` indicator with colour shifts toward the 0.85 proactive-compaction line.

The numbers already existed daemon-side (provider input tokens + the resolved `CONTEXT_BUDGET` task-local, now truthful for Ollama after #342); this just emits them.

- **api-model**: new `Event::ContextUsage { used_tokens, budget_tokens, compaction_active }`. Token COUNTS only — never message content. `compaction_active` is `#[serde(default)]` for forward/backward-compat.
- **core**: `ContextUsage` domain type + `CONTEXT_USAGE_SINK` task-local (mirrors `CONTEXT_BUDGET`/`CANCELLATION_TOKEN`) with `with_context_usage_sink` / `emit_context_usage`. Reported from the existing post-call token-pressure site — resolution logic untouched. No-op when no sink installed.
- **application**: installs the sink around dispatch; forwards each report on the existing event channel via non-blocking `try_send` (telemetry never stalls a turn). Restamps request_id on re-attach/retry.
- **client-common**: `SignalEvent::ContextUsage` + `map_event_to_signal` arm → shared UDS/WS Connector fans it to clients.
- **dbus-bridge**: deliberate `Ignored { kind: "context_usage" }` (the only D-Bus client, voice, shows no indicator; tui/gtk/KDE use UDS/WS).

## Transports
Carried over **UDS** and **WS** (the transports tui/gtk subscribe on) via the shared `map_event_to_signal`. **D-Bus** deliberately ignores it (voice N/A). The daemon emits a generic `api::Event` so UDS/WS serialization needed no per-variant work.

## Security
Token counts + one bool cross the IPC boundary — no content/PII. `try_send` is non-blocking (no backpressure/DoS). Missing/malformed `compaction_active` deserializes via `#[serde(default)]`; emission no-ops rather than panics when unset.

## Testing (named)
- core ports: `emit_context_usage_is_noop_when_no_sink_installed`, `emit_context_usage_invokes_installed_sink`
- core service: `emits_context_usage_with_correct_used_and_budget`, `emits_context_usage_at_0_85_boundary_without_compaction` (strict `>` → at-boundary does not flag compaction), `emits_context_usage_flagging_compaction_when_window_shrinks` (overflow used>budget), `no_context_usage_emitted_when_budget_unset`
- client-common: `maps_context_usage_event`
- dbus-bridge: `event_translator_marks_unhandled_variants_explicitly` (extended)

`just check` green.

Refs #341 (clients land in follow-on PRs; issue closed by the final client PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)