### PR TITLE
Learn & persist effective context window from overflow errors (adaptive budget safety-net) (#343)

### DIFF
--- a/crates/core/src/ports/llm.rs
+++ b/crates/core/src/ports/llm.rs
@@ -267,6 +267,11 @@ pub enum BudgetSource {
     /// Conservative universal fallback used when neither the purpose
     /// nor the connector supplied a value.
     UniversalFallback,
+    /// A learned observed-overflow window (issue #343) capped the budget
+    /// DOWN below the value the tiers above resolved. Only set when the
+    /// learned cap actually applied; identifies a budget driven by the
+    /// adaptive safety net rather than config/connector.
+    LearnedCap,
 }
 
 /// Run `fut` with `budget` installed as the resolved per-turn context

--- a/crates/core/src/ports/store.rs
+++ b/crates/core/src/ports/store.rs
@@ -340,6 +340,56 @@ pub trait ErrorClassificationStore: Send + Sync {
     async fn record(&self, connector: &str, signature: &str, cause: &str) -> Result<(), CoreError>;
 }
 
+/// A learned effective context-window observation (issue #343): the smallest
+/// provider-rejected window we have seen for a `(connector, model)` pair, paired
+/// with the configured window that was in force when we saw it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LearnedWindow {
+    /// The provider-reported `max_tokens` from an overflow error — a window we
+    /// observed reject a prompt, so the real ceiling is at most this.
+    pub observed_limit: u64,
+    /// The effective configured budget in force when the overflow happened.
+    /// Used for invalidation: a row whose `configured_window` differs from the
+    /// current effective budget is stale and must be ignored, so a config bump
+    /// starts fresh from the new ceiling rather than the old observation.
+    pub configured_window: u64,
+}
+
+/// Outbound port for the learned context-window cache (issue #343) — the
+/// reactive safety net that complements #342's proactive window provisioning.
+///
+/// Like [`ErrorClassificationStore`] this store is **global, not per-user**: it
+/// records how large a window a hosted model actually accepts (connector/model
+/// knowledge), not personal data, so it deliberately does not scope by
+/// `current_user_id()`.
+///
+/// The learned value is only ever applied as a `min()` CAP and only ratchets
+/// DOWN — raising a window is a deliberate config action (#342), never inferred.
+#[async_trait::async_trait]
+pub trait LearnedWindowStore: Send + Sync {
+    /// Return the learned observation for `(connector, model)`, or `Ok(None)` on
+    /// a miss. The caller is responsible for invalidation (comparing
+    /// `configured_window` against the current effective budget).
+    async fn lookup(
+        &self,
+        connector: &str,
+        model: &str,
+    ) -> Result<Option<LearnedWindow>, CoreError>;
+
+    /// Record an observed overflow ceiling for `(connector, model)` under the
+    /// given `configured_window`. Implementations enforce the down-only ratchet:
+    /// when an existing row shares the same `configured_window`, only a SMALLER
+    /// `observed_limit` overwrites it; a new (higher or equal) configured window
+    /// replaces the row entirely (a deliberate window change starts fresh).
+    async fn record(
+        &self,
+        connector: &str,
+        model: &str,
+        observed_limit: u64,
+        configured_window: u64,
+    ) -> Result<(), CoreError>;
+}
+
 /// Outbound port for persisting conversations.
 pub trait ConversationStore: Send + Sync {
     fn create(

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -42,6 +42,7 @@ use desktop_assistant_core::ports::llm::{
     ChunkCallback, LlmClient, ReasoningConfig, ReasoningLevel, StatusCallback, with_context_budget,
     with_model_override, with_personality, with_reasoning_config, with_system_refinement,
 };
+use desktop_assistant_core::ports::store::LearnedWindowStore;
 use desktop_assistant_core::prompts::{Personality, PersonalityOverride};
 
 use crate::config::{
@@ -616,6 +617,11 @@ where
     inner: Arc<Inner>,
     selection_store: Arc<S>,
     registry: Arc<RegistryHandle>,
+    /// Learned context-window cache (issue #343). When present, an
+    /// observed-overflow ceiling for the resolved `(connector, model)` caps the
+    /// per-turn budget DOWN (see [`crate::config::apply_learned_cap`]). `None`
+    /// (tests, no database) disables the safety net; resolution is unchanged.
+    window_store: Option<Arc<dyn LearnedWindowStore>>,
 }
 
 impl<S, Inner> RoutingConversationHandler<S, Inner>
@@ -628,7 +634,15 @@ where
             inner,
             selection_store,
             registry,
+            window_store: None,
         }
+    }
+
+    /// Install the learned context-window cache (issue #343) so budget
+    /// resolution applies the DOWN-only observed-overflow cap.
+    pub fn with_window_store(mut self, window_store: Arc<dyn LearnedWindowStore>) -> Self {
+        self.window_store = Some(window_store);
+        self
     }
 
     /// Resolve the interactive purpose from the current config. Used as
@@ -1073,6 +1087,32 @@ where
             None
         };
         let budget = crate::config::resolve_context_budget(purpose_override, connector_max);
+
+        // Issue #343: cap the resolved budget DOWN to a previously-observed
+        // overflow ceiling for this `(connector, model)`, if one was learned
+        // under the *same* effective configured window. `apply_learned_cap`
+        // enforces the down-only, invalidation, and sanity-floor rules; a miss
+        // or a stale/raising/pathological value leaves the budget untouched.
+        // The key MUST match the persist side in `ClassifyingLlmClient`:
+        // connector *type* string + the resolved model id.
+        let budget = if let (Some(store), Some(sel)) =
+            (self.window_store.as_ref(), effective_selection.as_ref())
+        {
+            let connector = ConnectionId::new(sel.connection_id.clone())
+                .ok()
+                .map(|id| self.registry.connector_type_for(&id).unwrap_or_default())
+                .unwrap_or_default();
+            match store.lookup(&connector, &sel.model_id).await {
+                Ok(learned) => crate::config::apply_learned_cap(budget, learned),
+                Err(e) => {
+                    tracing::warn!(error = %e, "learned-window lookup failed; using resolved budget");
+                    budget
+                }
+            }
+        } else {
+            budget
+        };
+
         tracing::info!(
             purpose = ?PurposeKind::Interactive,
             connection = ?effective_selection.as_ref().map(|s| s.connection_id.as_str()),
@@ -1998,6 +2038,11 @@ api_key_env = "{unused}"
             /// resolved the conversation override against the global config and
             /// installed the effective personality on the dispatch scope.
             captured_personality: StdMutex<Vec<Personality>>,
+            /// Snapshot of the `CONTEXT_BUDGET` task-local (#343) at each
+            /// `send_prompt` — proves the resolved (and possibly learned-capped)
+            /// budget reaches the dispatch scope.
+            captured_budget:
+                StdMutex<Vec<Option<desktop_assistant_core::ports::llm::ContextBudget>>>,
         }
 
         impl CapturingInner {
@@ -2007,6 +2052,7 @@ api_key_env = "{unused}"
                     captured_active_client_set: StdMutex::new(Vec::new()),
                     captured_model_override: StdMutex::new(Vec::new()),
                     captured_personality: StdMutex::new(Vec::new()),
+                    captured_budget: StdMutex::new(Vec::new()),
                 }
             }
         }
@@ -2068,6 +2114,8 @@ api_key_env = "{unused}"
                 self.captured_model_override.lock().unwrap().push(model);
                 let personality = desktop_assistant_core::ports::llm::current_personality();
                 self.captured_personality.lock().unwrap().push(personality);
+                let budget = desktop_assistant_core::ports::llm::current_context_budget();
+                self.captured_budget.lock().unwrap().push(budget);
                 Ok("ok".to_string())
             }
         }
@@ -2144,6 +2192,132 @@ api_key_env = "{unused}"
             assert_eq!(
                 captured[0], global,
                 "no override → the global personality must be installed verbatim"
+            );
+        }
+
+        // ─── Issue #343: learned context-window cap at dispatch ───────────
+
+        /// Window-store double returning a fixed learned observation.
+        struct FixedWindowStore(Option<desktop_assistant_core::ports::store::LearnedWindow>);
+        #[async_trait::async_trait]
+        impl LearnedWindowStore for FixedWindowStore {
+            async fn lookup(
+                &self,
+                _connector: &str,
+                _model: &str,
+            ) -> Result<Option<desktop_assistant_core::ports::store::LearnedWindow>, CoreError>
+            {
+                Ok(self.0)
+            }
+            async fn record(
+                &self,
+                _connector: &str,
+                _model: &str,
+                _observed_limit: u64,
+                _configured_window: u64,
+            ) -> Result<(), CoreError> {
+                Ok(())
+            }
+        }
+
+        /// End-to-end (issue #343): a turn-1 overflow learned a 4096 ceiling
+        /// under the same configured window the resolver produces (8192, the
+        /// Ollama effective num_ctx). On the NEXT turn budget resolution caps
+        /// DOWN to 4096, so the dispatch scope sees the smaller budget — the
+        /// turn no longer assumes the too-large window that overflowed.
+        #[tokio::test]
+        async fn learned_window_caps_budget_down_on_next_turn() {
+            let cfg = local_ollama_cfg();
+            let registry = make_handle_with(cfg);
+            let inner = Arc::new(CapturingInner::new());
+            let store = Arc::new(InMemoryConversationSelectionStore::default());
+            // Resolver yields 8192 for this dead-ollama connection (the
+            // configured effective num_ctx). The learned row matches that
+            // configured window and observed 4096, so it must cap DOWN.
+            let window = Arc::new(FixedWindowStore(Some(
+                desktop_assistant_core::ports::store::LearnedWindow {
+                    observed_limit: 4_096,
+                    configured_window: 8_192,
+                },
+            )));
+            let routing = Arc::new(
+                RoutingConversationHandler::new(
+                    Arc::clone(&inner),
+                    Arc::clone(&store),
+                    Arc::clone(&registry),
+                )
+                .with_window_store(window),
+            );
+
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("send_prompt");
+
+            let captured = inner.captured_budget.lock().unwrap();
+            let budget = captured[0].expect("budget installed");
+            assert_eq!(
+                budget.max_input_tokens, 4_096,
+                "next turn must start under the learned ceiling, not the 8192 window that overflowed"
+            );
+            assert_eq!(
+                budget.source,
+                desktop_assistant_core::ports::llm::BudgetSource::LearnedCap
+            );
+        }
+
+        /// Invalidation end-to-end: a learned observation recorded under a
+        /// DIFFERENT configured window than the resolver now produces is stale
+        /// and must NOT cap — the budget reflects the fresh resolved window.
+        #[tokio::test]
+        async fn stale_learned_window_does_not_cap_budget() {
+            let cfg = local_ollama_cfg();
+            let registry = make_handle_with(cfg);
+            let inner = Arc::new(CapturingInner::new());
+            let store = Arc::new(InMemoryConversationSelectionStore::default());
+            // Observed 4096, but under an OLD 2048 configured window — the
+            // resolver now produces 8192, so this row is stale and ignored.
+            let window = Arc::new(FixedWindowStore(Some(
+                desktop_assistant_core::ports::store::LearnedWindow {
+                    observed_limit: 4_096,
+                    configured_window: 2_048,
+                },
+            )));
+            let routing = Arc::new(
+                RoutingConversationHandler::new(
+                    Arc::clone(&inner),
+                    Arc::clone(&store),
+                    Arc::clone(&registry),
+                )
+                .with_window_store(window),
+            );
+
+            let (on_chunk, on_status) = noop_cb();
+            routing
+                .send_prompt(
+                    &ConversationId::from("c1"),
+                    "hi".into(),
+                    on_chunk,
+                    on_status,
+                )
+                .await
+                .expect("send_prompt");
+
+            let captured = inner.captured_budget.lock().unwrap();
+            let budget = captured[0].expect("budget installed");
+            assert_eq!(
+                budget.max_input_tokens, 8_192,
+                "a learned row under a different configured window is stale and must not cap"
+            );
+            assert_ne!(
+                budget.source,
+                desktop_assistant_core::ports::llm::BudgetSource::LearnedCap
             );
         }
 

--- a/crates/daemon/src/classifying_llm.rs
+++ b/crates/daemon/src/classifying_llm.rs
@@ -36,10 +36,10 @@ use desktop_assistant_core::error_classify::{
     ErrorContext, NormalizedCause, cause_to_core_error, classify_builtin,
 };
 use desktop_assistant_core::ports::llm::{
-    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig,
-    is_classification_in_progress, with_classification_in_progress,
+    ChunkCallback, LlmClient, LlmResponse, ModelInfo, ReasoningConfig, current_context_budget,
+    current_model_override, is_classification_in_progress, with_classification_in_progress,
 };
-use desktop_assistant_core::ports::store::ErrorClassificationStore;
+use desktop_assistant_core::ports::store::{ErrorClassificationStore, LearnedWindowStore};
 use desktop_assistant_core::sanitize::redact_secrets;
 
 /// Per-process dependencies for the learned (tier 2) and LLM (tier 3) tiers.
@@ -52,6 +52,12 @@ pub struct ClassificationDeps {
     /// Cheap LLM used to classify genuinely novel errors (tier 3). `None`
     /// disables tier 3 (tier 2 still runs).
     pub classifier: Option<Arc<dyn LlmClient>>,
+    /// Learned context-window cache (issue #343). When a context-overflow
+    /// error carries a parsed `max_tokens`, the observed ceiling is persisted
+    /// here per `(connector, model)` so the next turn's budget resolution can
+    /// cap DOWN to it. `None` disables window learning (classification still
+    /// works).
+    pub window_store: Option<Arc<dyn LearnedWindowStore>>,
 }
 
 static CLASSIFICATION_DEPS: OnceLock<ClassificationDeps> = OnceLock::new();
@@ -112,7 +118,10 @@ impl<L> ClassifyingLlmClient<L> {
     async fn reclassify(
         &self,
         result: Result<LlmResponse, CoreError>,
-    ) -> Result<LlmResponse, CoreError> {
+    ) -> Result<LlmResponse, CoreError>
+    where
+        L: LlmClient,
+    {
         self.reclassify_with(result, CLASSIFICATION_DEPS.get())
             .await
     }
@@ -124,7 +133,10 @@ impl<L> ClassifyingLlmClient<L> {
         &self,
         result: Result<LlmResponse, CoreError>,
         deps: Option<&ClassificationDeps>,
-    ) -> Result<LlmResponse, CoreError> {
+    ) -> Result<LlmResponse, CoreError>
+    where
+        L: LlmClient,
+    {
         let detail = match result {
             Err(CoreError::Llm(detail)) => detail,
             other => return other,
@@ -133,6 +145,11 @@ impl<L> ClassifyingLlmClient<L> {
         // Tier 1: deterministic, pure — always safe.
         let cause = classify_builtin(&self.ctx(&detail));
         if !matches!(cause, NormalizedCause::Unknown) {
+            // Issue #343: when this is a context overflow that surfaced a real
+            // provider-reported ceiling, persist it as a DOWN-ONLY learned cap
+            // for the next turn. Best-effort and side-channel — never blocks or
+            // changes the error that flows on to the recovery ladder.
+            self.learn_window(&cause, deps).await;
             return self.apply(cause, detail);
         }
 
@@ -178,6 +195,65 @@ impl<L> ClassifyingLlmClient<L> {
         }
 
         Err(CoreError::Llm(detail))
+    }
+
+    /// Issue #343: persist an observed context-overflow ceiling as a DOWN-ONLY
+    /// learned cap keyed by `(connector, model)`, tagged with the effective
+    /// configured window that was in force this turn (for invalidation).
+    ///
+    /// Best-effort and defensive:
+    /// - only fires for `ContextOverflow { max_tokens: Some(n) }` — no parsed
+    ///   ceiling means nothing to learn (`max_tokens: None` persists nothing);
+    /// - skipped while a classification is in progress, so the tier-3
+    ///   classifier's own overflow can't be mislearned (and its model/budget
+    ///   task-locals would be wrong);
+    /// - requires both a window store and a live `current_context_budget()` —
+    ///   without the in-flight budget we have nothing to key invalidation on;
+    /// - the persisted value is the raw provider ceiling; the sanity-floor and
+    ///   down-only/invalidation rules are enforced at apply time
+    ///   (`apply_learned_cap`) and in the store's ratchet, so a garbage parse
+    ///   can never pin the budget even if it is written.
+    async fn learn_window(&self, cause: &NormalizedCause, deps: Option<&ClassificationDeps>)
+    where
+        L: LlmClient,
+    {
+        let NormalizedCause::ContextOverflow {
+            max_tokens: Some(observed),
+            ..
+        } = cause
+        else {
+            return;
+        };
+        if is_classification_in_progress() {
+            return;
+        }
+        let Some(store) = deps.and_then(|d| d.window_store.as_deref()) else {
+            return;
+        };
+        // The effective configured window in force for this turn — the key for
+        // invalidation. Without it we can't tell a future config bump from the
+        // stale observation, so we decline to learn.
+        let Some(budget) = current_context_budget() else {
+            return;
+        };
+        let model = current_model_override()
+            .or_else(|| self.inner.get_default_model().map(str::to_string))
+            .unwrap_or_default();
+
+        if let Err(e) = store
+            .record(&self.connector, &model, *observed, budget.max_input_tokens)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to persist learned context window");
+        } else {
+            tracing::info!(
+                connector = %self.connector,
+                model = %model,
+                observed_limit = *observed,
+                configured_window = budget.max_input_tokens,
+                "learned observed context-window ceiling (#343)"
+            );
+        }
     }
 
     /// Tier 3: ask the cheap classifier LLM to label this error. Best-effort:
@@ -592,6 +668,7 @@ mod tests {
                 cause: "billing_fatal".into(),
             }))),
             classifier: None,
+            window_store: None,
         };
         let c = wrapped(Behavior::Ok);
         let err = c
@@ -618,6 +695,7 @@ mod tests {
         let deps = ClassificationDeps {
             store: store.clone(),
             classifier: Some(classifier.clone()),
+            window_store: None,
         };
         let c = wrapped(Behavior::Ok);
         let err = c
@@ -655,6 +733,7 @@ mod tests {
         let deps = ClassificationDeps {
             store: store.clone(),
             classifier: Some(classifier.clone()),
+            window_store: None,
         };
         let c = wrapped(Behavior::Ok);
         let err = c
@@ -675,6 +754,7 @@ mod tests {
         let deps = ClassificationDeps {
             store: store.clone(),
             classifier: Some(classifier.clone()),
+            window_store: None,
         };
         let c = wrapped(Behavior::Ok);
         let err = c
@@ -703,6 +783,7 @@ mod tests {
         let deps = ClassificationDeps {
             store: store.clone(),
             classifier: Some(classifier.clone()),
+            window_store: None,
         };
         let c = wrapped(Behavior::Ok);
         let err = with_classification_in_progress(
@@ -713,5 +794,202 @@ mod tests {
         assert!(matches!(err, CoreError::Llm(_)), "got {err:?}");
         assert_eq!(classifier.calls(), 0, "tier 3 must be skipped");
         assert!(store.recorded().is_empty());
+    }
+
+    // --- Window learning (issue #343) ----------------------------------------
+
+    use desktop_assistant_core::ports::llm::{
+        BudgetSource, ContextBudget, with_context_budget, with_model_override,
+    };
+    use desktop_assistant_core::ports::store::LearnedWindow;
+
+    /// Learned-window store double: records every `record()` call.
+    struct MockWindowStore {
+        recorded: Mutex<Vec<(String, String, u64, u64)>>,
+    }
+    impl MockWindowStore {
+        fn new() -> Self {
+            Self {
+                recorded: Mutex::new(vec![]),
+            }
+        }
+        fn recorded(&self) -> Vec<(String, String, u64, u64)> {
+            self.recorded.lock().unwrap().clone()
+        }
+    }
+    #[async_trait::async_trait]
+    impl LearnedWindowStore for MockWindowStore {
+        async fn lookup(
+            &self,
+            _connector: &str,
+            _model: &str,
+        ) -> Result<Option<LearnedWindow>, CoreError> {
+            Ok(None)
+        }
+        async fn record(
+            &self,
+            connector: &str,
+            model: &str,
+            observed_limit: u64,
+            configured_window: u64,
+        ) -> Result<(), CoreError> {
+            self.recorded.lock().unwrap().push((
+                connector.into(),
+                model.into(),
+                observed_limit,
+                configured_window,
+            ));
+            Ok(())
+        }
+    }
+
+    fn budget(max: u64) -> ContextBudget {
+        ContextBudget {
+            max_input_tokens: max,
+            source: BudgetSource::ConnectorTable,
+        }
+    }
+
+    #[tokio::test]
+    async fn overflow_with_max_tokens_persists_observed_window() {
+        // A `ContextOverflow { max_tokens: Some(n) }` persists `n` for the
+        // in-flight `(connector, model)`, keyed by the effective configured
+        // window in force this turn.
+        let window = Arc::new(MockWindowStore::new());
+        let deps = ClassificationDeps {
+            store: Arc::new(MockStore::new(None)),
+            classifier: None,
+            window_store: Some(window.clone()),
+        };
+        let c = wrapped(Behavior::Ok);
+        let _ = with_context_budget(
+            budget(8_192),
+            with_model_override("qwen2.5".to_string(), async {
+                c.reclassify_with(
+                    Err(CoreError::Llm(
+                        "Input length (479258) exceeds maximum context length (4096).".into(),
+                    )),
+                    Some(&deps),
+                )
+                .await
+            }),
+        )
+        .await;
+        assert_eq!(
+            window.recorded(),
+            vec![("bedrock".into(), "qwen2.5".into(), 4_096, 8_192)],
+            "observed ceiling + configured window must be persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn overflow_without_max_tokens_persists_nothing() {
+        // No parsed ceiling → nothing to learn. (The overflow phrasing here
+        // carries no two numbers, so `max_tokens` is `None`.)
+        let window = Arc::new(MockWindowStore::new());
+        let deps = ClassificationDeps {
+            store: Arc::new(MockStore::new(None)),
+            classifier: None,
+            window_store: Some(window.clone()),
+        };
+        let c = wrapped(Behavior::Ok);
+        let err = with_context_budget(
+            budget(8_192),
+            with_model_override("qwen2.5".to_string(), async {
+                c.reclassify_with(
+                    Err(CoreError::Llm("prompt is too long".into())),
+                    Some(&deps),
+                )
+                .await
+            }),
+        )
+        .await
+        .expect_err("must be an error");
+        assert!(
+            matches!(err, CoreError::ContextOverflow { .. }),
+            "got {err:?}"
+        );
+        assert!(
+            window.recorded().is_empty(),
+            "max_tokens=None must persist nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn window_not_learned_without_a_budget_in_flight() {
+        // Without `current_context_budget()` there is nothing to key
+        // invalidation on, so we decline to learn rather than store a bogus
+        // configured_window.
+        let window = Arc::new(MockWindowStore::new());
+        let deps = ClassificationDeps {
+            store: Arc::new(MockStore::new(None)),
+            classifier: None,
+            window_store: Some(window.clone()),
+        };
+        let c = wrapped(Behavior::Ok);
+        // No `with_context_budget` wrapper.
+        let _ = with_model_override("qwen2.5".to_string(), async {
+            c.reclassify_with(
+                Err(CoreError::Llm(
+                    "Input length (479258) exceeds maximum context length (4096).".into(),
+                )),
+                Some(&deps),
+            )
+            .await
+        })
+        .await;
+        assert!(window.recorded().is_empty());
+    }
+
+    #[tokio::test]
+    async fn non_overflow_error_does_not_learn_window() {
+        // A rate-limit (or any non-overflow) cause never touches the window
+        // store.
+        let window = Arc::new(MockWindowStore::new());
+        let deps = ClassificationDeps {
+            store: Arc::new(MockStore::new(None)),
+            classifier: None,
+            window_store: Some(window.clone()),
+        };
+        let c = wrapped(Behavior::Ok);
+        let _ = with_context_budget(
+            budget(8_192),
+            with_model_override("qwen2.5".to_string(), async {
+                c.reclassify_with(
+                    Err(CoreError::Llm("rate limit exceeded, slow down".into())),
+                    Some(&deps),
+                )
+                .await
+            }),
+        )
+        .await;
+        assert!(window.recorded().is_empty());
+    }
+
+    #[tokio::test]
+    async fn window_not_learned_while_classification_in_progress() {
+        // The tier-3 classifier's OWN overflow must not be mislearned (and its
+        // model/budget task-locals would be wrong).
+        let window = Arc::new(MockWindowStore::new());
+        let deps = ClassificationDeps {
+            store: Arc::new(MockStore::new(None)),
+            classifier: None,
+            window_store: Some(window.clone()),
+        };
+        let c = wrapped(Behavior::Ok);
+        let _ = with_context_budget(
+            budget(8_192),
+            with_model_override(
+                "qwen2.5".to_string(),
+                with_classification_in_progress(c.reclassify_with(
+                    Err(CoreError::Llm(
+                        "Input length (479258) exceeds maximum context length (4096).".into(),
+                    )),
+                    Some(&deps),
+                )),
+            ),
+        )
+        .await;
+        assert!(window.recorded().is_empty());
     }
 }

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -50,14 +50,15 @@ pub use oidc::OidcValidator;
 // at `config::` for external visibility.
 #[allow(unused_imports)]
 pub use resolution::DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS;
+pub use resolution::{
+    apply_learned_cap, purpose_max_context_override, resolve_backend_tasks_llm_config,
+    resolve_connection_llm_config, resolve_context_budget, resolve_database_config,
+    resolve_embeddings_config, resolve_llm_config, resolve_persistence_config,
+    resolve_purpose_llm_config,
+};
 pub(super) use resolution::{
     default_backend_llm_model, default_base_url, default_llm_model, normalize_optional_value,
     parse_connector_or_openai,
-};
-pub use resolution::{
-    purpose_max_context_override, resolve_backend_tasks_llm_config, resolve_connection_llm_config,
-    resolve_context_budget, resolve_database_config, resolve_embeddings_config, resolve_llm_config,
-    resolve_persistence_config, resolve_purpose_llm_config,
 };
 // Bring the secrets-backend helpers used by non-test code in
 // `mod.rs` (settings setters, audit logging) into scope so call
@@ -85,7 +86,7 @@ use crate::connections::{ConnectionConfig, ConnectionId, ConnectionsError, Conne
 use crate::purposes::PurposeKind;
 use crate::purposes::Purposes;
 #[allow(unused_imports)]
-use desktop_assistant_core::ports::llm::BudgetSource;
+use desktop_assistant_core::ports::llm::{BudgetSource, ContextBudget};
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DaemonConfig {
@@ -2628,6 +2629,128 @@ y = 2
         assert_eq!(budget.max_input_tokens, DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS);
         assert_eq!(budget.source, BudgetSource::UniversalFallback);
         assert_eq!(budget.max_input_tokens, 200_000);
+    }
+
+    // --- apply_learned_cap: DOWN-ONLY learned safety net (issue #343) ----
+
+    use crate::config::resolution::{MIN_LEARNED_WINDOW, apply_learned_cap};
+    use desktop_assistant_core::ports::store::LearnedWindow;
+
+    fn budget(max: u64, source: BudgetSource) -> ContextBudget {
+        ContextBudget {
+            max_input_tokens: max,
+            source,
+        }
+    }
+
+    #[test]
+    fn learned_cap_none_leaves_budget_untouched() {
+        let b = budget(8_192, BudgetSource::ConnectorTable);
+        assert_eq!(apply_learned_cap(b, None), b);
+    }
+
+    #[test]
+    fn learned_cap_mins_below_resolved_budget() {
+        // Resolved budget is 8192 (e.g. Ollama effective num_ctx), but we
+        // previously observed an overflow at 4096 under that same configured
+        // window: cap DOWN to 4096 and re-tag the source.
+        let b = budget(8_192, BudgetSource::ConnectorTable);
+        let learned = LearnedWindow {
+            observed_limit: 4_096,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, 4_096);
+        assert_eq!(capped.source, BudgetSource::LearnedCap);
+    }
+
+    #[test]
+    fn learned_cap_never_raises_budget() {
+        // A learned value HIGHER than the resolved budget must NOT raise it:
+        // the min() is a no-op and the original budget/source stand.
+        let b = budget(8_192, BudgetSource::ConnectorTable);
+        let learned = LearnedWindow {
+            observed_limit: 32_000,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, 8_192);
+        assert_eq!(capped.source, BudgetSource::ConnectorTable);
+    }
+
+    #[test]
+    fn learned_cap_equal_to_budget_is_noop() {
+        let b = budget(8_192, BudgetSource::ConnectorTable);
+        let learned = LearnedWindow {
+            observed_limit: 8_192,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, 8_192);
+        assert_eq!(capped.source, BudgetSource::ConnectorTable);
+    }
+
+    #[test]
+    fn learned_cap_invalidated_when_configured_window_bumped_up() {
+        // The user raised the configured window from 8192 to 16384 (the new
+        // resolved budget). The learned 4096 was observed under the OLD 8192
+        // window, so it is stale and ignored — the higher ceiling stands.
+        let b = budget(16_384, BudgetSource::PurposeOverride);
+        let learned = LearnedWindow {
+            observed_limit: 4_096,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, 16_384);
+        assert_eq!(capped.source, BudgetSource::PurposeOverride);
+    }
+
+    #[test]
+    fn learned_cap_invalidated_when_configured_window_lowered() {
+        // Invalidation triggers on ANY mismatch, including a lowered window.
+        // The learned 4096 was observed under 8192; now the configured window
+        // is 2048, so the learned row is stale and ignored (2048 < 4096 anyway,
+        // but the invalidation, not the min, is what discards it).
+        let b = budget(2_048, BudgetSource::ConnectorTable);
+        let learned = LearnedWindow {
+            observed_limit: 4_096,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, 2_048);
+        assert_eq!(capped.source, BudgetSource::ConnectorTable);
+    }
+
+    #[test]
+    fn learned_cap_sanity_floor_rejects_pathological_value() {
+        // A provider error string yielding a parsed `0`/`1`/tiny value must
+        // NOT pin the budget — that would brick the assistant (no prompt fits).
+        for pathological in [0_u64, 1, MIN_LEARNED_WINDOW - 1] {
+            let b = budget(8_192, BudgetSource::ConnectorTable);
+            let learned = LearnedWindow {
+                observed_limit: pathological,
+                configured_window: 8_192,
+            };
+            let capped = apply_learned_cap(b, Some(learned));
+            assert_eq!(
+                capped.max_input_tokens, 8_192,
+                "pathological observed_limit {pathological} must be ignored"
+            );
+            assert_eq!(capped.source, BudgetSource::ConnectorTable);
+        }
+    }
+
+    #[test]
+    fn learned_cap_at_sanity_floor_is_applied() {
+        // Exactly at the floor is a legitimately-tiny window, not pathological.
+        let b = budget(8_192, BudgetSource::ConnectorTable);
+        let learned = LearnedWindow {
+            observed_limit: MIN_LEARNED_WINDOW,
+            configured_window: 8_192,
+        };
+        let capped = apply_learned_cap(b, Some(learned));
+        assert_eq!(capped.max_input_tokens, MIN_LEARNED_WINDOW);
+        assert_eq!(capped.source, BudgetSource::LearnedCap);
     }
 
     /// Integration (issue #342): a real Ollama connector with a small

--- a/crates/daemon/src/config/resolution.rs
+++ b/crates/daemon/src/config/resolution.rs
@@ -9,6 +9,7 @@
 //! the secret backends.
 
 use desktop_assistant_core::ports::llm::{BudgetSource, ContextBudget};
+use desktop_assistant_core::ports::store::LearnedWindow;
 
 use crate::connections::{
     AnthropicConnection, BedrockConnection, ConnectionConfig, Connector, OllamaConnection,
@@ -318,6 +319,64 @@ pub fn resolve_context_budget(
     ContextBudget {
         max_input_tokens: DEFAULT_PURPOSE_MAX_CONTEXT_TOKENS,
         source: BudgetSource::UniversalFallback,
+    }
+}
+
+/// Sanity floor for a learned (observed-overflow) context-window cap.
+///
+/// `observed_limit` is parsed out of an upstream provider's error STRING
+/// (`error_classify::first_two_numbers`), which is untrusted-ish: a malicious
+/// or garbled message could yield `0`, `1`, or some absurdly small number that,
+/// applied as a `min()` cap, would brick the assistant (no prompt fits). We
+/// refuse to learn — and refuse to apply — any cap below this floor. The floor
+/// is intentionally tiny (a few hundred tokens is a legitimately small window
+/// on some embedded models) so it rejects only pathological values, not
+/// genuinely-small-but-usable ones.
+pub const MIN_LEARNED_WINDOW: u64 = 256;
+
+/// Apply a learned (observed-overflow) window as a DOWN-ONLY cap on an already
+/// resolved [`ContextBudget`] (issue #343).
+///
+/// This composes *after* [`resolve_context_budget`] so the documented
+/// precedence holds: `purpose-override > learned (min, DOWN-ONLY) > connector /
+/// Ollama-effective-window > 200K fallback`. The learned value is a `min()`
+/// CAP, never an additive tier — it can only lower the budget, never raise it.
+///
+/// Guards, in order:
+///   1. **Sanity floor.** A learned `observed_limit` below [`MIN_LEARNED_WINDOW`]
+///      is pathological (garbage/hostile parse) and is ignored — a parsed `0`
+///      or `1` must never pin the budget.
+///   2. **Invalidation.** The learned row carries the `configured_window` that
+///      was in force when the overflow was observed. If that differs from the
+///      *current* effective configured window (`budget.max_input_tokens`), the
+///      observation is stale — the user bumped (or lowered) the window — so it
+///      is discarded and the fresh, higher (or new) ceiling stands. This is how
+///      a config bump escapes a previously-learned-low value.
+///   3. **Down-only.** Even for a matching configured window, the cap only
+///      applies when it is strictly below the resolved budget; a learned value
+///      `>=` the budget never raises it (the `min()` is a no-op).
+///
+/// Returns the (possibly unchanged) budget; when the cap applies, the source is
+/// re-tagged [`BudgetSource::LearnedCap`].
+pub fn apply_learned_cap(budget: ContextBudget, learned: Option<LearnedWindow>) -> ContextBudget {
+    let Some(learned) = learned else {
+        return budget;
+    };
+    // Guard 1: pathological observed value — refuse to apply.
+    if learned.observed_limit < MIN_LEARNED_WINDOW {
+        return budget;
+    }
+    // Guard 2: invalidation — stale if the configured window has changed.
+    if learned.configured_window != budget.max_input_tokens {
+        return budget;
+    }
+    // Guard 3: down-only — never raise the budget.
+    if learned.observed_limit >= budget.max_input_tokens {
+        return budget;
+    }
+    ContextBudget {
+        max_input_tokens: learned.observed_limit,
+        source: BudgetSource::LearnedCap,
     }
 }
 

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1466,9 +1466,17 @@ async fn main() -> Result<()> {
                 Arc::clone(&registry_handle),
                 purposes::PurposeKind::Titling,
             ));
+        // #343: the learned context-window cache (DOWN-only safety net). Shares
+        // the same pool; absent without a database (window learning off, tier-1
+        // classification still works).
+        let window_store: Arc<dyn desktop_assistant_core::ports::store::LearnedWindowStore> =
+            Arc::new(desktop_assistant_storage::PgLearnedWindowStore::new(
+                pool.clone(),
+            ));
         classifying_llm::install_classification_deps(classifying_llm::ClassificationDeps {
             store,
             classifier: Some(classifier),
+            window_store: Some(window_store),
         });
     }
 
@@ -1556,12 +1564,22 @@ async fn main() -> Result<()> {
     // can call `send_prompt_with_override` and have the override/stored-
     // selection priority path applied.
     let inner_conv = Arc::new(handler);
-    let routing_conv = Arc::new(api_surface::RoutingConversationHandler::new(
+    // #343: the learned context-window cache also feeds budget resolution
+    // (caps DOWN to an observed-overflow ceiling). Same pool as the classifier
+    // side; absent without a database (safety net off, resolution unchanged).
+    let mut routing_conv = api_surface::RoutingConversationHandler::new(
         Arc::clone(&inner_conv),
         Arc::new(conversation_store),
         Arc::clone(&registry_handle),
-    ));
-    let conversation_service = routing_conv;
+    );
+    if let Some(pool) = &pg_pool {
+        let window_store: Arc<dyn desktop_assistant_core::ports::store::LearnedWindowStore> =
+            Arc::new(desktop_assistant_storage::PgLearnedWindowStore::new(
+                pool.clone(),
+            ));
+        routing_conv = routing_conv.with_window_store(window_store);
+    }
+    let conversation_service = Arc::new(routing_conv);
 
     let connections_service = Arc::new(api_surface::DaemonConnectionsService::new(Arc::clone(
         &registry_handle,

--- a/crates/storage/migrations/025_context_window_observations.sql
+++ b/crates/storage/migrations/025_context_window_observations.sql
@@ -1,0 +1,36 @@
+-- Learned effective context-window observations (issue #343): an adaptive
+-- safety net that complements #342.
+--
+-- When a turn overflows and the provider's error string yields a concrete
+-- `max_tokens` (parsed in `error_classify::first_two_numbers`), we persist that
+-- observed ceiling per `(connector, model)`. Budget resolution then `min()`s it
+-- into the resolved budget so the NEXT turn starts under the real observed
+-- limit instead of re-overflowing.
+--
+-- Down-only ratchet: this table only ever records a window we *saw* reject a
+-- prompt. Raising a window is a deliberate config action (#342), never inferred
+-- from success, so `record` keeps the SMALLEST observed limit seen for a given
+-- configured window.
+--
+-- Invalidation by configured window: `configured_window` stores the effective
+-- configured budget that was in force when the overflow happened. Resolution
+-- ignores a learned row whose `configured_window` differs from the current
+-- effective budget — so when the user raises (or lowers) the configured window
+-- the stale learned cap is naturally discarded and the next turn starts fresh
+-- from the new ceiling rather than being pinned to the old observation.
+--
+-- GLOBAL, not per-user: like `error_classifications` this is connector/model
+-- knowledge (how big a window a hosted model actually accepts), not personal
+-- data, so there is deliberately no `user_id` column and no per-user scoping.
+
+CREATE TABLE IF NOT EXISTS context_window_observations (
+    connector         TEXT   NOT NULL,
+    model             TEXT   NOT NULL,
+    -- Smallest provider-rejected window observed for this configured_window.
+    observed_limit    BIGINT NOT NULL,
+    -- The effective configured budget in force when the overflow was observed;
+    -- a learned row is treated as stale once this no longer matches.
+    configured_window BIGINT NOT NULL,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (connector, model)
+);

--- a/crates/storage/src/context_window_observations.rs
+++ b/crates/storage/src/context_window_observations.rs
@@ -1,0 +1,93 @@
+//! Postgres-backed [`LearnedWindowStore`] — the learned effective
+//! context-window cache (issue #343), the reactive safety net that complements
+//! #342.
+//!
+//! Global (no `user_id`): this is connector/model knowledge (how large a window
+//! a hosted model actually accepts), not personal data.
+//!
+//! `record` enforces the DOWN-ONLY ratchet at the SQL level:
+//!   - a fresh `(connector, model)` inserts the observation;
+//!   - an existing row with the SAME `configured_window` is overwritten only
+//!     when the new `observed_limit` is strictly smaller (ratchet down);
+//!   - an existing row with a DIFFERENT `configured_window` is replaced
+//!     wholesale — a deliberate window change (#342) invalidates the old
+//!     observation and starts fresh.
+//!
+//! `lookup` is a plain key read; invalidation (comparing `configured_window` to
+//! the current effective budget) is the caller's job, in `apply_learned_cap`.
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::store::{LearnedWindow, LearnedWindowStore};
+use sqlx::PgPool;
+
+pub struct PgLearnedWindowStore {
+    pool: PgPool,
+}
+
+impl PgLearnedWindowStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl LearnedWindowStore for PgLearnedWindowStore {
+    async fn lookup(
+        &self,
+        connector: &str,
+        model: &str,
+    ) -> Result<Option<LearnedWindow>, CoreError> {
+        let row = sqlx::query_as::<_, (i64, i64)>(
+            "SELECT observed_limit, configured_window \
+               FROM context_window_observations \
+              WHERE connector = $1 AND model = $2",
+        )
+        .bind(connector)
+        .bind(model)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+
+        // Stored as BIGINT (i64) but always non-negative on the write path
+        // (`record` rejects values below the sanity floor); clamp defensively
+        // so a manually-edited negative row can't underflow into a huge u64.
+        Ok(row.map(|(observed, configured)| LearnedWindow {
+            observed_limit: observed.max(0) as u64,
+            configured_window: configured.max(0) as u64,
+        }))
+    }
+
+    async fn record(
+        &self,
+        connector: &str,
+        model: &str,
+        observed_limit: u64,
+        configured_window: u64,
+    ) -> Result<(), CoreError> {
+        // Down-only ratchet in one statement:
+        //   - INSERT the new observation;
+        //   - ON CONFLICT, replace when the configured window CHANGED (stale →
+        //     start fresh) OR the new observed limit is strictly smaller than
+        //     the stored one for the same configured window (ratchet down).
+        //     Otherwise keep the existing (smaller-or-equal) row.
+        sqlx::query(
+            "INSERT INTO context_window_observations \
+                 (connector, model, observed_limit, configured_window, updated_at) \
+             VALUES ($1, $2, $3, $4, now()) \
+             ON CONFLICT (connector, model) DO UPDATE SET \
+                 observed_limit = EXCLUDED.observed_limit, \
+                 configured_window = EXCLUDED.configured_window, \
+                 updated_at = now() \
+             WHERE context_window_observations.configured_window <> EXCLUDED.configured_window \
+                OR EXCLUDED.observed_limit < context_window_observations.observed_limit",
+        )
+        .bind(connector)
+        .bind(model)
+        .bind(observed_limit as i64)
+        .bind(configured_window as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CoreError::Storage(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,6 +1,7 @@
 //! SQLite-backed persistence for conversations, knowledge, and assistant state.
 
 pub mod background_tasks;
+pub mod context_window_observations;
 pub mod conversation;
 pub mod conversation_search;
 pub mod database;
@@ -25,6 +26,7 @@ pub use desktop_assistant_auth_jwt::{DEFAULT_USER_ID, UserId};
 pub use desktop_assistant_core::ports::auth::{current_user_id, with_user_id};
 
 pub use background_tasks::PgBackgroundTaskStore;
+pub use context_window_observations::PgLearnedWindowStore;
 pub use conversation::PgConversationStore;
 pub use conversation_search::PgConversationSearchStore;
 pub use database::execute_database_query;

--- a/crates/storage/src/pool.rs
+++ b/crates/storage/src/pool.rs
@@ -195,5 +195,14 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // #343: learned effective context-window observations — the reactive
+    // safety net that `min()`s an observed-overflow ceiling into budget
+    // resolution (down-only), complementing #342's proactive provisioning.
+    sqlx::raw_sql(include_str!(
+        "../migrations/025_context_window_observations.sql"
+    ))
+    .execute(pool)
+    .await?;
+
     Ok(())
 }

--- a/crates/storage/tests/context_window_observations.rs
+++ b/crates/storage/tests/context_window_observations.rs
@@ -1,0 +1,195 @@
+//! Integration test for the learned context-window store (issue #343), the
+//! reactive safety net that complements #342. Gated on `TEST_DATABASE_URL`;
+//! pass-skips without a DB. Runs in a private throwaway schema, so it never
+//! touches live tables.
+
+use std::sync::Arc;
+
+use desktop_assistant_core::ports::store::LearnedWindowStore;
+use desktop_assistant_storage::{PgLearnedWindowStore, run_migrations};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+struct SchemaFixture {
+    pool: PgPool,
+    schema: String,
+    admin_url: String,
+}
+
+impl SchemaFixture {
+    async fn try_new() -> Option<Self> {
+        let url = std::env::var("TEST_DATABASE_URL").ok()?;
+        let schema = format!("cwo_test_{}", Uuid::now_v7().simple());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE SCHEMA \"{schema}\"")))
+            .execute(&admin)
+            .await
+            .expect("create test schema");
+        admin.close().await;
+
+        let schema_for_hook = Arc::new(schema.clone());
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .after_connect(move |conn, _meta| {
+                let schema = Arc::clone(&schema_for_hook);
+                Box::pin(async move {
+                    let sql = format!("SET search_path TO \"{schema}\", public");
+                    sqlx::query(sqlx::AssertSqlSafe(sql)).execute(conn).await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect per-test pool");
+
+        Some(Self {
+            pool,
+            schema,
+            admin_url: url,
+        })
+    }
+
+    async fn cleanup(self) {
+        self.pool.close().await;
+        if let Ok(admin) = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&self.admin_url)
+            .await
+        {
+            let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+                "DROP SCHEMA \"{}\" CASCADE",
+                self.schema
+            )))
+            .execute(&admin)
+            .await;
+            admin.close().await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn learned_window_ratchets_down_invalidates_and_isolates() {
+    let Some(fixture) = SchemaFixture::try_new().await else {
+        eprintln!(
+            "skip: TEST_DATABASE_URL not set; learned_window_ratchets_down_invalidates_and_isolates pass-skipped"
+        );
+        return;
+    };
+    run_migrations(&fixture.pool)
+        .await
+        .expect("migrations (incl. 025) apply");
+    let store = PgLearnedWindowStore::new(fixture.pool.clone());
+
+    // Turn 1: an overflow under an 8192 configured window observed a 4096
+    // ceiling — record it.
+    store
+        .record("ollama", "qwen2.5", 4_096, 8_192)
+        .await
+        .expect("record");
+    let got = store.lookup("ollama", "qwen2.5").await.expect("lookup");
+    assert_eq!(
+        got.map(|w| (w.observed_limit, w.configured_window)),
+        Some((4_096, 8_192))
+    );
+
+    // Ratchet DOWN: a smaller observation under the same configured window
+    // overwrites.
+    store
+        .record("ollama", "qwen2.5", 2_048, 8_192)
+        .await
+        .expect("record smaller");
+    assert_eq!(
+        store
+            .lookup("ollama", "qwen2.5")
+            .await
+            .expect("lookup")
+            .map(|w| w.observed_limit),
+        Some(2_048),
+        "a smaller observation must ratchet the stored ceiling down"
+    );
+
+    // NEVER UP: a larger observation under the same configured window is
+    // ignored (down-only).
+    store
+        .record("ollama", "qwen2.5", 6_000, 8_192)
+        .await
+        .expect("record larger");
+    assert_eq!(
+        store
+            .lookup("ollama", "qwen2.5")
+            .await
+            .expect("lookup")
+            .map(|w| w.observed_limit),
+        Some(2_048),
+        "a larger observation under the same configured window must NOT raise the stored ceiling"
+    );
+
+    // INVALIDATION: a record under a DIFFERENT configured window replaces the
+    // row wholesale — a deliberate window change starts fresh (even if the new
+    // observed value is larger than the old one).
+    store
+        .record("ollama", "qwen2.5", 12_000, 16_384)
+        .await
+        .expect("record new configured window");
+    assert_eq!(
+        store
+            .lookup("ollama", "qwen2.5")
+            .await
+            .expect("lookup")
+            .map(|w| (w.observed_limit, w.configured_window)),
+        Some((12_000, 16_384)),
+        "a new configured window must replace the stale lower observation"
+    );
+
+    // CROSS-(connector, model) ISOLATION: a different model's cap doesn't leak.
+    store
+        .record("ollama", "llama3", 1_024, 8_192)
+        .await
+        .expect("record other model");
+    assert_eq!(
+        store
+            .lookup("ollama", "qwen2.5")
+            .await
+            .expect("lookup")
+            .map(|w| w.observed_limit),
+        Some(12_000),
+        "another model's learned cap must not leak into qwen2.5"
+    );
+    assert_eq!(
+        store
+            .lookup("ollama", "llama3")
+            .await
+            .expect("lookup")
+            .map(|w| w.observed_limit),
+        Some(1_024)
+    );
+    // Different connector, same model name is also isolated.
+    assert!(
+        store
+            .lookup("bedrock", "qwen2.5")
+            .await
+            .expect("lookup")
+            .is_none(),
+        "another connector must not see this model's cap"
+    );
+
+    // SURVIVES RESTART: a fresh store over the same pool reads the persisted
+    // value (the row outlives any in-process state).
+    let reopened = PgLearnedWindowStore::new(fixture.pool.clone());
+    assert_eq!(
+        reopened
+            .lookup("ollama", "qwen2.5")
+            .await
+            .expect("lookup")
+            .map(|w| w.observed_limit),
+        Some(12_000),
+        "persisted observation must survive a store restart"
+    );
+
+    fixture.cleanup().await;
+}


### PR DESCRIPTION
Closes #343.

Reactive safety net complementing #342: when a context-overflow error yields a provider-reported `max_tokens`, persist it per `(connector, model)` and have budget resolution `min()` it into the resolved budget as a DOWN-ONLY cap. The next turn then starts under the real observed ceiling instead of overflowing → recovering → forgetting → overflowing again. Works on any provider (catches misconfigured Ollama `num_ctx`, or a hosted model smaller than the connector table claims).

## What changed
- **Storage** — new `context_window_observations` table (migration **025**) keyed `PK(connector, model)` with `(observed_limit, configured_window, updated_at)`; `PgLearnedWindowStore` mirroring `PgErrorClassificationStore`. Global (connector/model knowledge, not per-user). Core port `LearnedWindowStore` + `LearnedWindow`.
- **Persist** — `ClassifyingLlmClient::learn_window` records the observed ceiling when tier-1 classifies a `ContextOverflow { max_tokens: Some(n) }`, keyed by `current_model_override()` (falling back to the connector default model) + the effective configured window from `current_context_budget()`. Skipped while a classification is in flight and when no budget is in flight (nothing to key invalidation on). Plumbed via a new `window_store` on `ClassificationDeps`.
- **Resolve** — `apply_learned_cap` composes *after* `resolve_context_budget`, precedence: `purpose-override > learned (min, DOWN-only) > connector / Ollama-effective-window (#342) > 200K fallback`. New `BudgetSource::LearnedCap` tag. Wired at the dispatch site in `RoutingConversationHandler` via `with_window_store`.

## Down-only & invalidation rules
- **Down-only:** the SQL `ON CONFLICT` overwrites only with a *strictly smaller* observation for the same configured window; a higher observation never raises the stored ceiling. `apply_learned_cap` is a pure `min()` — a learned value `>=` the resolved budget is a no-op (never raises). Raising a window stays a deliberate action (#342), never inferred.
- **Invalidation:** the learned row carries the configured window in force when the overflow happened. `apply_learned_cap` discards a row whose `configured_window` differs from the *current* effective budget, so a config bump starts fresh from the new ceiling (not pinned to the stale lower one). The write side also replaces the row wholesale when the configured window changes.

## Security
`max_tokens` is parsed from an untrusted-ish provider **error string**. Sanity floor `MIN_LEARNED_WINDOW = 256` makes `apply_learned_cap` refuse to apply (and the store clamps negatives on read) pathological values (`0`/`1`/tiny) — a garbage or hostile parse can never pin the budget pathologically low and brick the assistant. Floor is intentionally tiny so it rejects only pathological values, not genuinely-small-but-usable windows. All SQL parameterized; no new dependencies (lockfile unchanged).

## Testing (named tests)
Unit — `apply_learned_cap` (`crates/daemon/src/config/mod.rs`):
- `learned_cap_none_leaves_budget_untouched`
- `learned_cap_mins_below_resolved_budget`
- `learned_cap_never_raises_budget`
- `learned_cap_equal_to_budget_is_noop`
- `learned_cap_invalidated_when_configured_window_bumped_up`
- `learned_cap_invalidated_when_configured_window_lowered`
- `learned_cap_sanity_floor_rejects_pathological_value` (0, 1, floor-1)
- `learned_cap_at_sanity_floor_is_applied`

Unit — persist (`crates/daemon/src/classifying_llm.rs`):
- `overflow_with_max_tokens_persists_observed_window`
- `overflow_without_max_tokens_persists_nothing`
- `window_not_learned_without_a_budget_in_flight`
- `non_overflow_error_does_not_learn_window`
- `window_not_learned_while_classification_in_progress`

Integration — store round-trip against real Postgres (`crates/storage/tests/context_window_observations.rs`, gated on `TEST_DATABASE_URL`, throwaway schema; verified locally against the dev DB):
- `learned_window_ratchets_down_invalidates_and_isolates` — ratchet down, never up, invalidation on configured-window change, cross-`(connector, model)` and cross-connector isolation, survives restart.

Integration — end-to-end dispatch (`crates/daemon/src/api_surface.rs`):
- `learned_window_caps_budget_down_on_next_turn` — turn 2 starts under the learned ceiling (budget 4096, source `LearnedCap`), not the 8192 window that overflowed.
- `stale_learned_window_does_not_cap_budget` — a row under a different configured window is ignored.

`just check` green (fmt + clippy + build + full test suite, daemon-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)