### PR TITLE
client-common: carry conversation_id on streaming SignalEvents

### DIFF
--- a/crates/client-common/src/connector.rs
+++ b/crates/client-common/src/connector.rs
@@ -547,6 +547,7 @@ mod tests {
         let mut b = register(&subs);
 
         tx.send(SignalEvent::Chunk {
+            conversation_id: "c".into(),
             request_id: "r".into(),
             chunk: "hi".into(),
         })
@@ -565,6 +566,7 @@ mod tests {
         drop(gone); // its receiver is dropped — must not break delivery to `live`
 
         tx.send(SignalEvent::Chunk {
+            conversation_id: "c".into(),
             request_id: "r".into(),
             chunk: "one".into(),
         })
@@ -572,6 +574,7 @@ mod tests {
         assert!(matches!(live.recv().await, Some(SignalEvent::Chunk { .. })));
         // After the dead subscriber is retained-out, only `live` remains.
         tx.send(SignalEvent::Chunk {
+            conversation_id: "c".into(),
             request_id: "r".into(),
             chunk: "two".into(),
         })
@@ -628,6 +631,7 @@ mod tests {
         // Send three events spaced under the stall window; none should trip it.
         for i in 0..3 {
             tx.send(SignalEvent::Chunk {
+                conversation_id: "c".into(),
                 request_id: "r".into(),
                 chunk: format!("c{i}"),
             })
@@ -659,6 +663,7 @@ mod tests {
         // First turn: subscribe, then events arrive — they must be delivered.
         let mut a = register(&subs);
         tx.send(SignalEvent::Chunk {
+            conversation_id: "c".into(),
             request_id: "r".into(),
             chunk: "hi".into(),
         })
@@ -699,6 +704,7 @@ mod tests {
         // still receive events — the pump survived the stall.
         let mut second = register(&subs);
         tx.send(SignalEvent::Chunk {
+            conversation_id: "c".into(),
             request_id: "r2".into(),
             chunk: "next".into(),
         })

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -369,6 +369,7 @@ impl DbusClient {
             while let Some(signal) = chunk_stream.next().await {
                 if let Ok(args) = signal.args() {
                     let _ = tx_chunk.send(SignalEvent::Chunk {
+                        conversation_id: args.conversation_id.to_string(),
                         request_id: args.request_id.to_string(),
                         chunk: args.chunk.to_string(),
                     });
@@ -382,6 +383,7 @@ impl DbusClient {
             while let Some(signal) = complete_stream.next().await {
                 if let Ok(args) = signal.args() {
                     let _ = tx_complete.send(SignalEvent::Complete {
+                        conversation_id: args.conversation_id.to_string(),
                         request_id: args.request_id.to_string(),
                         full_response: args.full_response.to_string(),
                     });
@@ -394,6 +396,7 @@ impl DbusClient {
             while let Some(signal) = error_stream.next().await {
                 if let Ok(args) = signal.args() {
                     let _ = tx.send(SignalEvent::Error {
+                        conversation_id: args.conversation_id.to_string(),
                         request_id: args.request_id.to_string(),
                         error: args.error.to_string(),
                     });

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -3,19 +3,27 @@ use desktop_assistant_api_model as api;
 // `Clone` lets the `Connector` fan one signal stream out to many subscribers.
 #[derive(Debug, Clone)]
 pub enum SignalEvent {
+    // The streaming events carry `conversation_id` (already present on the wire
+    // frames) so a client can route a turn it did NOT initiate — e.g. a voice
+    // turn streaming into a conversation the GUI is merely viewing — to the
+    // right chat view, instead of only rendering streams it started itself.
     Chunk {
+        conversation_id: String,
         request_id: String,
         chunk: String,
     },
     Complete {
+        conversation_id: String,
         request_id: String,
         full_response: String,
     },
     Error {
+        conversation_id: String,
         request_id: String,
         error: String,
     },
     Status {
+        conversation_id: String,
         request_id: String,
         message: String,
     },

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -391,19 +391,32 @@ fn build_tls_connector(ca_cert_path: Option<&Path>) -> Result<tokio_tungstenite:
 pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
     match event {
         api::Event::AssistantDelta {
-            request_id, chunk, ..
-        } => Some(SignalEvent::Chunk { request_id, chunk }),
+            conversation_id,
+            request_id,
+            chunk,
+        } => Some(SignalEvent::Chunk {
+            conversation_id,
+            request_id,
+            chunk,
+        }),
         api::Event::AssistantCompleted {
+            conversation_id,
             request_id,
             full_response,
-            ..
         } => Some(SignalEvent::Complete {
+            conversation_id,
             request_id,
             full_response,
         }),
         api::Event::AssistantError {
-            request_id, error, ..
-        } => Some(SignalEvent::Error { request_id, error }),
+            conversation_id,
+            request_id,
+            error,
+        } => Some(SignalEvent::Error {
+            conversation_id,
+            request_id,
+            error,
+        }),
         api::Event::ConversationTitleChanged {
             conversation_id,
             title,
@@ -412,10 +425,11 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             title,
         }),
         api::Event::AssistantStatus {
+            conversation_id,
             request_id,
             message,
-            ..
         } => Some(SignalEvent::Status {
+            conversation_id,
             request_id,
             message,
         }),

--- a/crates/client-common/tests/uds_real_turn.rs
+++ b/crates/client-common/tests/uds_real_turn.rs
@@ -662,6 +662,7 @@ async fn collect_turn(
             Ok(Some(SignalEvent::Complete {
                 request_id: rid,
                 full_response,
+                ..
             })) if rid == request_id => {
                 return full_response == "hello";
             }
@@ -835,12 +836,15 @@ async fn keyed_send_over_uds_streams_real_turn_events() {
             Ok(Some(SignalEvent::Status { request_id, .. })) if request_id == returned_id => {
                 got_status = true;
             }
-            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
+            Ok(Some(SignalEvent::Chunk {
+                request_id, chunk, ..
+            })) if request_id == returned_id => {
                 chunks.push_str(&chunk);
             }
             Ok(Some(SignalEvent::Complete {
                 request_id,
                 full_response,
+                ..
             })) if request_id == returned_id => {
                 assert_eq!(full_response, "hello");
                 got_complete = true;
@@ -927,12 +931,15 @@ async fn idle_past_stall_then_turn_still_streams_events() {
     let mut got_complete = false;
     for _ in 0..20 {
         match timeout(Duration::from_secs(5), events.recv()).await {
-            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
+            Ok(Some(SignalEvent::Chunk {
+                request_id, chunk, ..
+            })) if request_id == returned_id => {
                 chunks.push_str(&chunk);
             }
             Ok(Some(SignalEvent::Complete {
                 request_id,
                 full_response,
+                ..
             })) if request_id == returned_id => {
                 assert_eq!(full_response, "hello");
                 got_complete = true;

--- a/crates/client-common/tests/uds_streaming.rs
+++ b/crates/client-common/tests/uds_streaming.rs
@@ -191,7 +191,9 @@ async fn uds_streamed_response_is_correlatable_to_the_send() {
     let mut got_complete = false;
     for _ in 0..10 {
         match timeout(Duration::from_secs(2), signals.recv()).await {
-            Ok(Some(SignalEvent::Chunk { request_id, chunk })) => {
+            Ok(Some(SignalEvent::Chunk {
+                request_id, chunk, ..
+            })) => {
                 assert_eq!(
                     request_id, returned_id,
                     "chunk request_id must match the id send_prompt returned (voice#49)"
@@ -201,6 +203,7 @@ async fn uds_streamed_response_is_correlatable_to_the_send() {
             Ok(Some(SignalEvent::Complete {
                 request_id,
                 full_response,
+                ..
             })) => {
                 assert_eq!(
                     request_id, returned_id,
@@ -251,12 +254,13 @@ async fn connector_over_uds_delivers_correlated_response() {
     let mut got_complete = false;
     for _ in 0..10 {
         match timeout(Duration::from_secs(2), events.recv()).await {
-            Ok(Some(SignalEvent::Chunk { request_id, chunk })) if request_id == returned_id => {
-                chunks.push_str(&chunk)
-            }
+            Ok(Some(SignalEvent::Chunk {
+                request_id, chunk, ..
+            })) if request_id == returned_id => chunks.push_str(&chunk),
             Ok(Some(SignalEvent::Complete {
                 request_id,
                 full_response,
+                ..
             })) if request_id == returned_id => {
                 assert_eq!(full_response, "hello");
                 got_complete = true;


### PR DESCRIPTION
## What

`SignalEvent::{Chunk,Complete,Error,Status}` now carry `conversation_id`.

The wire frames (`AssistantDelta`/`AssistantCompleted`/`AssistantError`/`AssistantStatus`) already carry `conversation_id`, but `map_event_to_signal` (ws) and the D-Bus decoder were dropping it via `..`. This plumbs it through to the client-facing `SignalEvent`.

## Why

So a client can route a turn it did **not** initiate — e.g. a **voice** turn streaming into a conversation the GUI is merely *viewing* — to the right chat view, instead of only being able to render streams it started itself (keyed on `pending_request_id`).

This is the **foundation** for live-rendering externally-initiated (voice) turns in gtk/tui. By itself it's pure data plumbing — no consumer routes on it yet; the client-side rendering + a new user-message event are the follow-on work.

## Notes

- `Status` is ws-only; the D-Bus transport doesn't emit it (pre-existing limitation, unchanged here).
- Test patterns/constructions updated to match; client-common suite green (18 tests), fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)