### PR TITLE
Emit UserMessageAdded at turn start (live user-bubble for viewers)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -522,6 +522,24 @@ pub enum Event {
         compaction_active: bool,
     },
 
+    /// A user message was committed to a conversation and a turn started for
+    /// it. Emitted once at the start of every send turn — including turns a
+    /// given client did NOT initiate (e.g. a voice turn, or another client on
+    /// the same account). Lets a client render the user's bubble live in a
+    /// conversation it is merely *viewing*, instead of only seeing it after a
+    /// switch-away-and-back / reload. The turn's assistant reply then streams
+    /// via `AssistantDelta` / `AssistantCompleted` for the same
+    /// `conversation_id` and `request_id`.
+    ///
+    /// A client that initiated this turn already rendered the bubble
+    /// optimistically; it dedupes by matching `request_id` against its own
+    /// in-flight send and skips re-rendering.
+    UserMessageAdded {
+        conversation_id: String,
+        request_id: String,
+        content: String,
+    },
+
     /// Streaming chunk for a content response.
     AssistantDelta {
         conversation_id: String,

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -2510,6 +2510,20 @@ where
         }
     });
 
+    // Announce the user's prompt to every client viewing this conversation —
+    // including ones that did NOT initiate this turn (a voice turn, or a second
+    // client on the same account) — so they render the user bubble live rather
+    // than only after a reload (#1). Emitted before dispatch so it precedes the
+    // assistant's chunks; the initiating client dedupes on `request_id` (it
+    // already rendered the bubble optimistically).
+    let _ = sink
+        .emit(api::Event::UserMessageAdded {
+            conversation_id: conversation_id.clone(),
+            request_id: request_id.clone(),
+            content: content.clone(),
+        })
+        .await;
+
     // Bridge chunks from core callback -> canonical events.
     let conv_id_for_cb = conversation_id.clone();
     let req_id_for_cb = request_id.clone();
@@ -3762,9 +3776,12 @@ mod tests {
             .unwrap();
 
         let evs = sink.0.lock().await.clone();
-        assert!(matches!(evs[0], api::Event::AssistantDelta { .. }));
+        // A turn now opens with `UserMessageAdded` (#1) so viewers can render the
+        // user bubble live, before the assistant's deltas stream in.
+        assert!(matches!(evs[0], api::Event::UserMessageAdded { .. }));
         assert!(matches!(evs[1], api::Event::AssistantDelta { .. }));
-        assert!(matches!(evs[2], api::Event::AssistantCompleted { .. }));
+        assert!(matches!(evs[2], api::Event::AssistantDelta { .. }));
+        assert!(matches!(evs[3], api::Event::AssistantCompleted { .. }));
     }
 
     #[tokio::test]

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -7,6 +7,16 @@ pub enum SignalEvent {
     // frames) so a client can route a turn it did NOT initiate — e.g. a voice
     // turn streaming into a conversation the GUI is merely viewing — to the
     // right chat view, instead of only rendering streams it started itself.
+    /// A user message was committed and a turn started (api `UserMessageAdded`).
+    /// Emitted for every send turn, including ones this client did not initiate
+    /// (a voice turn, or another client on the same account). The client renders
+    /// the user bubble live in the matching `conversation_id`; the initiator
+    /// dedupes on `request_id` (it already rendered the bubble optimistically).
+    UserMessageAdded {
+        conversation_id: String,
+        request_id: String,
+        content: String,
+    },
     Chunk {
         conversation_id: String,
         request_id: String,

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -390,6 +390,15 @@ fn build_tls_connector(ca_cert_path: Option<&Path>) -> Result<tokio_tungstenite:
 
 pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
     match event {
+        api::Event::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        } => Some(SignalEvent::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        }),
         api::Event::AssistantDelta {
             conversation_id,
             request_id,

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -134,6 +134,14 @@ pub fn translate(event: api::Event) -> ForwardAction {
         api::Event::ConfigChanged { config } => ForwardAction::ConfigChanged {
             config: config_data_from_event(&config),
         },
+        // Live user-message echo (#1) is a UDS/WS-protocol concern — the GUI
+        // clients that render an external turn's user bubble live (adele-gtk,
+        // adele-tui) subscribe over UDS/WS. The sole D-Bus client (voice) is the
+        // *producer* of these turns, not a renderer, so there is no D-Bus signal
+        // for it. Deliberate ignore rather than a missed translation.
+        api::Event::UserMessageAdded { .. } => ForwardAction::Ignored {
+            kind: "user_message_added",
+        },
         api::Event::AssistantStatus { .. } => ForwardAction::Ignored {
             kind: "assistant_status",
         },

--- a/crates/ws-interface/tests/ping.rs
+++ b/crates/ws-interface/tests/ping.rs
@@ -1073,6 +1073,31 @@ async fn ws_send_message_ack_then_streaming_events() {
         other => panic!("expected SendMessageAck, got {other:?}"),
     };
 
+    // A turn now opens with `UserMessageAdded` (#1) — the user's prompt echoed
+    // to every viewer so they can render the bubble live — before the
+    // assistant's deltas. It carries the same request_id as the ack/stream.
+    let user_msg =
+        serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
+            .unwrap();
+    match user_msg {
+        WsFrame::Event {
+            event:
+                desktop_assistant_api_model::Event::UserMessageAdded {
+                    conversation_id,
+                    request_id,
+                    content,
+                },
+        } => {
+            assert_eq!(conversation_id, "c1");
+            assert_eq!(content, "hello");
+            assert_eq!(
+                request_id, ack_request_id,
+                "UserMessageAdded request_id must match the SendMessageAck request_id"
+            );
+        }
+        other => panic!("expected UserMessageAdded, got {other:?}"),
+    }
+
     let second =
         serde_json::from_str::<WsFrame>(&ws.next().await.unwrap().unwrap().into_text().unwrap())
             .unwrap();


### PR DESCRIPTION
## Problem (#1)

A conversation a client is merely **viewing** (not driving) never learned of a user message it didn't type. There was no user-message broadcast event — only the assistant stream (`AssistantDelta`/`AssistantCompleted`). So a **voice** turn, or a turn started by another client on the same account, only appeared in a viewing GUI after a switch-away-and-back / reload.

## Change

- **`Event::UserMessageAdded { conversation_id, request_id, content }`** (api-model) — emitted once at the start of every send turn in `run_send_turn`, the single chokepoint both the registry path (voice) and the direct path funnel through, **before** the assistant's deltas.
- Decoded to **`SignalEvent::UserMessageAdded`** via `map_event_to_signal`, which covers **both WS and UDS** (the transports gtk/tui use).
- **Dedup contract:** the initiating client already rendered its bubble optimistically, so it skips re-rendering by matching `request_id` against its in-flight send. A viewer that did *not* initiate the turn renders the bubble.

## Transport scope

Not forwarded over D-Bus — live external-turn rendering is a UDS/WS concern (gtk/tui), and the sole D-Bus client (**voice**) is the *producer* of these turns, not a renderer. Recorded as a deliberate `Ignored` arm in the bridge, matching `ContextUsage`.

## Scope

Foundation + emit only. The **gtk/tui rendering of external turns** is the follow-on client work (builds on the `conversation_id` plumbing from #352 + this event).

## Tests

- `send_message_emits_events_and_completes` now expects `UserMessageAdded` first.
- `ws_send_message_ack_then_streaming_events` reads the leading `UserMessageAdded` frame (asserts same `request_id` as the ack).
- Full workspace `fmt`/`clippy` clean; application, client-common, ws, uds, dbus-bridge, transport-dispatch, daemon-conversation suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)