### PR TITLE
Fan turn events to other connections viewing the conversation (#1)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -263,6 +263,19 @@ pub enum Command {
     SubscribeBackgroundTasks,
     /// Stop receiving `Task*` events on this connection.
     UnsubscribeBackgroundTasks,
+    /// Replace the set of conversations this connection is viewing (#1 live
+    /// multi-client sync). The daemon fans this connection's turn events
+    /// (`UserMessageAdded`/`AssistantDelta`/`AssistantCompleted`/`AssistantError`/
+    /// `AssistantStatus`) for any subscribed conversation to it — including
+    /// turns it did NOT initiate (a voice turn, or another client on the same
+    /// account) — so it can render them live. Set-replace, not a delta: the
+    /// client sends the WHOLE set each time its viewed set changes (open,
+    /// switch, close, tabs), so there is no per-side count to drift. An empty
+    /// list unsubscribes from all. A connection still receives turns it
+    /// initiated via its own request stream regardless of this set.
+    SubscribeConversations {
+        conversation_ids: Vec<String>,
+    },
     /// Launch a user-initiated standalone background agent. Returns
     /// `CommandResult::BackgroundTaskSpawned { id }` on success.
     SpawnStandaloneAgent {

--- a/crates/application/src/conversation_subs.rs
+++ b/crates/application/src/conversation_subs.rs
@@ -1,0 +1,268 @@
+//! Per-connection conversation subscriptions for live multi-client sync (#1).
+//!
+//! Each connection registers its outbound [`EventSink`] under its session id and
+//! declares the set of conversations it is currently viewing. A turn then fans
+//! its events to every OTHER connection viewing that conversation, so a turn
+//! started by one client — or by the voice daemon — renders live in another
+//! client that happens to be looking at the same conversation, instead of only
+//! appearing after a reload.
+//!
+//! The originating connection is deliberately excluded from the fan-out: it
+//! already receives the turn's events through its own per-request sink, so
+//! routing to it as well would double-render. Keyed by session id (one per
+//! connection), the registry stays correct when one account has several
+//! connections open (gtk + tui + voice).
+//!
+//! Delivery is via the connection's existing [`EventSink`] (an mpsc behind the
+//! transport writer), so it is reliable — not the lossy `Task*` broadcast — and
+//! this module never needs to know about wire frames or the D-Bus bridge.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use desktop_assistant_api_model as api;
+
+use crate::EventSink;
+
+/// Shared registry of which connections are viewing which conversations, plus
+/// each connection's sink, so turn events can be fanned to viewers.
+#[derive(Default)]
+pub struct ConversationSubscriptions {
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Live connections by session id → their outbound event sink.
+    sinks: HashMap<String, Arc<dyn EventSink>>,
+    /// Per-session set of subscribed conversation ids (what each connection is
+    /// viewing). Set-replaced wholesale by `SubscribeConversations`.
+    subscribed: HashMap<String, HashSet<String>>,
+}
+
+impl ConversationSubscriptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a connection's outbound sink, on connect. Idempotent.
+    pub fn register(&self, session_id: &str, sink: Arc<dyn EventSink>) {
+        let mut inner = self.lock();
+        inner.sinks.insert(session_id.to_string(), sink);
+    }
+
+    /// Drop a connection on disconnect: forget its sink and its subscriptions so
+    /// the maps stay bounded by live connections and no dead sink is routed to.
+    pub fn unregister(&self, session_id: &str) {
+        let mut inner = self.lock();
+        inner.sinks.remove(session_id);
+        inner.subscribed.remove(session_id);
+    }
+
+    /// Set-replace the conversations a connection is viewing. An empty list
+    /// unsubscribes it from all (it still gets turns it initiates via its own
+    /// request stream).
+    pub fn set_subscriptions(&self, session_id: &str, conversation_ids: Vec<String>) {
+        let mut inner = self.lock();
+        inner.subscribed.insert(
+            session_id.to_string(),
+            conversation_ids.into_iter().collect(),
+        );
+    }
+
+    /// Fan `event` (belonging to `conversation_id`) to every OTHER connection
+    /// subscribed to that conversation. The origin is excluded — it receives the
+    /// event via its own per-request sink. Best-effort: a sink whose connection
+    /// has gone simply fails its emit and is cleaned up on disconnect.
+    pub async fn route(&self, conversation_id: &str, event: &api::Event, origin_session: &str) {
+        // Snapshot the target sinks under the lock, then release it before the
+        // async emits so a slow/contended emit never holds the registry lock.
+        let targets = self.subscribers_except(conversation_id, origin_session);
+        for sink in targets {
+            let _ = sink.emit(event.clone()).await;
+        }
+    }
+
+    fn subscribers_except(
+        &self,
+        conversation_id: &str,
+        origin_session: &str,
+    ) -> Vec<Arc<dyn EventSink>> {
+        let inner = self.lock();
+        inner
+            .subscribed
+            .iter()
+            .filter(|(session, convs)| {
+                session.as_str() != origin_session && convs.contains(conversation_id)
+            })
+            .filter_map(|(session, _)| inner.sinks.get(session).cloned())
+            .collect()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner
+            .lock()
+            .expect("ConversationSubscriptions poisoned")
+    }
+}
+
+/// The conversation a turn event belongs to, for fan-out routing. `None` for
+/// events that are not part of a conversation's turn stream — those reach only
+/// the originating connection.
+fn turn_event_conversation_id(event: &api::Event) -> Option<&str> {
+    match event {
+        api::Event::UserMessageAdded {
+            conversation_id, ..
+        }
+        | api::Event::AssistantDelta {
+            conversation_id, ..
+        }
+        | api::Event::AssistantCompleted {
+            conversation_id, ..
+        }
+        | api::Event::AssistantError {
+            conversation_id, ..
+        }
+        | api::Event::AssistantStatus {
+            conversation_id, ..
+        } => Some(conversation_id),
+        _ => None,
+    }
+}
+
+/// A turn's event sink that delivers reliably to the originating connection
+/// (`inner`) AND fans each turn event to every OTHER connection viewing the
+/// same conversation (#1 live multi-client sync). Wrapping at the handler — the
+/// chokepoint every transport's turn funnels through — means a turn driven over
+/// ANY transport (a voice turn over D-Bus, a tui/gtk send over UDS/WS) fans to
+/// viewers, without each transport re-implementing it. The fan-out is
+/// best-effort and non-blocking (see [`FanoutTargetSink`]-style targets), so a
+/// slow viewer never backpressures the origin's reliable delivery.
+pub struct FanOutSink {
+    inner: Arc<dyn EventSink>,
+    subscriptions: Arc<ConversationSubscriptions>,
+    origin_session: String,
+}
+
+impl FanOutSink {
+    pub fn new(
+        inner: Arc<dyn EventSink>,
+        subscriptions: Arc<ConversationSubscriptions>,
+        origin_session: String,
+    ) -> Self {
+        Self {
+            inner,
+            subscriptions,
+            origin_session,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl EventSink for FanOutSink {
+    async fn emit(&self, event: api::Event) -> bool {
+        if let Some(conversation_id) = turn_event_conversation_id(&event) {
+            self.subscriptions
+                .route(conversation_id, &event, &self.origin_session)
+                .await;
+        }
+        self.inner.emit(event).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// Records emitted events so a test can assert what a connection received.
+    #[derive(Default)]
+    struct RecordingSink(StdMutex<Vec<api::Event>>);
+
+    #[async_trait::async_trait]
+    impl EventSink for RecordingSink {
+        async fn emit(&self, event: api::Event) -> bool {
+            self.0.lock().unwrap().push(event);
+            true
+        }
+    }
+
+    fn delta(conv: &str) -> api::Event {
+        api::Event::AssistantDelta {
+            conversation_id: conv.to_string(),
+            request_id: "r".into(),
+            chunk: "hi".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn routes_to_other_subscribers_of_the_conversation() {
+        let subs = ConversationSubscriptions::new();
+        let viewer = Arc::new(RecordingSink::default());
+        subs.register("viewer", viewer.clone());
+        subs.set_subscriptions("viewer", vec!["c1".into()]);
+
+        subs.route("c1", &delta("c1"), "origin").await;
+
+        assert_eq!(
+            viewer.0.lock().unwrap().len(),
+            1,
+            "viewer of c1 must receive the turn event"
+        );
+    }
+
+    #[tokio::test]
+    async fn excludes_the_origin_connection() {
+        let subs = ConversationSubscriptions::new();
+        let origin = Arc::new(RecordingSink::default());
+        subs.register("origin", origin.clone());
+        subs.set_subscriptions("origin", vec!["c1".into()]);
+
+        subs.route("c1", &delta("c1"), "origin").await;
+
+        assert!(
+            origin.0.lock().unwrap().is_empty(),
+            "origin must NOT be fanned its own turn (it gets it via its own sink)"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_route_to_subscribers_of_other_conversations() {
+        let subs = ConversationSubscriptions::new();
+        let viewer = Arc::new(RecordingSink::default());
+        subs.register("viewer", viewer.clone());
+        subs.set_subscriptions("viewer", vec!["c2".into()]);
+
+        subs.route("c1", &delta("c1"), "origin").await;
+
+        assert!(
+            viewer.0.lock().unwrap().is_empty(),
+            "a connection viewing c2 must not receive c1's turn events"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_replace_and_unregister_stop_delivery() {
+        let subs = ConversationSubscriptions::new();
+        let viewer = Arc::new(RecordingSink::default());
+        subs.register("viewer", viewer.clone());
+        subs.set_subscriptions("viewer", vec!["c1".into()]);
+
+        // Switch away from c1 (set-replace to a different set).
+        subs.set_subscriptions("viewer", vec!["c2".into()]);
+        subs.route("c1", &delta("c1"), "origin").await;
+        assert!(
+            viewer.0.lock().unwrap().is_empty(),
+            "after switching away, no c1 delivery"
+        );
+
+        // Re-subscribe, then disconnect.
+        subs.set_subscriptions("viewer", vec!["c1".into()]);
+        subs.unregister("viewer");
+        subs.route("c1", &delta("c1"), "origin").await;
+        assert!(
+            viewer.0.lock().unwrap().is_empty(),
+            "after disconnect, no delivery"
+        );
+    }
+}

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod background_tasks;
 pub mod client_tools;
+pub mod conversation_subs;
 mod inflight;
 pub mod subagent_tools;
 
@@ -257,6 +258,18 @@ pub trait AssistantApiHandler: Send + Sync {
         None
     }
 
+    /// The per-connection conversation-subscription registry (#1 live
+    /// multi-client sync), or `None` when the daemon was built without it — in
+    /// which case turn events reach only the connection that initiated them, as
+    /// before (graceful degradation). The dispatcher registers each connection's
+    /// sink here, applies `SubscribeConversations`, and fans a turn's events to
+    /// every other connection viewing that conversation.
+    fn conversation_subscriptions(
+        &self,
+    ) -> Option<Arc<crate::conversation_subs::ConversationSubscriptions>> {
+        None
+    }
+
     /// Register a `SendMessage` request as a background task and
     /// return the new task id synchronously. The body runs in the
     /// background; events stream through `sink` as before.
@@ -433,6 +446,11 @@ where
     /// pre-#234 behaviour: the two commands return `Unsupported` and every
     /// tool is server-side.
     client_tools: Option<ClientToolWiring>,
+    /// Optional per-connection conversation-subscription registry (#1 live
+    /// multi-client sync). When attached, the dispatcher fans a turn's events to
+    /// every other connection viewing that conversation. `None` keeps the prior
+    /// behaviour: turn events reach only the initiating connection.
+    conversation_subs: Option<Arc<crate::conversation_subs::ConversationSubscriptions>>,
 }
 
 /// The handler-resident client-tool dependencies (#234). Both halves are
@@ -475,6 +493,7 @@ where
             idempotency: None,
             inflight: Arc::new(InFlightRegistry::default()),
             client_tools: None,
+            conversation_subs: None,
         }
     }
 
@@ -521,6 +540,40 @@ where
     pub fn with_registry(mut self, registry: Arc<BackgroundTaskRegistry>) -> Self {
         self.registry = Some(registry);
         self
+    }
+
+    /// Attach the per-connection conversation-subscription registry (#1) so the
+    /// dispatcher can fan a turn's events to every other connection viewing that
+    /// conversation (live multi-client sync). The daemon wires one shared
+    /// instance in `main.rs`; callers that skip it keep turn events scoped to
+    /// the initiating connection.
+    pub fn with_conversation_subscriptions(
+        mut self,
+        subs: Arc<crate::conversation_subs::ConversationSubscriptions>,
+    ) -> Self {
+        self.conversation_subs = Some(subs);
+        self
+    }
+
+    /// Wrap a fresh turn's event sink so each event also fans to other
+    /// connections viewing the conversation (#1 live multi-client sync). A no-op
+    /// when the subscription registry isn't attached. The origin — this
+    /// request's connection session — is excluded from the fan-out (it receives
+    /// the events through `sink` directly). Read the session here, before any
+    /// spawn, while the dispatcher's per-request session scope is still active.
+    /// Applied only to the fresh-turn path, never to idempotent replays, so a
+    /// retried turn's stored reply is not re-broadcast to viewers.
+    fn fanout_sink(&self, sink: Arc<dyn EventSink>) -> Arc<dyn EventSink> {
+        match &self.conversation_subs {
+            Some(subs) => Arc::new(crate::conversation_subs::FanOutSink::new(
+                sink,
+                Arc::clone(subs),
+                desktop_assistant_core::ports::session::current_session_id()
+                    .as_str()
+                    .to_string(),
+            )),
+            None => sink,
+        }
     }
 
     /// Borrow the registry, if one is attached. Public so #112/#113 can
@@ -1595,6 +1648,9 @@ where
             // `Event::Task*` frames to the connection.
             api::Command::SubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
             api::Command::UnsubscribeBackgroundTasks => Ok(api::CommandResult::Ack),
+            // Dispatcher-handled (it owns the per-connection subscription set +
+            // fan-out sink, #1); Ack here for the direct-call path.
+            api::Command::SubscribeConversations { .. } => Ok(api::CommandResult::Ack),
 
             // Standalone agent spawn (issue #113). Creates a fresh
             // conversation scoped to the calling user, registers a
@@ -1857,6 +1913,11 @@ where
         // records the reply on completion for a future retry.
         let idempotency = self.idempotency.clone().zip(idempotency_key);
 
+        // Fan this fresh turn's events to other connections viewing the
+        // conversation (#1); no-op without the registry. After the replay
+        // shortcut above, so a replayed reply is not re-broadcast.
+        let sink = self.fanout_sink(sink);
+
         // When a registry is attached we route the turn body through
         // it so the user has a cancellable, identifiable handle on the
         // running work (#111). When no registry is attached we fall back
@@ -2005,6 +2066,11 @@ where
         };
         let title = format!("Conversation: {conversation_id}");
 
+        // Fan this fresh turn's events to other connections viewing the
+        // conversation (#1); no-op without the registry. After the reattach /
+        // completed-replay shortcuts above, so only a genuinely fresh turn fans.
+        let sink = self.fanout_sink(sink);
+
         // A keyed turn emits through a `TeeSink` so its events both reach the
         // caller and feed the in-flight hub for re-attachers; an unkeyed turn
         // emits straight to the caller's sink.
@@ -2096,6 +2162,12 @@ where
         let registry = self.registry.as_ref()?;
         let user_id = desktop_assistant_core::ports::auth::current_user_id();
         Some(registry.subscribe(&user_id))
+    }
+
+    fn conversation_subscriptions(
+        &self,
+    ) -> Option<Arc<crate::conversation_subs::ConversationSubscriptions>> {
+        self.conversation_subs.clone()
     }
 }
 
@@ -3783,6 +3855,58 @@ mod tests {
         assert!(matches!(evs[1], api::Event::AssistantDelta { .. }));
         assert!(matches!(evs[2], api::Event::AssistantDelta { .. }));
         assert!(matches!(evs[3], api::Event::AssistantCompleted { .. }));
+    }
+
+    /// #1 live multi-client sync: a turn fans its events to other connections
+    /// viewing the conversation, and excludes the originating connection (which
+    /// gets them through its own request stream).
+    #[tokio::test]
+    async fn turn_fans_out_to_other_subscribers_excluding_origin() {
+        let subs = Arc::new(crate::conversation_subs::ConversationSubscriptions::new());
+
+        // A viewer connection looking at c1, on a different session than the
+        // sender (whose session is "unscoped" with no `with_session_id` scope).
+        let viewer = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
+        subs.register("viewer-session", viewer.clone());
+        subs.set_subscriptions("viewer-session", vec!["c1".to_string()]);
+
+        // A connection registered under the SENDER's own session, also viewing
+        // c1 — it must NOT be fanned its own turn.
+        let self_view = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
+        subs.register("unscoped", self_view.clone());
+        subs.set_subscriptions("unscoped", vec!["c1".to_string()]);
+
+        let h = DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            Arc::new(FakeSettings),
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        )
+        .with_conversation_subscriptions(Arc::clone(&subs));
+
+        let origin = Arc::new(CollectSink(tokio::sync::Mutex::new(vec![])));
+        h.handle_send_message("c1".into(), "hi".into(), "r1".into(), origin.clone())
+            .await
+            .unwrap();
+
+        let viewed = viewer.0.lock().await.clone();
+        assert!(
+            viewed
+                .iter()
+                .any(|e| matches!(e, api::Event::UserMessageAdded { .. })),
+            "viewer of c1 must receive the user message live: {viewed:?}"
+        );
+        assert!(
+            viewed
+                .iter()
+                .any(|e| matches!(e, api::Event::AssistantCompleted { .. })),
+            "viewer of c1 must receive the assistant reply live: {viewed:?}"
+        );
+        assert!(
+            self_view.0.lock().await.is_empty(),
+            "a connection on the origin's own session must be excluded from the fan-out"
+        );
     }
 
     #[tokio::test]

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1684,7 +1684,14 @@ async fn main() -> Result<()> {
         Arc::clone(&connections_service),
         Arc::clone(&knowledge_service),
     )
-    .with_registry(Arc::clone(&background_task_registry));
+    .with_registry(Arc::clone(&background_task_registry))
+    // Live multi-client sync (#1): one shared subscription registry, so a turn
+    // started by any connection (or by voice) is fanned to every other
+    // connection viewing that conversation. Shared via the single handler all
+    // dispatch loops hold, so every connection sees the same registrations.
+    .with_conversation_subscriptions(Arc::new(
+        desktop_assistant_application::conversation_subs::ConversationSubscriptions::new(),
+    ));
     if let Some((write, get_many, list, delete_many, clear)) = scratchpad_handler_fns {
         api_handler_impl =
             api_handler_impl.with_scratchpad(write, get_many, list, delete_many, clear);

--- a/crates/transport-dispatch/src/lib.rs
+++ b/crates/transport-dispatch/src/lib.rs
@@ -149,6 +149,24 @@ impl EventSink for ChannelEventSink {
     }
 }
 
+/// Best-effort sink registered in [`ConversationSubscriptions`] for fanning a
+/// turn's events to OTHER connections viewing the conversation (#1). Uses
+/// `try_send`, so a slow or backed-up viewer drops events (and resyncs on its
+/// next reload) instead of backpressuring the *originating* turn — the live
+/// render is a convenience, never a guarantee, and the sender's own stream
+/// stays reliable on its separate [`ChannelEventSink`].
+struct FanoutTargetSink {
+    tx: mpsc::Sender<WsFrame>,
+}
+
+#[async_trait::async_trait]
+impl EventSink for FanoutTargetSink {
+    async fn emit(&self, event: api::Event) -> bool {
+        // Non-blocking: a full or closed channel drops rather than awaiting.
+        self.tx.try_send(WsFrame::Event { event }).is_ok()
+    }
+}
+
 /// Run the dispatcher loop on `inbound` / `outbound` until the inbound
 /// stream ends or the outbound sink errors.
 ///
@@ -229,6 +247,21 @@ pub async fn dispatch_loop<R, W>(
     // teardown so the broadcast receiver is dropped cleanly.
     let mut bg_subscription: Option<tokio::task::JoinHandle<()>> = None;
 
+    // Per-connection conversation subscriptions (#1 live multi-client sync).
+    // When the handler provides the registry, register this connection's
+    // best-effort fan-out sink under its session id so a turn in any
+    // conversation it later subscribes to is delivered here. The set of
+    // subscribed conversations is applied by `SubscribeConversations`; the
+    // registration is torn down on disconnect. `None` keeps the prior behaviour
+    // (turn events reach only the initiating connection).
+    let conv_subs = handler.conversation_subscriptions();
+    if let Some(ref subs) = conv_subs {
+        subs.register(
+            &auth.session_id,
+            Arc::new(FanoutTargetSink { tx: out_tx.clone() }),
+        );
+    }
+
     while let Some(item) = inbound.next().await {
         let req = match item {
             Ok(req) => req,
@@ -265,6 +298,10 @@ pub async fn dispatch_loop<R, W>(
             } => {
                 // Per-request id for event correlation (matches old WS path).
                 let request_id = uuid::Uuid::new_v4().to_string();
+                // Reliable delivery to THIS connection. The handler additionally
+                // fans each turn event to other connections viewing the
+                // conversation (#1) — done there, not here, so the fan-out is
+                // transport-agnostic and also covers voice turns over D-Bus.
                 let sink: Arc<dyn EventSink> = Arc::new(ChannelEventSink::new(out_tx.clone()));
 
                 // Prefer the new `start_send_message` registration
@@ -530,6 +567,27 @@ pub async fn dispatch_loop<R, W>(
                 }
             }
 
+            api::Command::SubscribeConversations { conversation_ids } => {
+                // Set-replace the conversations this connection is viewing (#1).
+                // When the registry is attached, the connection's fan-out sink
+                // (registered on connect) now receives turn events for these
+                // conversations from other connections. A no-registry handler
+                // just Acks — the feature is simply off, the client unaffected.
+                if let Some(ref subs) = conv_subs {
+                    subs.set_subscriptions(&auth.session_id, conversation_ids);
+                }
+                if out_tx
+                    .send(WsFrame::Result {
+                        id: req.id,
+                        result: api::CommandResult::Ack,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+
             api::Command::SetConfig { changes } => {
                 let res = with_user_id(
                     user_id.clone(),
@@ -649,6 +707,13 @@ pub async fn dispatch_loop<R, W>(
     // shuts down (#114).
     if let Some(handle) = bg_subscription.take() {
         handle.abort();
+    }
+
+    // Drop this connection's conversation subscriptions + fan-out sink (#1) so
+    // the registry stays bounded by live connections and no turn is routed to a
+    // dead channel.
+    if let Some(ref subs) = conv_subs {
+        subs.unregister(&auth.session_id);
     }
 
     // Connection closed: evict any client-local tools this session


### PR DESCRIPTION
## Problem

Turn events were delivered only to the connection that **initiated** the turn. A conversation a client was merely *viewing* — gtk while tui or **voice** drove it — never received them, so the turn appeared only after a reload. (This is the "I typed in each and nothing crossed" symptom.)

## Fix — per-connection subscription + reliable fan-out

- **`ConversationSubscriptions`** (application): each connection registers its outbound `EventSink` under its session id and declares the set of conversations it's viewing; `route()` fans a turn event to every *other* connection viewing that conversation. EventSink-based, so it never touches wire frames or the D-Bus bridge.
- **`SubscribeConversations { conversation_ids }`** (new command): **set-replace** — the client sends the whole set each time its viewed set changes (open/switch/close/tabs); no per-side count to drift. Empty list = unsubscribe-all. Handled in the dispatcher, which registers/unregisters the connection on connect/disconnect.
- **Fan-out lives in the HANDLER, not per-transport** — so it's transport-agnostic: a **voice turn over D-Bus** fans to gtk/tui on UDS/WS exactly as a tui send does. Applied only to *fresh* turns (after the idempotency-replay shortcuts), so a replayed reply isn't re-broadcast.
- **Origin excluded** (it gets events via its own stream); **viewers are best-effort** (`try_send`) so a slow viewer can never backpressure the sender's reliable turn — it resyncs on reload.

## Graceful degradation

No registry attached → handler is a no-op, turn events reach only the initiating connection (prior behaviour).

## Scope

This is the delivery mechanism. **Not** included (separate): the per-user conversation-list signal (new conversation appearing in the sidebar) and the gtk/tui client changes to send `SubscribeConversations`.

## Tests

Registry unit tests (route / exclude-origin / scoping / unregister) + a handler-level test that drives a *real* turn through the registry (viewer receives `UserMessageAdded` + `AssistantCompleted`; origin excluded). fmt/clippy clean; application/transport-dispatch/uds/ws suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)