### PR TITLE
Broadcast conversation-list changes (live sidebar sync) (#1)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -580,6 +580,17 @@ pub enum Event {
         title: String,
     },
 
+    /// A user's conversation list changed — a conversation was created,
+    /// renamed, deleted, or (un)archived (#1 live multi-client sync).
+    /// Broadcast to ALL of the user's subscribed connections so every client's
+    /// sidebar stays in sync no matter which client (or the voice daemon) made
+    /// the change. Carries only the affected `conversation_id`; clients re-fetch
+    /// the list (the change kind is intentionally not encoded — a refetch is
+    /// simplest and correct for create/rename/delete/archive alike).
+    ConversationListChanged {
+        conversation_id: String,
+    },
+
     /// A one-time advisory for a conversation (e.g. the stored model
     /// selection no longer resolves and was cleared). Emitted at most once
     /// per underlying condition — the server clears the stored state so

--- a/crates/application/src/background_tasks.rs
+++ b/crates/application/src/background_tasks.rs
@@ -570,6 +570,24 @@ impl BackgroundTaskRegistry {
         );
     }
 
+    /// Notify a user's subscribed connections that their conversation list
+    /// changed — created/renamed/deleted/(un)archived (#1) — so every client's
+    /// sidebar refreshes regardless of which client made the change. Rides the
+    /// same per-user broadcast as `Task*`/`ScratchpadChanged`; best-effort
+    /// (dropped if no connection for the user is currently subscribed).
+    pub fn notify_conversation_list_changed(
+        &self,
+        user_id: &UserId,
+        conversation_id: impl Into<String>,
+    ) {
+        self.inner.broadcast(
+            user_id,
+            api::Event::ConversationListChanged {
+                conversation_id: conversation_id.into(),
+            },
+        );
+    }
+
     /// Append a log entry to `id`'s log ring from outside the task's
     /// body. Used by callers that produce events on behalf of a task
     /// they don't own the body of — for example, the `spawn_subagent`
@@ -1143,6 +1161,24 @@ mod tests {
                 assert_eq!(conversation_id, "conv-1");
             }
             other => panic!("expected ScratchpadChanged, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn notify_conversation_list_changed_reaches_subscribers() {
+        // #1: conversation create/rename/delete rides the same per-user
+        // broadcast, so every subscribed connection refreshes its sidebar.
+        let registry = BackgroundTaskRegistry::new();
+        let user = UserId::new("alice");
+        let mut events = registry.subscribe(&user);
+
+        registry.notify_conversation_list_changed(&user, "conv-7");
+
+        match tokio::time::timeout(std::time::Duration::from_secs(5), events.recv()).await {
+            Ok(Ok(api::Event::ConversationListChanged { conversation_id })) => {
+                assert_eq!(conversation_id, "conv-7");
+            }
+            other => panic!("expected ConversationListChanged, got {other:?}"),
         }
     }
 

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -576,6 +576,18 @@ where
         }
     }
 
+    /// Broadcast a conversation-list change (#1) to the calling user's
+    /// connections so every client's sidebar refreshes, regardless of which
+    /// client made the change. No-op without a registry attached.
+    fn notify_conversation_list_changed(&self, conversation_id: &str) {
+        if let Some(reg) = &self.registry {
+            reg.notify_conversation_list_changed(
+                &desktop_assistant_core::ports::auth::current_user_id(),
+                conversation_id,
+            );
+        }
+    }
+
     /// Borrow the registry, if one is attached. Public so #112/#113 can
     /// reach the same instance the foreground send path uses; for #111
     /// only the foreground path itself needs it.
@@ -1127,7 +1139,9 @@ where
                     .create_conversation(title)
                     .await
                     .map_err(Self::map_core_err)?;
-                Ok(api::CommandResult::ConversationId { id: conv.id.0 })
+                let id = conv.id.0;
+                self.notify_conversation_list_changed(&id);
+                Ok(api::CommandResult::ConversationId { id })
             }
 
             api::Command::ListConversations {
@@ -1219,6 +1233,7 @@ where
                     ))
                     .await
                     .map_err(Self::map_core_err)?;
+                self.notify_conversation_list_changed(&id);
                 Ok(api::CommandResult::Ack)
             }
 
@@ -1230,6 +1245,7 @@ where
                     )
                     .await
                     .map_err(Self::map_core_err)?;
+                self.notify_conversation_list_changed(&id);
                 Ok(api::CommandResult::Ack)
             }
 
@@ -1240,6 +1256,7 @@ where
                     ))
                     .await
                     .map_err(Self::map_core_err)?;
+                self.notify_conversation_list_changed(&id);
                 Ok(api::CommandResult::Ack)
             }
 
@@ -1250,6 +1267,7 @@ where
                     ))
                     .await
                     .map_err(Self::map_core_err)?;
+                self.notify_conversation_list_changed(&id);
                 Ok(api::CommandResult::Ack)
             }
 

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -53,6 +53,13 @@ pub enum SignalEvent {
         conversation_id: String,
         title: String,
     },
+    /// The user's conversation list changed elsewhere — a conversation was
+    /// created, renamed, deleted, or (un)archived by another client or the
+    /// voice daemon (#1). The client re-fetches its conversation list so its
+    /// sidebar stays in sync. Carries only the affected `conversation_id`.
+    ConversationListChanged {
+        conversation_id: String,
+    },
     /// One-time advisory emitted by the daemon (e.g. the conversation's
     /// stored model selection no longer resolves and was cleared).
     ConversationWarning {

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -433,6 +433,9 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             conversation_id,
             title,
         }),
+        api::Event::ConversationListChanged { conversation_id } => {
+            Some(SignalEvent::ConversationListChanged { conversation_id })
+        }
         api::Event::AssistantStatus {
             conversation_id,
             request_id,

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -156,6 +156,11 @@ pub fn translate(event: api::Event) -> ForwardAction {
         api::Event::ConversationTitleChanged { .. } => ForwardAction::Ignored {
             kind: "conversation_title_changed",
         },
+        // The conversation-list refresh (#1) is a UDS/WS sidebar concern; the
+        // D-Bus client (voice) renders no conversation list.
+        api::Event::ConversationListChanged { .. } => ForwardAction::Ignored {
+            kind: "conversation_list_changed",
+        },
         api::Event::ConversationWarningEmitted { .. } => ForwardAction::Ignored {
             kind: "conversation_warning_emitted",
         },


### PR DESCRIPTION
## Problem

A conversation created, renamed, deleted, or (un)archived in one client — or by the **voice** daemon — didn't appear in another client's sidebar until restart. Conversation-lifecycle changes were never signalled cross-connection.

## Fix

`Event::ConversationListChanged { conversation_id }`, broadcast on the **existing per-user channel** (the one `Task*`/`ScratchpadChanged` ride, which gtk/tui already subscribe to via `SubscribeBackgroundTasks`) from the **Create / Rename / Delete / Archive / Unarchive** handlers, via a new `BackgroundTaskRegistry::notify_conversation_list_changed`. Decoded to `SignalEvent::ConversationListChanged`; the client **re-fetches its conversation list** on receipt — a refetch is simplest and correct for every change kind, so the event carries only the affected id (no kind). Not forwarded over D-Bus (voice has no sidebar).

## Scope

Daemon + client-common. The client-side sidebar refresh on this signal is the follow-on gtk/tui change. Graceful: no-op without a registry.

## Tests

Registry broadcast-reaches-subscribers test; fmt/clippy clean; application/client-common/dbus-bridge suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)