### PR TITLE
Wire-model GetMessages as api::Command (CC-5 / #361)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -35,6 +35,21 @@ pub enum Command {
     GetConversation {
         id: String,
     },
+    /// Windowed message fetch (CC-5 / #361) so a GUI can load a slice of a
+    /// conversation instead of the whole transcript — the socket-transport
+    /// equivalent of the D-Bus `GetMessages` method. `after_count >= 0` returns
+    /// messages from that raw index onward; otherwise `tail > 0` returns the
+    /// last `tail` messages (`tail <= 0` with no `after_count` = all).
+    /// `include_roles` is an allowlist (empty = every role). Returns
+    /// `CommandResult::Messages` with full `MessageView`s including the UUIDv7
+    /// `id`, so the client can dedupe / order / back-page by id.
+    GetMessages {
+        conversation_id: String,
+        tail: i32,
+        after_count: i32,
+        #[serde(default)]
+        include_roles: Vec<String>,
+    },
     DeleteConversation {
         id: String,
     },

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1205,6 +1205,36 @@ where
                 }))
             }
 
+            api::Command::GetMessages {
+                conversation_id,
+                tail,
+                after_count,
+                include_roles,
+            } => {
+                let conv = self
+                    .conversations
+                    .get_conversation(&desktop_assistant_core::domain::ConversationId::from(
+                        conversation_id.as_str(),
+                    ))
+                    .await
+                    .map_err(Self::map_core_err)?;
+                let all: Vec<api::MessageView> = conv
+                    .messages
+                    .into_iter()
+                    .map(|m| api::MessageView {
+                        id: m.id,
+                        role: format!("{:?}", m.role).to_lowercase(),
+                        content: m.content,
+                    })
+                    .collect();
+                Ok(api::CommandResult::Messages(window_messages(
+                    all,
+                    tail,
+                    after_count,
+                    &include_roles,
+                )))
+            }
+
             api::Command::SetConversationPersonality {
                 conversation_id,
                 personality,
@@ -2555,6 +2585,45 @@ async fn replay_completed_response(
             full_response: response,
         })
         .await;
+}
+
+/// Windowed-message slicing for `Command::GetMessages` (CC-5 / #361), mirroring
+/// the D-Bus `get_messages` semantics so the bridge maps the two 1:1:
+/// `after_count >= 0` slices from that raw index onward (a stable position
+/// cursor); otherwise `tail > 0` keeps the last `tail`. The `include_roles`
+/// allowlist is applied AFTER the position slice (empty = no filter), matching
+/// the D-Bus method. `total_raw_count` is always the pre-slice message count so
+/// the client knows how much history exists; `truncated` is set only in tail
+/// mode when older messages were dropped.
+fn window_messages(
+    all: Vec<api::MessageView>,
+    tail: i32,
+    after_count: i32,
+    include_roles: &[String],
+) -> api::MessagesView {
+    let total = all.len() as u32;
+    let use_after = after_count >= 0;
+    let sliced: Vec<api::MessageView> = if use_after {
+        let start = (after_count as usize).min(all.len());
+        all[start..].to_vec()
+    } else {
+        all
+    };
+    let filtered: Vec<api::MessageView> = sliced
+        .into_iter()
+        .filter(|m| include_roles.is_empty() || include_roles.contains(&m.role))
+        .collect();
+    let (truncated, messages) = if !use_after && tail > 0 && filtered.len() > tail as usize {
+        let start = filtered.len() - tail as usize;
+        (true, filtered[start..].to_vec())
+    } else {
+        (false, filtered)
+    };
+    api::MessagesView {
+        total_raw_count: total,
+        truncated,
+        messages,
+    }
 }
 
 /// Inline turn body, shared between the registry-aware and the
@@ -3925,6 +3994,84 @@ mod tests {
             self_view.0.lock().await.is_empty(),
             "a connection on the origin's own session must be excluded from the fan-out"
         );
+    }
+
+    // --- GetMessages windowing (CC-5 / #361) ------------------------------
+
+    fn mv(id: &str, role: &str, content: &str) -> api::MessageView {
+        api::MessageView {
+            id: id.into(),
+            role: role.into(),
+            content: content.into(),
+        }
+    }
+
+    #[test]
+    fn window_messages_tail_keeps_last_n_and_flags_truncated() {
+        let all = vec![
+            mv("1", "user", "a"),
+            mv("2", "assistant", "b"),
+            mv("3", "user", "c"),
+        ];
+        let w = window_messages(all, 2, -1, &[]);
+        assert_eq!(w.total_raw_count, 3, "total is the full pre-slice count");
+        assert!(w.truncated, "tail dropped older messages");
+        assert_eq!(
+            w.messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["2", "3"],
+            "keeps the last `tail`, ids intact for the client cursor"
+        );
+    }
+
+    #[test]
+    fn window_messages_after_count_slices_from_index_and_never_truncates() {
+        let all = vec![
+            mv("1", "user", "a"),
+            mv("2", "assistant", "b"),
+            mv("3", "user", "c"),
+        ];
+        let w = window_messages(all, 0, 1, &[]);
+        assert_eq!(w.total_raw_count, 3);
+        assert!(
+            !w.truncated,
+            "after_count is an exact position cursor, not a truncation"
+        );
+        assert_eq!(
+            w.messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["2", "3"]
+        );
+    }
+
+    #[test]
+    fn window_messages_role_filter_applies_after_slice_and_total_is_pre_slice() {
+        let all = vec![
+            mv("1", "user", "a"),
+            mv("2", "assistant", "b"),
+            mv("3", "user", "c"),
+            mv("4", "tool", "d"),
+        ];
+        let w = window_messages(all, 0, -1, &["user".to_string()]);
+        assert_eq!(w.total_raw_count, 4, "total counts every role, pre-filter");
+        assert_eq!(
+            w.messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["1", "3"],
+            "only the allowlisted role survives"
+        );
+    }
+
+    #[test]
+    fn window_messages_tail_within_limit_is_not_truncated() {
+        let all = vec![mv("1", "user", "a"), mv("2", "assistant", "b")];
+        let w = window_messages(all, 5, -1, &[]);
+        assert!(!w.truncated);
+        assert_eq!(w.messages.len(), 2);
+    }
+
+    #[test]
+    fn window_messages_after_count_past_end_is_empty() {
+        let w = window_messages(vec![mv("1", "user", "a")], 0, 9, &[]);
+        assert_eq!(w.total_raw_count, 1);
+        assert!(w.messages.is_empty());
     }
 
     #[tokio::test]

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -65,6 +65,31 @@ pub trait AssistantCommands: Send + Sync {
         Ok(ConversationDetail::from(conversation))
     }
 
+    /// Windowed message fetch (CC-5 / #361): a slice of a conversation's
+    /// messages instead of the whole transcript, with the UUIDv7 id on each so
+    /// the client can dedupe/order/back-page. `after_count >= 0` = from that raw
+    /// index; else `tail > 0` = the last `tail`; `include_roles` empty = all.
+    async fn get_messages(
+        &self,
+        conversation_id: &str,
+        tail: i32,
+        after_count: i32,
+        include_roles: Vec<String>,
+    ) -> Result<api::MessagesView> {
+        let result = self
+            .send_command(api::Command::GetMessages {
+                conversation_id: conversation_id.to_string(),
+                tail,
+                after_count,
+                include_roles,
+            })
+            .await?;
+        let api::CommandResult::Messages(messages) = result else {
+            return Err(anyhow!("unexpected response for get_messages"));
+        };
+        Ok(messages)
+    }
+
     async fn create_conversation(&self, title: &str) -> Result<String> {
         let result = self
             .send_command(api::Command::CreateConversation {

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -57,6 +57,10 @@ type DbusConversationSummary = (String, String, u32, String, bool);
 /// is `(role, content)` — mirrors the D-Bus `(ssa(ss))` reply.
 type DbusConversationDetail = (String, String, Vec<(String, String)>);
 
+/// The D-Bus `GetMessages` reply: `(total_raw_count, truncated, [(role, content)])`.
+/// Aliased to keep the proxy signature within clippy's type-complexity bar.
+type DbusMessagesPage = (u32, bool, Vec<(String, String)>);
+
 #[zbus::proxy(interface = "org.desktopAssistant.Conversations")]
 trait Conversations {
     async fn create_conversation(&self, title: &str) -> zbus::fdo::Result<String>;
@@ -72,6 +76,14 @@ trait Conversations {
     async fn unarchive_conversation(&self, id: &str) -> zbus::fdo::Result<()>;
 
     async fn get_conversation(&self, id: &str) -> zbus::fdo::Result<DbusConversationDetail>;
+
+    async fn get_messages(
+        &self,
+        id: &str,
+        tail: i32,
+        after_count: i32,
+        include_roles: Vec<String>,
+    ) -> zbus::fdo::Result<DbusMessagesPage>;
 
     async fn delete_conversation(&self, id: &str) -> zbus::fdo::Result<()>;
 
@@ -265,6 +277,34 @@ impl DbusClient {
                 .collect(),
             model_selection: None,
             conversation_personality: None,
+        })
+    }
+
+    pub async fn get_messages(
+        &self,
+        conversation_id: &str,
+        tail: i32,
+        after_count: i32,
+        include_roles: Vec<String>,
+    ) -> Result<api::MessagesView> {
+        let (total, truncated, messages) = self
+            .proxy
+            .get_messages(conversation_id, tail, after_count, include_roles)
+            .await?;
+        Ok(api::MessagesView {
+            total_raw_count: total,
+            truncated,
+            // The D-Bus get_messages predates message ids (#1) and returns only
+            // (role, content); leave the id empty — this transport is the
+            // producer side, not a windowed-render consumer.
+            messages: messages
+                .into_iter()
+                .map(|(role, content)| api::MessageView {
+                    id: String::new(),
+                    role,
+                    content,
+                })
+                .collect(),
         })
     }
 

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -16,6 +16,16 @@ pub trait AssistantClient: Send + Sync {
     async fn list_conversations(&self) -> Result<Vec<ConversationSummary>>;
     async fn list_conversations_with_archived(&self) -> Result<Vec<ConversationSummary>>;
     async fn get_conversation(&self, id: &str) -> Result<ConversationDetail>;
+    /// Windowed message fetch (CC-5 / #361): a slice of a conversation instead
+    /// of the full transcript. `after_count >= 0` = from that raw index; else
+    /// `tail > 0` = the last `tail`; `include_roles` empty = all roles.
+    async fn get_messages(
+        &self,
+        conversation_id: &str,
+        tail: i32,
+        after_count: i32,
+        include_roles: Vec<String>,
+    ) -> Result<api::MessagesView>;
     async fn create_conversation(&self, title: &str) -> Result<String>;
     async fn delete_conversation(&self, id: &str) -> Result<()>;
     async fn rename_conversation(&self, id: &str, title: &str) -> Result<()>;
@@ -169,6 +179,33 @@ impl AssistantClient for TransportClient {
             Self::Dbus(client) => client.get_conversation(id).await,
             Self::Ws(client) => client.get_conversation(id).await,
             Self::Uds(client) => client.get_conversation(id).await,
+        }
+    }
+
+    async fn get_messages(
+        &self,
+        conversation_id: &str,
+        tail: i32,
+        after_count: i32,
+        include_roles: Vec<String>,
+    ) -> Result<api::MessagesView> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => {
+                client
+                    .get_messages(conversation_id, tail, after_count, include_roles)
+                    .await
+            }
+            Self::Ws(client) => {
+                client
+                    .get_messages(conversation_id, tail, after_count, include_roles)
+                    .await
+            }
+            Self::Uds(client) => {
+                client
+                    .get_messages(conversation_id, tail, after_count, include_roles)
+                    .await
+            }
         }
     }
 


### PR DESCRIPTION
Closes #361. **Keystone interlock for epic #358 (CC-2 paging) and the dbus-bridge cutover #314/#315.**

## What

Windowed message fetch `GetMessages(id, tail, after_count, include_roles)` existed **only** on the D-Bus surface — UDS/WS clients (and the new `client-ui-common` core) had no way to load a *slice* of a conversation, so GUIs fetch the full transcript via `get_conversation`. This is the daemon side of message pagination.

`api::Command::GetMessages { conversation_id, tail, after_count, include_roles }` → `CommandResult::Messages(MessagesView)`. The result is full `MessageView`s **including the UUIDv7 `id`** (DA#355), so the windowed client can dedupe / order / back-page by id — position params do the fetch, the id does the reconciliation.

## Why this shape

- `window_messages` **mirrors the D-Bus `get_messages` slicing 1:1** (after_count = stable raw-index cursor; else tail = last N; `include_roles` applied after the slice; `total_raw_count` always pre-slice). So the cutover (#314/#315) maps the D-Bus method onto this command with no semantic drift — the bridge projects `MessagesView` back to the D-Bus `(total, truncated, [(role, content)])` tuple (dropping ids, which that shape never had).
- `AssistantClient::get_messages` on all three transports: socket clients via the shared `AssistantCommands` send-command path; the D-Bus variant proxies the existing method.

## For the UI session (CC-2)

Consume `client.get_messages(conversation_id, tail, after_count, include_roles)` → `MessagesView { total_raw_count, truncated, messages: Vec<MessageView> }`. Default to `tail=50, after_count=-1` for latest-N; back-page with `after_count`/position; the v7 `id` on each message is your dedupe/order key against the live stream.

## Tests

Five pure windowing cases (tail+truncate, after_count slice, role filter + pre-slice total, within-limit, past-end). Additive + backwards-compatible. fmt/clippy clean; application + client-common green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)