### PR TITLE
Wire-model the missing Settings commands — bridge cutover (2/7) (#314)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -142,6 +142,71 @@ pub enum Command {
         push_on_update: bool,
     },
 
+    // Database / backend-tasks / WS-auth settings (bridge cutover 2/7, #314).
+    //
+    // These mirror the in-process D-Bus `org.desktopAssistant.Settings`
+    // methods of the same name 1:1 (same fields, same `None`/empty-clears
+    // semantics) so the dbus-bridge can proxy them over a socket transport and
+    // reach parity with the in-process adapter. They are the wire equivalents
+    // the bridge needs; the KCM already calls the D-Bus methods these mirror.
+    /// Read database settings. Returns
+    /// [`CommandResult::DatabaseSettings`].
+    ///
+    /// SECURITY: the returned `url` is the raw PostgreSQL connection string,
+    /// which for a password-auth deployment embeds the password inline
+    /// (`postgres://user:pass@host/db`). This mirrors the D-Bus
+    /// `GetDatabaseSettings` method exactly, which returns `settings.url`
+    /// verbatim with no redaction. Wire-modeling makes this reachable over a
+    /// socket (incl. WS); the secret exposure is unchanged from today's D-Bus
+    /// surface but is now reachable by a remote WS client if one is configured.
+    GetDatabaseSettings,
+    /// Update database settings. An empty `url` clears it (no database
+    /// configured). Mirrors the D-Bus `SetDatabaseSettings` method.
+    SetDatabaseSettings {
+        /// Empty string clears the configured URL.
+        url: String,
+        max_connections: u32,
+    },
+
+    /// Read backend-tasks settings (the LLM override used for background work
+    /// plus the dreaming / archive config). Returns
+    /// [`CommandResult::BackendTasksSettings`]. No secret is exposed: the
+    /// fields are the resolved connector/model/base-URL (an endpoint, not a
+    /// credential) and the dreaming/archive knobs; API keys live only in the
+    /// secret backend and are never returned here, matching the D-Bus
+    /// `GetBackendTasksSettings` method.
+    GetBackendTasksSettings,
+    /// Update backend-tasks settings. An empty `llm_connector` clears the LLM
+    /// override (background work falls back to the primary LLM). Mirrors the
+    /// D-Bus `SetBackendTasksSettings` method.
+    SetBackendTasksSettings {
+        /// Empty string clears the separate backend-tasks LLM override.
+        llm_connector: String,
+        llm_model: String,
+        llm_base_url: String,
+        dreaming_enabled: bool,
+        dreaming_interval_secs: u64,
+        archive_after_days: u32,
+    },
+
+    /// Read WebSocket auth settings (enabled auth methods + OIDC discovery
+    /// config). Returns [`CommandResult::WsAuthSettings`]. No secret is
+    /// exposed: the JWT HS256 signing key is stored in the secret backend and
+    /// is never read by this command; only the method list and the
+    /// non-sensitive OIDC issuer / endpoints / client id / scopes are
+    /// returned, matching the D-Bus `GetWsAuthSettings` method.
+    GetWsAuthSettings,
+    /// Update WebSocket auth settings. Mirrors the D-Bus `SetWsAuthSettings`
+    /// method.
+    SetWsAuthSettings {
+        methods: Vec<String>,
+        oidc_issuer: String,
+        oidc_auth_endpoint: String,
+        oidc_token_endpoint: String,
+        oidc_client_id: String,
+        oidc_scopes: String,
+    },
+
     // Named connections (issue #11).
     /// Enumerate every configured connection with its availability and
     /// whether credentials are present.
@@ -414,6 +479,13 @@ pub enum CommandResult {
     EmbeddingsSettings(EmbeddingsSettingsView),
     ConnectorDefaults(ConnectorDefaultsView),
     PersistenceSettings(PersistenceSettingsView),
+
+    /// Response to `GetDatabaseSettings` / `SetDatabaseSettings` (#314).
+    DatabaseSettings(DatabaseSettingsView),
+    /// Response to `GetBackendTasksSettings` / `SetBackendTasksSettings` (#314).
+    BackendTasksSettings(BackendTasksSettingsView),
+    /// Response to `GetWsAuthSettings` / `SetWsAuthSettings` (#314).
+    WsAuthSettings(WsAuthSettingsView),
 
     McpServers(Vec<McpServerView>),
 
@@ -826,6 +898,60 @@ pub struct McpServerView {
     /// "running" | "stopped" | "disabled"
     pub status: String,
     pub tool_count: u32,
+}
+
+/// Wire form of the database settings (#314). Mirrors the core
+/// [`desktop_assistant_core::ports::inbound::DatabaseSettingsView`] but lives
+/// here (serializable) so it can travel over the socket transports.
+///
+/// SECURITY: `url` is the raw PostgreSQL connection string and, for a
+/// password-auth deployment, embeds the password inline. It is returned
+/// verbatim, exactly as the in-process D-Bus `GetDatabaseSettings` method
+/// does — this view does NOT redact. See `Command::GetDatabaseSettings`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DatabaseSettingsView {
+    /// Empty string means no URL is configured.
+    pub url: String,
+    pub max_connections: u32,
+}
+
+/// Wire form of the backend-tasks settings (#314). Mirrors the core
+/// [`desktop_assistant_core::ports::inbound::BackendTasksSettingsView`].
+/// Carries no secret — `llm_base_url` is an endpoint, not a credential.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackendTasksSettingsView {
+    /// Whether `[backend_tasks.llm]` is explicitly configured (vs. falling
+    /// back to the primary LLM).
+    pub has_separate_llm: bool,
+    /// Resolved connector (from backend_tasks.llm or fallback).
+    pub llm_connector: String,
+    /// Resolved model (from backend_tasks.llm or fallback).
+    pub llm_model: String,
+    /// Resolved base URL (from backend_tasks.llm or fallback).
+    pub llm_base_url: String,
+    /// Whether periodic fact extraction ("dreaming") is enabled.
+    pub dreaming_enabled: bool,
+    /// Interval in seconds between dreaming cycles.
+    pub dreaming_interval_secs: u64,
+    /// Archive conversations older than this many days (0 = disabled).
+    pub archive_after_days: u32,
+}
+
+/// Wire form of the WebSocket auth settings (#314). Mirrors the core
+/// [`desktop_assistant_core::ports::inbound::WsAuthSettingsView`].
+///
+/// SECURITY: this carries only the enabled auth `methods` and the
+/// non-sensitive OIDC discovery fields. The JWT HS256 signing key lives in
+/// the secret backend and is intentionally NOT a field here — matching the
+/// in-process D-Bus `GetWsAuthSettings` method, which never returns it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WsAuthSettingsView {
+    pub methods: Vec<String>,
+    pub oidc_issuer: String,
+    pub oidc_auth_endpoint: String,
+    pub oidc_token_endpoint: String,
+    pub oidc_client_id: String,
+    pub oidc_scopes: String,
 }
 
 // --- Named-connection views (#11) ------------------------------------------
@@ -2015,6 +2141,175 @@ mod tests {
         .unwrap();
         assert_eq!(v, expected);
         assert_eq!(cmd, serde_json::from_value(v).unwrap());
+    }
+
+    // --- #314 settings commands: database / backend-tasks / ws-auth ---------
+
+    #[test]
+    fn database_settings_commands_match_documented_snake_case() {
+        // GetDatabaseSettings is a unit variant.
+        let cmd = Command::GetDatabaseSettings;
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(v, serde_json::json!("get_database_settings"));
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+
+        // SetDatabaseSettings carries the raw url + max_connections.
+        let cmd = Command::SetDatabaseSettings {
+            url: "postgres://u:p@host/db".into(),
+            max_connections: 7,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"set_database_settings":{"url":"postgres://u:p@host/db","max_connections":7}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+    }
+
+    #[test]
+    fn database_settings_result_round_trips() {
+        let res = CommandResult::DatabaseSettings(DatabaseSettingsView {
+            url: "postgres://u:p@host/db".into(),
+            max_connections: 9,
+        });
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        let dbv = v.get("database_settings").expect("database_settings key");
+        assert_eq!(
+            dbv.get("url"),
+            Some(&serde_json::json!("postgres://u:p@host/db"))
+        );
+        assert_eq!(dbv.get("max_connections"), Some(&serde_json::json!(9)));
+        let back: CommandResult = serde_json::from_value(v).unwrap();
+        assert_eq!(res, back);
+    }
+
+    #[test]
+    fn backend_tasks_settings_commands_match_documented_snake_case() {
+        let cmd = Command::GetBackendTasksSettings;
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(v, serde_json::json!("get_backend_tasks_settings"));
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+
+        let cmd = Command::SetBackendTasksSettings {
+            llm_connector: "ollama".into(),
+            llm_model: "qwen3".into(),
+            llm_base_url: "http://localhost:11434".into(),
+            dreaming_enabled: true,
+            dreaming_interval_secs: 1800,
+            archive_after_days: 30,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"set_backend_tasks_settings":{"llm_connector":"ollama","llm_model":"qwen3","llm_base_url":"http://localhost:11434","dreaming_enabled":true,"dreaming_interval_secs":1800,"archive_after_days":30}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+    }
+
+    #[test]
+    fn backend_tasks_settings_result_round_trips() {
+        let res = CommandResult::BackendTasksSettings(BackendTasksSettingsView {
+            has_separate_llm: true,
+            llm_connector: "ollama".into(),
+            llm_model: "qwen3".into(),
+            llm_base_url: "http://localhost:11434".into(),
+            dreaming_enabled: true,
+            dreaming_interval_secs: 1800,
+            archive_after_days: 30,
+        });
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        assert!(v.get("backend_tasks_settings").is_some());
+        let back: CommandResult = serde_json::from_value(v).unwrap();
+        assert_eq!(res, back);
+    }
+
+    #[test]
+    fn ws_auth_settings_commands_match_documented_snake_case() {
+        let cmd = Command::GetWsAuthSettings;
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(v, serde_json::json!("get_ws_auth_settings"));
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+
+        let cmd = Command::SetWsAuthSettings {
+            methods: vec!["password".into(), "oidc".into()],
+            oidc_issuer: "https://issuer.example".into(),
+            oidc_auth_endpoint: "https://issuer.example/authorize".into(),
+            oidc_token_endpoint: "https://issuer.example/token".into(),
+            oidc_client_id: "client-123".into(),
+            oidc_scopes: "openid profile".into(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&cmd).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(
+            r#"{"set_ws_auth_settings":{"methods":["password","oidc"],"oidc_issuer":"https://issuer.example","oidc_auth_endpoint":"https://issuer.example/authorize","oidc_token_endpoint":"https://issuer.example/token","oidc_client_id":"client-123","oidc_scopes":"openid profile"}}"#,
+        )
+        .unwrap();
+        assert_eq!(v, expected);
+        assert_eq!(cmd, serde_json::from_value(v).unwrap());
+    }
+
+    #[test]
+    fn ws_auth_settings_result_round_trips_and_exposes_no_signing_secret() {
+        let res = CommandResult::WsAuthSettings(WsAuthSettingsView {
+            methods: vec!["password".into()],
+            oidc_issuer: "https://issuer.example".into(),
+            oidc_auth_endpoint: String::new(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+            oidc_scopes: String::new(),
+        });
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        let ws = v.get("ws_auth_settings").expect("ws_auth_settings key");
+        // Security guard: the WS-auth view must never carry the HS256 signing
+        // key (it lives in the secret backend). Pin the exact field set so a
+        // future change that adds a secret-bearing field trips this test.
+        let obj = ws.as_object().expect("object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "methods",
+                "oidc_auth_endpoint",
+                "oidc_client_id",
+                "oidc_issuer",
+                "oidc_scopes",
+                "oidc_token_endpoint",
+            ],
+            "WsAuthSettingsView must expose only methods + OIDC fields, no signing secret"
+        );
+        let back: CommandResult = serde_json::from_value(v).unwrap();
+        assert_eq!(res, back);
+    }
+
+    #[test]
+    fn mcp_server_view_round_trips_command_args_and_namespace() {
+        // #314 MCP CRUD round-trip: a written command/args/namespace must read
+        // back. Pin the full wire shape (incl. `command`, which the bridge note
+        // flagged as not round-tripping).
+        let res = CommandResult::McpServers(vec![McpServerView {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec!["--mode".into(), "stdio".into()],
+            namespace: Some("jira".into()),
+            enabled: true,
+            status: "running".into(),
+            tool_count: 4,
+        }]);
+        let v: serde_json::Value = serde_json::to_value(&res).unwrap();
+        let server = &v.get("mcp_servers").expect("mcp_servers key")[0];
+        assert_eq!(
+            server.get("command"),
+            Some(&serde_json::json!("/usr/bin/tasks-mcp"))
+        );
+        assert_eq!(
+            server.get("args"),
+            Some(&serde_json::json!(["--mode", "stdio"]))
+        );
+        assert_eq!(server.get("namespace"), Some(&serde_json::json!("jira")));
+        let back: CommandResult = serde_json::from_value(v).unwrap();
+        assert_eq!(res, back);
     }
 
     #[test]

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1397,6 +1397,125 @@ where
                 Ok(api::CommandResult::Ack)
             }
 
+            // Database / backend-tasks / WS-auth settings (bridge cutover 2/7,
+            // #314). Each mirrors the in-process D-Bus method of the same name:
+            // the getters return the same fields the D-Bus method returns (no
+            // new secret exposure — see the `Command` doc-comments), and the
+            // setters apply the same `empty-string clears` normalization the
+            // D-Bus methods apply before delegating to `SettingsService`.
+            api::Command::GetDatabaseSettings => {
+                let s = self
+                    .settings
+                    .get_database_settings()
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::DatabaseSettings(
+                    api::DatabaseSettingsView {
+                        url: s.url,
+                        max_connections: s.max_connections,
+                    },
+                ))
+            }
+
+            api::Command::SetDatabaseSettings {
+                url,
+                max_connections,
+            } => {
+                // Mirror the D-Bus `set_database_settings`: an empty/whitespace
+                // url clears the configured URL.
+                self.settings
+                    .set_database_settings(normalize_empty(url), max_connections)
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            api::Command::GetBackendTasksSettings => {
+                let s = self
+                    .settings
+                    .get_backend_tasks_settings()
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::BackendTasksSettings(
+                    api::BackendTasksSettingsView {
+                        has_separate_llm: s.has_separate_llm,
+                        llm_connector: s.llm_connector,
+                        llm_model: s.llm_model,
+                        llm_base_url: s.llm_base_url,
+                        dreaming_enabled: s.dreaming_enabled,
+                        dreaming_interval_secs: s.dreaming_interval_secs,
+                        archive_after_days: s.archive_after_days,
+                    },
+                ))
+            }
+
+            api::Command::SetBackendTasksSettings {
+                llm_connector,
+                llm_model,
+                llm_base_url,
+                dreaming_enabled,
+                dreaming_interval_secs,
+                archive_after_days,
+            } => {
+                // Mirror the D-Bus `set_backend_tasks_settings`: an empty
+                // llm_connector clears the separate LLM override; empty
+                // model/base_url normalize to "unset" too.
+                self.settings
+                    .set_backend_tasks_settings(
+                        normalize_empty(llm_connector),
+                        normalize_empty(llm_model),
+                        normalize_empty(llm_base_url),
+                        dreaming_enabled,
+                        dreaming_interval_secs,
+                        archive_after_days,
+                    )
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
+            api::Command::GetWsAuthSettings => {
+                let s = self
+                    .settings
+                    .get_ws_auth_settings()
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::WsAuthSettings(
+                    api::WsAuthSettingsView {
+                        methods: s.methods,
+                        oidc_issuer: s.oidc_issuer,
+                        oidc_auth_endpoint: s.oidc_auth_endpoint,
+                        oidc_token_endpoint: s.oidc_token_endpoint,
+                        oidc_client_id: s.oidc_client_id,
+                        oidc_scopes: s.oidc_scopes,
+                    },
+                ))
+            }
+
+            api::Command::SetWsAuthSettings {
+                methods,
+                oidc_issuer,
+                oidc_auth_endpoint,
+                oidc_token_endpoint,
+                oidc_client_id,
+                oidc_scopes,
+            } => {
+                // Mirror the D-Bus `set_ws_auth_settings`: pass strings through
+                // verbatim (the D-Bus method does no normalization here).
+                self.settings
+                    .set_ws_auth_settings(
+                        methods,
+                        oidc_issuer,
+                        oidc_auth_endpoint,
+                        oidc_token_endpoint,
+                        oidc_client_id,
+                        oidc_scopes,
+                    )
+                    .await
+                    .map_err(Self::map_core_err)?;
+                Ok(api::CommandResult::Ack)
+            }
+
             // Knowledge base management (issue #73)
             api::Command::ListKnowledgeEntries {
                 limit,
@@ -2587,6 +2706,19 @@ async fn replay_completed_response(
         .await;
 }
 
+/// Normalize a wire `String` into `Option<String>` for the `set_*` settings
+/// commands (#314): a trimmed-empty string becomes `None` (clears the field),
+/// matching the in-process D-Bus settings adapters which treat an empty string
+/// as "clear this optional field". Non-empty values are trimmed and kept.
+fn normalize_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Windowed-message slicing for `Command::GetMessages` (CC-5 / #361), mirroring
 /// the D-Bus `get_messages` semantics so the bridge maps the two 1:1:
 /// `after_count >= 0` slices from that raw index onward (a stable position
@@ -3203,6 +3335,11 @@ mod tests {
         persistence: PersistenceSettingsView,
         personality: PersonalitySettingsView,
         api_key_set: bool,
+        // #314 round-trip state: database / backend-tasks / ws-auth / MCP.
+        database: DatabaseSettingsView,
+        backend_tasks: BackendTasksSettingsView,
+        ws_auth: desktop_assistant_core::ports::inbound::WsAuthSettingsView,
+        mcp_servers: Vec<desktop_assistant_core::ports::inbound::McpServerView>,
     }
 
     struct ConfigurableSettings {
@@ -3239,6 +3376,28 @@ mod tests {
                     },
                     personality: PersonalitySettingsView::default(),
                     api_key_set: false,
+                    database: DatabaseSettingsView {
+                        url: String::new(),
+                        max_connections: 5,
+                    },
+                    backend_tasks: BackendTasksSettingsView {
+                        has_separate_llm: false,
+                        llm_connector: "openai".into(),
+                        llm_model: "gpt-5".into(),
+                        llm_base_url: "https://api.openai.com/v1".into(),
+                        dreaming_enabled: false,
+                        dreaming_interval_secs: 3600,
+                        archive_after_days: 0,
+                    },
+                    ws_auth: desktop_assistant_core::ports::inbound::WsAuthSettingsView {
+                        methods: vec!["password".into()],
+                        oidc_issuer: String::new(),
+                        oidc_auth_endpoint: String::new(),
+                        oidc_token_endpoint: String::new(),
+                        oidc_client_id: String::new(),
+                        oidc_scopes: String::new(),
+                    },
+                    mcp_servers: vec![],
                 }),
             }
         }
@@ -3372,94 +3531,161 @@ mod tests {
         }
 
         async fn get_database_settings(&self) -> Result<DatabaseSettingsView, CoreError> {
-            Ok(DatabaseSettingsView {
-                url: String::new(),
-                max_connections: 5,
-            })
+            Ok(self.state.lock().unwrap().database.clone())
         }
 
         async fn set_database_settings(
             &self,
-            _url: Option<String>,
-            _max_connections: u32,
+            url: Option<String>,
+            max_connections: u32,
         ) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            // Mirror the daemon: `None` (empty url) clears the URL.
+            state.database.url = url.unwrap_or_default();
+            state.database.max_connections = max_connections;
             Ok(())
         }
         async fn get_backend_tasks_settings(&self) -> Result<BackendTasksSettingsView, CoreError> {
-            Ok(BackendTasksSettingsView {
-                has_separate_llm: false,
-                llm_connector: "openai".into(),
-                llm_model: "gpt-5".into(),
-                llm_base_url: "https://api.openai.com/v1".into(),
-                dreaming_enabled: false,
-                dreaming_interval_secs: 3600,
-                archive_after_days: 0,
-            })
+            Ok(self.state.lock().unwrap().backend_tasks.clone())
         }
         async fn set_backend_tasks_settings(
             &self,
-            _llm_connector: Option<String>,
-            _llm_model: Option<String>,
-            _llm_base_url: Option<String>,
-            _dreaming_enabled: bool,
-            _dreaming_interval_secs: u64,
-            _archive_after_days: u32,
+            llm_connector: Option<String>,
+            llm_model: Option<String>,
+            llm_base_url: Option<String>,
+            dreaming_enabled: bool,
+            dreaming_interval_secs: u64,
+            archive_after_days: u32,
         ) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            // Mirror the daemon: presence of a connector means a separate
+            // backend-tasks LLM override; absence clears it.
+            state.backend_tasks.has_separate_llm = llm_connector.is_some();
+            if let Some(connector) = llm_connector {
+                state.backend_tasks.llm_connector = connector;
+            }
+            if let Some(model) = llm_model {
+                state.backend_tasks.llm_model = model;
+            }
+            if let Some(base_url) = llm_base_url {
+                state.backend_tasks.llm_base_url = base_url;
+            }
+            state.backend_tasks.dreaming_enabled = dreaming_enabled;
+            state.backend_tasks.dreaming_interval_secs = dreaming_interval_secs;
+            state.backend_tasks.archive_after_days = archive_after_days;
             Ok(())
         }
         async fn list_mcp_servers(
             &self,
         ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError> {
-            Ok(vec![])
+            Ok(self.state.lock().unwrap().mcp_servers.clone())
         }
         async fn add_mcp_server(
             &self,
-            _name: String,
-            _command: String,
-            _args: Vec<String>,
-            _namespace: Option<String>,
-            _enabled: bool,
+            name: String,
+            command: String,
+            args: Vec<String>,
+            namespace: Option<String>,
+            enabled: bool,
         ) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            if state.mcp_servers.iter().any(|s| s.name == name) {
+                return Err(CoreError::SystemService(format!(
+                    "MCP server '{name}' already exists"
+                )));
+            }
+            // Persist the full config so command/args/namespace round-trip on a
+            // later list (#314), mirroring the daemon persisting to TOML.
+            state
+                .mcp_servers
+                .push(desktop_assistant_core::ports::inbound::McpServerView {
+                    name,
+                    command,
+                    args,
+                    namespace,
+                    enabled,
+                    status: if enabled { "running" } else { "disabled" }.to_string(),
+                    tool_count: 0,
+                });
             Ok(())
         }
-        async fn remove_mcp_server(&self, _name: String) -> Result<(), CoreError> {
+        async fn remove_mcp_server(&self, name: String) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            let before = state.mcp_servers.len();
+            state.mcp_servers.retain(|s| s.name != name);
+            if state.mcp_servers.len() == before {
+                return Err(CoreError::SystemService(format!(
+                    "MCP server '{name}' not found"
+                )));
+            }
             Ok(())
         }
         async fn set_mcp_server_enabled(
             &self,
-            _name: String,
-            _enabled: bool,
+            name: String,
+            enabled: bool,
         ) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            let server = state
+                .mcp_servers
+                .iter_mut()
+                .find(|s| s.name == name)
+                .ok_or_else(|| {
+                    CoreError::SystemService(format!("MCP server '{name}' not found"))
+                })?;
+            server.enabled = enabled;
+            server.status = if enabled { "running" } else { "disabled" }.to_string();
             Ok(())
         }
         async fn mcp_server_action(
             &self,
-            _action: String,
-            _server: Option<String>,
+            action: String,
+            server: Option<String>,
         ) -> Result<Vec<desktop_assistant_core::ports::inbound::McpServerView>, CoreError> {
-            Ok(vec![])
+            // Validate the action like the daemon, then return current status.
+            match action.as_str() {
+                "status" | "start" | "stop" | "restart" => {}
+                other => {
+                    return Err(CoreError::SystemService(format!(
+                        "unknown MCP action: {other}"
+                    )));
+                }
+            }
+            let state = self.state.lock().unwrap();
+            let servers = match server {
+                Some(name) => state
+                    .mcp_servers
+                    .iter()
+                    .filter(|s| s.name == name)
+                    .cloned()
+                    .collect(),
+                None => state.mcp_servers.clone(),
+            };
+            Ok(servers)
         }
         async fn get_ws_auth_settings(
             &self,
         ) -> Result<desktop_assistant_core::ports::inbound::WsAuthSettingsView, CoreError> {
-            Ok(desktop_assistant_core::ports::inbound::WsAuthSettingsView {
-                methods: vec![],
-                oidc_issuer: String::new(),
-                oidc_auth_endpoint: String::new(),
-                oidc_token_endpoint: String::new(),
-                oidc_client_id: String::new(),
-                oidc_scopes: String::new(),
-            })
+            Ok(self.state.lock().unwrap().ws_auth.clone())
         }
         async fn set_ws_auth_settings(
             &self,
-            _methods: Vec<String>,
-            _oidc_issuer: String,
-            _oidc_auth_endpoint: String,
-            _oidc_token_endpoint: String,
-            _oidc_client_id: String,
-            _oidc_scopes: String,
+            methods: Vec<String>,
+            oidc_issuer: String,
+            oidc_auth_endpoint: String,
+            oidc_token_endpoint: String,
+            oidc_client_id: String,
+            oidc_scopes: String,
         ) -> Result<(), CoreError> {
+            let mut state = self.state.lock().unwrap();
+            state.ws_auth = desktop_assistant_core::ports::inbound::WsAuthSettingsView {
+                methods,
+                oidc_issuer,
+                oidc_auth_endpoint,
+                oidc_token_endpoint,
+                oidc_client_id,
+                oidc_scopes,
+            };
             Ok(())
         }
     }
@@ -4146,6 +4372,407 @@ mod tests {
         assert_eq!(config.embeddings.model, "text-embedding-3-large");
         assert_eq!(config.persistence.remote_name, "upstream");
         assert!(!config.persistence.push_on_update);
+    }
+
+    // --- #314 bridge cutover (2/7): database / backend-tasks / ws-auth ------
+    //
+    // Each new command gets a handler round-trip test (set then get returns the
+    // written value) plus unhappy paths. The fakes mirror the daemon's
+    // `empty-clears` semantics so the normalization in the handler arm is
+    // exercised end-to-end.
+
+    fn handler_with(
+        settings: Arc<ConfigurableSettings>,
+    ) -> DefaultAssistantApiHandler<
+        FakeAssistant,
+        FakeConversations,
+        ConfigurableSettings,
+        FakeConnections,
+        FakeKnowledge,
+    > {
+        DefaultAssistantApiHandler::new(
+            Arc::new(FakeAssistant),
+            Arc::new(FakeConversations),
+            settings,
+            Arc::new(FakeConnections),
+            Arc::new(FakeKnowledge),
+        )
+    }
+
+    #[tokio::test]
+    async fn set_then_get_database_settings_round_trips() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        let ack = h
+            .handle_command(api::Command::SetDatabaseSettings {
+                url: "postgres://u:p@host/db".into(),
+                max_connections: 12,
+            })
+            .await
+            .unwrap();
+        assert_eq!(ack, api::CommandResult::Ack);
+
+        let res = h
+            .handle_command(api::Command::GetDatabaseSettings)
+            .await
+            .unwrap();
+        let api::CommandResult::DatabaseSettings(db) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(db.url, "postgres://u:p@host/db");
+        assert_eq!(db.max_connections, 12);
+    }
+
+    #[tokio::test]
+    async fn set_database_settings_empty_url_clears_it() {
+        // Seed a URL, then an empty url must clear it (mirrors the D-Bus method).
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        h.handle_command(api::Command::SetDatabaseSettings {
+            url: "postgres://u:p@host/db".into(),
+            max_connections: 4,
+        })
+        .await
+        .unwrap();
+        h.handle_command(api::Command::SetDatabaseSettings {
+            url: "   ".into(),
+            max_connections: 4,
+        })
+        .await
+        .unwrap();
+
+        let res = h
+            .handle_command(api::Command::GetDatabaseSettings)
+            .await
+            .unwrap();
+        let api::CommandResult::DatabaseSettings(db) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(db.url, "", "empty/whitespace url clears the configured URL");
+    }
+
+    #[tokio::test]
+    async fn set_then_get_backend_tasks_settings_round_trips() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        let ack = h
+            .handle_command(api::Command::SetBackendTasksSettings {
+                llm_connector: "ollama".into(),
+                llm_model: "qwen3".into(),
+                llm_base_url: "http://localhost:11434".into(),
+                dreaming_enabled: true,
+                dreaming_interval_secs: 1800,
+                archive_after_days: 14,
+            })
+            .await
+            .unwrap();
+        assert_eq!(ack, api::CommandResult::Ack);
+
+        let res = h
+            .handle_command(api::Command::GetBackendTasksSettings)
+            .await
+            .unwrap();
+        let api::CommandResult::BackendTasksSettings(bt) = res else {
+            panic!("unexpected result variant");
+        };
+        assert!(bt.has_separate_llm, "a set connector means a separate LLM");
+        assert_eq!(bt.llm_connector, "ollama");
+        assert_eq!(bt.llm_model, "qwen3");
+        assert_eq!(bt.llm_base_url, "http://localhost:11434");
+        assert!(bt.dreaming_enabled);
+        assert_eq!(bt.dreaming_interval_secs, 1800);
+        assert_eq!(bt.archive_after_days, 14);
+    }
+
+    #[tokio::test]
+    async fn set_backend_tasks_empty_connector_clears_separate_llm() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        // First set a separate LLM, then clear it with an empty connector.
+        h.handle_command(api::Command::SetBackendTasksSettings {
+            llm_connector: "ollama".into(),
+            llm_model: "qwen3".into(),
+            llm_base_url: "http://localhost:11434".into(),
+            dreaming_enabled: false,
+            dreaming_interval_secs: 3600,
+            archive_after_days: 0,
+        })
+        .await
+        .unwrap();
+        h.handle_command(api::Command::SetBackendTasksSettings {
+            llm_connector: "".into(),
+            llm_model: "".into(),
+            llm_base_url: "".into(),
+            dreaming_enabled: false,
+            dreaming_interval_secs: 3600,
+            archive_after_days: 0,
+        })
+        .await
+        .unwrap();
+
+        let res = h
+            .handle_command(api::Command::GetBackendTasksSettings)
+            .await
+            .unwrap();
+        let api::CommandResult::BackendTasksSettings(bt) = res else {
+            panic!("unexpected result variant");
+        };
+        assert!(
+            !bt.has_separate_llm,
+            "empty connector clears the separate backend-tasks LLM override"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_then_get_ws_auth_settings_round_trips() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        let ack = h
+            .handle_command(api::Command::SetWsAuthSettings {
+                methods: vec!["password".into(), "oidc".into()],
+                oidc_issuer: "https://issuer.example".into(),
+                oidc_auth_endpoint: "https://issuer.example/authorize".into(),
+                oidc_token_endpoint: "https://issuer.example/token".into(),
+                oidc_client_id: "client-123".into(),
+                oidc_scopes: "openid profile".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(ack, api::CommandResult::Ack);
+
+        let res = h
+            .handle_command(api::Command::GetWsAuthSettings)
+            .await
+            .unwrap();
+        let api::CommandResult::WsAuthSettings(ws) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(ws.methods, vec!["password".to_string(), "oidc".to_string()]);
+        assert_eq!(ws.oidc_issuer, "https://issuer.example");
+        assert_eq!(ws.oidc_auth_endpoint, "https://issuer.example/authorize");
+        assert_eq!(ws.oidc_token_endpoint, "https://issuer.example/token");
+        assert_eq!(ws.oidc_client_id, "client-123");
+        assert_eq!(ws.oidc_scopes, "openid profile");
+    }
+
+    // --- #314 MCP CRUD round-trip ------------------------------------------
+
+    #[tokio::test]
+    async fn add_then_list_mcp_server_round_trips_command_args_namespace() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        let ack = h
+            .handle_command(api::Command::AddMcpServer {
+                name: "tasks".into(),
+                command: "/usr/bin/tasks-mcp".into(),
+                args: vec!["--mode".into(), "stdio".into()],
+                namespace: Some("jira".into()),
+                enabled: true,
+            })
+            .await
+            .unwrap();
+        assert_eq!(ack, api::CommandResult::Ack);
+
+        let res = h
+            .handle_command(api::Command::ListMcpServers)
+            .await
+            .unwrap();
+        let api::CommandResult::McpServers(servers) = res else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(servers.len(), 1);
+        let s = &servers[0];
+        assert_eq!(s.name, "tasks");
+        // The crux of #314: command/args/namespace written via AddMcpServer
+        // must read back on ListMcpServers.
+        assert_eq!(s.command, "/usr/bin/tasks-mcp");
+        assert_eq!(s.args, vec!["--mode".to_string(), "stdio".to_string()]);
+        assert_eq!(s.namespace.as_deref(), Some("jira"));
+        assert!(s.enabled);
+    }
+
+    #[tokio::test]
+    async fn set_mcp_server_enabled_toggles_and_round_trips() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        h.handle_command(api::Command::AddMcpServer {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec![],
+            namespace: None,
+            enabled: true,
+        })
+        .await
+        .unwrap();
+        h.handle_command(api::Command::SetMcpServerEnabled {
+            name: "tasks".into(),
+            enabled: false,
+        })
+        .await
+        .unwrap();
+
+        let api::CommandResult::McpServers(servers) = h
+            .handle_command(api::Command::ListMcpServers)
+            .await
+            .unwrap()
+        else {
+            panic!("unexpected result variant");
+        };
+        assert!(!servers[0].enabled, "enabled flag must round-trip");
+        assert_eq!(servers[0].status, "disabled");
+    }
+
+    #[tokio::test]
+    async fn remove_then_list_mcp_server_drops_it() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        h.handle_command(api::Command::AddMcpServer {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec![],
+            namespace: None,
+            enabled: true,
+        })
+        .await
+        .unwrap();
+        let ack = h
+            .handle_command(api::Command::RemoveMcpServer {
+                name: "tasks".into(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(ack, api::CommandResult::Ack);
+
+        let api::CommandResult::McpServers(servers) = h
+            .handle_command(api::Command::ListMcpServers)
+            .await
+            .unwrap()
+        else {
+            panic!("unexpected result variant");
+        };
+        assert!(servers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_unknown_mcp_server_errors() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(settings);
+
+        let err = h
+            .handle_command(api::Command::RemoveMcpServer {
+                name: "does-not-exist".into(),
+            })
+            .await
+            .expect_err("removing an unknown MCP server must error");
+        assert!(
+            format!("{err:?}").contains("not found"),
+            "unknown server id should surface a not-found error, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_enabled_unknown_mcp_server_errors() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(settings);
+
+        let err = h
+            .handle_command(api::Command::SetMcpServerEnabled {
+                name: "does-not-exist".into(),
+                enabled: true,
+            })
+            .await
+            .expect_err("toggling an unknown MCP server must error");
+        assert!(format!("{err:?}").contains("not found"), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn mcp_server_action_unknown_action_errors() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(settings);
+
+        let err = h
+            .handle_command(api::Command::McpServerAction {
+                action: "frobnicate".into(),
+                server: None,
+            })
+            .await
+            .expect_err("an unknown MCP action must error");
+        assert!(
+            format!("{err:?}").contains("unknown MCP action"),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_server_action_status_returns_servers() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        h.handle_command(api::Command::AddMcpServer {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec!["--mode".into(), "stdio".into()],
+            namespace: Some("jira".into()),
+            enabled: true,
+        })
+        .await
+        .unwrap();
+
+        let api::CommandResult::McpServers(servers) = h
+            .handle_command(api::Command::McpServerAction {
+                action: "status".into(),
+                server: Some("tasks".into()),
+            })
+            .await
+            .unwrap()
+        else {
+            panic!("unexpected result variant");
+        };
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].command, "/usr/bin/tasks-mcp");
+        assert_eq!(
+            servers[0].args,
+            vec!["--mode".to_string(), "stdio".to_string()]
+        );
+        assert_eq!(servers[0].namespace.as_deref(), Some("jira"));
+    }
+
+    #[tokio::test]
+    async fn add_duplicate_mcp_server_errors() {
+        let settings = Arc::new(ConfigurableSettings::new());
+        let h = handler_with(Arc::clone(&settings));
+
+        h.handle_command(api::Command::AddMcpServer {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec![],
+            namespace: None,
+            enabled: true,
+        })
+        .await
+        .unwrap();
+        let err = h
+            .handle_command(api::Command::AddMcpServer {
+                name: "tasks".into(),
+                command: "/usr/bin/other".into(),
+                args: vec![],
+                namespace: None,
+                enabled: true,
+            })
+            .await
+            .expect_err("adding a duplicate MCP server name must error");
+        assert!(
+            format!("{err:?}").contains("already exists"),
+            "got: {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/client-common/src/commands.rs
+++ b/crates/client-common/src/commands.rs
@@ -521,6 +521,116 @@ pub trait AssistantCommands: Send + Sync {
         };
         Ok(())
     }
+
+    // --- Database / backend-tasks / WS-auth settings (#314) ----------------
+    //
+    // Socket-transport equivalents of the in-process D-Bus settings methods
+    // (bridge cutover 2/7). Each is a thin default over `send_command`, so the
+    // UDS, WS, and D-Bus clients all inherit it.
+
+    /// Read database settings (#314). SECURITY: the returned `url` is the raw
+    /// connection string and may embed a password inline — this mirrors the
+    /// D-Bus `GetDatabaseSettings` method, which returns it verbatim.
+    async fn get_database_settings(&self) -> Result<api::DatabaseSettingsView> {
+        let result = self.send_command(api::Command::GetDatabaseSettings).await?;
+        let api::CommandResult::DatabaseSettings(view) = result else {
+            return Err(anyhow!("unexpected response for get_database_settings"));
+        };
+        Ok(view)
+    }
+
+    /// Update database settings (#314). An empty `url` clears it.
+    async fn set_database_settings(&self, url: &str, max_connections: u32) -> Result<()> {
+        let result = self
+            .send_command(api::Command::SetDatabaseSettings {
+                url: url.to_string(),
+                max_connections,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!("unexpected response for set_database_settings"));
+        };
+        Ok(())
+    }
+
+    /// Read backend-tasks settings (#314). No secret is returned.
+    async fn get_backend_tasks_settings(&self) -> Result<api::BackendTasksSettingsView> {
+        let result = self
+            .send_command(api::Command::GetBackendTasksSettings)
+            .await?;
+        let api::CommandResult::BackendTasksSettings(view) = result else {
+            return Err(anyhow!(
+                "unexpected response for get_backend_tasks_settings"
+            ));
+        };
+        Ok(view)
+    }
+
+    /// Update backend-tasks settings (#314). An empty `llm_connector` clears the
+    /// separate backend-tasks LLM override.
+    #[allow(clippy::too_many_arguments)]
+    async fn set_backend_tasks_settings(
+        &self,
+        llm_connector: &str,
+        llm_model: &str,
+        llm_base_url: &str,
+        dreaming_enabled: bool,
+        dreaming_interval_secs: u64,
+        archive_after_days: u32,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::SetBackendTasksSettings {
+                llm_connector: llm_connector.to_string(),
+                llm_model: llm_model.to_string(),
+                llm_base_url: llm_base_url.to_string(),
+                dreaming_enabled,
+                dreaming_interval_secs,
+                archive_after_days,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!(
+                "unexpected response for set_backend_tasks_settings"
+            ));
+        };
+        Ok(())
+    }
+
+    /// Read WebSocket auth settings (#314). No signing secret is returned — only
+    /// the method list and the non-sensitive OIDC discovery fields.
+    async fn get_ws_auth_settings(&self) -> Result<api::WsAuthSettingsView> {
+        let result = self.send_command(api::Command::GetWsAuthSettings).await?;
+        let api::CommandResult::WsAuthSettings(view) = result else {
+            return Err(anyhow!("unexpected response for get_ws_auth_settings"));
+        };
+        Ok(view)
+    }
+
+    /// Update WebSocket auth settings (#314).
+    async fn set_ws_auth_settings(
+        &self,
+        methods: Vec<String>,
+        oidc_issuer: &str,
+        oidc_auth_endpoint: &str,
+        oidc_token_endpoint: &str,
+        oidc_client_id: &str,
+        oidc_scopes: &str,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::SetWsAuthSettings {
+                methods,
+                oidc_issuer: oidc_issuer.to_string(),
+                oidc_auth_endpoint: oidc_auth_endpoint.to_string(),
+                oidc_token_endpoint: oidc_token_endpoint.to_string(),
+                oidc_client_id: oidc_client_id.to_string(),
+                oidc_scopes: oidc_scopes.to_string(),
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!("unexpected response for set_ws_auth_settings"));
+        };
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -939,5 +1049,145 @@ mod tests {
             }
             other => panic!("expected ClientToolResult, got {other:?}"),
         }
+    }
+
+    // --- #314 settings client methods --------------------------------------
+
+    #[tokio::test]
+    async fn get_database_settings_emits_command_and_decodes_view() {
+        let client = RecordingClient::new(api::CommandResult::DatabaseSettings(
+            api::DatabaseSettingsView {
+                url: "postgres://u:p@host/db".into(),
+                max_connections: 8,
+            },
+        ));
+        let view = client.get_database_settings().await.unwrap();
+        assert_eq!(view.url, "postgres://u:p@host/db");
+        assert_eq!(view.max_connections, 8);
+        assert!(matches!(client.last(), api::Command::GetDatabaseSettings));
+    }
+
+    #[tokio::test]
+    async fn set_database_settings_emits_command_with_args() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .set_database_settings("postgres://u:p@host/db", 8)
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::SetDatabaseSettings {
+                url,
+                max_connections,
+            } => {
+                assert_eq!(url, "postgres://u:p@host/db");
+                assert_eq!(max_connections, 8);
+            }
+            other => panic!("expected SetDatabaseSettings, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_backend_tasks_settings_emits_command_and_decodes_view() {
+        let client = RecordingClient::new(api::CommandResult::BackendTasksSettings(
+            api::BackendTasksSettingsView {
+                has_separate_llm: true,
+                llm_connector: "ollama".into(),
+                llm_model: "qwen3".into(),
+                llm_base_url: "http://localhost:11434".into(),
+                dreaming_enabled: true,
+                dreaming_interval_secs: 1800,
+                archive_after_days: 7,
+            },
+        ));
+        let view = client.get_backend_tasks_settings().await.unwrap();
+        assert!(view.has_separate_llm);
+        assert_eq!(view.llm_connector, "ollama");
+        assert!(matches!(
+            client.last(),
+            api::Command::GetBackendTasksSettings
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_backend_tasks_settings_emits_command_with_args() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .set_backend_tasks_settings("ollama", "qwen3", "http://localhost:11434", true, 1800, 7)
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::SetBackendTasksSettings {
+                llm_connector,
+                llm_model,
+                llm_base_url,
+                dreaming_enabled,
+                dreaming_interval_secs,
+                archive_after_days,
+            } => {
+                assert_eq!(llm_connector, "ollama");
+                assert_eq!(llm_model, "qwen3");
+                assert_eq!(llm_base_url, "http://localhost:11434");
+                assert!(dreaming_enabled);
+                assert_eq!(dreaming_interval_secs, 1800);
+                assert_eq!(archive_after_days, 7);
+            }
+            other => panic!("expected SetBackendTasksSettings, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_ws_auth_settings_emits_command_and_decodes_view() {
+        let client = RecordingClient::new(api::CommandResult::WsAuthSettings(
+            api::WsAuthSettingsView {
+                methods: vec!["password".into()],
+                oidc_issuer: "https://issuer.example".into(),
+                oidc_auth_endpoint: String::new(),
+                oidc_token_endpoint: String::new(),
+                oidc_client_id: String::new(),
+                oidc_scopes: String::new(),
+            },
+        ));
+        let view = client.get_ws_auth_settings().await.unwrap();
+        assert_eq!(view.methods, vec!["password".to_string()]);
+        assert_eq!(view.oidc_issuer, "https://issuer.example");
+        assert!(matches!(client.last(), api::Command::GetWsAuthSettings));
+    }
+
+    #[tokio::test]
+    async fn set_ws_auth_settings_emits_command_with_args() {
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        client
+            .set_ws_auth_settings(
+                vec!["password".into(), "oidc".into()],
+                "https://issuer.example",
+                "https://issuer.example/authorize",
+                "https://issuer.example/token",
+                "client-123",
+                "openid profile",
+            )
+            .await
+            .unwrap();
+        match client.last() {
+            api::Command::SetWsAuthSettings {
+                methods,
+                oidc_issuer,
+                oidc_client_id,
+                ..
+            } => {
+                assert_eq!(methods, vec!["password".to_string(), "oidc".to_string()]);
+                assert_eq!(oidc_issuer, "https://issuer.example");
+                assert_eq!(oidc_client_id, "client-123");
+            }
+            other => panic!("expected SetWsAuthSettings, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn settings_getters_reject_unexpected_result() {
+        // A mismatched result variant must be a clean error, not a panic.
+        let client = RecordingClient::new(api::CommandResult::Ack);
+        assert!(client.get_database_settings().await.is_err());
+        assert!(client.get_backend_tasks_settings().await.is_err());
+        assert!(client.get_ws_auth_settings().await.is_err());
     }
 }

--- a/crates/daemon/src/settings_service.rs
+++ b/crates/daemon/src/settings_service.rs
@@ -258,8 +258,8 @@ impl SettingsService for DaemonSettingsService {
             .map(|s| McpServerView {
                 name: s.name,
                 command: s.command,
-                args: vec![],
-                namespace: None,
+                args: s.args,
+                namespace: s.namespace,
                 enabled: s.enabled,
                 status: s.status,
                 tool_count: s.tool_count,
@@ -355,8 +355,8 @@ impl SettingsService for DaemonSettingsService {
             .map(|s| McpServerView {
                 name: s.name,
                 command: s.command,
-                args: vec![],
-                namespace: None,
+                args: s.args,
+                namespace: s.namespace,
                 enabled: s.enabled,
                 status: s.status,
                 tool_count: s.tool_count,

--- a/crates/dbus-bridge/src/adapter/settings.rs
+++ b/crates/dbus-bridge/src/adapter/settings.rs
@@ -4,31 +4,35 @@
 //!
 //! The in-process settings adapter
 //! (`crates/dbus-interface/src/settings.rs`) calls methods on
-//! `SettingsService` that have **no `api::Command` equivalent on the
-//! wire today**:
+//! `SettingsService`. Most now have an `api::Command` wire equivalent;
+//! the bridge adapter below still proxies only a subset of them.
 //!
+//! - `GetDatabaseSettings` / `SetDatabaseSettings`,
+//!   `GetBackendTasksSettings` / `SetBackendTasksSettings`,
+//!   `GetWsAuthSettings` / `SetWsAuthSettings`: **wire-modeled as of
+//!   #314** (bridge cutover 2/7). Proxying them through this adapter is
+//!   the next step (#315); they are not yet exposed here.
+//! - The MCP server CRUD methods
+//!   (`AddMcpServer`/`RemoveMcpServer`/`SetMcpServerEnabled`/
+//!   `McpServerAction`) are wire-modeled and now fully round-trip
+//!   `command`/`args`/`namespace` (#314 surfaced them on
+//!   `McpServerStatusInfo`); the bridge still proxies only
+//!   `ListMcpServers`, with CRUD proxying deferred to #315.
 //! - `GetLlmSettings` / `SetLlmSettings` (legacy single-connection
 //!   surface, removed from `api-model`; supplanted by named
-//!   connections via the `Connections` adapter).
-//! - `GenerateWsJwt`, `ValidateWsJwt` (the bridge already has a JWT
-//!   from the local minter; clients that need their own should call
-//!   the minter directly).
-//! - `GetDatabaseSettings` / `SetDatabaseSettings`.
-//! - `GetBackendTasksSettings` / `SetBackendTasksSettings`.
-//! - `GetWsAuthSettings` / `SetWsAuthSettings`.
-//! - The MCP server CRUD methods
-//!   (`AddMcpServer`/`RemoveMcpServer`/...) are wire-modeled but the
-//!   bridge currently only proxies `ListMcpServers`. MCP CRUD is
-//!   wired up in a follow-up because the wire surface for
-//!   `ServerView` does not yet round-trip the `command` arg the
-//!   in-process adapter requires.
+//!   connections via the `Connections` adapter) and `ValidateWsJwt`
+//!   have **no callers in adele-kde** (#314 Q2) and are intentionally
+//!   NOT wire-modeled.
+//! - `GenerateWsJwt` (#314 Q1, gated on a security review) is also not
+//!   wire-modeled; the bridge already has a JWT from the local minter,
+//!   and clients that need their own should call the minter directly.
 //!
 //! Per Option A in PR #106, this is acceptable: the daemon still
 //! ships the in-process surface, and existing TUI/KCM/plasmoid clients
 //! talk to that. The bridge exposes the wire-proxyable subset under a
 //! configurable name (default `org.desktopAssistant.Bridge`), and the
-//! follow-up issue widens the api-model so the bridge can subsume the
-//! full surface.
+//! follow-up step (#315) proxies the now-wire-modeled settings methods
+//! through this adapter.
 
 use std::sync::Arc;
 

--- a/crates/mcp-client/src/executor.rs
+++ b/crates/mcp-client/src/executor.rs
@@ -43,6 +43,12 @@ pub struct McpServerConfig {
 pub struct McpServerStatusInfo {
     pub name: String,
     pub command: String,
+    /// Configured launch arguments. Surfaced so the settings layer can project
+    /// an `McpServerView` that round-trips what `add_mcp_server` wrote (#314).
+    pub args: Vec<String>,
+    /// Optional tool-namespace prefix, mirrored from the config so it
+    /// round-trips through the settings surface (#314).
+    pub namespace: Option<String>,
     pub enabled: bool,
     pub status: String,
     pub tool_count: u32,
@@ -359,6 +365,8 @@ impl McpControlHandle {
                 Some(McpServerStatusInfo {
                     name: config.name.clone(),
                     command: config.command.clone(),
+                    args: config.args.clone(),
+                    namespace: config.namespace.clone(),
                     enabled: config.enabled,
                     status: status.to_string(),
                     tool_count,
@@ -1033,6 +1041,32 @@ mod tests {
         assert_eq!(status[1].name, "jira");
         assert_eq!(status[1].status, "disabled");
         assert!(!status[1].enabled);
+    }
+
+    #[tokio::test]
+    async fn control_handle_status_carries_command_args_namespace() {
+        // #314 MCP CRUD round-trip: `status()` must surface the full config
+        // (command + args + namespace), not just the command, so the settings
+        // layer can project an `McpServerView` that round-trips what was added.
+        let configs = vec![McpServerConfig {
+            name: "tasks".into(),
+            command: "/usr/bin/tasks-mcp".into(),
+            args: vec!["--mode".into(), "stdio".into()],
+            namespace: Some("jira".into()),
+            enabled: true,
+            env: HashMap::new(),
+            env_secrets: HashMap::new(),
+        }];
+        let executor = McpToolExecutor::new(configs);
+        let handle = executor.control_handle();
+        let status = handle.status(None).await;
+        assert_eq!(status.len(), 1);
+        assert_eq!(status[0].command, "/usr/bin/tasks-mcp");
+        assert_eq!(
+            status[0].args,
+            vec!["--mode".to_string(), "stdio".to_string()]
+        );
+        assert_eq!(status[0].namespace.as_deref(), Some("jira"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Step **2 of 7** of the dbus-bridge cutover (#281, §G2). `dbus-interface` serves Settings methods that had **no `api::Command` wire equivalent**, so the dbus-bridge could not reach parity. This adds the wire model for the socket transports (UDS/WS). **Daemon-side only; no client behavior change.** Mirrors the just-merged `GetMessages` pattern (#363).

**Do NOT merge yet** — please security-review the diff first (the DB-URL passthrough below is the part to scrutinize).

## Commands added

Each = `api::Command` variant + `CommandResult` variant + new `DatabaseSettingsView`/`BackendTasksSettingsView`/`WsAuthSettingsView` (serializable api-model views mirroring the core `ports::inbound` views) + an application handler arm + an `AssistantCommands` default method (so UDS/WS/D-Bus clients all inherit it via `send_command`).

| Command | Result | Notes |
|---|---|---|
| `GetDatabaseSettings` | `DatabaseSettings(DatabaseSettingsView)` | returns `{ url, max_connections }` |
| `SetDatabaseSettings { url, max_connections }` | `Ack` | empty `url` clears it |
| `GetBackendTasksSettings` | `BackendTasksSettings(BackendTasksSettingsView)` | resolved connector/model/base_url + dreaming/archive |
| `SetBackendTasksSettings { llm_connector, llm_model, llm_base_url, dreaming_enabled, dreaming_interval_secs, archive_after_days }` | `Ack` | empty `llm_connector` clears the separate-LLM override |
| `GetWsAuthSettings` | `WsAuthSettings(WsAuthSettingsView)` | methods + OIDC discovery fields |
| `SetWsAuthSettings { methods, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_client_id, oidc_scopes }` | `Ack` | |

Each handler arm mirrors the in-process D-Bus `org.desktopAssistant.Settings` method of the same name **1:1** — same fields, same `empty-string clears` normalization on setters (new `normalize_empty` helper).

## MCP CRUD round-trip fix

`McpServerStatusInfo` (returned by the MCP control handle's `status()`) carried only `command`, so the daemon's `list_mcp_servers` / `mcp_server_action` hardcoded `args: vec![]` / `namespace: None` — a written `args`/`namespace` did **not** read back. Added `args` + `namespace` to `McpServerStatusInfo` (populated from the config) and wired them through both settings methods. `Add/RemoveMcpServer`, `SetMcpServerEnabled`, `McpServerAction` now fully round-trip command/args/namespace. (The wire `McpServerView` already carried all three fields; this closes the daemon-side read-back gap the bridge note flagged.)

## 🔐 Per-getter secret-exposure report (mirrors the D-Bus methods exactly)

I report each new getter's exact returned fields and whether any secret is exposed, quoting the D-Bus behavior mirrored. **No getter newly exposes or newly redacts anything vs. today's D-Bus surface.** Wire-modeling does make these reachable over WS (potentially remote) where before they were D-Bus-only.

**`GetDatabaseSettings` → `{ url, max_connections }` — ⚠️ EXPOSES A SECRET (unchanged from D-Bus).**
- Mirrors `dbus-interface/src/settings.rs::get_database_settings` (`Returns: (url, max_connections)`), which does `Ok((settings.url, settings.max_connections))` — the URL **verbatim, no redaction**.
- `database.url` is documented in `config/mod.rs` as `"postgres://user:pass@localhost/desktop_assistant"`, i.e. for password auth the **DB password is embedded inline** in the URL.
- So this getter returns the DB password to any caller — **exactly as the existing D-Bus `GetDatabaseSettings` already does.** This PR does not change that; it does not add redaction (the instruction was to mirror exactly). Flagging because wire-modeling makes it reachable over WS. Doc-commented as such on `Command::GetDatabaseSettings` and `DatabaseSettingsView`. **This is the item to security-review** — if redaction is wanted, it should be a deliberate, separate change applied to both surfaces.

**`GetWsAuthSettings` → `{ methods, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_client_id, oidc_scopes }` — NO secret.**
- Mirrors `get_ws_auth_settings` (`Returns: (methods, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_client_id, oidc_scopes)`).
- The JWT **HS256 signing key** is stored in the secret backend (keyring account `ws_jwt_hs256_signing_key`, see `config/jwt.rs`) and is **not a field** on `WsAuthConfig` (`methods`/`oidc`/`allowed_origins` only) nor on `WsAuthSettingsView`. It is structurally impossible to return here, matching the D-Bus method which never reads it. An api-model guard test pins the exact field set so a future secret-bearing field trips CI. (Note: `allowed_origins` exists in the config but the D-Bus getter omits it — I mirror that omission.)

**`GetBackendTasksSettings` → `{ has_separate_llm, llm_connector, llm_model, llm_base_url, dreaming_enabled, dreaming_interval_secs, archive_after_days }` — NO secret.**
- Mirrors `get_backend_tasks_settings`. `llm_base_url` is an endpoint, not a credential; API keys live only in the secret backend and are never returned. No secret.

## Q2 caller findings (adele-kde grep)

Investigated `/home/dave/Projects/adelie-ai/adele-kde` for callers of the keep-or-drop methods:

- **`GetLlmSettings` — NO CALLERS.** Only deprecation comments: `desktopassistantkcm.cpp:662` ("legacy single-LLM/embeddings settings … no longer surfaced by this KCM") and `ui/main.qml:44` ("the daemon still exposes Get/SetLlmSettings but this KCM no longer uses them").
- **`SetLlmSettings` — NO CALLERS.** (same comment-only references.)
- **`ValidateWsJwt` — NO CALLERS.**
- **`GenerateWsJwt` — NO CALLERS** (relevant to Q1; also unused by the KCM).

Cross-check (the ones I wire-modeled) — all **actively called** by the KCM, validating the shapes:
- `GetDatabaseSettings` @ `desktopassistantkcm.cpp:745`, `SetDatabaseSettings` @ `:949`.
- `GetBackendTasksSettings` @ `:764`, `SetBackendTasksSettings` @ `:955`.
- `GetWsAuthSettings` @ `:790`, `SetWsAuthSettings` @ `:966`.

→ **Q2 recommendation:** `GetLlmSettings`/`SetLlmSettings`/`ValidateWsJwt` are safe to **drop** from the surface (zero adele-kde callers). Left for your decision; not wire-modeled in this PR. (Other clients outside adele-kde not surveyed.)

## Tests (TDD, failing-first)

- **api-model:** snake_case wire-shape + round-trip per new command/result; a guard test pinning the exact `WsAuthSettingsView` field set; full `McpServerView` round-trip incl. command/args/namespace.
- **application:** handler set→get round-trips for all three settings pairs + empty-clears unhappy paths; MCP add→list/status round-trip of command/args/namespace; unknown-server-id, unknown-action, duplicate-add error paths.
- **mcp-client:** `status()` carries command/args/namespace.
- **client-common:** each method emits the right command + decodes the result; getters reject a mismatched result variant.

`cargo build --workspace`, `cargo test` (api-model/application/client-common/mcp-client/daemon), `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` — all clean.

## Couldn't verify
- No live end-to-end test against a running daemon over an actual WS/UDS socket (handler + wire round-trips are unit-tested; the transports inherit the typed methods via the shared `send_command` path proven by the `GetMessages` template).
- adele-kde survey covers that repo only; other external clients not surveyed for the Q2 methods.

Closes #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)