### PR TITLE
Flip the bridge to org.desktopAssistant; daemon steps off the name (#318)

### DIFF
--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -245,11 +245,11 @@ fn default_ws_auth_methods() -> Vec<String> {
 
 /// Transport enable/bind configuration (#279 item 3).
 ///
-/// Defaults are local-first and identical to the historical
-/// `DESKTOP_ASSISTANT_*` env-var defaults: WebSocket off, D-Bus best-effort,
-/// UDS on (Unix). The matching env var still overrides each field when set, so
-/// this table is purely additive — a config without a `[transports]` section
-/// behaves exactly as before.
+/// Defaults are local-first: WebSocket off, UDS on (Unix), and — since the
+/// dbus-bridge cutover (#281) — the legacy in-process D-Bus surface **off** (the
+/// standalone `adelie-dbus-bridge` owns `org.desktopAssistant`; set
+/// `dbus_inprocess = true` to restore it). The matching `DESKTOP_ASSISTANT_*`
+/// env var still overrides each field when set.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct TransportsConfig {
@@ -264,10 +264,20 @@ pub struct TransportsConfig {
     /// `DESKTOP_ASSISTANT_UDS_SOCKET`.
     pub uds_socket: Option<String>,
     /// Fail startup if the session D-Bus is unavailable. Env:
-    /// `DESKTOP_ASSISTANT_DBUS_REQUIRED`.
+    /// `DESKTOP_ASSISTANT_DBUS_REQUIRED`. Only consulted when
+    /// [`Self::dbus_inprocess`] is on.
     pub dbus_required: bool,
-    /// D-Bus well-known name to claim. Env: `DESKTOP_ASSISTANT_DBUS_SERVICE`.
+    /// D-Bus well-known name to claim *when serving the in-process surface*.
+    /// Env: `DESKTOP_ASSISTANT_DBUS_SERVICE`.
     pub dbus_service: String,
+    /// Serve the legacy **in-process** D-Bus surface (the daemon claims
+    /// [`Self::dbus_service`] and answers method calls itself). Default
+    /// **false** since the dbus-bridge cutover (#281): the standalone
+    /// `adelie-dbus-bridge` now owns `org.desktopAssistant`, and the daemon
+    /// keeps exactly one local ingress (UDS). Set true (env:
+    /// `DESKTOP_ASSISTANT_DBUS_INPROCESS`) to re-enable the legacy surface — the
+    /// revert lever during the cutover; removed entirely in #319.
+    pub dbus_inprocess: bool,
 }
 
 /// Local-first WebSocket-off default, mirroring the historical env defaults.
@@ -278,6 +288,9 @@ pub const DEFAULT_WS_BIND: &str = "127.0.0.1:11339";
 pub const DEFAULT_DBUS_REQUIRED: bool = false;
 /// Historical default D-Bus well-known name.
 pub const DEFAULT_DBUS_SERVICE: &str = "org.desktopAssistant";
+/// In-process D-Bus surface **off** by default since the cutover (#281) — the
+/// standalone `adelie-dbus-bridge` owns `org.desktopAssistant`.
+pub const DEFAULT_DBUS_INPROCESS: bool = false;
 
 impl Default for TransportsConfig {
     fn default() -> Self {
@@ -288,6 +301,7 @@ impl Default for TransportsConfig {
             uds_socket: None,
             dbus_required: DEFAULT_DBUS_REQUIRED,
             dbus_service: DEFAULT_DBUS_SERVICE.to_string(),
+            dbus_inprocess: DEFAULT_DBUS_INPROCESS,
         }
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1724,85 +1724,112 @@ async fn main() -> Result<()> {
     let api_handler: Arc<dyn desktop_assistant_application::AssistantApiHandler> =
         Arc::new(api_handler_impl);
 
-    let dbus_service_name = std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
-        .ok()
-        .map(|v| v.trim().to_string())
-        .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| transports_config.dbus_service.clone());
-    let dbus_required = env_bool(
-        "DESKTOP_ASSISTANT_DBUS_REQUIRED",
-        transports_config.dbus_required,
+    // In-process D-Bus surface (#281 cutover): OFF by default — the standalone
+    // adelie-dbus-bridge owns org.desktopAssistant now, leaving the daemon a
+    // single privileged local ingress (UDS). Set
+    // DESKTOP_ASSISTANT_DBUS_INPROCESS=true (or `dbus_inprocess = true` under
+    // [transports]) to re-enable the legacy in-process surface — the cutover
+    // revert lever; removed entirely in #319.
+    let dbus_inprocess = env_bool(
+        "DESKTOP_ASSISTANT_DBUS_INPROCESS",
+        transports_config.dbus_inprocess,
     );
-    tracing::info!("D-Bus well-known name={dbus_service_name}");
-    tracing::info!("D-Bus required={dbus_required}");
+    let dbus_connection = if !dbus_inprocess {
+        tracing::info!(
+            "in-process D-Bus surface disabled; adelie-dbus-bridge owns the well-known name \
+             (set DESKTOP_ASSISTANT_DBUS_INPROCESS=true to re-enable the legacy surface)"
+        );
+        None
+    } else {
+        let dbus_service_name = std::env::var("DESKTOP_ASSISTANT_DBUS_SERVICE")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| transports_config.dbus_service.clone());
+        let dbus_required = env_bool(
+            "DESKTOP_ASSISTANT_DBUS_REQUIRED",
+            transports_config.dbus_required,
+        );
+        tracing::info!("D-Bus well-known name={dbus_service_name}");
+        tracing::info!("D-Bus required={dbus_required}");
 
-    // Set up D-Bus connection (required by default; optional in headless/container mode).
-    let dbus_connection = match zbus::connection::Builder::session() {
-        Ok(builder) => match builder
-            .name(dbus_service_name.as_str())
-            .and_then(|b| {
-                b.serve_at(
-                    "/org/desktopAssistant/Conversations",
-                    DbusConversationAdapter::new(Arc::clone(&conversation_service)),
-                )
-            })
-            .and_then(|b| {
-                b.serve_at(
-                    "/org/desktopAssistant/Settings",
-                    DbusSettingsAdapter::new(Arc::clone(&settings_service)),
-                )
-            })
-            .and_then(|b| {
-                b.serve_at(
-                    "/org/desktopAssistant/Connections",
-                    desktop_assistant_dbus::connections::DbusConnectionsAdapter::new(Arc::clone(
-                        &api_handler,
-                    )),
-                )
-            })
-            .and_then(|b| {
-                b.serve_at(
-                    "/org/desktopAssistant/Knowledge",
-                    desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(Arc::clone(
-                        &api_handler,
-                    )),
-                )
-            })
-            .and_then(|b| {
-                // Generic command channel (#213): the shared `AssistantCommands`
-                // surface over D-Bus, dispatching through the same handler the
-                // socket transports use, so `TransportClient::as_commands` works
-                // on every transport.
-                b.serve_at(
-                    "/org/desktopAssistant/Commands",
-                    desktop_assistant_dbus::commands::DbusCommandsAdapter::new(Arc::clone(
-                        &api_handler,
-                    )),
-                )
-            })
-            .and_then(|b| {
-                // Hot-reload trigger (#222): the KCM calls `Reload` after
-                // writing daemon.toml so changes apply without a restart.
-                b.serve_at(
-                    "/org/desktopAssistant/Reload",
-                    DbusReloadAdapter::new(reload_tx.clone()),
-                )
-            }) {
-            Ok(builder) => match builder.build().await {
-                Ok(connection) => {
-                    if let Some(unique_name) = connection.unique_name() {
-                        tracing::info!("D-Bus service registered at {}", unique_name);
-                    } else {
-                        tracing::info!("D-Bus service registered");
+        // Set up D-Bus connection (required by default; optional in headless mode).
+        match zbus::connection::Builder::session() {
+            Ok(builder) => match builder
+                .name(dbus_service_name.as_str())
+                .and_then(|b| {
+                    b.serve_at(
+                        "/org/desktopAssistant/Conversations",
+                        DbusConversationAdapter::new(Arc::clone(&conversation_service)),
+                    )
+                })
+                .and_then(|b| {
+                    b.serve_at(
+                        "/org/desktopAssistant/Settings",
+                        DbusSettingsAdapter::new(Arc::clone(&settings_service)),
+                    )
+                })
+                .and_then(|b| {
+                    b.serve_at(
+                        "/org/desktopAssistant/Connections",
+                        desktop_assistant_dbus::connections::DbusConnectionsAdapter::new(
+                            Arc::clone(&api_handler),
+                        ),
+                    )
+                })
+                .and_then(|b| {
+                    b.serve_at(
+                        "/org/desktopAssistant/Knowledge",
+                        desktop_assistant_dbus::knowledge::DbusKnowledgeAdapter::new(Arc::clone(
+                            &api_handler,
+                        )),
+                    )
+                })
+                .and_then(|b| {
+                    // Generic command channel (#213): the shared `AssistantCommands`
+                    // surface over D-Bus, dispatching through the same handler the
+                    // socket transports use, so `TransportClient::as_commands` works
+                    // on every transport.
+                    b.serve_at(
+                        "/org/desktopAssistant/Commands",
+                        desktop_assistant_dbus::commands::DbusCommandsAdapter::new(Arc::clone(
+                            &api_handler,
+                        )),
+                    )
+                })
+                .and_then(|b| {
+                    // Hot-reload trigger (#222): the KCM calls `Reload` after
+                    // writing daemon.toml so changes apply without a restart.
+                    b.serve_at(
+                        "/org/desktopAssistant/Reload",
+                        DbusReloadAdapter::new(reload_tx.clone()),
+                    )
+                }) {
+                Ok(builder) => match builder.build().await {
+                    Ok(connection) => {
+                        if let Some(unique_name) = connection.unique_name() {
+                            tracing::info!("D-Bus service registered at {}", unique_name);
+                        } else {
+                            tracing::info!("D-Bus service registered");
+                        }
+                        Some(connection)
                     }
-                    Some(connection)
-                }
+                    Err(error) => {
+                        if dbus_required {
+                            return Err(error.into());
+                        }
+                        tracing::warn!(
+                            "D-Bus unavailable; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
+                        );
+                        None
+                    }
+                },
                 Err(error) => {
                     if dbus_required {
                         return Err(error.into());
                     }
                     tracing::warn!(
-                        "D-Bus unavailable; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
+                        "failed to configure D-Bus interface; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
                     );
                     None
                 }
@@ -1812,19 +1839,10 @@ async fn main() -> Result<()> {
                     return Err(error.into());
                 }
                 tracing::warn!(
-                    "failed to configure D-Bus interface; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
+                    "failed to connect to session D-Bus; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
                 );
                 None
             }
-        },
-        Err(error) => {
-            if dbus_required {
-                return Err(error.into());
-            }
-            tracing::warn!(
-                "failed to connect to session D-Bus; continuing without D-Bus API (set DESKTOP_ASSISTANT_DBUS_REQUIRED=true to fail): {error}"
-            );
-            None
         }
     };
 

--- a/crates/dbus-bridge/src/main.rs
+++ b/crates/dbus-bridge/src/main.rs
@@ -11,11 +11,11 @@
 //!    across reconnects).
 //! 4. Wait for SIGTERM / SIGINT; tear down cleanly.
 //!
-//! The well-known bus name is configurable (`--name`, default
-//! `org.desktopAssistant.Bridge`). This default deliberately differs from the
-//! daemon's in-process name (`org.desktopAssistant`) so the bridge can run
-//! alongside it during the transition (PR #106 Option A); a follow-up flips the
-//! default and removes the in-process surface.
+//! The well-known bus name is configurable (`--name`); it defaults to
+//! `org.desktopAssistant` — the bridge is the live D-Bus surface as of the
+//! cutover name flip (#318), and the daemon no longer claims the name (its
+//! in-process surface is off by default). Pass `--name org.desktopAssistant.Bridge`
+//! or `.Dev` to run a side-by-side instance for QA without colliding.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -35,7 +35,12 @@ use desktop_assistant_dbus_bridge::adapter::{
 use desktop_assistant_dbus_bridge::transport::ConnectorBridgeTransport;
 use tokio::signal::unix::{SignalKind, signal};
 
-const DEFAULT_BRIDGE_NAME: &str = "org.desktopAssistant.Bridge";
+// The bridge is the live D-Bus surface as of the cutover's name flip (#318):
+// it claims `org.desktopAssistant` and the daemon steps off the name (its
+// in-process surface is off by default; `DESKTOP_ASSISTANT_DBUS_INPROCESS=true`
+// re-enables it as a revert). Use `--name org.desktopAssistant.Bridge`/`.Dev`
+// to run a side-by-side instance for QA without colliding.
+const DEFAULT_BRIDGE_NAME: &str = "org.desktopAssistant";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -54,11 +59,9 @@ struct Cli {
     #[arg(long, env = "ADELIE_BRIDGE_DAEMON_SOCKET")]
     daemon_socket: Option<PathBuf>,
 
-    /// D-Bus well-known name to bind. Defaults to
-    /// `org.desktopAssistant.Bridge` so the bridge can run alongside
-    /// the daemon's in-process surface during the Option-A
-    /// transition. Set to `org.desktopAssistant` (and remove the
-    /// daemon's surface) to flip the cutover.
+    /// D-Bus well-known name to bind. Defaults to `org.desktopAssistant` — the
+    /// bridge is the live D-Bus surface (#318). Use `org.desktopAssistant.Bridge`
+    /// or `.Dev` to run a side-by-side instance for QA.
     #[arg(long, env = "ADELIE_BRIDGE_NAME", default_value = DEFAULT_BRIDGE_NAME)]
     name: String,
 

--- a/docs/dbus-bridge.md
+++ b/docs/dbus-bridge.md
@@ -41,8 +41,8 @@ User systemd units live in `systemd/`. With binaries installed (`cargo install
 --path crates/daemon`, `--path crates/jwt-minter`, `--path crates/dbus-bridge`):
 
 ```sh
-just install-service     # daemon unit + org.desktopAssistant D-Bus activation
-just install-bridge      # bridge + minter units + org.desktopAssistant.Bridge activation
+just install-service     # daemon unit + the org.desktopAssistant activation (→ the bridge)
+just install-bridge      # bridge + minter units
 just backend-enable      # enable + start the daemon
 just bridge-enable       # enable + start the minter, then the bridge
 ```
@@ -58,16 +58,24 @@ tap (Linux-only, alongside `adelie-mint`). `brew install` lays down the binaries
 the systemd units above are installed separately (Homebrew does not manage user
 services). The tap is currently untested end-to-end — see the homebrew-tap notes.
 
-## Default name and the cutover
+## The name flip (#318)
 
-The bridge binds `org.desktopAssistant.Bridge` by default (`ADELIE_BRIDGE_NAME`)
-so it can run **alongside** the daemon's in-process surface during the
-transition (Option A, PR #106). The flip to `org.desktopAssistant` — and removal
-of the in-process surface plus its `DESKTOP_ASSISTANT_DBUS_SERVICE` /
-`DESKTOP_ASSISTANT_DBUS_REQUIRED` env knobs — is the cutover's steps 6 and 7
-([#318](https://github.com/adelie-ai/desktop-assistant/issues/318) /
-[#319](https://github.com/adelie-ai/desktop-assistant/issues/319)). To run a dev
-bridge under a side-name for QA, set `ADELIE_BRIDGE_NAME=org.desktopAssistant.Dev`.
+The bridge binds `org.desktopAssistant` by default (`ADELIE_BRIDGE_NAME`) — it is
+the live D-Bus surface. The daemon no longer claims the name: its legacy
+in-process surface is **off** by default (`dbus_inprocess = false` /
+`DESKTOP_ASSISTANT_DBUS_INPROCESS`), so its systemd unit is `Type=simple` (not
+`Type=dbus` with `BusName=`), and the `org.desktopAssistant` D-Bus activation
+file points at the bridge.
+
+**Revert** (if the bridge misbehaves): set `DESKTOP_ASSISTANT_DBUS_INPROCESS=true`
+on the daemon (env, or `dbus_inprocess = true` under `[transports]` in
+daemon.toml), restore its unit to `Type=dbus` + `BusName=org.desktopAssistant`,
+stop the bridge, and restart the daemon — the legacy in-process surface returns.
+Deleting that surface for good (so the flag goes away) is step 7
+([#319](https://github.com/adelie-ai/desktop-assistant/issues/319)).
+
+For a side-by-side QA instance, run a second bridge with
+`ADELIE_BRIDGE_NAME=org.desktopAssistant.Bridge` (or `.Dev`).
 
 ## Failure mode + health
 
@@ -83,7 +91,7 @@ The authoritative "is the bridge up?" fact is the unit's own state:
 
 ```sh
 systemctl --user is-active adelie-dbus-bridge.service   # active | failed | inactive
-busctl --user list | grep org.desktopAssistant.Bridge   # is the name claimed?
+busctl --user list | grep org.desktopAssistant          # is the name claimed (by the bridge)?
 just bridge-status                                       # bridge + minter at a glance
 ```
 

--- a/justfile
+++ b/justfile
@@ -17,11 +17,9 @@ bridge_service_name := "adelie-dbus-bridge"
 mint_service_name := "adelie-mint"
 bridge_service_src := "systemd/adelie-dbus-bridge.service"
 mint_service_src := "systemd/adelie-mint.service"
-bridge_dbus_service_src := "systemd/org.desktopAssistant.Bridge.service"
 systemd_user_dir := env_var_or_default("XDG_CONFIG_HOME", env_var("HOME") + "/.config") + "/systemd/user"
 bridge_service_dst := systemd_user_dir + "/adelie-dbus-bridge.service"
 mint_service_dst := systemd_user_dir + "/adelie-mint.service"
-bridge_dbus_service_dst := dbus_service_dir + "/org.desktopAssistant.Bridge.service"
 container_cli := env_var_or_default("CONTAINER_CLI", "docker")
 container_security_opts := env_var_or_default("CONTAINER_SECURITY_OPTS", "--security-opt label=disable")
 debian_builder_image := env_var_or_default("DEBIAN_BUILDER_IMAGE", "debian:trixie")
@@ -190,16 +188,15 @@ uninstall-dbus-activation:
 # The bridge re-exposes org.desktopAssistant.* by talking to the daemon over an
 # authenticated UDS connection; it mints its JWT from adelie-mint. Install both.
 
-# Install the bridge + minter user units (+ bridge D-Bus activation) and reload
+# Install the bridge + minter user units and reload. The org.desktopAssistant
+# D-Bus activation file (which now points to the bridge) is installed by
+# `install-service` / `install-dbus-activation`.
 install-bridge:
     [ -f "{{bridge_service_src}}" ] || (echo "Missing service file: {{bridge_service_src}}" >&2; exit 1)
     [ -f "{{mint_service_src}}" ] || (echo "Missing service file: {{mint_service_src}}" >&2; exit 1)
-    [ -f "{{bridge_dbus_service_src}}" ] || (echo "Missing D-Bus service file: {{bridge_dbus_service_src}}" >&2; exit 1)
     mkdir -p "{{systemd_user_dir}}"
-    mkdir -p "{{dbus_service_dir}}"
     cp "{{mint_service_src}}" "{{mint_service_dst}}"
     cp "{{bridge_service_src}}" "{{bridge_service_dst}}"
-    cp "{{bridge_dbus_service_src}}" "{{bridge_dbus_service_dst}}"
     systemctl --user daemon-reload
 
 # Enable + start the minter, then the bridge (the bridge is ordered After= it)
@@ -235,7 +232,7 @@ bridge-reinstall:
 uninstall-bridge:
     systemctl --user disable --now {{bridge_service_name}} || true
     systemctl --user disable --now {{mint_service_name}} || true
-    rm -f "{{bridge_service_dst}}" "{{mint_service_dst}}" "{{bridge_dbus_service_dst}}"
+    rm -f "{{bridge_service_dst}}" "{{mint_service_dst}}"
     systemctl --user daemon-reload
 
 # Uninstall everything (services)

--- a/systemd/adelie-dbus-bridge.service
+++ b/systemd/adelie-dbus-bridge.service
@@ -25,19 +25,19 @@ PartOf=default.target
 # With the bridge, a missing/crashed bridge leaves D-Bus clients (KDE) dark even
 # while the daemon is healthy. Observe liveness with:
 #   systemctl --user is-active adelie-dbus-bridge.service
-#   busctl --user list | grep org.desktopAssistant.Bridge
+#   busctl --user list | grep org.desktopAssistant
 
 [Service]
 Type=simple
 ExecStart=%h/.cargo/bin/adelie-dbus-bridge
 Restart=on-failure
 RestartSec=2
-# Default well-known name is `org.desktopAssistant.Bridge` so the bridge can run
-# alongside the daemon's in-process D-Bus surface during the Option-A
-# transition (PR #106). The flip to `org.desktopAssistant` — and removing the
-# daemon's in-process surface + the DESKTOP_ASSISTANT_DBUS_SERVICE/REQUIRED
-# env knobs — is the cutover's steps 6/7 (#318/#319).
-Environment=ADELIE_BRIDGE_NAME=org.desktopAssistant.Bridge
+# The bridge IS the live D-Bus surface (#318 name flip): it claims
+# `org.desktopAssistant`, and the daemon no longer serves the in-process surface
+# (DESKTOP_ASSISTANT_DBUS_INPROCESS=false by default — set it true + stop the
+# bridge to revert). For a side-by-side QA instance, run a second bridge with
+# ADELIE_BRIDGE_NAME=org.desktopAssistant.Bridge or .Dev.
+Environment=ADELIE_BRIDGE_NAME=org.desktopAssistant
 Environment=RUST_LOG=info,desktop_assistant_dbus_bridge=debug
 
 [Install]

--- a/systemd/desktop-assistant-daemon-dev.service
+++ b/systemd/desktop-assistant-daemon-dev.service
@@ -10,6 +10,9 @@ Restart=on-failure
 RestartSec=2
 Environment=RUST_LOG=info
 Environment=DESKTOP_ASSISTANT_DBUS_SERVICE=org.desktopAssistant.Dev
+# The dev daemon keeps serving the in-process surface at .Dev (the cutover
+# default is off; re-enable it here so Type=dbus/BusName works for dev QA).
+Environment=DESKTOP_ASSISTANT_DBUS_INPROCESS=true
 
 [Install]
 WantedBy=default.target

--- a/systemd/desktop-assistant-daemon.service
+++ b/systemd/desktop-assistant-daemon.service
@@ -3,8 +3,13 @@ Description=Desktop Assistant Backend Daemon
 After=default.target
 
 [Service]
-Type=dbus
-BusName=org.desktopAssistant
+# Type=simple (not dbus): since the cutover name flip (#318) the daemon no longer
+# claims a session-bus name — the standalone adelie-dbus-bridge owns
+# org.desktopAssistant. The daemon serves UDS (and optionally WS); its readiness
+# is process start, not a bus-name acquisition. To run the legacy in-process
+# D-Bus surface instead, set Type=dbus + BusName=org.desktopAssistant and
+# Environment=DESKTOP_ASSISTANT_DBUS_INPROCESS=true (and stop the bridge).
+Type=simple
 ExecStart=%h/.cargo/bin/desktop-assistant-daemon
 Restart=on-failure
 RestartSec=2

--- a/systemd/org.desktopAssistant.Bridge.service
+++ b/systemd/org.desktopAssistant.Bridge.service
@@ -1,4 +1,0 @@
-[D-BUS Service]
-Name=org.desktopAssistant.Bridge
-Exec=/bin/false
-SystemdService=adelie-dbus-bridge.service

--- a/systemd/org.desktopAssistant.service
+++ b/systemd/org.desktopAssistant.service
@@ -1,4 +1,6 @@
 [D-BUS Service]
 Name=org.desktopAssistant
 Exec=/bin/false
-SystemdService=desktop-assistant-daemon.service
+# The cutover (#318) moved org.desktopAssistant from the daemon's in-process
+# surface to the standalone bridge, so on-demand activation starts the bridge.
+SystemdService=adelie-dbus-bridge.service


### PR DESCRIPTION
Step **6 of 7** of the dbus-bridge cutover (#281): the name flip. The standalone bridge becomes the live `org.desktopAssistant` D-Bus surface and the daemon steps off the name — going straight to the main bus (per the decision to flip live and test/fix in place, skipping the side-name soak).

Closes #318.

## What flips

- **Daemon stops claiming the name.** New `[transports] dbus_inprocess` flag (env `DESKTOP_ASSISTANT_DBUS_INPROCESS`), **default `false`**: the daemon no longer serves the legacy in-process D-Bus surface, keeping exactly one privileged local ingress (UDS). The big `serve_at` block is gated on it (intact, just skipped) so re-enabling is one toggle.
- **Daemon unit `Type=dbus` → `Type=simple`** (drop `BusName=`). Critical: a `Type=dbus` unit that never claims its `BusName` would hang systemd waiting for readiness. The daemon's readiness is now process start.
- **Bridge default name → `org.desktopAssistant`** (code `DEFAULT_BRIDGE_NAME` + the unit's `ADELIE_BRIDGE_NAME`). It's the live surface now.
- **D-Bus activation `org.desktopAssistant.service` repointed** to `adelie-dbus-bridge.service` (on-demand activation starts the bridge). The redundant `org.desktopAssistant.Bridge.service` side-name file is removed; `install-bridge` no longer installs an activation (the daemon recipe installs the repointed one).
- **Dev daemon keeps its in-process surface** (`desktop-assistant-daemon-dev.service` sets `DESKTOP_ASSISTANT_DBUS_INPROCESS=true`) so `.Dev` side-by-side QA still works.
- Docs (`docs/dbus-bridge.md`) updated: the flip, and the **revert recipe**.

## Revert (if the live bridge misbehaves)

Set `DESKTOP_ASSISTANT_DBUS_INPROCESS=true` on the daemon (env or `dbus_inprocess = true` in daemon.toml), restore its unit to `Type=dbus` + `BusName=org.desktopAssistant`, stop the bridge, restart the daemon — the legacy in-process surface returns. The in-process code is still in the tree until #319 deletes it, so this revert is real.

## Not in this PR

**#319** — delete `crates/dbus-interface` (~4.3k LOC) + the daemon `serve_at` block + the `dbus_inprocess` flag, once the live bridge is proven. Keeping it now is what makes the revert above possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
