### PR TITLE
Spec-driven contract coverage for the dbus-bridge adapters

### DIFF
--- a/crates/dbus-bridge/src/adapter/connections.rs
+++ b/crates/dbus-bridge/src/adapter/connections.rs
@@ -151,3 +151,303 @@ impl<T: BridgeTransport + 'static> DbusConnectionsAdapter<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Contract tests for the Connections adapter. The spec is the *canonical*
+    //! `api::Command` each D-Bus method must build and the result it must map —
+    //! the same command/result contract every transport (UDS/WS/D-Bus) honors,
+    //! so the bridge behaves identically to any other client. Unhappy paths
+    //! (malformed JSON, unknown purpose, result-variant mismatch, daemon error)
+    //! are enumerated as named tests.
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records each dispatched command and replies with a scripted result (or a
+    /// daemon error). The recorded command is the assertion surface.
+    struct FakeTransport {
+        seen: Mutex<Vec<api::Command>>,
+        reply: Result<api::CommandResult, String>,
+    }
+
+    impl FakeTransport {
+        fn replying(reply: api::CommandResult) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply: Ok(reply),
+            })
+        }
+        fn failing(daemon_msg: &str) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply: Err(daemon_msg.to_string()),
+            })
+        }
+        fn count(&self) -> usize {
+            self.seen.lock().unwrap().len()
+        }
+        fn last(&self) -> api::Command {
+            self.seen
+                .lock()
+                .unwrap()
+                .last()
+                .cloned()
+                .expect("a command was dispatched")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeTransport for FakeTransport {
+        async fn request(
+            &self,
+            command: api::Command,
+        ) -> Result<api::CommandResult, BridgeTransportError> {
+            self.seen.lock().unwrap().push(command);
+            self.reply.clone().map_err(BridgeTransportError::Daemon)
+        }
+    }
+
+    fn adapter(t: Arc<FakeTransport>) -> DbusConnectionsAdapter<FakeTransport> {
+        DbusConnectionsAdapter::new(t)
+    }
+
+    // --- list_connections -----------------------------------------------------
+
+    #[tokio::test]
+    async fn list_connections_dispatches_list_and_returns_json_envelope() {
+        let t = FakeTransport::replying(api::CommandResult::Connections(Vec::new()));
+        let json = adapter(Arc::clone(&t)).list_connections().await.unwrap();
+        assert!(matches!(t.last(), api::Command::ListConnections));
+        // The wire contract is the JSON-serialized CommandResult envelope.
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::Connections(_)));
+    }
+
+    #[tokio::test]
+    async fn list_connections_errors_on_unexpected_result_variant() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .list_connections()
+            .await
+            .expect_err("a non-Connections result must surface as an error, not a panic");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
+
+    // --- create_connection ----------------------------------------------------
+
+    #[tokio::test]
+    async fn create_connection_builds_command_with_parsed_config() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        adapter(Arc::clone(&t))
+            .create_connection(
+                "anthropic-main",
+                r#"{"type":"anthropic","base_url":"https://x"}"#,
+            )
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::CreateConnection { id, config } => {
+                assert_eq!(id, "anthropic-main");
+                assert_eq!(
+                    config,
+                    api::ConnectionConfigView::Anthropic {
+                        base_url: Some("https://x".to_string()),
+                        api_key_env: None,
+                        connect_timeout_secs: None,
+                        stream_timeout_secs: None,
+                        max_context_tokens: None,
+                    }
+                );
+            }
+            other => panic!("expected CreateConnection, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_connection_rejects_malformed_config_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .create_connection("c", "{ not json")
+            .await
+            .expect_err("malformed config must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(
+            t.count(),
+            0,
+            "a malformed command must never reach the daemon"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_connection_errors_on_unexpected_result_variant() {
+        let t = FakeTransport::replying(api::CommandResult::Connections(Vec::new()));
+        let err = adapter(Arc::clone(&t))
+            .create_connection("c", r#"{"type":"anthropic"}"#)
+            .await
+            .expect_err("a non-Ack result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
+
+    // --- update_connection ----------------------------------------------------
+
+    #[tokio::test]
+    async fn update_connection_builds_command_with_parsed_config() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        adapter(Arc::clone(&t))
+            .update_connection("c1", r#"{"type":"anthropic"}"#)
+            .await
+            .unwrap();
+        assert!(matches!(
+            t.last(),
+            api::Command::UpdateConnection { id, config: api::ConnectionConfigView::Anthropic { .. } } if id == "c1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn update_connection_rejects_malformed_config_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .update_connection("c", "nope")
+            .await
+            .expect_err("malformed config must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(t.count(), 0);
+    }
+
+    // --- delete_connection ----------------------------------------------------
+
+    #[tokio::test]
+    async fn delete_connection_carries_the_force_flag_verbatim() {
+        for force in [false, true] {
+            let t = FakeTransport::replying(api::CommandResult::Ack);
+            adapter(Arc::clone(&t))
+                .delete_connection("doomed", force)
+                .await
+                .unwrap();
+            match t.last() {
+                api::Command::DeleteConnection { id, force: f } => {
+                    assert_eq!(id, "doomed");
+                    assert_eq!(f, force);
+                }
+                other => panic!("expected DeleteConnection, got {other:?}"),
+            }
+        }
+    }
+
+    // --- list_available_models ------------------------------------------------
+
+    #[tokio::test]
+    async fn list_available_models_passes_connection_id_and_refresh() {
+        let t = FakeTransport::replying(api::CommandResult::Models(Vec::new()));
+        adapter(Arc::clone(&t))
+            .list_available_models("bedrock", true)
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::ListAvailableModels {
+                connection_id,
+                refresh,
+            } => {
+                assert_eq!(connection_id, Some("bedrock".to_string()));
+                assert!(refresh);
+            }
+            other => panic!("expected ListAvailableModels, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_available_models_blank_id_means_all_connections() {
+        // Empty/whitespace connection id is the contract's "aggregate across all
+        // healthy connections" signal — it must become `None`, not `Some("")`.
+        for blank in ["", "   "] {
+            let t = FakeTransport::replying(api::CommandResult::Models(Vec::new()));
+            adapter(Arc::clone(&t))
+                .list_available_models(blank, false)
+                .await
+                .unwrap();
+            assert!(matches!(
+                t.last(),
+                api::Command::ListAvailableModels {
+                    connection_id: None,
+                    refresh: false
+                }
+            ));
+        }
+    }
+
+    // --- get_purposes ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_purposes_dispatches_and_returns_json_envelope() {
+        let purposes = api::PurposesView {
+            interactive: None,
+            dreaming: None,
+            embedding: None,
+            titling: None,
+        };
+        let t = FakeTransport::replying(api::CommandResult::Purposes(purposes));
+        let json = adapter(Arc::clone(&t)).get_purposes().await.unwrap();
+        assert!(matches!(t.last(), api::Command::GetPurposes));
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::Purposes(_)));
+    }
+
+    // --- set_purpose ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn set_purpose_builds_command_with_parsed_purpose_and_config() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        adapter(Arc::clone(&t))
+            .set_purpose(
+                "interactive",
+                r#"{"connection":"primary","model":"primary"}"#,
+            )
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::SetPurpose { purpose, config } => {
+                assert_eq!(purpose, api::PurposeKindApi::Interactive);
+                assert_eq!(config.connection, "primary");
+                assert_eq!(config.model, "primary");
+            }
+            other => panic!("expected SetPurpose, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_purpose_rejects_unknown_purpose_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .set_purpose("not-a-purpose", r#"{"connection":"p","model":"m"}"#)
+            .await
+            .expect_err("an unknown purpose kind must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(t.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn set_purpose_rejects_malformed_config_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .set_purpose("dreaming", "{ bad")
+            .await
+            .expect_err("malformed purpose config must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(t.count(), 0);
+    }
+
+    // --- transport / daemon errors --------------------------------------------
+
+    #[tokio::test]
+    async fn daemon_error_is_propagated_verbatim() {
+        let t = FakeTransport::failing("connection pool exhausted");
+        let err = adapter(Arc::clone(&t))
+            .list_connections()
+            .await
+            .expect_err("a daemon error must surface");
+        assert!(
+            format!("{err}").contains("connection pool exhausted"),
+            "daemon message must be preserved: {err}"
+        );
+    }
+}

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -670,4 +670,367 @@ mod tests {
         // Validation happens before dispatch — no command sent.
         assert!(transport.commands.lock().await.is_empty());
     }
+
+    // -------------------------------------------------------------------------
+    // Contract coverage for the remaining methods: each builds the canonical
+    // `api::Command` and maps its result; the rich logic (get_messages slicing,
+    // list_conversations normalization) gets edge-case tests.
+    // -------------------------------------------------------------------------
+
+    fn conv(messages: Vec<(&str, &str)>) -> api::CommandResult {
+        api::CommandResult::Conversation(api::ConversationView {
+            id: "c1".to_string(),
+            title: "Chat".to_string(),
+            messages: messages
+                .into_iter()
+                .map(|(role, content)| api::MessageView {
+                    id: String::new(),
+                    role: role.to_string(),
+                    content: content.to_string(),
+                })
+                .collect(),
+            warnings: Vec::new(),
+            model_selection: None,
+            conversation_personality: None,
+        })
+    }
+
+    async fn only_command(t: &CannedTransport) -> api::Command {
+        let cmds = t.commands.lock().await;
+        assert_eq!(cmds.len(), 1, "expected exactly one dispatched command");
+        cmds[0].clone()
+    }
+
+    // --- create_conversation --------------------------------------------------
+
+    #[tokio::test]
+    async fn create_conversation_builds_command_and_returns_id() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::ConversationId {
+            id: "new-id".to_string(),
+        }));
+        let id = DbusConversationsAdapter::new(Arc::clone(&t))
+            .create_conversation("Trip planning")
+            .await
+            .unwrap();
+        assert_eq!(id, "new-id");
+        assert!(matches!(
+            only_command(&t).await,
+            api::Command::CreateConversation { title } if title == "Trip planning"
+        ));
+    }
+
+    // --- list_conversations ---------------------------------------------------
+
+    #[tokio::test]
+    async fn list_conversations_positive_max_age_passes_through() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Conversations(
+            Vec::new(),
+        )));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .list_conversations(7, true)
+            .await
+            .unwrap();
+        assert!(matches!(
+            only_command(&t).await,
+            api::Command::ListConversations {
+                max_age_days: Some(7),
+                include_archived: true
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_conversations_nonpositive_max_age_means_no_limit() {
+        // The contract: 0 or negative max_age_days means "no age cutoff" → None,
+        // never Some(0) (which the daemon would read as "younger than 0 days").
+        for days in [0, -1, -365] {
+            let t = Arc::new(CannedTransport::new(api::CommandResult::Conversations(
+                Vec::new(),
+            )));
+            DbusConversationsAdapter::new(Arc::clone(&t))
+                .list_conversations(days, false)
+                .await
+                .unwrap();
+            assert!(
+                matches!(
+                    only_command(&t).await,
+                    api::Command::ListConversations {
+                        max_age_days: None,
+                        ..
+                    }
+                ),
+                "days={days} must normalize to None"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn list_conversations_maps_summaries_to_tuples() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Conversations(
+            vec![api::ConversationSummary {
+                id: "a".into(),
+                title: "Alpha".into(),
+                message_count: 3,
+                updated_at: "2026-06-14".into(),
+                archived: false,
+            }],
+        )));
+        let rows = DbusConversationsAdapter::new(Arc::clone(&t))
+            .list_conversations(0, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(
+                "a".to_string(),
+                "Alpha".to_string(),
+                3,
+                "2026-06-14".to_string(),
+                false
+            )]
+        );
+    }
+
+    // --- archive / unarchive / delete / rename (Ack) --------------------------
+
+    #[tokio::test]
+    async fn archive_conversation_builds_command_and_acks() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .archive_conversation("x")
+            .await
+            .unwrap();
+        assert!(
+            matches!(only_command(&t).await, api::Command::ArchiveConversation { id } if id == "x")
+        );
+    }
+
+    #[tokio::test]
+    async fn unarchive_conversation_builds_command_and_acks() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .unarchive_conversation("x")
+            .await
+            .unwrap();
+        assert!(
+            matches!(only_command(&t).await, api::Command::UnarchiveConversation { id } if id == "x")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_conversation_builds_command_and_acks() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .delete_conversation("x")
+            .await
+            .unwrap();
+        assert!(
+            matches!(only_command(&t).await, api::Command::DeleteConversation { id } if id == "x")
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_conversation_builds_command_with_id_and_title() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .rename_conversation("c1", "Renamed")
+            .await
+            .unwrap();
+        assert!(matches!(
+            only_command(&t).await,
+            api::Command::RenameConversation { id, title } if id == "c1" && title == "Renamed"
+        ));
+    }
+
+    // --- get_conversation -----------------------------------------------------
+
+    #[tokio::test]
+    async fn get_conversation_maps_view_to_id_title_and_role_content_tuples() {
+        let t = Arc::new(CannedTransport::new(conv(vec![
+            ("user", "hi"),
+            ("assistant", "hello"),
+        ])));
+        let (id, title, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_conversation("c1")
+            .await
+            .unwrap();
+        assert_eq!(id, "c1");
+        assert_eq!(title, "Chat");
+        assert_eq!(
+            messages,
+            vec![
+                ("user".to_string(), "hi".to_string()),
+                ("assistant".to_string(), "hello".to_string())
+            ]
+        );
+    }
+
+    // --- get_messages: the bridge-side pagination / filter / tail -------------
+
+    fn five_msgs() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("user", "m0"),
+            ("assistant", "m1"),
+            ("user", "m2"),
+            ("assistant", "m3"),
+            ("user", "m4"),
+        ]
+    }
+
+    #[tokio::test]
+    async fn get_messages_dispatches_get_conversation() {
+        let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", -1, -1, vec![])
+            .await
+            .unwrap();
+        assert!(
+            matches!(only_command(&t).await, api::Command::GetConversation { id } if id == "c1")
+        );
+    }
+
+    #[tokio::test]
+    async fn get_messages_after_count_slices_from_offset() {
+        let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+        let (total, truncated, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", -1, 2, vec![])
+            .await
+            .unwrap();
+        assert_eq!(total, 5, "total is the raw count, pre-slice");
+        assert!(!truncated, "after-paging does not truncate");
+        assert_eq!(
+            messages.iter().map(|(_, c)| c.as_str()).collect::<Vec<_>>(),
+            vec!["m2", "m3", "m4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_messages_after_count_past_end_is_empty() {
+        let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+        let (total, truncated, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", -1, 99, vec![])
+            .await
+            .unwrap();
+        assert_eq!(total, 5);
+        assert!(!truncated);
+        assert!(messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_messages_tail_returns_last_n_and_marks_truncated() {
+        let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+        let (total, truncated, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", 2, -1, vec![])
+            .await
+            .unwrap();
+        assert_eq!(total, 5);
+        assert!(
+            truncated,
+            "tail dropped older messages, so truncated is true"
+        );
+        assert_eq!(
+            messages.iter().map(|(_, c)| c.as_str()).collect::<Vec<_>>(),
+            vec!["m3", "m4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_messages_tail_not_smaller_than_len_returns_all_untruncated() {
+        for tail in [0, 5, 10] {
+            let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+            let (total, truncated, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+                .get_messages("c1", tail, -1, vec![])
+                .await
+                .unwrap();
+            assert_eq!(total, 5);
+            assert!(!truncated, "tail={tail} should not truncate");
+            assert_eq!(messages.len(), 5, "tail={tail}");
+        }
+    }
+
+    #[tokio::test]
+    async fn get_messages_role_filter_keeps_only_named_roles() {
+        let t = Arc::new(CannedTransport::new(conv(five_msgs())));
+        let (total, _truncated, messages) = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", -1, -1, vec!["user".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(total, 5, "total counts all roles, even filtered-out ones");
+        assert_eq!(
+            messages.iter().map(|(_, c)| c.as_str()).collect::<Vec<_>>(),
+            vec!["m0", "m2", "m4"],
+            "only user messages survive the filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_messages_errors_on_unexpected_result_variant() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        let err = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_messages("c1", -1, -1, vec![])
+            .await
+            .expect_err("a non-Conversation result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
+
+    // --- clear_all_history ----------------------------------------------------
+
+    #[tokio::test]
+    async fn clear_all_history_returns_the_deleted_count() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Cleared {
+            deleted_count: 9,
+        }));
+        let n = DbusConversationsAdapter::new(Arc::clone(&t))
+            .clear_all_history()
+            .await
+            .unwrap();
+        assert_eq!(n, 9);
+        assert!(matches!(
+            only_command(&t).await,
+            api::Command::ClearAllHistory
+        ));
+    }
+
+    // --- get_conversation_personality -----------------------------------------
+
+    #[tokio::test]
+    async fn get_conversation_personality_is_all_unset_when_none_stored() {
+        // No stored override → every trait reads back as -1 (fall back to global).
+        let t = Arc::new(CannedTransport::new(conv(vec![])));
+        let ordinals = DbusConversationsAdapter::new(Arc::clone(&t))
+            .get_conversation_personality("c1")
+            .await
+            .unwrap();
+        assert_eq!(ordinals, (-1, -1, -1, -1, -1, -1, -1));
+    }
+
+    // --- send_prompt ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn send_prompt_builds_send_message_with_empty_refinement() {
+        let t = Arc::new(CannedTransport::new(api::CommandResult::SendMessageAck {
+            request_id: "r".into(),
+            task_id: "t".into(),
+        }));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .send_prompt("c1", "hello there")
+            .await
+            .unwrap();
+        match only_command(&t).await {
+            api::Command::SendMessage {
+                conversation_id,
+                content,
+                system_refinement,
+                ..
+            } => {
+                assert_eq!(conversation_id, "c1");
+                assert_eq!(content, "hello there");
+                assert!(
+                    system_refinement.is_empty(),
+                    "plain send_prompt carries no refinement"
+                );
+            }
+            other => panic!("expected SendMessage, got {other:?}"),
+        }
+    }
 }

--- a/crates/dbus-bridge/src/adapter/knowledge.rs
+++ b/crates/dbus-bridge/src/adapter/knowledge.rs
@@ -187,3 +187,353 @@ pub(crate) fn parse_metadata(raw: &str) -> fdo::Result<serde_json::Value> {
     }
     serde_json::from_str(trimmed).map_err(to_fdo)
 }
+
+#[cfg(test)]
+mod tests {
+    //! Contract tests for the Knowledge adapter. The spec is the canonical
+    //! `api::Command` each method builds + the result it maps (the same contract
+    //! every transport honors), plus the JSON-string normalization rules for
+    //! tags / tag-filter / metadata. Unhappy paths (malformed JSON not
+    //! dispatched, result-variant mismatch, daemon error) are named tests.
+    use super::*;
+    use std::sync::Mutex;
+
+    struct FakeTransport {
+        seen: Mutex<Vec<api::Command>>,
+        reply: Result<api::CommandResult, String>,
+    }
+
+    impl FakeTransport {
+        fn replying(reply: api::CommandResult) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply: Ok(reply),
+            })
+        }
+        fn failing(daemon_msg: &str) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                reply: Err(daemon_msg.to_string()),
+            })
+        }
+        fn count(&self) -> usize {
+            self.seen.lock().unwrap().len()
+        }
+        fn last(&self) -> api::Command {
+            self.seen
+                .lock()
+                .unwrap()
+                .last()
+                .cloned()
+                .expect("a command was dispatched")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeTransport for FakeTransport {
+        async fn request(
+            &self,
+            command: api::Command,
+        ) -> Result<api::CommandResult, BridgeTransportError> {
+            self.seen.lock().unwrap().push(command);
+            self.reply.clone().map_err(BridgeTransportError::Daemon)
+        }
+    }
+
+    fn adapter(t: Arc<FakeTransport>) -> DbusKnowledgeAdapter<FakeTransport> {
+        DbusKnowledgeAdapter::new(t)
+    }
+
+    fn sample_entry() -> api::KnowledgeEntryView {
+        api::KnowledgeEntryView {
+            id: "k1".to_string(),
+            content: "hello".to_string(),
+            tags: vec!["t".to_string()],
+            metadata: serde_json::Value::Null,
+            created_at: "2026-06-14T00:00:00Z".to_string(),
+            updated_at: "2026-06-14T00:00:00Z".to_string(),
+        }
+    }
+
+    // --- normalization: parse_tag_filter -------------------------------------
+
+    #[test]
+    fn tag_filter_blank_or_null_is_no_filter() {
+        for raw in ["", "   ", "null", "  null  "] {
+            assert_eq!(parse_tag_filter(raw).unwrap(), None, "input {raw:?}");
+        }
+    }
+
+    #[test]
+    fn tag_filter_json_array_parses_to_tags() {
+        assert_eq!(
+            parse_tag_filter(r#"["rust","dbus"]"#).unwrap(),
+            Some(vec!["rust".to_string(), "dbus".to_string()])
+        );
+    }
+
+    #[test]
+    fn tag_filter_malformed_is_an_error() {
+        assert!(parse_tag_filter("{ not an array").is_err());
+        assert!(
+            parse_tag_filter("[1, 2]").is_err(),
+            "must be strings, not numbers"
+        );
+    }
+
+    // --- normalization: parse_tags -------------------------------------------
+
+    #[test]
+    fn tags_blank_is_empty_vec_not_null() {
+        assert_eq!(parse_tags("").unwrap(), Vec::<String>::new());
+        assert_eq!(parse_tags("   ").unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn tags_json_array_parses() {
+        assert_eq!(
+            parse_tags(r#"["a","b"]"#).unwrap(),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn tags_malformed_is_an_error() {
+        assert!(parse_tags("not json").is_err());
+    }
+
+    // --- normalization: parse_metadata ---------------------------------------
+
+    #[test]
+    fn metadata_blank_is_json_null() {
+        assert_eq!(parse_metadata("").unwrap(), serde_json::Value::Null);
+        assert_eq!(parse_metadata("  ").unwrap(), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn metadata_json_object_parses() {
+        assert_eq!(
+            parse_metadata(r#"{"source":"manual","score":3}"#).unwrap(),
+            serde_json::json!({"source": "manual", "score": 3})
+        );
+    }
+
+    #[test]
+    fn metadata_malformed_is_an_error() {
+        assert!(parse_metadata("{ broken").is_err());
+    }
+
+    // --- list_entries ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_entries_builds_command_with_limit_offset_and_tag_filter() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntries(Vec::new()));
+        let json = adapter(Arc::clone(&t))
+            .list_entries(25, 50, r#"["howto"]"#)
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::ListKnowledgeEntries {
+                limit,
+                offset,
+                tag_filter,
+            } => {
+                assert_eq!(limit, 25);
+                assert_eq!(offset, 50);
+                assert_eq!(tag_filter, Some(vec!["howto".to_string()]));
+            }
+            other => panic!("expected ListKnowledgeEntries, got {other:?}"),
+        }
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::KnowledgeEntries(_)));
+    }
+
+    #[tokio::test]
+    async fn list_entries_blank_tag_filter_is_none() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntries(Vec::new()));
+        adapter(Arc::clone(&t))
+            .list_entries(10, 0, "")
+            .await
+            .unwrap();
+        assert!(matches!(
+            t.last(),
+            api::Command::ListKnowledgeEntries {
+                tag_filter: None,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn list_entries_rejects_malformed_tag_filter_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntries(Vec::new()));
+        let err = adapter(Arc::clone(&t))
+            .list_entries(10, 0, "{ bad")
+            .await
+            .expect_err("malformed tag filter must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(t.count(), 0);
+    }
+
+    #[tokio::test]
+    async fn list_entries_errors_on_unexpected_result_variant() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = adapter(Arc::clone(&t))
+            .list_entries(10, 0, "")
+            .await
+            .expect_err("a non-KnowledgeEntries result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
+
+    // --- get_entry ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_entry_builds_command_and_maps_present_entry() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntry(Some(sample_entry())));
+        let json = adapter(Arc::clone(&t)).get_entry("k1").await.unwrap();
+        assert!(matches!(t.last(), api::Command::GetKnowledgeEntry { id } if id == "k1"));
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::KnowledgeEntry(Some(_))));
+    }
+
+    #[tokio::test]
+    async fn get_entry_maps_missing_entry_as_null_envelope() {
+        // The contract carries "not found" as KnowledgeEntry(None); the adapter
+        // must serialize it, not error.
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntry(None));
+        let json = adapter(Arc::clone(&t)).get_entry("nope").await.unwrap();
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::KnowledgeEntry(None)));
+    }
+
+    // --- search_entries -------------------------------------------------------
+
+    #[tokio::test]
+    async fn search_entries_builds_command_with_query_filter_and_limit() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntries(Vec::new()));
+        adapter(Arc::clone(&t))
+            .search_entries("how to mint", r#"["jwt"]"#, 7)
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::SearchKnowledgeEntries {
+                query,
+                tag_filter,
+                limit,
+            } => {
+                assert_eq!(query, "how to mint");
+                assert_eq!(tag_filter, Some(vec!["jwt".to_string()]));
+                assert_eq!(limit, 7);
+            }
+            other => panic!("expected SearchKnowledgeEntries, got {other:?}"),
+        }
+    }
+
+    // --- create_entry ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn create_entry_builds_command_with_parsed_tags_and_metadata() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntryWritten(sample_entry()));
+        let json = adapter(Arc::clone(&t))
+            .create_entry("a fact", r#"["x","y"]"#, r#"{"src":"doc"}"#)
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::CreateKnowledgeEntry {
+                content,
+                tags,
+                metadata,
+            } => {
+                assert_eq!(content, "a fact");
+                assert_eq!(tags, vec!["x".to_string(), "y".to_string()]);
+                assert_eq!(metadata, serde_json::json!({"src": "doc"}));
+            }
+            other => panic!("expected CreateKnowledgeEntry, got {other:?}"),
+        }
+        let back: api::CommandResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, api::CommandResult::KnowledgeEntryWritten(_)));
+    }
+
+    #[tokio::test]
+    async fn create_entry_defaults_blank_tags_and_metadata() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntryWritten(sample_entry()));
+        adapter(Arc::clone(&t))
+            .create_entry("c", "", "")
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::CreateKnowledgeEntry { tags, metadata, .. } => {
+                assert!(tags.is_empty());
+                assert_eq!(metadata, serde_json::Value::Null);
+            }
+            other => panic!("expected CreateKnowledgeEntry, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_entry_rejects_malformed_metadata_without_dispatching() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntryWritten(sample_entry()));
+        let err = adapter(Arc::clone(&t))
+            .create_entry("c", "[]", "{ bad")
+            .await
+            .expect_err("malformed metadata must be rejected");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+        assert_eq!(t.count(), 0);
+    }
+
+    // --- update_entry ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn update_entry_builds_command_with_id_content_tags_metadata() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntryWritten(sample_entry()));
+        adapter(Arc::clone(&t))
+            .update_entry("k9", "new body", r#"["z"]"#, "")
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::UpdateKnowledgeEntry {
+                id,
+                content,
+                tags,
+                metadata,
+            } => {
+                assert_eq!(id, "k9");
+                assert_eq!(content, "new body");
+                assert_eq!(tags, vec!["z".to_string()]);
+                assert_eq!(metadata, serde_json::Value::Null);
+            }
+            other => panic!("expected UpdateKnowledgeEntry, got {other:?}"),
+        }
+    }
+
+    // --- delete_entry ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn delete_entry_builds_command_and_acks() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        adapter(Arc::clone(&t)).delete_entry("k1").await.unwrap();
+        assert!(matches!(t.last(), api::Command::DeleteKnowledgeEntry { id } if id == "k1"));
+    }
+
+    #[tokio::test]
+    async fn delete_entry_errors_on_unexpected_result_variant() {
+        let t = FakeTransport::replying(api::CommandResult::KnowledgeEntries(Vec::new()));
+        let err = adapter(Arc::clone(&t))
+            .delete_entry("k1")
+            .await
+            .expect_err("a non-Ack result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
+
+    // --- daemon error ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn daemon_error_is_propagated_verbatim() {
+        let t = FakeTransport::failing("knowledge store offline");
+        let err = adapter(Arc::clone(&t))
+            .get_entry("k1")
+            .await
+            .expect_err("a daemon error must surface");
+        assert!(format!("{err}").contains("knowledge store offline"));
+    }
+}

--- a/crates/dbus-bridge/src/adapter/settings.rs
+++ b/crates/dbus-bridge/src/adapter/settings.rs
@@ -901,4 +901,275 @@ mod tests {
         assert_eq!(cid, "cid");
         assert_eq!(scopes, "openid");
     }
+
+    // --- pure helpers ---------------------------------------------------------
+
+    #[test]
+    fn normalize_trims_and_maps_blank_to_none() {
+        assert_eq!(normalize(""), None);
+        assert_eq!(normalize("   "), None);
+        assert_eq!(normalize("  ollama  "), Some("ollama".to_string()));
+    }
+
+    #[test]
+    fn ordinal_to_level_pins_in_range_unsets_absent_and_rejects_out_of_range() {
+        // Not set → the field is left untouched (it stays at the ConfigChanges
+        // default of None for that trait); the ordinal is ignored.
+        let mut slot = Some(api::PersonalityLevel::Always);
+        ordinal_to_level(false, 0, &mut slot).unwrap();
+        assert_eq!(
+            slot,
+            Some(api::PersonalityLevel::Always),
+            "an unset trait must not be mutated"
+        );
+
+        // In-range bounds pin the level.
+        let mut slot = None;
+        ordinal_to_level(true, 0, &mut slot).unwrap();
+        assert_eq!(slot, Some(api::PersonalityLevel::Never));
+        let mut slot = None;
+        ordinal_to_level(true, 4, &mut slot).unwrap();
+        assert_eq!(slot, Some(api::PersonalityLevel::Always));
+
+        // Out of range (>4) is a clean error, not a silent clamp.
+        let mut slot = None;
+        assert!(ordinal_to_level(true, 5, &mut slot).is_err());
+    }
+
+    #[test]
+    fn config_from_wire_carries_embeddings_persistence_and_sentinels_llm() {
+        let wire = api::Config {
+            embeddings: api::EmbeddingsSettingsView {
+                connector: "openai".into(),
+                model: "text-embedding-3-small".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                has_api_key: true,
+                available: true,
+                is_default: false,
+            },
+            persistence: api::PersistenceSettingsView {
+                enabled: true,
+                remote_url: "git@h:r.git".into(),
+                remote_name: "origin".into(),
+                push_on_update: false,
+            },
+            personality: api::PersonalitySettingsView::default(),
+        };
+        let data = config_from_wire(&wire);
+        assert_eq!(data.embeddings_connector, "openai");
+        assert!(data.embeddings_has_api_key);
+        assert!(data.persistence_enabled);
+        assert_eq!(data.persistence_remote_name, "origin");
+        // The legacy LLM block is no longer on `Config`; the bridge surfaces
+        // stable sentinels so the D-Bus signature doesn't drift.
+        assert_eq!(data.llm_connector, "");
+        assert_eq!(data.llm_max_tokens, 0);
+    }
+
+    // --- untested methods: command construction + result mapping --------------
+
+    #[tokio::test]
+    async fn set_api_key_builds_command_and_acks() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        settings(Arc::clone(&t))
+            .set_api_key("sk-123")
+            .await
+            .unwrap();
+        assert!(matches!(t.last(), api::Command::SetApiKey { api_key } if api_key == "sk-123"));
+    }
+
+    #[tokio::test]
+    async fn get_embeddings_settings_maps_view_to_tuple() {
+        let t = FakeTransport::replying(api::CommandResult::EmbeddingsSettings(
+            api::EmbeddingsSettingsView {
+                connector: "openai".into(),
+                model: "m".into(),
+                base_url: "u".into(),
+                has_api_key: true,
+                available: true,
+                is_default: false,
+            },
+        ));
+        let (connector, model, _url, has_key, available, is_default) = settings(Arc::clone(&t))
+            .get_embeddings_settings()
+            .await
+            .unwrap();
+        assert_eq!(connector, "openai");
+        assert_eq!(model, "m");
+        assert!(has_key && available && !is_default);
+    }
+
+    #[tokio::test]
+    async fn set_embeddings_settings_normalizes_blank_fields_to_none() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        settings(Arc::clone(&t))
+            .set_embeddings_settings("ollama", "  ", "")
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::SetEmbeddingsSettings {
+                connector,
+                model,
+                base_url,
+            } => {
+                assert_eq!(connector, Some("ollama".to_string()));
+                assert_eq!(model, None, "blank model clears the field");
+                assert_eq!(base_url, None, "blank base_url clears the field");
+            }
+            other => panic!("expected SetEmbeddingsSettings, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_connector_defaults_passes_connector_and_maps_result() {
+        let t = FakeTransport::replying(api::CommandResult::ConnectorDefaults(
+            api::ConnectorDefaultsView {
+                llm_model: "claude".into(),
+                llm_base_url: "lu".into(),
+                embeddings_model: "emb".into(),
+                embeddings_base_url: "eu".into(),
+                embeddings_available: true,
+                hosted_tool_search_available: false,
+                backend_llm_model: "haiku".into(),
+            },
+        ));
+        let (llm_model, ..) = settings(Arc::clone(&t))
+            .get_connector_defaults("anthropic")
+            .await
+            .unwrap();
+        assert_eq!(llm_model, "claude");
+        assert!(matches!(
+            t.last(),
+            api::Command::GetConnectorDefaults { connector } if connector == "anthropic"
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_persistence_settings_normalizes_blank_remote_fields() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        settings(Arc::clone(&t))
+            .set_persistence_settings(true, "", "  ", false)
+            .await
+            .unwrap();
+        match t.last() {
+            api::Command::SetPersistenceSettings {
+                enabled,
+                remote_url,
+                remote_name,
+                push_on_update,
+            } => {
+                assert!(enabled);
+                assert_eq!(remote_url, None);
+                assert_eq!(remote_name, None);
+                assert!(!push_on_update);
+            }
+            other => panic!("expected SetPersistenceSettings, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_config_maps_wire_config_via_config_from_wire() {
+        let t = FakeTransport::replying(api::CommandResult::Config(api::Config {
+            embeddings: api::EmbeddingsSettingsView {
+                connector: "openai".into(),
+                model: "m".into(),
+                base_url: "u".into(),
+                has_api_key: false,
+                available: true,
+                is_default: true,
+            },
+            persistence: api::PersistenceSettingsView {
+                enabled: false,
+                remote_url: String::new(),
+                remote_name: "origin".into(),
+                push_on_update: true,
+            },
+            personality: api::PersonalitySettingsView::default(),
+        }));
+        let data = settings(Arc::clone(&t)).get_config().await.unwrap();
+        assert_eq!(data.embeddings_connector, "openai");
+        assert!(matches!(t.last(), api::Command::GetConfig));
+    }
+
+    #[tokio::test]
+    async fn list_mcp_servers_maps_to_five_tuples() {
+        let t = FakeTransport::replying(api::CommandResult::McpServers(vec![api::McpServerView {
+            name: "weather".into(),
+            command: "weather-mcp".into(),
+            args: vec!["serve".into()],
+            namespace: None,
+            enabled: true,
+            status: "running".into(),
+            tool_count: 2,
+        }]));
+        let rows = settings(Arc::clone(&t)).list_mcp_servers().await.unwrap();
+        assert_eq!(
+            rows,
+            vec![(
+                "weather".to_string(),
+                "weather-mcp".to_string(),
+                true,
+                "running".to_string(),
+                2
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_backend_tasks_settings_maps_view_to_tuple() {
+        let t = FakeTransport::replying(api::CommandResult::BackendTasksSettings(
+            api::BackendTasksSettingsView {
+                has_separate_llm: true,
+                llm_connector: "ollama".into(),
+                llm_model: "qwen".into(),
+                llm_base_url: "u".into(),
+                dreaming_enabled: true,
+                dreaming_interval_secs: 3600,
+                archive_after_days: 30,
+            },
+        ));
+        let (has_separate, connector, model, _u, dreaming, interval, archive) =
+            settings(Arc::clone(&t))
+                .get_backend_tasks_settings()
+                .await
+                .unwrap();
+        assert!(has_separate && dreaming);
+        assert_eq!(
+            (connector, model, interval, archive),
+            ("ollama".to_string(), "qwen".to_string(), 3600, 30)
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_and_toggle_mcp_server_build_their_commands() {
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        settings(Arc::clone(&t))
+            .remove_mcp_server("weather")
+            .await
+            .unwrap();
+        assert!(matches!(t.last(), api::Command::RemoveMcpServer { name } if name == "weather"));
+
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        settings(Arc::clone(&t))
+            .set_mcp_server_enabled("weather", false)
+            .await
+            .unwrap();
+        assert!(matches!(
+            t.last(),
+            api::Command::SetMcpServerEnabled { name, enabled } if name == "weather" && !enabled
+        ));
+    }
+
+    #[tokio::test]
+    async fn unexpected_result_variant_is_a_clean_error() {
+        // Representative: a getter that receives the wrong CommandResult must
+        // surface an error rather than panic. The same match-arm guards every
+        // method.
+        let t = FakeTransport::replying(api::CommandResult::Ack);
+        let err = settings(Arc::clone(&t))
+            .get_embeddings_settings()
+            .await
+            .expect_err("a non-EmbeddingsSettings result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
+    }
 }


### PR DESCRIPTION
Spec-driven contract coverage for the `dbus-bridge` adapters, before #319 deletes the old in-process surface (and its tests).

## The spec under test

The bridge adapters are translators: D-Bus method ⇄ `api::Command` / `CommandResult`. The contract they must honor is the **canonical command** for each operation + the canonical result mapping + the normalization rules — the *same* contract every transport (UDS / WS / D-Bus) honors, so the bridge behaves identically to any other client regardless of connection method. These tests pin that contract; they don't reproduce the old `dbus-interface` tests (different layer — those mocked in-process services).

Each acceptance criterion is a named test, with unhappy paths enumerated (malformed JSON not dispatched, blank→`None` normalization, partial/optional fields, result-variant mismatch → clean error not panic, daemon error propagated).

## What's added (~70 contract tests)

- **Connections (0 → 15):** every method builds its canonical command (`Create/Update/DeleteConnection`, `ListAvailableModels`, `Get/SetPurpose`, `ListConnections`); malformed connection-config / purpose-config JSON and unknown purpose kinds are rejected **without dispatching**; blank `connection_id` → `None` (aggregate-all); result-variant mismatch + daemon error.
- **Knowledge (0 → 23):** the three pure normalizers (`parse_tag_filter` blank/`"null"`/array/malformed, `parse_tags` blank→`[]`, `parse_metadata` blank→`Null`) tested directly; every method builds its canonical command with parsed tags/metadata; `KnowledgeEntry(None)` "not found" maps to a null envelope (not an error); malformed metadata not dispatched; variant mismatch + daemon error.
- **Conversations (4 → 23):** the remaining methods (`create/list/archive/unarchive/delete/rename/get_conversation/clear_all_history/get_conversation_personality/send_prompt`) + thorough edge coverage of the **bridge-side `get_messages` slicing**: after-count offset, past-end→empty, tail truncation + `truncated` flag, tail≥len→all, role filter, and `total` always the raw count. Plus `list_conversations` `max_age_days` normalization (0/negative → `None`, never `Some(0)`).
- **Settings (6 → 19):** the pure helpers `normalize` (trim + blank→`None`), `ordinal_to_level` (unset leaves untouched, in-range bounds pin, >4 errors), `config_from_wire` (carries embeddings/persistence + LLM sentinels); plus the untested methods (`set_api_key`, embeddings/persistence/connector-defaults/backend-tasks/config/MCP-list/remove/toggle) — command construction, blank-field normalization, result mapping, variant mismatch.

A spec test already earned its keep: it caught my own wrong assumption that `ordinal_to_level(set=false)` *clears* the field — the contract is "leave untouched," now pinned correctly.

## Result

`cargo test -p desktop-assistant-dbus-bridge`: ~140 green (lib + integration + introspection gate). `just check` green. No production changes — pure test additions, so deleting `dbus-interface` in #319 now loses no behavioral coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
