### PR TITLE
Per-sender daemon sessions in the D-Bus bridge (#367/#320 foundation)

### DIFF
--- a/crates/dbus-bridge/Cargo.toml
+++ b/crates/dbus-bridge/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive", "env"] }
 desktop-assistant-api-model = { path = "../api-model" }
 desktop-assistant-client-common = { path = "../client-common" }
 desktop-assistant-frame-codec = { workspace = true }
+futures-util = "0.3"
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -31,7 +32,6 @@ zbus.workspace = true
 [dev-dependencies]
 async-trait.workspace = true
 desktop-assistant-auth-jwt.workspace = true
-futures-util = "0.3"
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
 zbus = { version = "5", default-features = false, features = ["tokio", "p2p"] }

--- a/crates/dbus-bridge/src/adapter/commands.rs
+++ b/crates/dbus-bridge/src/adapter/commands.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 use desktop_assistant_api_model as api;
 use zbus::{fdo, interface};
 
+use crate::session::SessionRegistry;
 use crate::transport::{BridgeTransport, BridgeTransportError};
 
 /// Translate a transport error into the `fdo::Error` the D-Bus caller sees.
@@ -95,11 +96,54 @@ fn reject_reason(command: &api::Command) -> Option<&'static str> {
 /// [`BridgeTransport`] instead of into an in-process handler.
 pub struct DbusCommandsAdapter<T: BridgeTransport + 'static> {
     transport: Arc<T>,
+    /// Per-sender daemon sessions (#367/#320). Wired in production via
+    /// [`with_sessions`](Self::with_sessions); `None` in unit tests.
+    sessions: Option<Arc<SessionRegistry>>,
 }
 
 impl<T: BridgeTransport + 'static> DbusCommandsAdapter<T> {
     pub fn new(transport: Arc<T>) -> Self {
-        Self { transport }
+        Self {
+            transport,
+            sessions: None,
+        }
+    }
+
+    /// Wire the per-sender session registry (production) so a turn-driving command
+    /// arriving on this generic JSON channel routes through the *caller's* own
+    /// session — identical to the typed Conversations methods. Without it (unit
+    /// tests), everything uses the shared transport.
+    pub fn with_sessions(mut self, sessions: Arc<SessionRegistry>) -> Self {
+        self.sessions = Some(sessions);
+        self
+    }
+
+    /// Parse, policy-check, and dispatch one serialized `api::Command`, returning
+    /// the serialized `api::CommandResult`. The testable core of `send_command`;
+    /// `caller` is the D-Bus sender's unique name (from the message header), used
+    /// to route turn-driving commands to that caller's session.
+    async fn run_command(&self, caller: Option<&str>, command_json: &str) -> fdo::Result<String> {
+        let command: api::Command = serde_json::from_str(command_json)
+            .map_err(|e| fdo::Error::InvalidArgs(format!("invalid command JSON: {e}")))?;
+
+        if let Some(reason) = reject_reason(&command) {
+            return Err(fdo::Error::NotSupported(reason.to_string()));
+        }
+
+        let result = match self.sessions.as_ref() {
+            Some(registry) => registry
+                .route(caller, command, self.transport.as_ref())
+                .await
+                .map_err(map_transport_err)?,
+            None => self
+                .transport
+                .request(command)
+                .await
+                .map_err(map_transport_err)?,
+        };
+
+        serde_json::to_string(&result)
+            .map_err(|e| fdo::Error::Failed(format!("serialize command result: {e}")))
     }
 }
 
@@ -114,22 +158,13 @@ impl<T: BridgeTransport + 'static> DbusCommandsAdapter<T> {
     /// authenticated UDS session, whose minted identity is the user scope —
     /// there is no `$USER` resolution here (contrast the in-process adapter),
     /// because the daemon derives the user from the bridge's JWT.
-    async fn send_command(&self, command_json: &str) -> fdo::Result<String> {
-        let command: api::Command = serde_json::from_str(command_json)
-            .map_err(|e| fdo::Error::InvalidArgs(format!("invalid command JSON: {e}")))?;
-
-        if let Some(reason) = reject_reason(&command) {
-            return Err(fdo::Error::NotSupported(reason.to_string()));
-        }
-
-        let result = self
-            .transport
-            .request(command)
-            .await
-            .map_err(map_transport_err)?;
-
-        serde_json::to_string(&result)
-            .map_err(|e| fdo::Error::Failed(format!("serialize command result: {e}")))
+    async fn send_command(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        command_json: &str,
+    ) -> fdo::Result<String> {
+        let caller = hdr.sender().map(|s| s.as_str());
+        self.run_command(caller, command_json).await
     }
 }
 
@@ -213,7 +248,7 @@ mod tests {
         })
         .unwrap();
 
-        let raw = adapter.send_command(&request).await.unwrap();
+        let raw = adapter.run_command(None, &request).await.unwrap();
         let decoded: api::CommandResult = serde_json::from_str(&raw).unwrap();
         assert_eq!(decoded, reply);
         assert!(matches!(
@@ -236,7 +271,7 @@ mod tests {
             let request = serde_json::to_string(&cmd).unwrap();
 
             let err = adapter
-                .send_command(&request)
+                .run_command(None, &request)
                 .await
                 .expect_err("streaming subscription must be rejected");
             assert!(matches!(err, fdo::Error::NotSupported(_)), "got {err:?}");
@@ -258,7 +293,7 @@ mod tests {
         .unwrap();
 
         let err = adapter
-            .send_command(&request)
+            .run_command(None, &request)
             .await
             .expect_err("conversation subscription must be rejected over D-Bus");
         assert!(matches!(err, fdo::Error::NotSupported(_)), "got {err:?}");
@@ -282,7 +317,7 @@ mod tests {
             let request = serde_json::to_string(&cmd).unwrap();
 
             let err = adapter
-                .send_command(&request)
+                .run_command(None, &request)
                 .await
                 .expect_err("client-tool commands must be rejected over D-Bus");
             assert!(matches!(err, fdo::Error::NotSupported(_)), "got {err:?}");
@@ -297,7 +332,7 @@ mod tests {
         let request = serde_json::to_string(&api::Command::Ping).unwrap();
 
         let err = adapter
-            .send_command(&request)
+            .run_command(None, &request)
             .await
             .expect_err("a daemon error must surface as an fdo error");
         assert!(matches!(err, fdo::Error::Failed(_)));
@@ -313,7 +348,7 @@ mod tests {
         let adapter = adapter(Arc::clone(&transport));
 
         let err = adapter
-            .send_command("{not valid json")
+            .run_command(None, "{not valid json")
             .await
             .expect_err("malformed command JSON must be rejected");
         assert!(matches!(err, fdo::Error::InvalidArgs(_)), "got {err:?}");

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -11,11 +11,8 @@ use desktop_assistant_api_model as api;
 use zbus::object_server::SignalEmitter;
 use zbus::{fdo, interface};
 
+use crate::session::SessionRegistry;
 use crate::transport::{BridgeTransport, BridgeTransportError};
-
-fn to_fdo<E: std::fmt::Display>(error: E) -> fdo::Error {
-    fdo::Error::Failed(error.to_string())
-}
 
 /// D-Bus ordinal contract for one personality-override trait (#227): `-1` =
 /// unset (fall back to global), `0..=4` pins the level (Never=0 … Always=4).
@@ -97,45 +94,81 @@ fn map_transport_err(error: BridgeTransportError) -> fdo::Error {
 /// `ResponseError` signals by [`super::event_forwarder`].
 pub struct DbusConversationsAdapter<T: BridgeTransport + 'static> {
     transport: Arc<T>,
+    /// Per-sender daemon sessions (#367/#320). Wired in production via
+    /// [`with_sessions`](Self::with_sessions); `None` in unit tests, where
+    /// turn-driving falls back to the shared `transport`.
+    sessions: Option<Arc<SessionRegistry>>,
 }
 
 impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
     pub fn new(transport: Arc<T>) -> Self {
-        Self { transport }
+        Self {
+            transport,
+            sessions: None,
+        }
+    }
+
+    /// Wire the per-sender session registry (production). Turn-driving methods
+    /// then dispatch through the *caller's* own daemon session, so a turn's
+    /// streamed events come back on that session and unicast to only that caller
+    /// (#367/#320). Without it (unit tests), they use the shared transport.
+    pub fn with_sessions(mut self, sessions: Arc<SessionRegistry>) -> Self {
+        self.sessions = Some(sessions);
+        self
     }
 
     async fn dispatch(&self, cmd: api::Command) -> fdo::Result<api::CommandResult> {
         self.transport.request(cmd).await.map_err(map_transport_err)
     }
 
+    /// Dispatch a turn-driving command. With the registry wired and the caller
+    /// known, route through that caller's per-sender session (so the daemon
+    /// streams the turn's events back on that session, which the unicast
+    /// forwarder delivers to only this caller); otherwise fall back to the shared
+    /// transport. `caller` is the D-Bus sender's unique bus name from the message
+    /// header.
+    async fn dispatch_turn(
+        &self,
+        caller: Option<&str>,
+        cmd: api::Command,
+    ) -> fdo::Result<api::CommandResult> {
+        match self.sessions.as_ref() {
+            Some(registry) => registry
+                .route(caller, cmd, self.transport.as_ref())
+                .await
+                .map_err(map_transport_err),
+            None => self.transport.request(cmd).await.map_err(map_transport_err),
+        }
+    }
+
     /// Shared body for `SendPrompt` / `SendPromptWithSystemRefinement`:
     /// builds the `SendMessage` command (with the given
-    /// `system_refinement`; empty = none), dispatches it, and maps the
-    /// immediate result to a correlation id for the caller. Keeping this
-    /// in one place guarantees the two D-Bus methods stay
+    /// `system_refinement`; empty = none), dispatches it **through the caller's
+    /// session**, and maps the immediate result to a correlation id for the
+    /// caller. Keeping this in one place guarantees the two D-Bus methods stay
     /// byte-identical apart from the refinement.
     async fn dispatch_send_message(
         &self,
+        caller: Option<&str>,
         conversation_id: &str,
         prompt: &str,
         system_refinement: String,
     ) -> fdo::Result<String> {
+        // SendMessage returns an immediate Ack/SendMessageAck; a daemon refusal
+        // before streaming surfaces here as the mapped transport error.
         let result = self
-            .dispatch(api::Command::SendMessage {
-                conversation_id: conversation_id.to_string(),
-                content: prompt.to_string(),
-                override_selection: None,
-                system_refinement,
-                // The D-Bus bridge does not originate idempotency keys (#204).
-                idempotency_key: None,
-            })
-            .await
-            .map_err(|e| {
-                // SendMessage returns an immediate Ack on success; if
-                // the daemon refused the request before streaming, we
-                // surface the error directly.
-                to_fdo(e)
-            })?;
+            .dispatch_turn(
+                caller,
+                api::Command::SendMessage {
+                    conversation_id: conversation_id.to_string(),
+                    content: prompt.to_string(),
+                    override_selection: None,
+                    system_refinement,
+                    // The D-Bus bridge does not originate idempotency keys (#204).
+                    idempotency_key: None,
+                },
+            )
+            .await?;
 
         match result {
             api::CommandResult::Ack => {
@@ -404,8 +437,14 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
     /// and the daemon's id is what shows up on the signal — same as
     /// the in-process adapter where the dbus-interface created its
     /// own request id.
-    async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> fdo::Result<String> {
-        self.dispatch_send_message(conversation_id, prompt, String::new())
+    async fn send_prompt(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        conversation_id: &str,
+        prompt: &str,
+    ) -> fdo::Result<String> {
+        let caller = hdr.sender().map(|s| s.as_str());
+        self.dispatch_send_message(caller, conversation_id, prompt, String::new())
             .await
     }
 
@@ -423,12 +462,19 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
     /// byte-identical for existing chat clients.
     async fn send_prompt_with_system_refinement(
         &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
         conversation_id: &str,
         prompt: &str,
         system_refinement: &str,
     ) -> fdo::Result<String> {
-        self.dispatch_send_message(conversation_id, prompt, system_refinement.to_string())
-            .await
+        let caller = hdr.sender().map(|s| s.as_str());
+        self.dispatch_send_message(
+            caller,
+            conversation_id,
+            prompt,
+            system_refinement.to_string(),
+        )
+        .await
     }
 
     /// Signal emitted for each chunk of a streaming response.
@@ -509,11 +555,15 @@ mod tests {
         let transport = Arc::new(RecordingTransport::new());
         let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
 
+        // Drives the shared body directly (the `#[interface]` method only adds
+        // header→caller extraction, which zbus fills at dispatch). `None` caller
+        // ⇒ shared transport, exactly what a registry-less adapter does.
         let request_id = adapter
-            .send_prompt_with_system_refinement(
+            .dispatch_send_message(
+                None,
                 "conv-1",
                 "what's the weather?",
-                "Respond briefly, by voice.",
+                "Respond briefly, by voice.".to_string(),
             )
             .await
             .expect("send returns the daemon correlation id");
@@ -550,7 +600,10 @@ mod tests {
         let transport = Arc::new(RecordingTransport::new());
         let adapter = DbusConversationsAdapter::new(Arc::clone(&transport));
 
-        adapter.send_prompt("conv-2", "hello").await.unwrap();
+        adapter
+            .dispatch_send_message(None, "conv-2", "hello", String::new())
+            .await
+            .unwrap();
 
         let commands = transport.commands.lock().await;
         assert_eq!(commands.len(), 1);
@@ -971,7 +1024,7 @@ mod tests {
             task_id: "t".into(),
         }));
         DbusConversationsAdapter::new(Arc::clone(&t))
-            .send_prompt("c1", "hello there")
+            .dispatch_send_message(None, "c1", "hello there", String::new())
             .await
             .unwrap();
         match only_command(&t).await {

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -213,7 +213,10 @@ pub async fn run<F: std::future::Future<Output = ()> + Send + 'static>(
                     events = connector.subscribe();
                     spawn_background_task_subscription(&connector);
                 }
-                Some(event) => emit(&connection, translate(event)).await,
+                // Broadcast (destination `None`): this shared connection carries
+                // the per-user stream (`Task*`, and post-#367 the conversation-list
+                // signal). Per-sender turn responses ride `run_unicast` instead.
+                Some(event) => emit(&connection, None, translate(event)).await,
                 None => {
                     // Sender dropped without a Disconnected (shouldn't happen while
                     // the bridge holds the Connector). Re-subscribe defensively.
@@ -262,11 +265,48 @@ fn spawn_background_task_subscription(connector: &Arc<Connector>) {
 /// Translate and emit one signal event as its D-Bus signal. The single-event
 /// seam `run` uses internally, exposed so integration tests can drive the emit
 /// path over a p2p connection without standing up a full Connector.
-pub async fn forward_one(connection: &Connection, event: SignalEvent) {
-    emit(connection, translate(event)).await;
+///
+/// `destination` mirrors [`emit`]: `None` broadcasts, `Some(unique_name)`
+/// unicasts to one D-Bus sender (the per-sender session path).
+pub async fn forward_one(connection: &Connection, destination: Option<&str>, event: SignalEvent) {
+    emit(connection, destination, translate(event)).await;
 }
 
-async fn emit(connection: &Connection, action: ForwardAction) {
+/// Run a **per-sender** forwarder until the task is aborted (on session
+/// eviction). Unlike [`run`], this pumps one [`SenderSession`](crate::session)'s
+/// own daemon connection — which carries only that session's turn responses
+/// (`AssistantDelta`/`Completed`/`Error`), because the sub-session holds no
+/// `SubscribeBackgroundTasks`/`SubscribeConversations` registration of its own —
+/// and emits each as a signal **unicast to `destination`** (the sender's unique
+/// bus name). So a turn driven by one D-Bus caller streams back only to that
+/// caller, never broadcast across the session bus.
+///
+/// No shutdown future and no background-task subscription: the session owns this
+/// task's `JoinHandle` and aborts it on eviction, and there is nothing to
+/// re-subscribe across a reconnect (the sub-session carries no subscriptions).
+pub async fn run_unicast(connector: Arc<Connector>, connection: Connection, destination: String) {
+    let mut events = connector.subscribe();
+    loop {
+        match events.recv().await {
+            Some(SignalEvent::Disconnected { reason }) => {
+                debug!(
+                    "unicast forwarder for {destination}: transport dropped ({reason}); re-subscribing"
+                );
+                events = connector.subscribe();
+            }
+            Some(event) => emit(&connection, Some(&destination), translate(event)).await,
+            None => events = connector.subscribe(),
+        }
+    }
+}
+
+/// Emit `action` as its D-Bus signal. `destination` is the signal's intended
+/// recipient: `None` broadcasts (the shared per-user stream — `Task*` and, post
+/// #367, the conversation-list signal), `Some(unique_name)` **unicasts** to one
+/// D-Bus sender (a per-sender session's own turn responses — #367/#320). A
+/// unicast signal still matches an ordinary member match rule at the recipient,
+/// so a client subscribed the usual way receives it transparently.
+async fn emit(connection: &Connection, destination: Option<&str>, action: ForwardAction) {
     match action {
         ForwardAction::ResponseChunk {
             conversation_id,
@@ -276,7 +316,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (conversation_id, request_id, chunk);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::CONVERSATIONS,
                     CONV_INTERFACE,
                     "ResponseChunk",
@@ -295,7 +335,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (conversation_id, request_id, full_response);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::CONVERSATIONS,
                     CONV_INTERFACE,
                     "ResponseComplete",
@@ -314,7 +354,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (conversation_id, request_id, error);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::CONVERSATIONS,
                     CONV_INTERFACE,
                     "ResponseError",
@@ -329,7 +369,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (id, task);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::BACKGROUND_TASKS,
                     BG_INTERFACE,
                     "TaskStarted",
@@ -344,7 +384,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (id, hint);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::BACKGROUND_TASKS,
                     BG_INTERFACE,
                     "TaskProgress",
@@ -359,7 +399,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (id, entry);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::BACKGROUND_TASKS,
                     BG_INTERFACE,
                     "TaskLogAppended",
@@ -378,7 +418,7 @@ async fn emit(connection: &Connection, action: ForwardAction) {
             let body = (id, status, last_error);
             if let Err(e) = connection
                 .emit_signal::<&str, _, _, _, _>(
-                    None,
+                    destination,
                     paths::BACKGROUND_TASKS,
                     BG_INTERFACE,
                     "TaskCompleted",

--- a/crates/dbus-bridge/src/lib.rs
+++ b/crates/dbus-bridge/src/lib.rs
@@ -28,8 +28,14 @@
 //!   authenticated UDS connection, reconnect, and JWT minting — #316).
 //! - [`adapter`]: D-Bus adapter structs (one per object path) that
 //!   speak only `api-model` types — no `core`/`application` deps.
+//! - [`session`]: per-D-Bus-sender daemon sessions — each sender gets its own
+//!   authenticated `Connector` + a unicast event forwarder, so turn responses
+//!   (and, post-#367/#320, live sync and client tools) reach only that caller
+//!   instead of broadcasting across the bus.
 
 pub mod adapter;
+pub mod session;
 pub mod transport;
 
+pub use session::{ConnectorSessionFactory, SessionRegistry, spawn_name_owner_watcher};
 pub use transport::{BridgeTransport, BridgeTransportError, ConnectorBridgeTransport};

--- a/crates/dbus-bridge/src/main.rs
+++ b/crates/dbus-bridge/src/main.rs
@@ -18,7 +18,7 @@
 //! or `.Dev` to run a side-by-side instance for QA without colliding.
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -31,6 +31,9 @@ use desktop_assistant_dbus_bridge::adapter::{
     DBUS_SERVICE_NAME, DbusBackgroundTasksAdapter, DbusCommandsAdapter, DbusConnectionsAdapter,
     DbusConversationsAdapter, DbusKnowledgeAdapter, DbusReloadAdapter, DbusSettingsAdapter,
     event_forwarder, paths,
+};
+use desktop_assistant_dbus_bridge::session::{
+    ConnectorSessionFactory, SessionRegistry, spawn_name_owner_watcher,
 };
 use desktop_assistant_dbus_bridge::transport::ConnectorBridgeTransport;
 use tokio::signal::unix::{SignalKind, signal};
@@ -115,14 +118,33 @@ async fn main() -> anyhow::Result<()> {
     })?;
     let connector = Arc::new(connector);
 
+    // Per-sender daemon sessions (#367/#320). The shared `connector` above stays
+    // the bridge's connection for stateless request/response (and the broadcast
+    // `Task*` stream); but a turn a D-Bus caller drives needs its OWN daemon
+    // session so the turn's events come back on that session and unicast to only
+    // that caller. The registry mints one such session per sender on demand
+    // (same `config`), and the name-owner watcher evicts it when the sender
+    // leaves the bus. The forwarders emit on the bus connection, which only
+    // exists after the name is bound below, so it's supplied through a slot
+    // filled immediately after `build()` (before any session can be requested —
+    // a session is only created from inside a served method).
+    let bus_connection: Arc<OnceLock<zbus::Connection>> = Arc::new(OnceLock::new());
+    let session_factory = Arc::new(ConnectorSessionFactory::new(
+        config.clone(),
+        Arc::clone(&bus_connection),
+    ));
+    let sessions = Arc::new(SessionRegistry::new(session_factory));
+
     // 2. Stand up adapters over a Connector-backed transport + bind the name.
     tracing::info!(name = %cli.name, "binding D-Bus name");
     let _ = DBUS_SERVICE_NAME; // referenced for symmetry; CLI flag overrides
     let transport = Arc::new(ConnectorBridgeTransport::new(Arc::clone(&connector)));
     // Generic command channel (#213 / #315 G1): the JSON-in/JSON-out surface
-    // tui/gtk use on `--transport dbus`.
-    let commands = DbusCommandsAdapter::new(Arc::clone(&transport));
-    let conversations = DbusConversationsAdapter::new(Arc::clone(&transport));
+    // tui/gtk use on `--transport dbus`. Turn-driving commands route per-sender.
+    let commands =
+        DbusCommandsAdapter::new(Arc::clone(&transport)).with_sessions(Arc::clone(&sessions));
+    let conversations =
+        DbusConversationsAdapter::new(Arc::clone(&transport)).with_sessions(Arc::clone(&sessions));
     let settings = DbusSettingsAdapter::new(Arc::clone(&transport));
     let connections = DbusConnectionsAdapter::new(Arc::clone(&transport));
     let knowledge = DbusKnowledgeAdapter::new(Arc::clone(&transport));
@@ -146,6 +168,16 @@ async fn main() -> anyhow::Result<()> {
         .context("failed to build D-Bus connection")?;
     tracing::info!(name = %cli.name, "D-Bus bridge ready");
 
+    // Hand the per-sender session forwarders the live bus connection. Safe to set
+    // now: a session is only ever created from inside a served D-Bus method,
+    // which cannot dispatch until this point.
+    let _ = bus_connection.set(connection.clone());
+
+    // Evict a sender's session when it drops off the bus, so a crashed/exited
+    // D-Bus client can't leak its daemon session (and — post-#320 — can't wedge a
+    // turn on a tool call it will never answer).
+    let name_owner_watcher = spawn_name_owner_watcher(connection.clone(), Arc::clone(&sessions));
+
     // 3. Event forwarder. It issues the initial `SubscribeBackgroundTasks` and
     //    re-issues it (and re-subscribes the stream) across daemon restarts.
     let forwarder_shutdown = build_shutdown_signal()?;
@@ -163,9 +195,13 @@ async fn main() -> anyhow::Result<()> {
     // Dropping the connection stops serving; the forwarder exits on its own
     // shutdown signal. Give it a moment to drain, then drop the Connector
     // (which aborts its reconnect supervisor).
+    name_owner_watcher.abort();
     let _ = tokio::time::timeout(Duration::from_secs(2), forwarder).await;
     drop(connection);
     drop(connector);
+    // Drop every per-sender session: each session's `Drop` aborts its forwarder
+    // and releases its `Connector`, disconnecting it from the daemon.
+    drop(sessions);
     Ok(())
 }
 

--- a/crates/dbus-bridge/src/session.rs
+++ b/crates/dbus-bridge/src/session.rs
@@ -1,0 +1,650 @@
+//! Per-D-Bus-sender daemon sessions (#367 / #320).
+//!
+//! Before this, the bridge multiplexed **every** D-Bus caller onto one shared
+//! daemon UDS session (`main.rs`'s startup [`Connector`]). That is fine for
+//! stateless request/response, but it is exactly why live multi-client sync
+//! (#367) and working client tools (#320) were rejected over D-Bus: both pin
+//! per-*connection* state in the daemon (the `SubscribeConversations` viewed-set;
+//! the client-tool bucket; the turn's event stream), and one shared connection
+//! cannot keep one D-Bus caller's state from capturing or leaking to another's.
+//!
+//! This module gives each D-Bus sender its **own** daemon session: a private,
+//! authenticated [`Connector`] (own daemon `session_id`, own minted JWT, own
+//! reconnect supervisor) plus a per-session [unicast forwarder] that streams that
+//! session's turn responses back to *only* that sender's unique bus name. A turn
+//! a caller drives therefore behaves exactly as it would over UDS/WS — its events
+//! come back on its own connection — instead of broadcasting across the bus.
+//!
+//! Sessions are created lazily, on a sender's first session-scoped call, and
+//! evicted when that sender drops off the bus ([`spawn_name_owner_watcher`]);
+//! dropping the [`SenderSession`] aborts its forwarder and drops its `Connector`,
+//! which disconnects from the daemon — clearing that session's subscriptions and
+//! tool registrations daemon-side.
+//!
+//! [unicast forwarder]: crate::adapter::event_forwarder::run_unicast
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use desktop_assistant_api_model as api;
+use desktop_assistant_client_common::{ConnectionConfig, Connector};
+use tracing::debug;
+use zbus::Connection;
+
+use crate::adapter::event_forwarder;
+use crate::transport::{BridgeTransport, BridgeTransportError, ConnectorBridgeTransport};
+
+/// Whether `command` drives a conversation turn and so must run on the caller's
+/// **own** per-sender session — only then do its streamed `Assistant*` events
+/// come back on that session (to be unicast to the caller), instead of being
+/// lost on the shared connection. Everything else is fine on the shared
+/// connection: stateless request/response returns its result inline, and
+/// background-task commands are addressed by id, not by which connection owns
+/// the turn. Cancelling a turn is `CancelBackgroundTask` (daemon-global by id),
+/// so it is deliberately *not* here.
+pub fn is_turn_driving(command: &api::Command) -> bool {
+    matches!(command, api::Command::SendMessage { .. })
+}
+
+/// One D-Bus sender's private daemon session: the transport its commands
+/// dispatch through, plus the handle of the unicast forwarder pumping that
+/// session's events to the sender. Dropping it aborts the forwarder (and, with
+/// the forwarder gone and the transport's `Connector` Arc released, disconnects
+/// from the daemon).
+pub struct SenderSession {
+    transport: Arc<dyn BridgeTransport>,
+    forwarder: tokio::task::JoinHandle<()>,
+}
+
+impl SenderSession {
+    /// Assemble a session from its transport and an already-spawned forwarder
+    /// task. Production builds these in [`ConnectorSessionFactory`]; tests build
+    /// them with a recording transport and a stub task.
+    pub fn new(
+        transport: Arc<dyn BridgeTransport>,
+        forwarder: tokio::task::JoinHandle<()>,
+    ) -> Self {
+        Self {
+            transport,
+            forwarder,
+        }
+    }
+
+    /// Dispatch `command` over this session's own daemon connection.
+    pub async fn request(
+        &self,
+        command: api::Command,
+    ) -> Result<api::CommandResult, BridgeTransportError> {
+        self.transport.request(command).await
+    }
+}
+
+impl Drop for SenderSession {
+    fn drop(&mut self) {
+        // Stop the forwarder so an evicted session leaves no task pumping a dead
+        // connection. The forwarder holds the only other `Connector` Arc, so
+        // aborting it lets the `Connector` drop and disconnect from the daemon.
+        self.forwarder.abort();
+    }
+}
+
+/// Builds a fresh [`SenderSession`] for a sender. Abstracted so [`SessionRegistry`]
+/// can be unit-tested without a live daemon or bus: production
+/// ([`ConnectorSessionFactory`]) connects a real `Connector` and spawns the
+/// unicast forwarder; tests return a recording transport and a stub task.
+#[async_trait::async_trait]
+pub trait SessionFactory: Send + Sync {
+    /// Create a session whose forwarder unicasts to `sender` (a unique bus name).
+    async fn create(&self, sender: &str) -> Result<SenderSession, BridgeTransportError>;
+}
+
+/// Production factory: each session is its own authenticated `Connector` to the
+/// daemon plus a [`run_unicast`](event_forwarder::run_unicast) forwarder bound to
+/// the sender's bus name.
+///
+/// The bus [`Connection`] (needed to emit the unicast signals) only exists after
+/// the bridge binds its name, whereas the registry must be constructed *before*
+/// that to be handed to the adapters. So the connection is supplied through a
+/// shared slot filled immediately after `build()`. The slot is always populated
+/// by the time `create` runs, because `create` is only reached from inside a
+/// served D-Bus method — which cannot dispatch until the connection is up.
+pub struct ConnectorSessionFactory {
+    /// Template for each per-sender `Connector` (daemon + minter sockets, TTL).
+    config: ConnectionConfig,
+    /// The bridge's bus connection, filled right after the name is bound.
+    connection: Arc<std::sync::OnceLock<Connection>>,
+}
+
+impl ConnectorSessionFactory {
+    pub fn new(config: ConnectionConfig, connection: Arc<std::sync::OnceLock<Connection>>) -> Self {
+        Self { config, connection }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionFactory for ConnectorSessionFactory {
+    async fn create(&self, sender: &str) -> Result<SenderSession, BridgeTransportError> {
+        let connection = self
+            .connection
+            .get()
+            .ok_or_else(|| {
+                BridgeTransportError::Daemon(
+                    "bridge bus connection not initialised before a session was requested"
+                        .to_string(),
+                )
+            })?
+            .clone();
+
+        // A private, authenticated daemon session for this sender: mints its own
+        // JWT, handshakes, and owns reconnect + re-minting from here on.
+        let connector = Arc::new(Connector::connect(&self.config).await.map_err(|e| {
+            BridgeTransportError::Daemon(format!("failed to open a per-sender daemon session: {e}"))
+        })?);
+        let transport = Arc::new(ConnectorBridgeTransport::new(Arc::clone(&connector)));
+        let forwarder = tokio::spawn(event_forwarder::run_unicast(
+            connector,
+            connection,
+            sender.to_string(),
+        ));
+        Ok(SenderSession::new(transport, forwarder))
+    }
+}
+
+/// Registry of live per-sender sessions, keyed by the caller's unique bus name.
+pub struct SessionRegistry {
+    factory: Arc<dyn SessionFactory>,
+    sessions: Mutex<HashMap<String, Arc<SenderSession>>>,
+}
+
+impl SessionRegistry {
+    pub fn new(factory: Arc<dyn SessionFactory>) -> Self {
+        Self {
+            factory,
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get the session for `sender`, creating it on first use. Idempotent: a
+    /// sender that calls repeatedly reuses one daemon session.
+    ///
+    /// The async `create` runs outside the lock (so opening a connection never
+    /// blocks other senders); if a concurrent first-call for the same sender wins
+    /// the race, this call adopts the winner and drops its own freshly-built
+    /// session (whose `Drop` disconnects it) — at most a wasted connect, never a
+    /// duplicate in the map.
+    pub async fn session_for(
+        &self,
+        sender: &str,
+    ) -> Result<Arc<SenderSession>, BridgeTransportError> {
+        if let Some(existing) = self.lock().get(sender).cloned() {
+            return Ok(existing);
+        }
+        let session = Arc::new(self.factory.create(sender).await?);
+        let mut sessions = self.lock();
+        Ok(sessions
+            .entry(sender.to_string())
+            .or_insert(session)
+            .clone())
+    }
+
+    /// Route `command` to the right daemon connection: the caller's own session
+    /// when the command [drives a turn](is_turn_driving) and the caller is known,
+    /// otherwise the shared `fallback` transport. This is the one place the
+    /// shared-vs-per-sender decision lives, so both D-Bus surfaces (the typed
+    /// Conversations methods and the generic Commands channel) route identically.
+    pub async fn route(
+        &self,
+        caller: Option<&str>,
+        command: api::Command,
+        fallback: &dyn BridgeTransport,
+    ) -> Result<api::CommandResult, BridgeTransportError> {
+        if is_turn_driving(&command)
+            && let Some(sender) = caller
+        {
+            return self.session_for(sender).await?.request(command).await;
+        }
+        fallback.request(command).await
+    }
+
+    /// Drop `sender`'s session if present, returning whether one was removed.
+    /// Removing the last `Arc` runs [`SenderSession`]'s `Drop` (aborts the
+    /// forwarder, disconnects the daemon session).
+    pub fn evict(&self, sender: &str) -> bool {
+        self.lock().remove(sender).is_some()
+    }
+
+    /// Number of live sessions (for the watcher's logging and tests).
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, Arc<SenderSession>>> {
+        self.sessions.lock().expect("SessionRegistry poisoned")
+    }
+}
+
+/// Apply one `NameOwnerChanged` to the registry: when a tracked sender's name has
+/// **no new owner** (`new_owner` empty), it has dropped off the bus, so evict its
+/// session. Factored out of [`spawn_name_owner_watcher`] so the eviction rule is
+/// unit-testable without standing up a bus. Returns whether a session was evicted.
+pub fn handle_name_owner_change(
+    registry: &SessionRegistry,
+    name: &str,
+    new_owner: Option<&str>,
+) -> bool {
+    if new_owner.is_some() {
+        return false; // name acquired or transferred, not a disconnect
+    }
+    let evicted = registry.evict(name);
+    if evicted {
+        debug!("evicted per-sender session for departed bus name {name}");
+    }
+    evicted
+}
+
+/// Watch `org.freedesktop.DBus` `NameOwnerChanged` and evict a sender's session
+/// when it drops off the bus, so a crashed/exited D-Bus client can't leak its
+/// daemon session (and, post-#320, can't wedge a turn on a tool call it will
+/// never answer). Holds only a `Weak<SessionRegistry>` so the watcher cannot keep
+/// the registry alive past shutdown.
+pub fn spawn_name_owner_watcher(
+    connection: Connection,
+    registry: Arc<SessionRegistry>,
+) -> tokio::task::JoinHandle<()> {
+    use futures_util::StreamExt;
+    let weak = Arc::downgrade(&registry);
+    drop(registry);
+    tokio::spawn(async move {
+        let proxy = match zbus::fdo::DBusProxy::new(&connection).await {
+            Ok(proxy) => proxy,
+            Err(e) => {
+                debug!(
+                    "name-owner watcher: failed to build DBusProxy ({e}); sessions won't be GC'd on disconnect"
+                );
+                return;
+            }
+        };
+        let mut stream = match proxy.receive_name_owner_changed().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                debug!("name-owner watcher: failed to subscribe NameOwnerChanged ({e})");
+                return;
+            }
+        };
+        while let Some(signal) = stream.next().await {
+            let Ok(args) = signal.args() else { continue };
+            let new_owner = args.new_owner().as_ref().map(|n| n.as_str());
+            let Some(registry) = weak.upgrade() else {
+                return; // registry gone — bridge shutting down
+            };
+            handle_name_owner_change(&registry, args.name().as_str(), new_owner);
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// Records every dispatched command so a test can assert isolation (which
+    /// sender's session a command was routed to).
+    #[derive(Default)]
+    struct RecordingTransport {
+        commands: StdMutex<Vec<api::Command>>,
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeTransport for RecordingTransport {
+        async fn request(
+            &self,
+            command: api::Command,
+        ) -> Result<api::CommandResult, BridgeTransportError> {
+            self.commands.lock().unwrap().push(command);
+            Ok(api::CommandResult::Ack)
+        }
+    }
+
+    /// Fake factory: hands back a recording transport per sender, records the
+    /// order of `create` calls, and spawns a forever-pending forwarder so a test
+    /// can prove eviction aborts it.
+    #[derive(Default)]
+    struct FakeFactory {
+        created: StdMutex<Vec<String>>,
+        transports: StdMutex<HashMap<String, Arc<RecordingTransport>>>,
+        /// Optional per-sender forwarder probe: the spawned forwarder fires
+        /// `started` once it is running (so a test can wait until the abort guard
+        /// is installed, avoiding a spawn-vs-abort race) and `aborted` when its
+        /// future is dropped on eviction.
+        forwarder_probes: StdMutex<HashMap<String, ForwarderProbe>>,
+        /// Optional barrier that parks `create` until N racers have arrived, so a
+        /// test can deterministically force the concurrent-first-call path
+        /// (create-outside-the-lock then `or_insert`) instead of a sequential
+        /// create-then-reuse.
+        gate: Option<Arc<tokio::sync::Barrier>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionFactory for FakeFactory {
+        async fn create(&self, sender: &str) -> Result<SenderSession, BridgeTransportError> {
+            // Park here until every racer has entered `create`, guaranteeing both
+            // passed the empty-map check before either inserts.
+            if let Some(gate) = &self.gate {
+                gate.wait().await;
+            }
+            self.created.lock().unwrap().push(sender.to_string());
+            let transport = Arc::new(RecordingTransport::default());
+            self.transports
+                .lock()
+                .unwrap()
+                .insert(sender.to_string(), Arc::clone(&transport));
+
+            let probe = self.forwarder_probes.lock().unwrap().remove(sender);
+            let forwarder = tokio::spawn(async move {
+                // Signal "started", then install a guard that fires on abort
+                // (when this future is dropped).
+                let _aborted = probe.map(|p| {
+                    let _ = p.started.send(());
+                    SendOnDrop(Some(p.aborted))
+                });
+                std::future::pending::<()>().await;
+            });
+            Ok(SenderSession::new(transport, forwarder))
+        }
+    }
+
+    /// Probes a fake forwarder's lifecycle for the eviction test.
+    struct ForwarderProbe {
+        started: tokio::sync::oneshot::Sender<()>,
+        aborted: tokio::sync::oneshot::Sender<()>,
+    }
+
+    /// Fires its oneshot when dropped — lets a test observe a forwarder's future
+    /// being dropped (on abort).
+    struct SendOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
+    impl Drop for SendOnDrop {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    fn registry_with(factory: Arc<FakeFactory>) -> SessionRegistry {
+        SessionRegistry::new(factory)
+    }
+
+    #[tokio::test]
+    async fn session_for_creates_once_then_reuses() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+
+        let a1 = registry.session_for(":1.10").await.unwrap();
+        let a2 = registry.session_for(":1.10").await.unwrap();
+
+        assert_eq!(
+            *factory.created.lock().unwrap(),
+            vec![":1.10".to_string()],
+            "a repeat caller must reuse one daemon session, not open a second"
+        );
+        assert!(
+            Arc::ptr_eq(&a1, &a2),
+            "same sender must get the same session"
+        );
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_senders_get_distinct_sessions() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+
+        let a = registry.session_for(":1.10").await.unwrap();
+        let b = registry.session_for(":1.11").await.unwrap();
+
+        assert!(!Arc::ptr_eq(&a, &b));
+        assert_eq!(registry.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn routes_each_command_to_its_callers_own_session() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+
+        registry
+            .session_for(":1.10")
+            .await
+            .unwrap()
+            .request(api::Command::Ping)
+            .await
+            .unwrap();
+        registry
+            .session_for(":1.11")
+            .await
+            .unwrap()
+            .request(api::Command::GetStatus)
+            .await
+            .unwrap();
+
+        let transports = factory.transports.lock().unwrap();
+        let a_cmds = transports[":1.10"].commands.lock().unwrap().clone();
+        let b_cmds = transports[":1.11"].commands.lock().unwrap().clone();
+        assert!(
+            matches!(a_cmds.as_slice(), [api::Command::Ping]),
+            "sender A's command must land only on A's session, got {a_cmds:?}"
+        );
+        assert!(
+            matches!(b_cmds.as_slice(), [api::Command::GetStatus]),
+            "sender B's command must land only on B's session, got {b_cmds:?}"
+        );
+    }
+
+    fn send_message(conv: &str) -> api::Command {
+        api::Command::SendMessage {
+            conversation_id: conv.to_string(),
+            content: "hi".to_string(),
+            override_selection: None,
+            system_refinement: String::new(),
+            idempotency_key: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn route_sessions_turn_driving_commands_but_shares_everything_else() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+        let fallback = Arc::new(RecordingTransport::default());
+
+        // Turn-driving + known caller → the caller's own session, never the
+        // shared connection (else the turn's events would be lost / broadcast).
+        registry
+            .route(Some(":1.10"), send_message("c1"), fallback.as_ref())
+            .await
+            .unwrap();
+        assert!(
+            fallback.commands.lock().unwrap().is_empty(),
+            "a turn must not ride the shared connection"
+        );
+        {
+            let transports = factory.transports.lock().unwrap();
+            assert!(matches!(
+                transports[":1.10"].commands.lock().unwrap().as_slice(),
+                [api::Command::SendMessage { .. }]
+            ));
+        }
+
+        // A non-turn command rides the shared fallback even with a known caller.
+        registry
+            .route(Some(":1.10"), api::Command::Ping, fallback.as_ref())
+            .await
+            .unwrap();
+        assert!(matches!(
+            fallback.commands.lock().unwrap().as_slice(),
+            [api::Command::Ping]
+        ));
+
+        // Turn-driving but no identifiable caller → shared fallback (the bridge
+        // can't pick a session), preserving today's behaviour for such callers.
+        registry
+            .route(None, send_message("c2"), fallback.as_ref())
+            .await
+            .unwrap();
+        assert_eq!(
+            fallback.commands.lock().unwrap().len(),
+            2,
+            "a caller-less turn falls back to the shared connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_removes_and_a_later_call_recreates() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+
+        registry.session_for(":1.10").await.unwrap();
+        assert!(registry.evict(":1.10"), "evict must report a removal");
+        assert!(registry.is_empty());
+        assert!(!registry.evict(":1.10"), "second evict is a no-op");
+
+        registry.session_for(":1.10").await.unwrap();
+        assert_eq!(
+            *factory.created.lock().unwrap(),
+            vec![":1.10".to_string(), ":1.10".to_string()],
+            "a call after eviction must open a fresh session"
+        );
+    }
+
+    #[tokio::test]
+    async fn evicting_a_session_aborts_its_forwarder() {
+        let factory = Arc::new(FakeFactory::default());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (aborted_tx, aborted_rx) = tokio::sync::oneshot::channel();
+        factory.forwarder_probes.lock().unwrap().insert(
+            ":1.10".to_string(),
+            ForwarderProbe {
+                started: started_tx,
+                aborted: aborted_tx,
+            },
+        );
+        let registry = registry_with(Arc::clone(&factory));
+
+        registry.session_for(":1.10").await.unwrap();
+        // Wait until the forwarder is actually running (abort guard installed), so
+        // the eviction below can't race ahead of the task's first poll.
+        tokio::time::timeout(std::time::Duration::from_secs(1), started_rx)
+            .await
+            .expect("forwarder should start")
+            .expect("started signal");
+
+        assert!(registry.evict(":1.10"));
+
+        // Aborting the task drops its future, firing the guard.
+        tokio::time::timeout(std::time::Duration::from_secs(1), aborted_rx)
+            .await
+            .expect("forwarder should be aborted promptly on eviction")
+            .expect("aborted signal");
+    }
+
+    #[tokio::test]
+    async fn name_owner_change_evicts_only_on_empty_new_owner() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+        registry.session_for(":1.10").await.unwrap();
+
+        // A new owner (name acquired/transferred) must NOT evict.
+        assert!(!handle_name_owner_change(&registry, ":1.10", Some(":1.99")));
+        assert_eq!(registry.len(), 1, "a live name must keep its session");
+
+        // An untracked name dropping is a harmless no-op.
+        assert!(!handle_name_owner_change(&registry, ":1.55", None));
+
+        // The tracked name dropping (empty new owner) evicts.
+        assert!(handle_name_owner_change(&registry, ":1.10", None));
+        assert!(registry.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_calls_for_one_sender_yield_one_session() {
+        // Force both racers to be inside `create` at once (barrier of 2), so this
+        // exercises the real create-outside-the-lock + `or_insert` path rather
+        // than a sequential create-then-reuse.
+        let factory = Arc::new(FakeFactory {
+            gate: Some(Arc::new(tokio::sync::Barrier::new(2))),
+            ..Default::default()
+        });
+        let registry = Arc::new(registry_with(Arc::clone(&factory)));
+
+        let r1 = Arc::clone(&registry);
+        let r2 = Arc::clone(&registry);
+        let h1 = tokio::spawn(async move { r1.session_for(":1.10").await.unwrap() });
+        let h2 = tokio::spawn(async move { r2.session_for(":1.10").await.unwrap() });
+        let a = h1.await.unwrap();
+        let b = h2.await.unwrap();
+
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "racing first-calls for one sender must converge on a single session"
+        );
+        assert_eq!(
+            registry.len(),
+            1,
+            "the loser's freshly-built session must not linger in the map"
+        );
+        assert_eq!(
+            factory.created.lock().unwrap().len(),
+            2,
+            "both racers built a session (at most one wasted connect) — but only one is kept"
+        );
+    }
+
+    #[test]
+    fn is_turn_driving_is_send_message_only() {
+        assert!(is_turn_driving(&send_message("c1")));
+        // Stateless / id-addressed commands are fine on the shared connection.
+        assert!(!is_turn_driving(&api::Command::Ping));
+        assert!(!is_turn_driving(&api::Command::GetStatus));
+        // Cancelling a turn is `CancelBackgroundTask` (daemon-global, by id), so
+        // it deliberately does NOT need to run on the caller's session.
+        assert!(!is_turn_driving(&api::Command::CancelBackgroundTask {
+            id: "t".into()
+        }));
+    }
+
+    /// A factory whose `create` always fails — to prove a turn whose session
+    /// can't be opened surfaces the error instead of silently sharing.
+    struct FailingFactory;
+    #[async_trait::async_trait]
+    impl SessionFactory for FailingFactory {
+        async fn create(&self, _sender: &str) -> Result<SenderSession, BridgeTransportError> {
+            Err(BridgeTransportError::Daemon("cannot open session".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn route_surfaces_a_session_creation_failure_without_falling_back() {
+        let registry = SessionRegistry::new(Arc::new(FailingFactory));
+        let fallback = Arc::new(RecordingTransport::default());
+
+        let result = registry
+            .route(Some(":1.10"), send_message("c1"), fallback.as_ref())
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a turn whose session can't be opened must surface the error"
+        );
+        assert!(
+            fallback.commands.lock().unwrap().is_empty(),
+            "a failed session must NOT silently fall back to the shared connection — \
+             that would broadcast the turn across the bus"
+        );
+        assert!(
+            registry.is_empty(),
+            "a failed create must leave no half-session behind"
+        );
+    }
+}

--- a/crates/dbus-bridge/tests/background_tasks.rs
+++ b/crates/dbus-bridge/tests/background_tasks.rs
@@ -790,7 +790,7 @@ impl ZbusPair {
                 tokio::select! {
                     _ = &mut shutdown_rx => break,
                     ev = signal_rx.recv() => match ev {
-                        Some(sig) => forward_one(&forwarder_conn, sig).await,
+                        Some(sig) => forward_one(&forwarder_conn, None, sig).await,
                         None => break,
                     }
                 }


### PR DESCRIPTION
## What & why

Before this, the standalone D-Bus bridge multiplexed **every** D-Bus caller onto one shared daemon UDS session (the startup `Connector`). That is fine for stateless request/response, but it is exactly why **live multi-client sync (#367)** and **working client tools (#320)** were *rejected* over D-Bus: both pin **per-connection** state in the daemon (the `SubscribeConversations` viewed-set, the client-tool bucket, the turn's event stream), and one shared connection cannot keep one caller's state from capturing or leaking to another's. It is also the post-cutover form of **#270 (DT-4)** — the "one immortal unscoped D-Bus session" defect.

This PR is **B1**: the per-sender session foundation. It is a behaviour-preserving refactor that ships on its own (no KDE change needed), and #367 + #320 ride directly on top.

## How

Give each D-Bus sender its **own** daemon session, keyed by the caller's unique bus name (`:1.42`, from the message header):

- **`session.rs` (new)** — `SenderSession` (own authenticated `Connector`: own daemon `session_id`, own minted JWT, own reconnect) + a `SessionFactory` seam (so the registry is unit-testable without a live daemon/bus) + `SessionRegistry` (lazy get-or-create, evict) + `is_turn_driving`/`route` (the single shared-vs-per-sender decision, used by both D-Bus surfaces) + a `NameOwnerChanged` watcher that evicts a sender's session when it drops off the bus.
- **`event_forwarder.rs`** — `emit()` gains a destination; `run_unicast()` pumps **one** session's stream and unicasts `ResponseChunk`/`Complete`/`Error` to **only** that sender's bus name. The shared `run()` stays broadcast for `Task*`.
- **`conversations.rs` / `commands.rs`** — turn-driving methods (`SendPrompt[+refinement]`, the generic `SendMessage` on `send_command`) read the caller from the message header and route through that caller's session; stateless commands keep the shared transport. `#[zbus(header)]` args are excluded from introspection, so **the parity golden is unchanged**.
- **`main.rs`** — build the registry + factory, wire it into the two adapters, fill the bus-connection slot right after the name binds, spawn the watcher.

A turn a caller drives now behaves exactly as it would over UDS/WS — its events come back on its own connection — instead of broadcasting across the session bus. From a client's POV this is behaviour-preserving: a caller still receives its own `ResponseChunk`/`Complete`, now unicast (a unicast signal still matches an ordinary member match rule).

## Testing (spec-driven, with edge cases)

Unit (`session.rs`):
- registry reuse / isolation across senders;
- the **routing contract**: turn → caller's session, everything else → shared, caller-less turn → shared;
- the **concurrent first-call race** converges on a single session (barrier-forced both racers into `create`; the loser's connect is discarded, never duplicated in the map);
- `is_turn_driving` is `SendMessage`-only — explicitly **not** `CancelBackgroundTask` (cancel is daemon-global by id);
- a **session-creation failure on a turn surfaces as an error** rather than silently falling back to the shared connection (silent fallback would broadcast the turn — a correctness bug);
- forwarder **abort-on-evict**;
- the `NameOwnerChanged` **eviction rule** (new owner present → keep; untracked → no-op; tracked drop → evict).

Suite: full bridge unit + integration suites + the **introspection golden** green; `clippy -D warnings` clean; `cargo fmt --check` clean; full-workspace `just check` green (daemon up).

**Live-verified end to end** against the running daemon: two independent bus connections, one drove a real LLM turn and the other only subscribed to the same `ResponseChunk` signal — the driver received the full stream (every chunk addressed to its own unique name), the co-subscribed observer received **zero**. That is the unicast property demonstrated on a live bus.

## Scope

- **In:** the per-sender session machinery + turn routing + eviction.
- **Not yet (follow-ups):** `SubscribeConversations` and `RegisterClientTools`/`ClientToolResult` stay rejected over D-Bus here — they are wired onto these sessions in **#367** (new `UserMessageAdded`/`ConversationListChanged` signals + per-sender subscribe) and **#320** (client tools). adele-kde subscribe/render is separate.

Refs #270 (realises its per-sender-session + `NameOwnerChanged`-eviction design at the post-cutover bridge layer; #320 completes the client-tool-eviction half), #367, #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
