### PR TITLE
Live multi-client sync over D-Bus: new signals + per-sender SubscribeConversations (#367)

### DIFF
--- a/crates/dbus-bridge/src/adapter/commands.rs
+++ b/crates/dbus-bridge/src/adapter/commands.rs
@@ -10,12 +10,15 @@
 //! through this one method. This adapter restores that parity over the bridge's
 //! UDS connection: `command_json` in, `api::CommandResult` JSON out.
 //!
-//! ## Why some commands are rejected here
+//! ## Routing and why some commands are still rejected here
 //!
-//! The bridge multiplexes **every** D-Bus caller onto its *single* daemon UDS
-//! session (the one minted at startup, [`crate::transport`]). A handful of
-//! commands assume a private, persistent, per-caller channel and would either
-//! be undeliverable or leak across callers if forwarded blindly, so they are
+//! Turn-driving (`SendMessage`) and session-pinned (`SubscribeConversations`)
+//! commands route through the **caller's own per-sender daemon session**
+//! ([`crate::session`]) — keyed by the D-Bus sender on the message header — so a
+//! turn's events come back on that session and a subscription's fan-out is
+//! isolated to that caller. Stateless request/response uses the bridge's shared
+//! session. A few commands still assume a private, persistent, per-caller
+//! *streaming* channel that a one-shot D-Bus method cannot provide, so they are
 //! rejected up front with `NotSupported` rather than silently mis-served:
 //!
 //! - **`SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks`** — set up a
@@ -24,23 +27,15 @@
 //!   background-task subscription open and re-emits them as
 //!   `BackgroundTasks.*` signals instead (see `main.rs`). Mirrors the
 //!   in-process adapter's rejection (`dbus-interface/src/commands.rs`).
-//! - **`SubscribeConversations`** — the set-replace live-sync subscription
-//!   (#356) registers the *connection's* sink against a set of conversations.
-//!   Over the bridge that is the one shared UDS connection, so a single D-Bus
-//!   caller's subscription would silently capture fan-out for every other
-//!   D-Bus caller. Live multi-client sync over D-Bus needs per-caller routing
-//!   the bridge does not model in v1 (it is a post-cutover follow-up, after
-//!   the in-process surface is retired in #319); reject it for now.
 //! - **`RegisterClientTools` / `ClientToolResult`** — the #270 / DT-4 hazard.
-//!   Registrations would land in the bridge session's single tool bucket,
-//!   shared across every D-Bus caller, and the resulting `Event::ClientToolCall`
-//!   has no D-Bus signal to be delivered on, so the turn would wedge until the
-//!   suspension timeout. Reject both, exactly as the tactical fix does for the
-//!   in-process surface.
+//!   The per-sender session machinery (B1) now makes safe routing *possible*,
+//!   but wiring it — registering tools on the caller's session and delivering
+//!   the resulting tool call as a unicast `ClientToolCall` signal — is #320.
+//!   Until then, reject both rather than wedge a turn on a tool call that has
+//!   no D-Bus signal to be delivered on.
 //!
-//! A client that genuinely needs streaming subscriptions or working
-//! client-side tools should use a socket transport (WS/UDS), which gives each
-//! client its own session.
+//! A client that needs working client-side tools today should use a socket
+//! transport (WS/UDS), which already gives each client its own session.
 
 use std::sync::Arc;
 
@@ -71,17 +66,13 @@ fn reject_reason(command: &api::Command) -> Option<&'static str> {
              BackgroundTasks signals, or use a socket transport (WS/UDS) and \
              Command::SubscribeBackgroundTasks for the live stream",
         ),
-        api::Command::SubscribeConversations { .. } => Some(
-            "live conversation subscription is not available over the generic D-Bus command \
-             channel: the bridge multiplexes every D-Bus caller onto one daemon session, so a \
-             subscription would capture fan-out for all callers; use a socket transport (WS/UDS) \
-             for live multi-client sync",
-        ),
+        // NOTE: `SubscribeConversations` is intentionally NOT rejected — it routes
+        // to the caller's per-sender session (#367, see the module docs and
+        // `crate::session::route`), so each caller's viewed-set is isolated.
         api::Command::RegisterClientTools { .. } | api::Command::ClientToolResult { .. } => Some(
-            "client-tool registration is not available over the generic D-Bus command channel: \
-             the bridge shares one daemon session across all D-Bus callers, so a registration \
-             would leak across callers, and the resulting tool-call events cannot be delivered \
-             back over a one-shot method; use a socket transport (WS/UDS)",
+            "client-tool registration is not yet available over D-Bus: routing onto per-sender \
+             sessions and delivering the resulting tool call as a ClientToolCall signal is #320; \
+             until then use a socket transport (WS/UDS)",
         ),
         _ => None,
     }
@@ -284,7 +275,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_conversation_subscription_before_dispatch() {
+    async fn subscribe_conversations_is_routed_not_rejected() {
+        // #367: SubscribeConversations now routes to the caller's per-sender
+        // session instead of being rejected. With no registry wired (unit test),
+        // run_command falls back to the shared transport, so it reaches the daemon
+        // rather than erroring — the regression guard for "we stopped rejecting it".
         let transport = FakeTransport::replying(api::CommandResult::Ack);
         let adapter = adapter(Arc::clone(&transport));
         let request = serde_json::to_string(&api::Command::SubscribeConversations {
@@ -292,13 +287,19 @@ mod tests {
         })
         .unwrap();
 
-        let err = adapter
-            .run_command(None, &request)
+        adapter
+            .run_command(Some(":1.10"), &request)
             .await
-            .expect_err("conversation subscription must be rejected over D-Bus");
-        assert!(matches!(err, fdo::Error::NotSupported(_)), "got {err:?}");
-        assert!(format!("{err}").contains("live multi-client sync"));
-        assert_eq!(transport.count(), 0);
+            .expect("SubscribeConversations must no longer be rejected over D-Bus");
+        assert_eq!(
+            transport.count(),
+            1,
+            "it must reach the daemon (be routed), not be rejected"
+        );
+        assert!(matches!(
+            transport.last(),
+            api::Command::SubscribeConversations { .. }
+        ));
     }
 
     #[tokio::test]

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -121,13 +121,16 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         self.transport.request(cmd).await.map_err(map_transport_err)
     }
 
-    /// Dispatch a turn-driving command. With the registry wired and the caller
-    /// known, route through that caller's per-sender session (so the daemon
-    /// streams the turn's events back on that session, which the unicast
-    /// forwarder delivers to only this caller); otherwise fall back to the shared
-    /// transport. `caller` is the D-Bus sender's unique bus name from the message
-    /// header.
-    async fn dispatch_turn(
+    /// Dispatch a command that may be **session-scoped**, routing it through the
+    /// per-sender [`SessionRegistry`]: a turn runs on the caller's own session (so
+    /// its streamed events come back there, to be unicast to only this caller);
+    /// `SubscribeConversations` is pinned to that session too (#367); everything
+    /// else uses the shared connection. The registry's
+    /// [`route`](SessionRegistry::route) makes that decision in one place, so the
+    /// typed methods and the generic Commands channel route identically. Without a
+    /// registry (unit tests) the command falls back to the shared transport.
+    /// `caller` is the D-Bus sender's unique bus name from the message header.
+    async fn dispatch_routed(
         &self,
         caller: Option<&str>,
         cmd: api::Command,
@@ -157,7 +160,7 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         // SendMessage returns an immediate Ack/SendMessageAck; a daemon refusal
         // before streaming surfaces here as the mapped transport error.
         let result = self
-            .dispatch_turn(
+            .dispatch_routed(
                 caller,
                 api::Command::SendMessage {
                     conversation_id: conversation_id.to_string(),
@@ -186,6 +189,33 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
             api::CommandResult::SendMessageAck { request_id, .. } => Ok(request_id),
             other => Err(fdo::Error::Failed(format!(
                 "unexpected SendMessage result: {other:?}"
+            ))),
+        }
+    }
+
+    /// Shared body for `SubscribeConversations` (#367): set-replace the set of
+    /// conversations this caller is viewing, **pinned to the caller's own
+    /// session**, so the daemon fans those conversations' turn events
+    /// (`UserMessageAdded` + the response stream, including turns this caller did
+    /// not initiate) back on that session — which the per-sender unicast forwarder
+    /// delivers to only this caller. An empty list unsubscribes from all.
+    /// Factored out (no header) so it is unit-testable; the `#[interface]` method
+    /// extracts `caller` and calls it.
+    async fn dispatch_subscribe_conversations(
+        &self,
+        caller: Option<&str>,
+        conversation_ids: Vec<String>,
+    ) -> fdo::Result<()> {
+        let result = self
+            .dispatch_routed(
+                caller,
+                api::Command::SubscribeConversations { conversation_ids },
+            )
+            .await?;
+        match result {
+            api::CommandResult::Ack => Ok(()),
+            other => Err(fdo::Error::Failed(format!(
+                "unexpected SubscribeConversations result: {other:?}"
             ))),
         }
     }
@@ -477,6 +507,24 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         .await
     }
 
+    /// Set-replace the conversations this caller is viewing, for live
+    /// multi-client sync (#367). The daemon fans these conversations' turn events
+    /// back on the caller's per-sender session — including turns it did NOT
+    /// initiate (a voice turn, or another client) — delivered as
+    /// `UserMessageAdded` + `ResponseChunk`/`ResponseComplete`/`ResponseError`
+    /// signals unicast to this caller. Send the WHOLE set each time it changes
+    /// (open/switch/close); an empty list unsubscribes from all. A caller still
+    /// receives turns it drives itself regardless of this set.
+    async fn subscribe_conversations(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        conversation_ids: Vec<String>,
+    ) -> fdo::Result<()> {
+        let caller = hdr.sender().map(|s| s.as_str());
+        self.dispatch_subscribe_conversations(caller, conversation_ids)
+            .await
+    }
+
     /// Signal emitted for each chunk of a streaming response.
     /// Body is forwarded by [`super::event_forwarder`] from
     /// `Event::AssistantDelta`.
@@ -506,6 +554,29 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         conversation_id: &str,
         request_id: &str,
         error: &str,
+    ) -> zbus::Result<()>;
+
+    /// Signal emitted when a user message is committed and a turn starts in a
+    /// conversation this caller is viewing (via `SubscribeConversations`) —
+    /// including turns this caller did NOT initiate. Forwarded from
+    /// `Event::UserMessageAdded`; the initiator dedupes on `request_id` (#367).
+    #[zbus(signal)]
+    async fn user_message_added(
+        emitter: &SignalEmitter<'_>,
+        conversation_id: &str,
+        request_id: &str,
+        content: &str,
+    ) -> zbus::Result<()>;
+
+    /// Signal emitted when the user's conversation list changed
+    /// (created/renamed/deleted/(un)archived) by any client or the voice daemon.
+    /// Broadcast to every D-Bus client so sidebars refresh; carries only the
+    /// affected `conversation_id` (clients re-fetch the list). Forwarded from
+    /// `Event::ConversationListChanged` (#367).
+    #[zbus(signal)]
+    async fn conversation_list_changed(
+        emitter: &SignalEmitter<'_>,
+        conversation_id: &str,
     ) -> zbus::Result<()>;
 }
 
@@ -1043,6 +1114,56 @@ mod tests {
             }
             other => panic!("expected SendMessage, got {other:?}"),
         }
+    }
+
+    // --- subscribe_conversations (#367) ---------------------------------------
+
+    #[tokio::test]
+    async fn subscribe_conversations_builds_set_replace_command() {
+        // The bridge forwards the WHOLE viewed-set verbatim — the daemon does the
+        // set-replace. (Routing to the caller's session is covered in session.rs;
+        // with no registry wired here it falls back to the shared transport, which
+        // is enough to assert the command the adapter builds.)
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .dispatch_subscribe_conversations(Some(":1.10"), vec!["c1".into(), "c2".into()])
+            .await
+            .unwrap();
+        match only_command(&t).await {
+            api::Command::SubscribeConversations { conversation_ids } => {
+                assert_eq!(conversation_ids, vec!["c1".to_string(), "c2".to_string()]);
+            }
+            other => panic!("expected SubscribeConversations, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_conversations_empty_list_is_forwarded_as_unsubscribe() {
+        // An empty set is the documented "unsubscribe from all"; it must still be
+        // forwarded (not dropped) so the daemon clears the viewed-set.
+        let t = Arc::new(CannedTransport::new(api::CommandResult::Ack));
+        DbusConversationsAdapter::new(Arc::clone(&t))
+            .dispatch_subscribe_conversations(Some(":1.10"), vec![])
+            .await
+            .unwrap();
+        assert!(matches!(
+            only_command(&t).await,
+            api::Command::SubscribeConversations { conversation_ids } if conversation_ids.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn subscribe_conversations_errors_on_unexpected_result_variant() {
+        // A non-Ack result is a contract violation and must surface as an error,
+        // not be swallowed.
+        let t = Arc::new(CannedTransport::new(api::CommandResult::ConversationId {
+            id: "x".into(),
+        }));
+        let err = DbusConversationsAdapter::new(Arc::clone(&t))
+            .dispatch_subscribe_conversations(Some(":1.10"), vec!["c1".into()])
+            .await
+            .expect_err("a non-Ack SubscribeConversations result must error");
+        assert!(matches!(err, fdo::Error::Failed(_)));
     }
 
     // -------------------------------------------------------------------------

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -5,16 +5,18 @@
 //! the matching object path on a [`zbus::Connection`]. Translation mirrors the
 //! in-process daemon's signal vocabulary one-for-one:
 //!
-//! | Signal event       | D-Bus signal                              |
-//! | ------------------ | ----------------------------------------- |
-//! | `Chunk`            | `Conversations.ResponseChunk`             |
-//! | `Complete`         | `Conversations.ResponseComplete`          |
-//! | `Error`            | `Conversations.ResponseError`             |
-//! | `TaskStarted`      | `BackgroundTasks.TaskStarted` (#116)      |
-//! | `TaskProgress`     | `BackgroundTasks.TaskProgress` (#116)     |
-//! | `TaskLogAppended`  | `BackgroundTasks.TaskLogAppended` (#116)  |
-//! | `TaskCompleted`    | `BackgroundTasks.TaskCompleted` (#116)    |
-//! | other              | dropped (see #367 for the parity follow-up)|
+//! | Signal event            | D-Bus signal                                   |
+//! | ----------------------- | ---------------------------------------------- |
+//! | `Chunk`                 | `Conversations.ResponseChunk`                  |
+//! | `Complete`              | `Conversations.ResponseComplete`               |
+//! | `Error`                 | `Conversations.ResponseError`                  |
+//! | `UserMessageAdded`      | `Conversations.UserMessageAdded` (#367)        |
+//! | `ConversationListChanged`| `Conversations.ConversationListChanged` (#367)|
+//! | `TaskStarted`           | `BackgroundTasks.TaskStarted` (#116)           |
+//! | `TaskProgress`          | `BackgroundTasks.TaskProgress` (#116)          |
+//! | `TaskLogAppended`       | `BackgroundTasks.TaskLogAppended` (#116)       |
+//! | `TaskCompleted`         | `BackgroundTasks.TaskCompleted` (#116)         |
+//! | other                   | dropped (Status/ContextUsage/Title; #320 tools)|
 //!
 //! `Settings.ConfigChanged` is **not** forwarded here: the decoded
 //! [`SignalEvent`] stream carries no config event, and the bridge's
@@ -72,6 +74,21 @@ pub enum ForwardAction {
         request_id: String,
         error: String,
     },
+    /// A user message was committed and a turn started in a conversation the
+    /// recipient is viewing (#367). Unicast to a per-sender session: it arrives
+    /// via that session's `SubscribeConversations` fan-out — including turns the
+    /// recipient did NOT initiate (a voice turn, or another client) — so a client
+    /// can render the user bubble live. The initiator dedupes on `request_id`.
+    UserMessageAdded {
+        conversation_id: String,
+        request_id: String,
+        content: String,
+    },
+    /// The user's conversation list changed — created/renamed/deleted/(un)archived
+    /// by any client or the voice daemon (#367). Broadcast on the shared per-user
+    /// stream so every D-Bus client refreshes its sidebar; carries only the
+    /// affected `conversation_id` (clients re-fetch the list).
+    ConversationListChanged { conversation_id: String },
     /// Task is now `Pending`/`Running`. `task` is the JSON-keyed `TaskView`
     /// encoded as `a{sv}`.
     TaskStarted {
@@ -97,6 +114,31 @@ pub enum ForwardAction {
     /// these to D-Bus (UserMessageAdded / ConversationListChanged / …) for full
     /// UDS/WS parity is the #367 follow-up.
     Ignored { kind: &'static str },
+}
+
+impl ForwardAction {
+    /// Whether this action belongs on the per-user **broadcast** stream (the
+    /// shared connection, `destination = None`) rather than a per-sender
+    /// **unicast** session stream. `Task*` and `ConversationListChanged` ride the
+    /// daemon's per-user broadcast (the `SubscribeBackgroundTasks` tap the shared
+    /// connection holds); the response stream and `UserMessageAdded` are
+    /// per-conversation fan-out delivered to a session's own connection.
+    ///
+    /// Used by [`run_unicast`] to defensively skip any broadcast-class action: a
+    /// per-sender session never *should* receive one (it holds no
+    /// `SubscribeBackgroundTasks`), but if daemon delivery ever changed, this
+    /// keeps a list-change from being re-emitted once per session on top of the
+    /// shared broadcast.
+    fn is_broadcast(&self) -> bool {
+        matches!(
+            self,
+            ForwardAction::TaskStarted { .. }
+                | ForwardAction::TaskProgress { .. }
+                | ForwardAction::TaskLogAppended { .. }
+                | ForwardAction::TaskCompleted { .. }
+                | ForwardAction::ConversationListChanged { .. }
+        )
+    }
 }
 
 /// Pure translator: one signal event → a D-Bus action. Sync / no-side-effects so
@@ -130,6 +172,21 @@ pub fn translate(event: SignalEvent) -> ForwardAction {
             request_id,
             error,
         },
+        // #367: forwarded for full UDS/WS parity. `UserMessageAdded` reaches a
+        // per-sender session via its `SubscribeConversations` fan-out (unicast);
+        // `ConversationListChanged` rides the shared per-user broadcast.
+        SignalEvent::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        } => ForwardAction::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        },
+        SignalEvent::ConversationListChanged { conversation_id } => {
+            ForwardAction::ConversationListChanged { conversation_id }
+        }
         SignalEvent::TaskStarted { task } => {
             let id = task.id.0.clone();
             ForwardAction::TaskStarted {
@@ -154,10 +211,9 @@ pub fn translate(event: SignalEvent) -> ForwardAction {
             status: task_status_str(status).to_string(),
             last_error: last_error.unwrap_or_default(),
         },
-        // --- deliberately not forwarded in v1 (see the module docs + #367) ---
-        SignalEvent::UserMessageAdded { .. } => ForwardAction::Ignored {
-            kind: "user_message_added",
-        },
+        // --- not (yet) forwarded: no D-Bus signal for these. Status/ContextUsage/
+        // TitleChanged are richer-parity follow-ups; ClientToolCall is #320;
+        // recorded as a deliberate ignore rather than a missed translation. ---
         SignalEvent::Status { .. } => ForwardAction::Ignored {
             kind: "assistant_status",
         },
@@ -166,9 +222,6 @@ pub fn translate(event: SignalEvent) -> ForwardAction {
         },
         SignalEvent::TitleChanged { .. } => ForwardAction::Ignored {
             kind: "conversation_title_changed",
-        },
-        SignalEvent::ConversationListChanged { .. } => ForwardAction::Ignored {
-            kind: "conversation_list_changed",
         },
         SignalEvent::ConversationWarning { .. } => ForwardAction::Ignored {
             kind: "conversation_warning",
@@ -294,7 +347,18 @@ pub async fn run_unicast(connector: Arc<Connector>, connection: Connection, dest
                 );
                 events = connector.subscribe();
             }
-            Some(event) => emit(&connection, Some(&destination), translate(event)).await,
+            Some(event) => {
+                let action = translate(event);
+                if action.is_broadcast() {
+                    // A per-sender session holds no `SubscribeBackgroundTasks`, so
+                    // it should never receive a broadcast-class event; if it ever
+                    // did, the shared forwarder already broadcasts it — don't also
+                    // unicast a duplicate to this one sender.
+                    debug!("unicast forwarder for {destination}: skipping broadcast-class action");
+                } else {
+                    emit(&connection, Some(&destination), action).await;
+                }
+            }
             None => events = connector.subscribe(),
         }
     }
@@ -363,6 +427,40 @@ async fn emit(connection: &Connection, destination: Option<&str>, action: Forwar
                 .await
             {
                 warn!("response_error emit failed: {e}");
+            }
+        }
+        ForwardAction::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        } => {
+            let body = (conversation_id, request_id, content);
+            if let Err(e) = connection
+                .emit_signal::<&str, _, _, _, _>(
+                    destination,
+                    paths::CONVERSATIONS,
+                    CONV_INTERFACE,
+                    "UserMessageAdded",
+                    &body,
+                )
+                .await
+            {
+                warn!("user_message_added emit failed: {e}");
+            }
+        }
+        ForwardAction::ConversationListChanged { conversation_id } => {
+            let body = (conversation_id,);
+            if let Err(e) = connection
+                .emit_signal::<&str, _, _, _, _>(
+                    destination,
+                    paths::CONVERSATIONS,
+                    CONV_INTERFACE,
+                    "ConversationListChanged",
+                    &body,
+                )
+                .await
+            {
+                warn!("conversation_list_changed emit failed: {e}");
             }
         }
         ForwardAction::TaskStarted { id, task } => {
@@ -445,5 +543,73 @@ fn task_status_str(status: api::TaskStatus) -> &'static str {
         api::TaskStatus::Completed => "completed",
         api::TaskStatus::Failed => "failed",
         api::TaskStatus::Cancelled => "cancelled",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_broadcast_separates_per_user_stream_from_per_session_fanout() {
+        // Per-user BROADCAST stream (rides the shared connection's
+        // SubscribeBackgroundTasks): Task* + ConversationListChanged.
+        assert!(
+            ForwardAction::ConversationListChanged {
+                conversation_id: "c".into()
+            }
+            .is_broadcast()
+        );
+        assert!(
+            ForwardAction::TaskProgress {
+                id: "t".into(),
+                hint: String::new()
+            }
+            .is_broadcast()
+        );
+        assert!(
+            ForwardAction::TaskCompleted {
+                id: "t".into(),
+                status: "completed".into(),
+                last_error: String::new(),
+            }
+            .is_broadcast()
+        );
+
+        // Per-conversation fan-out (delivered to a per-sender session, UNICAST):
+        // the response stream + UserMessageAdded must NOT be classed broadcast, or
+        // `run_unicast` would drop them and a viewer would see no live turn.
+        assert!(
+            !ForwardAction::UserMessageAdded {
+                conversation_id: "c".into(),
+                request_id: "r".into(),
+                content: "hi".into(),
+            }
+            .is_broadcast()
+        );
+        assert!(
+            !ForwardAction::ResponseChunk {
+                conversation_id: "c".into(),
+                request_id: "r".into(),
+                chunk: "x".into(),
+            }
+            .is_broadcast()
+        );
+        assert!(
+            !ForwardAction::ResponseComplete {
+                conversation_id: "c".into(),
+                request_id: "r".into(),
+                full_response: "x".into(),
+            }
+            .is_broadcast()
+        );
+        assert!(
+            !ForwardAction::ResponseError {
+                conversation_id: "c".into(),
+                request_id: "r".into(),
+                error: "x".into(),
+            }
+            .is_broadcast()
+        );
     }
 }

--- a/crates/dbus-bridge/src/session.rs
+++ b/crates/dbus-bridge/src/session.rs
@@ -46,6 +46,17 @@ pub fn is_turn_driving(command: &api::Command) -> bool {
     matches!(command, api::Command::SendMessage { .. })
 }
 
+/// Whether `command` registers **per-connection** state that only has meaning on
+/// the caller's own session — currently `SubscribeConversations` (the live-sync
+/// viewed-set; #367), and post-#320 the client-tool registration/result. Unlike a
+/// turn (which can fall back to the shared connection for a caller-less message),
+/// a session-pinned command with no identifiable caller is rejected: routing it
+/// to the shared connection would let one D-Bus caller's subscription capture or
+/// broadcast every other caller's fan-out (#270 / DT-4).
+pub fn is_session_pinned(command: &api::Command) -> bool {
+    matches!(command, api::Command::SubscribeConversations { .. })
+}
+
 /// One D-Bus sender's private daemon session: the transport its commands
 /// dispatch through, plus the handle of the unicast forwarder pumping that
 /// session's events to the sender. Dropping it aborts the forwarder (and, with
@@ -198,9 +209,26 @@ impl SessionRegistry {
         command: api::Command,
         fallback: &dyn BridgeTransport,
     ) -> Result<api::CommandResult, BridgeTransportError> {
+        // Turn-driving: run on the caller's own session so its streamed events
+        // come back on that session (to be unicast). A caller-less turn (no bus
+        // sender — not expected on a real bus) falls back to the shared
+        // connection, preserving prior behaviour.
         if is_turn_driving(&command)
             && let Some(sender) = caller
         {
+            return self.session_for(sender).await?.request(command).await;
+        }
+        // Session-pinned: registers per-connection state that only has meaning on
+        // the caller's own session. With no identifiable caller, reject rather
+        // than fall back to the shared connection — a shared subscription would
+        // capture or broadcast every caller's fan-out (#270).
+        if is_session_pinned(&command) {
+            let sender = caller.ok_or_else(|| {
+                BridgeTransportError::Daemon(
+                    "a session-scoped command requires a D-Bus sender (none on the message)"
+                        .to_string(),
+                )
+            })?;
             return self.session_for(sender).await?.request(command).await;
         }
         fallback.request(command).await
@@ -497,6 +525,66 @@ mod tests {
             fallback.commands.lock().unwrap().len(),
             2,
             "a caller-less turn falls back to the shared connection"
+        );
+    }
+
+    fn subscribe(convs: &[&str]) -> api::Command {
+        api::Command::SubscribeConversations {
+            conversation_ids: convs.iter().map(|c| c.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn is_session_pinned_is_subscribe_conversations_only() {
+        assert!(is_session_pinned(&subscribe(&["c1"])));
+        // A turn is routed via is_turn_driving (which has a caller-less shared
+        // fallback), NOT pinned; stateless commands are neither.
+        assert!(!is_session_pinned(&send_message("c1")));
+        assert!(!is_session_pinned(&api::Command::Ping));
+    }
+
+    #[tokio::test]
+    async fn route_pins_session_scoped_commands_and_rejects_caller_less() {
+        let factory = Arc::new(FakeFactory::default());
+        let registry = registry_with(Arc::clone(&factory));
+        let fallback = Arc::new(RecordingTransport::default());
+
+        // SubscribeConversations with a known caller → that caller's own session,
+        // never the shared connection (a shared sub would capture every caller's
+        // fan-out — the #270 hazard).
+        registry
+            .route(Some(":1.10"), subscribe(&["c1"]), fallback.as_ref())
+            .await
+            .unwrap();
+        assert!(
+            fallback.commands.lock().unwrap().is_empty(),
+            "a subscription must not ride the shared connection"
+        );
+        {
+            let transports = factory.transports.lock().unwrap();
+            assert!(matches!(
+                transports[":1.10"].commands.lock().unwrap().as_slice(),
+                [api::Command::SubscribeConversations { .. }]
+            ));
+        }
+
+        // Caller-less session-pinned command → rejected, and crucially NOT routed
+        // to the shared connection (which would broadcast its fan-out).
+        let err = registry
+            .route(None, subscribe(&["c2"]), fallback.as_ref())
+            .await;
+        assert!(
+            err.is_err(),
+            "a caller-less session-scoped command must be rejected"
+        );
+        assert!(
+            fallback.commands.lock().unwrap().is_empty(),
+            "and must not fall back to the shared connection"
+        );
+        assert_eq!(
+            registry.len(),
+            1,
+            "the rejected caller-less command must add no session (only :1.10's remains)"
         );
     }
 

--- a/crates/dbus-bridge/tests/bridge.rs
+++ b/crates/dbus-bridge/tests/bridge.rs
@@ -205,19 +205,11 @@ fn translate_covers_streaming_response_variants() {
 
 #[test]
 fn translate_marks_unforwarded_variants_explicitly() {
-    // Variants not yet surfaced as D-Bus signals must hit `Ignored` with a
-    // stable kind, so the #367 follow-up (full UDS/WS parity) is a deliberate,
-    // visible step rather than silent drift. Task* variants are forwarded and
-    // covered in `tests/background_tasks.rs`.
+    // Variants with no D-Bus signal must hit `Ignored` with a stable kind, so a
+    // future parity step is deliberate rather than silent drift. (UserMessageAdded
+    // + ConversationListChanged ARE now forwarded — see the next test. Task*
+    // variants are forwarded and covered in `tests/background_tasks.rs`.)
     let cases: Vec<(SignalEvent, &str)> = vec![
-        (
-            SignalEvent::UserMessageAdded {
-                conversation_id: "c".into(),
-                request_id: "r".into(),
-                content: "hi".into(),
-            },
-            "user_message_added",
-        ),
         (
             SignalEvent::Status {
                 conversation_id: "c".into(),
@@ -243,12 +235,6 @@ fn translate_marks_unforwarded_variants_explicitly() {
             },
             "context_usage",
         ),
-        (
-            SignalEvent::ConversationListChanged {
-                conversation_id: "c".into(),
-            },
-            "conversation_list_changed",
-        ),
     ];
     for (event, expected_kind) in cases {
         match translate(event) {
@@ -256,6 +242,27 @@ fn translate_marks_unforwarded_variants_explicitly() {
             other => panic!("expected Ignored {expected_kind}, got {other:?}"),
         }
     }
+}
+
+#[test]
+fn translate_forwards_user_message_added_and_conversation_list_changed() {
+    // #367: both are now real D-Bus signals on Conversations, carrying their
+    // payload through verbatim.
+    assert!(matches!(
+        translate(SignalEvent::UserMessageAdded {
+            conversation_id: "c".into(),
+            request_id: "r".into(),
+            content: "hi".into(),
+        }),
+        ForwardAction::UserMessageAdded { conversation_id, request_id, content }
+            if conversation_id == "c" && request_id == "r" && content == "hi"
+    ));
+    assert!(matches!(
+        translate(SignalEvent::ConversationListChanged {
+            conversation_id: "c".into(),
+        }),
+        ForwardAction::ConversationListChanged { conversation_id } if conversation_id == "c"
+    ));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dbus-bridge/tests/introspection.rs
+++ b/crates/dbus-bridge/tests/introspection.rs
@@ -9,18 +9,30 @@
 //! canonicalizes its introspection XML down to a sorted set of signature lines,
 //! and asserts it matches the committed golden for that interface.
 //!
-//! ## Where the goldens come from (and why that makes this a real gate)
+//! ## Where the goldens come from (and why this is a real gate)
 //!
-//! The goldens under `tests/goldens/*.canon` are the *canonicalized live
-//! surface*, captured from a running daemon — not a snapshot of the bridge
-//! against itself. They are therefore authoritative: a divergence is a genuine
-//! parity bug in the bridge, not drift in the test. Two documented intentional
-//! drops are removed from the captured Settings surface (`Q2_DROPS`): the
-//! legacy `Get/SetLlmSettings` (superseded by named connections) and
-//! `GenerateWsJwt` (JWT minting is off D-Bus entirely — #281).
+//! The goldens under `tests/goldens/*.canon` are the *canonicalized live surface*
+//! captured from the original in-process daemon — the frozen, KDE-facing **parity
+//! floor**. They are authoritative and intentionally NOT regenerated: the
+//! in-process `dbus-interface` was deleted in #319, so there is no surface left
+//! to re-capture, and re-freezing from the bridge itself would let a dropped
+//! member (a KDE regression) silently re-baseline. Two documented intentional
+//! drops are removed from the captured Settings surface (`Q2_DROPS`): the legacy
+//! `Get/SetLlmSettings` (superseded by named connections) and `GenerateWsJwt`
+//! (JWT minting is off D-Bus entirely — #281).
 //!
-//! Re-capture only when the frozen surface legitimately changes (before #319
-//! deletes `dbus-interface`):
+//! The gate checks two things, NOT byte-equality:
+//!   1. **No floor regression** — every golden member is still present on the
+//!      bridge (a missing one would break adele-kde).
+//!   2. **No undeclared additions** — any member the bridge exposes beyond the
+//!      floor must be listed in [`ADDITIONS`] with its issue. Post-cutover the
+//!      bridge legitimately grows a superset (e.g. #367's live-sync signals +
+//!      `SubscribeConversations`); each addition is declared so the surface can't
+//!      change silently.
+//!
+//! The capture recipe below built the original floor (pre-#319). It now targets
+//! the bridge's own name, so do NOT re-run it to "update" the floor — add new
+//! members to [`ADDITIONS`] instead.
 //!
 //! ```text
 //! mkdir -p /tmp/live-xml
@@ -67,6 +79,27 @@ const Q2_DROPS: &[(&str, &str)] = &[
     ("org.desktopAssistant.Settings", "GetLlmSettings"),
     ("org.desktopAssistant.Settings", "SetLlmSettings"),
     ("org.desktopAssistant.Settings", "GenerateWsJwt"),
+];
+
+/// Post-cutover **superset** members the bridge adds beyond the frozen floor.
+/// Each is declared with its issue so the gate treats it as an intentional
+/// addition rather than drift; everything else must still match the floor exactly
+/// (no silent surface changes). Values are canonical member lines, exactly as
+/// [`canonicalize`] emits them (see an existing `.canon` golden for the format).
+const ADDITIONS: &[(&str, &str)] = &[
+    // #367 — live multi-client sync over D-Bus.
+    (
+        "org.desktopAssistant.Conversations",
+        "method SubscribeConversations(in:as:conversation_ids)",
+    ),
+    (
+        "org.desktopAssistant.Conversations",
+        "signal UserMessageAdded(:s:conversation_id, :s:request_id, :s:content)",
+    ),
+    (
+        "org.desktopAssistant.Conversations",
+        "signal ConversationListChanged(:s:conversation_id)",
+    ),
 ];
 
 // --- fake transport ---------------------------------------------------------
@@ -240,25 +273,11 @@ fn golden_path(label: &str) -> PathBuf {
         .join(format!("{label}.canon"))
 }
 
-/// Human-readable symmetric difference of two canonical surfaces.
-fn line_diff(want: &str, got: &str) -> String {
-    use std::collections::BTreeSet;
-    let want_set: BTreeSet<&str> = want.lines().collect();
-    let got_set: BTreeSet<&str> = got.lines().collect();
-    let mut out = String::new();
-    for l in want_set.difference(&got_set) {
-        out.push_str(&format!("  - missing on bridge: {l}\n"));
-    }
-    for l in got_set.difference(&want_set) {
-        out.push_str(&format!("  + extra on bridge:   {l}\n"));
-    }
-    out
-}
-
 // --- the gate ---------------------------------------------------------------
 
 #[test]
 fn bridge_matches_live_golden() {
+    use std::collections::BTreeSet;
     let mut failures = Vec::new();
     for (label, iface) in PARITY {
         let got = canonicalize(&bridge_introspection(iface), iface);
@@ -267,23 +286,58 @@ fn bridge_matches_live_golden() {
             Ok(s) => s.trim_end().to_string(),
             Err(e) => {
                 failures.push(format!(
-                    "missing golden for {iface} at {} ({e}); regenerate with capture_goldens_from_live",
+                    "missing golden for {iface} at {} ({e}); see the capture recipe in the module docs",
                     path.display()
                 ));
                 continue;
             }
         };
-        if got != want {
-            failures.push(format!(
-                "interface {iface} diverged from the frozen live surface ({}):\n{}",
-                path.display(),
-                line_diff(&want, &got)
-            ));
+        let want_set: BTreeSet<&str> = want.lines().collect();
+        let got_set: BTreeSet<&str> = got.lines().collect();
+        let additions: BTreeSet<&str> = ADDITIONS
+            .iter()
+            .filter(|(i, _)| i == iface)
+            .map(|(_, m)| *m)
+            .collect();
+
+        // 1. No floor regression: every frozen member must still be present.
+        let missing: Vec<&str> = want_set.difference(&got_set).copied().collect();
+        // 2. No undeclared additions: any extra member must be in ADDITIONS.
+        let undeclared: Vec<&str> = got_set
+            .difference(&want_set)
+            .copied()
+            .filter(|l| !additions.contains(l))
+            .collect();
+        // 3. No stale declarations: an ADDITIONS entry the bridge no longer
+        //    exposes is dead weight — flag it so the list stays honest.
+        let stale: Vec<&str> = additions.difference(&got_set).copied().collect();
+
+        if !missing.is_empty() || !undeclared.is_empty() || !stale.is_empty() {
+            let mut msg = format!(
+                "interface {iface} diverged from the frozen floor ({}):\n",
+                path.display()
+            );
+            for l in &missing {
+                msg.push_str(&format!(
+                    "  - missing on bridge (KDE-facing floor regression): {l}\n"
+                ));
+            }
+            for l in &undeclared {
+                msg.push_str(&format!(
+                    "  + undeclared addition (add to ADDITIONS with its issue, or remove from the bridge): {l}\n"
+                ));
+            }
+            for l in &stale {
+                msg.push_str(&format!(
+                    "  ! stale ADDITIONS entry (bridge no longer exposes it — delete the entry): {l}\n"
+                ));
+            }
+            failures.push(msg);
         }
     }
     assert!(
         failures.is_empty(),
-        "D-Bus introspection parity gate failed (#315):\n\n{}",
+        "D-Bus introspection parity gate failed (#315/#367):\n\n{}",
         failures.join("\n\n")
     );
 }


### PR DESCRIPTION
## What & why

B1 (#374) gave each D-Bus sender its own daemon session + a unicast forwarder. This wires the **live multi-client sync** surface on top, so a turn driven by one client appears live in every client *viewing* the same conversation — the D-Bus equivalent of what UDS/WS clients already get (#355–357).

This is the **bridge/daemon side of #367**. Its protocol acceptance — "a D-Bus client sees live cross-client messages + conversation-list changes identically to a UDS/WS client" — is demonstrated by the live test below. The remaining #367 scope item (adele-kde subscribing + rendering) lands separately.

## How

- **`session.rs`** — `is_session_pinned` (`SubscribeConversations`) + `route()` now pins it to the caller's own session, **rejecting** a caller-less one rather than leaking it onto the shared connection (the #270 hazard). Unlike a turn (which keeps a caller-less shared fallback), a session-pinned command has no meaning on the shared connection.
- **`event_forwarder.rs`** — translate `UserMessageAdded` + `ConversationListChanged` (were `Ignored`) into two new `Conversations` signals.
  - `UserMessageAdded` reaches a per-sender session via its `SubscribeConversations` fan-out → **unicast** to that caller.
  - `ConversationListChanged` rides the shared **per-user broadcast** (the daemon's `notify_conversation_list_changed` lands on the `SubscribeBackgroundTasks` tap the shared connection holds).
  - An `is_broadcast()` classifier lets `run_unicast` defensively skip any broadcast-class event, so a list-change can't be re-emitted once per session *on top of* the broadcast.
- **`conversations.rs`** — typed `SubscribeConversations` method (KDE uses typed methods) + the two `#[zbus(signal)]` declarations; `dispatch_turn` generalised to `dispatch_routed` (it now also carries the session-pinned subscribe through the registry).
- **`commands.rs`** — stop rejecting `SubscribeConversations` on the generic channel (tui/gtk over `--transport dbus`); it routes per-sender like the typed method. `RegisterClientTools`/`ClientToolResult` stay rejected → #320.
- **introspection gate** — the in-process surface the goldens were captured from is gone (#319), so the goldens are now the frozen, KDE-facing parity **floor**. The gate enforces *no floor regression* + *no undeclared additions* (`ADDITIONS` lists the three new members with their issue) + *no stale declarations*, instead of byte-equality.

## Testing (spec-driven, with edge cases)

- `route` pins `SubscribeConversations` and **rejects a caller-less one** (creating no session — no silent shared fallback);
- `is_session_pinned` and `is_broadcast` contracts (the latter is the crux of no-double-emit);
- `translate` forwards both events with their payload intact;
- the typed method builds the set-replace command, treats an **empty list as unsubscribe**, and **errors on a non-Ack** result;
- the generic channel no longer rejects `SubscribeConversations`;
- full bridge suite + the rebuilt introspection gate green; `clippy -D warnings` + `cargo fmt --check` clean; full-workspace `just check` green (daemon up).

**Live-verified** over a side-by-side bridge: two independent bus connections → two daemon sessions. Connection **A** subscribed to a conversation; connection **B** drove a real turn in it. A (which did **not** drive the turn) received B's `UserMessageAdded` ("Reply with exactly: hello there") + the response stream (`ResponseChunk` → `ResponseComplete` = "hello there") **and** a `ConversationListChanged` from B's rename — #367's acceptance, on a live bus.

## Scope

- **In:** the two new signals + per-sender `SubscribeConversations` routing (typed method + generic channel).
- **Next:** **adele-kde** subscribes + renders live cross-client messages/sidebar (the remaining #367 item); client tools over D-Bus is **#320** (`RegisterClientTools`/`ClientToolResult` still rejected here).

Refs #367 (delivers its D-Bus signals + per-sender `SubscribeConversations`; adele-kde rendering completes it). Builds on #374 (B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
