### PR TITLE
Client tools over D-Bus: unicast ClientToolCall + per-sender Register/Result routing (#320)

### DIFF
--- a/crates/dbus-bridge/src/adapter/commands.rs
+++ b/crates/dbus-bridge/src/adapter/commands.rs
@@ -10,32 +10,25 @@
 //! through this one method. This adapter restores that parity over the bridge's
 //! UDS connection: `command_json` in, `api::CommandResult` JSON out.
 //!
-//! ## Routing and why some commands are still rejected here
+//! ## Routing and why background-task subscriptions are rejected here
 //!
-//! Turn-driving (`SendMessage`) and session-pinned (`SubscribeConversations`)
-//! commands route through the **caller's own per-sender daemon session**
-//! ([`crate::session`]) — keyed by the D-Bus sender on the message header — so a
-//! turn's events come back on that session and a subscription's fan-out is
-//! isolated to that caller. Stateless request/response uses the bridge's shared
-//! session. A few commands still assume a private, persistent, per-caller
-//! *streaming* channel that a one-shot D-Bus method cannot provide, so they are
-//! rejected up front with `NotSupported` rather than silently mis-served:
+//! Turn-driving (`SendMessage`) and session-pinned commands —
+//! `SubscribeConversations` (#367) and `RegisterClientTools` / `ClientToolResult`
+//! (#320) — route through the **caller's own per-sender daemon session**
+//! ([`crate::session`]), keyed by the D-Bus sender on the message header. So a
+//! turn's events come back on that session, a subscription's fan-out is isolated
+//! to that caller, and a registered tool's `ClientToolCall` unicasts back to the
+//! registrant. Stateless request/response uses the bridge's shared session.
 //!
-//! - **`SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks`** — set up a
-//!   streaming push of `Event::Task*` frames for the lifetime of a connection.
-//!   A one-shot D-Bus method cannot push events; the bridge holds its own
-//!   background-task subscription open and re-emits them as
-//!   `BackgroundTasks.*` signals instead (see `main.rs`). Mirrors the
-//!   in-process adapter's rejection (`dbus-interface/src/commands.rs`).
-//! - **`RegisterClientTools` / `ClientToolResult`** — the #270 / DT-4 hazard.
-//!   The per-sender session machinery (B1) now makes safe routing *possible*,
-//!   but wiring it — registering tools on the caller's session and delivering
-//!   the resulting tool call as a unicast `ClientToolCall` signal — is #320.
-//!   Until then, reject both rather than wedge a turn on a tool call that has
-//!   no D-Bus signal to be delivered on.
+//! Only the background-task subscriptions are rejected, because they set up a
+//! streaming push for the lifetime of a connection that a one-shot D-Bus method
+//! cannot provide:
 //!
-//! A client that needs working client-side tools today should use a socket
-//! transport (WS/UDS), which already gives each client its own session.
+//! - **`SubscribeBackgroundTasks` / `UnsubscribeBackgroundTasks`** — a one-shot
+//!   D-Bus method cannot push the `Event::Task*` frame stream they request; the
+//!   bridge holds its own background-task subscription open and re-emits them as
+//!   `BackgroundTasks.*` signals instead (see `main.rs`). Rejected up front with
+//!   `NotSupported` rather than silently mis-served.
 
 use std::sync::Arc;
 
@@ -66,14 +59,11 @@ fn reject_reason(command: &api::Command) -> Option<&'static str> {
              BackgroundTasks signals, or use a socket transport (WS/UDS) and \
              Command::SubscribeBackgroundTasks for the live stream",
         ),
-        // NOTE: `SubscribeConversations` is intentionally NOT rejected — it routes
-        // to the caller's per-sender session (#367, see the module docs and
-        // `crate::session::route`), so each caller's viewed-set is isolated.
-        api::Command::RegisterClientTools { .. } | api::Command::ClientToolResult { .. } => Some(
-            "client-tool registration is not yet available over D-Bus: routing onto per-sender \
-             sessions and delivering the resulting tool call as a ClientToolCall signal is #320; \
-             until then use a socket transport (WS/UDS)",
-        ),
+        // NOTE: `SubscribeConversations` (#367) and `RegisterClientTools` /
+        // `ClientToolResult` (#320) are intentionally NOT rejected — they route to
+        // the caller's per-sender session (see the module docs and
+        // `crate::session::route`), so each caller's viewed-set + tool bucket are
+        // isolated and the turn's `ClientToolCall` unicasts back to that caller.
         _ => None,
     }
 }
@@ -303,8 +293,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_client_tool_registration_and_result_before_dispatch() {
-        // The DT-4 / #270 hazard: never forward these onto the shared session.
+    async fn client_tool_commands_are_routed_not_rejected() {
+        // #320: RegisterClientTools + ClientToolResult now route to the caller's
+        // per-sender session instead of being rejected. With no registry wired
+        // (unit test) run_command falls back to the shared transport, so they
+        // reach the daemon — the regression guard for "we stopped rejecting them".
         let register = api::Command::RegisterClientTools { tools: vec![] };
         let result = api::Command::ClientToolResult {
             task_id: api::TaskId("t1".into()),
@@ -317,12 +310,15 @@ mod tests {
             let adapter = adapter(Arc::clone(&transport));
             let request = serde_json::to_string(&cmd).unwrap();
 
-            let err = adapter
-                .run_command(None, &request)
+            adapter
+                .run_command(Some(":1.10"), &request)
                 .await
-                .expect_err("client-tool commands must be rejected over D-Bus");
-            assert!(matches!(err, fdo::Error::NotSupported(_)), "got {err:?}");
-            assert_eq!(transport.count(), 0);
+                .expect("client-tool commands must no longer be rejected over D-Bus");
+            assert_eq!(
+                transport.count(),
+                1,
+                "it must reach the daemon (be routed), not be rejected"
+            );
         }
     }
 

--- a/crates/dbus-bridge/src/adapter/conversations.rs
+++ b/crates/dbus-bridge/src/adapter/conversations.rs
@@ -578,6 +578,22 @@ impl<T: BridgeTransport + 'static> DbusConversationsAdapter<T> {
         emitter: &SignalEmitter<'_>,
         conversation_id: &str,
     ) -> zbus::Result<()>;
+
+    /// Signal emitted when a turn suspends on a client-side tool call (#320),
+    /// **unicast** to the session that registered the tool. The client runs
+    /// `tool_name` with `arguments_json` (the tool input as a JSON string) and
+    /// posts the outcome back via a `ClientToolResult` command on the generic
+    /// `Commands` channel, carrying the same `task_id` + `tool_call_id`. Forwarded
+    /// from `Event::ClientToolCall`.
+    #[zbus(signal)]
+    async fn client_tool_call(
+        emitter: &SignalEmitter<'_>,
+        task_id: &str,
+        conversation_id: &str,
+        tool_call_id: &str,
+        tool_name: &str,
+        arguments_json: &str,
+    ) -> zbus::Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/dbus-bridge/src/adapter/event_forwarder.rs
+++ b/crates/dbus-bridge/src/adapter/event_forwarder.rs
@@ -12,11 +12,12 @@
 //! | `Error`                 | `Conversations.ResponseError`                  |
 //! | `UserMessageAdded`      | `Conversations.UserMessageAdded` (#367)        |
 //! | `ConversationListChanged`| `Conversations.ConversationListChanged` (#367)|
+//! | `ClientToolCall`        | `Conversations.ClientToolCall` (#320)          |
 //! | `TaskStarted`           | `BackgroundTasks.TaskStarted` (#116)           |
 //! | `TaskProgress`          | `BackgroundTasks.TaskProgress` (#116)          |
 //! | `TaskLogAppended`       | `BackgroundTasks.TaskLogAppended` (#116)       |
 //! | `TaskCompleted`         | `BackgroundTasks.TaskCompleted` (#116)         |
-//! | other                   | dropped (Status/ContextUsage/Title; #320 tools)|
+//! | other                   | dropped (Status/ContextUsage/Title/Warning/Scratch)|
 //!
 //! `Settings.ConfigChanged` is **not** forwarded here: the decoded
 //! [`SignalEvent`] stream carries no config event, and the bridge's
@@ -89,6 +90,18 @@ pub enum ForwardAction {
     /// stream so every D-Bus client refreshes its sidebar; carries only the
     /// affected `conversation_id` (clients re-fetch the list).
     ConversationListChanged { conversation_id: String },
+    /// A turn suspended on a client-side tool call (#320). Unicast to the session
+    /// that registered the tool (= the session driving the turn), so the caller
+    /// runs the tool and posts the outcome back via a `ClientToolResult` command
+    /// carrying the same `task_id` + `tool_call_id`. `arguments_json` is the tool
+    /// input serialized to JSON (the wire event carries a `serde_json::Value`).
+    ClientToolCall {
+        task_id: String,
+        conversation_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments_json: String,
+    },
     /// Task is now `Pending`/`Running`. `task` is the JSON-keyed `TaskView`
     /// encoded as `a{sv}`.
     TaskStarted {
@@ -187,6 +200,21 @@ pub fn translate(event: SignalEvent) -> ForwardAction {
         SignalEvent::ConversationListChanged { conversation_id } => {
             ForwardAction::ConversationListChanged { conversation_id }
         }
+        // #320: the turn suspended on a client tool. Unicast to the registrant's
+        // session; the args ride as a JSON string (the wire event is a Value).
+        SignalEvent::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => ForwardAction::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments_json: arguments.to_string(),
+        },
         SignalEvent::TaskStarted { task } => {
             let id = task.id.0.clone();
             ForwardAction::TaskStarted {
@@ -228,9 +256,6 @@ pub fn translate(event: SignalEvent) -> ForwardAction {
         },
         SignalEvent::ScratchpadChanged { .. } => ForwardAction::Ignored {
             kind: "scratchpad_changed",
-        },
-        SignalEvent::ClientToolCall { .. } => ForwardAction::Ignored {
-            kind: "client_tool_call",
         },
         // Control signal handled by `run` before it reaches `translate`; mapped
         // here only for match exhaustiveness.
@@ -463,6 +488,33 @@ async fn emit(connection: &Connection, destination: Option<&str>, action: Forwar
                 warn!("conversation_list_changed emit failed: {e}");
             }
         }
+        ForwardAction::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments_json,
+        } => {
+            let body = (
+                task_id,
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                arguments_json,
+            );
+            if let Err(e) = connection
+                .emit_signal::<&str, _, _, _, _>(
+                    destination,
+                    paths::CONVERSATIONS,
+                    CONV_INTERFACE,
+                    "ClientToolCall",
+                    &body,
+                )
+                .await
+            {
+                warn!("client_tool_call emit failed: {e}");
+            }
+        }
         ForwardAction::TaskStarted { id, task } => {
             let body = (id, task);
             if let Err(e) = connection
@@ -608,6 +660,18 @@ mod tests {
                 conversation_id: "c".into(),
                 request_id: "r".into(),
                 error: "x".into(),
+            }
+            .is_broadcast()
+        );
+        // #320: a tool call is unicast to the registrant — never broadcast (args
+        // can be sensitive).
+        assert!(
+            !ForwardAction::ClientToolCall {
+                task_id: "t".into(),
+                conversation_id: "c".into(),
+                tool_call_id: "tc".into(),
+                tool_name: "echo".into(),
+                arguments_json: "{}".into(),
             }
             .is_broadcast()
         );

--- a/crates/dbus-bridge/src/session.rs
+++ b/crates/dbus-bridge/src/session.rs
@@ -47,14 +47,21 @@ pub fn is_turn_driving(command: &api::Command) -> bool {
 }
 
 /// Whether `command` registers **per-connection** state that only has meaning on
-/// the caller's own session — currently `SubscribeConversations` (the live-sync
-/// viewed-set; #367), and post-#320 the client-tool registration/result. Unlike a
-/// turn (which can fall back to the shared connection for a caller-less message),
-/// a session-pinned command with no identifiable caller is rejected: routing it
-/// to the shared connection would let one D-Bus caller's subscription capture or
-/// broadcast every other caller's fan-out (#270 / DT-4).
+/// the caller's own session: the `SubscribeConversations` live-sync viewed-set
+/// (#367), and the client-tool registration + its result (#320) — a tool bucket
+/// the daemon keys to the connection, whose `ClientToolCall` must come back on
+/// that same connection (to be unicast to the caller). Unlike a turn (which can
+/// fall back to the shared connection for a caller-less message), a session-pinned
+/// command with no identifiable caller is rejected: routing it to the shared
+/// connection would let one D-Bus caller's subscription or tools capture or leak
+/// across every other caller (#270 / DT-4).
 pub fn is_session_pinned(command: &api::Command) -> bool {
-    matches!(command, api::Command::SubscribeConversations { .. })
+    matches!(
+        command,
+        api::Command::SubscribeConversations { .. }
+            | api::Command::RegisterClientTools { .. }
+            | api::Command::ClientToolResult { .. }
+    )
 }
 
 /// One D-Bus sender's private daemon session: the transport its commands
@@ -535,8 +542,19 @@ mod tests {
     }
 
     #[test]
-    fn is_session_pinned_is_subscribe_conversations_only() {
+    fn is_session_pinned_covers_subscribe_and_client_tools() {
         assert!(is_session_pinned(&subscribe(&["c1"])));
+        // #320: client-tool registration + its result are pinned to the session
+        // that owns the tool bucket / the suspended turn.
+        assert!(is_session_pinned(&api::Command::RegisterClientTools {
+            tools: vec![]
+        }));
+        assert!(is_session_pinned(&api::Command::ClientToolResult {
+            task_id: api::TaskId("t".into()),
+            tool_call_id: "tc".into(),
+            result: Some("ok".into()),
+            error: None,
+        }));
         // A turn is routed via is_turn_driving (which has a caller-less shared
         // fallback), NOT pinned; stateless commands are neither.
         assert!(!is_session_pinned(&send_message("c1")));

--- a/crates/dbus-bridge/tests/bridge.rs
+++ b/crates/dbus-bridge/tests/bridge.rs
@@ -265,6 +265,36 @@ fn translate_forwards_user_message_added_and_conversation_list_changed() {
     ));
 }
 
+#[test]
+fn translate_forwards_client_tool_call_with_json_string_args() {
+    // #320: ClientToolCall is forwarded; the serde_json::Value arguments are
+    // serialized to a JSON string for the D-Bus signal (which has no Value type),
+    // round-tripping back to the same Value.
+    match translate(SignalEvent::ClientToolCall {
+        task_id: "task".into(),
+        conversation_id: "c".into(),
+        tool_call_id: "call".into(),
+        tool_name: "echo".into(),
+        arguments: serde_json::json!({"x": 1, "y": "hi"}),
+    }) {
+        ForwardAction::ClientToolCall {
+            task_id,
+            conversation_id,
+            tool_call_id,
+            tool_name,
+            arguments_json,
+        } => {
+            assert_eq!(task_id, "task");
+            assert_eq!(conversation_id, "c");
+            assert_eq!(tool_call_id, "call");
+            assert_eq!(tool_name, "echo");
+            let parsed: serde_json::Value = serde_json::from_str(&arguments_json).unwrap();
+            assert_eq!(parsed, serde_json::json!({"x": 1, "y": "hi"}));
+        }
+        other => panic!("expected ClientToolCall, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Frozen D-Bus surface (object paths + well-known name)
 // ---------------------------------------------------------------------------

--- a/crates/dbus-bridge/tests/introspection.rs
+++ b/crates/dbus-bridge/tests/introspection.rs
@@ -100,6 +100,12 @@ const ADDITIONS: &[(&str, &str)] = &[
         "org.desktopAssistant.Conversations",
         "signal ConversationListChanged(:s:conversation_id)",
     ),
+    // #320 — client tools over D-Bus (the call is a unicast signal; register +
+    // result ride the generic Commands channel).
+    (
+        "org.desktopAssistant.Conversations",
+        "signal ClientToolCall(:s:task_id, :s:conversation_id, :s:tool_call_id, :s:tool_name, :s:arguments_json)",
+    ),
 ];
 
 // --- fake transport ---------------------------------------------------------


### PR DESCRIPTION
## What & why

B1 (#374) gave each D-Bus sender its own daemon session (evicted on `NameOwnerChanged`); B2 (#375) added the live-sync signals + per-sender `SubscribeConversations`. This wires **working client-side tools** over D-Bus on top — the last per-sender ("B") step, and the **bridge side of #320**.

## How

- **`session.rs`** — `is_session_pinned` += `RegisterClientTools` + `ClientToolResult`, so both route to the caller's own session (where the tool bucket lives and the turn suspends). A caller-less one is rejected, never leaked onto the shared connection (#270/DT-4).
- **`event_forwarder.rs`** — translate `ClientToolCall` (was `Ignored`) into a new `Conversations.ClientToolCall` signal; `arguments` (a `serde_json::Value`) ride as a **JSON string**, since D-Bus has no Value type. **Unicast** (`is_broadcast` = false) to the registrant — never broadcast, because tool args can be sensitive.
- **`conversations.rs`** — the `#[zbus(signal)] client_tool_call` declaration.
- **`commands.rs`** — stop rejecting `RegisterClientTools` / `ClientToolResult`; they route per-sender like `SubscribeConversations`. Only the background-task subscriptions remain rejected (a one-shot method can't stream `Task*` frames).
- **introspection `ADDITIONS`** += the `ClientToolCall` signal.

The whole loop rides one per-sender session: the client registers tools (session-pinned), drives a turn on that session, the turn's `ClientToolCall` comes back on that session → unicasts to the caller, and the `ClientToolResult` (generic Commands channel) routes back to resume the turn. A registrant that drops off the bus is evicted by B1's `NameOwnerChanged` watcher → drops its `Connector` → the daemon's existing session-end path cancels the suspended turn (fast, not the 60s tool timeout) — **no new daemon code**.

## Testing (spec-driven, with edge cases)

- `is_session_pinned` covers both client-tool commands;
- `translate` forwards `ClientToolCall` and **JSON-stringifies the args** (round-trip asserted);
- `is_broadcast` keeps it unicast (args can be sensitive — must not broadcast);
- the generic channel no longer rejects register/result, while background-task subscriptions still are;
- the introspection gate accepts the declared addition;
- full bridge suite green; `clippy -D warnings` + `cargo fmt --check` clean; full-workspace `just check` green (daemon up).

**Live-verified** over a side-by-side bridge: a D-Bus client registered an `echo_marker` tool, drove a turn, received the `ClientToolCall` **unicast** signal (real Bedrock tool-use id, `args={}`), posted `ClientToolResult` = "MARKER-7Q" via the Commands channel, and the turn **completed with "MARKER-7Q"** — the LLM used the client-side tool's result.

## Scope

- **In:** the `ClientToolCall` unicast signal + per-sender routing of `RegisterClientTools`/`ClientToolResult`.
- **Next (closes #320):** client-common's `DbusClient` gains a `ClientToolCall` listener + re-register-on-reconnect, so **tui/gtk over `--transport dbus`** use it (most clients default to UDS, where client tools already work — hence this is adoption, not a blocker).

Refs #320 (bridge side). Builds on #374 (B1) + #375 (B2). With this, the per-sender "B" work (#367 + #320 bridge sides) is complete; remaining is client adoption (client-common `DbusClient`, adele-kde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
