### PR TITLE
client-ffi: expand the C ABI to the full KDE chat surface

### DIFF
--- a/crates/client-ffi/include/adele_client.h
+++ b/crates/client-ffi/include/adele_client.h
@@ -71,6 +71,123 @@ char *adele_client_send_prompt(struct AdeleClient *client,
                                const char *prompt);
 
 /**
+ * List the user's conversations as a JSON array of `ConversationSummary` (the
+ * daemon's order, newest-first). `include_archived` adds archived ones. Returns
+ * NULL on a bad handle / dispatch failure; caller frees with [`adele_string_free`].
+ *
+ * # Safety
+ * `client` must be a live handle from [`adele_client_connect`].
+ */
+char *adele_client_list_conversations(struct AdeleClient *client, bool include_archived);
+
+/**
+ * Fetch a window of a conversation's messages as a JSON `MessagesView`
+ * (`{messages, message_count, truncated, ...}`). `tail` caps to the most recent
+ * N (`<= 0` = no cap); `after_count` returns only messages past that many
+ * already-seen (incremental refresh; `<= 0` = from the start);
+ * `include_roles_json` is a JSON array of role names to include (NULL/empty =
+ * all roles). Returns NULL on failure; caller frees.
+ *
+ * # Safety
+ * `client` must be live; `conversation_id` a valid C string; `include_roles_json`
+ * NULL or a valid C string.
+ */
+char *adele_client_get_messages(struct AdeleClient *client,
+                                const char *conversation_id,
+                                int32_t tail,
+                                int32_t after_count,
+                                const char *include_roles_json);
+
+/**
+ * Create a conversation with `title`; returns the new conversation id as an
+ * owned C string (caller frees), or NULL on failure.
+ *
+ * # Safety
+ * `client` must be live; `title` a valid C string.
+ */
+char *adele_client_create_conversation(struct AdeleClient *client, const char *title);
+
+/**
+ * Delete a conversation. Returns `false` on a bad handle / failure.
+ *
+ * # Safety
+ * `client` must be live; `conversation_id` a valid C string.
+ */
+bool adele_client_delete_conversation(struct AdeleClient *client, const char *conversation_id);
+
+/**
+ * Send a prompt with an optional per-message model override. `override_json`,
+ * when non-NULL, is `{"connection_id":"..","model_id":"..","effort":"low|medium|high"?}`
+ * (a malformed value is treated as no override). Returns the turn request-id as
+ * an owned C string (caller frees), or NULL on failure.
+ *
+ * # Safety
+ * `client` must be live; `conversation_id` and `prompt` valid C strings;
+ * `override_json` NULL or a valid C string.
+ */
+char *adele_client_send_prompt_with_override(struct AdeleClient *client,
+                                             const char *conversation_id,
+                                             const char *prompt,
+                                             const char *override_json);
+
+/**
+ * List available models as a JSON array of `ModelListing`. `connection_id`, when
+ * non-NULL, scopes to one connection; `refresh` forces a provider refetch.
+ * Returns NULL on failure; caller frees.
+ *
+ * # Safety
+ * `client` must be live; `connection_id` NULL or a valid C string.
+ */
+char *adele_client_list_available_models(struct AdeleClient *client,
+                                         const char *connection_id,
+                                         bool refresh);
+
+/**
+ * Subscribe this connection to background-task events (`task_started`,
+ * `task_progress`, `task_log_appended`, `task_completed`) and
+ * `scratchpad_changed`, which then arrive on the signal callback. Returns
+ * `false` on a bad handle / failure.
+ *
+ * # Safety
+ * `client` must be a live handle from [`adele_client_connect`].
+ */
+bool adele_client_subscribe_background_tasks(struct AdeleClient *client);
+
+/**
+ * List background tasks as a JSON array of `TaskView`. `include_finished` adds
+ * terminal tasks; `limit` caps the count (`<= 0` = no limit). Returns NULL on
+ * failure; caller frees.
+ *
+ * # Safety
+ * `client` must be a live handle from [`adele_client_connect`].
+ */
+char *adele_client_list_background_tasks(struct AdeleClient *client,
+                                         bool include_finished,
+                                         int32_t limit);
+
+/**
+ * Cancel a background task. Returns `false` on a bad handle / failure.
+ *
+ * # Safety
+ * `client` must be live; `task_id` a valid C string.
+ */
+bool adele_client_cancel_background_task(struct AdeleClient *client, const char *task_id);
+
+/**
+ * Fetch a page of a background task's logs as JSON
+ * (`{"entries":[TaskLogEntry...],"next_seq":N}`). `after_seq` skips already-seen
+ * entries (`< 0` = from oldest); `limit` caps the page (`<= 0` = server
+ * default). Returns NULL on failure; caller frees.
+ *
+ * # Safety
+ * `client` must be live; `task_id` a valid C string.
+ */
+char *adele_client_get_background_task_logs(struct AdeleClient *client,
+                                            const char *task_id,
+                                            int64_t after_seq,
+                                            int32_t limit);
+
+/**
  * Free a string returned by this library.
  *
  * # Safety

--- a/crates/client-ffi/src/lib.rs
+++ b/crates/client-ffi/src/lib.rs
@@ -58,6 +58,12 @@ unsafe fn cstr(ptr: *const c_char) -> Option<String> {
         .map(str::to_owned)
 }
 
+/// Move an owned `String` into a C string the caller frees with
+/// [`adele_string_free`], or NULL if it contains an interior NUL byte.
+fn string_to_cstr(s: String) -> *mut c_char {
+    CString::new(s).map_or(ptr::null_mut(), CString::into_raw)
+}
+
 /// Connect to the daemon over UDS. `socket_path` / `minter_socket` may be NULL
 /// to use the platform defaults (`$XDG_RUNTIME_DIR/adelie/{sock,mint.sock}`).
 /// Returns NULL on failure (bad runtime, daemon unreachable, mint failure).
@@ -217,6 +223,364 @@ pub unsafe extern "C" fn adele_client_send_prompt(
     }
 }
 
+/// List the user's conversations as a JSON array of `ConversationSummary` (the
+/// daemon's order, newest-first). `include_archived` adds archived ones. Returns
+/// NULL on a bad handle / dispatch failure; caller frees with [`adele_string_free`].
+///
+/// # Safety
+/// `client` must be a live handle from [`adele_client_connect`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_list_conversations(
+    client: *mut AdeleClient,
+    include_archived: bool,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_command(api::Command::ListConversations {
+                max_age_days: None,
+                include_archived,
+            })
+            .await
+        {
+            Ok(api::CommandResult::Conversations(conversations)) => {
+                serde_json::to_string(&conversations)
+                    .ok()
+                    .map_or(ptr::null_mut(), string_to_cstr)
+            }
+            _ => ptr::null_mut(),
+        }
+    })
+}
+
+/// Fetch a window of a conversation's messages as a JSON `MessagesView`
+/// (`{messages, message_count, truncated, ...}`). `tail` caps to the most recent
+/// N (`<= 0` = no cap); `after_count` returns only messages past that many
+/// already-seen (incremental refresh; `<= 0` = from the start);
+/// `include_roles_json` is a JSON array of role names to include (NULL/empty =
+/// all roles). Returns NULL on failure; caller frees.
+///
+/// # Safety
+/// `client` must be live; `conversation_id` a valid C string; `include_roles_json`
+/// NULL or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_get_messages(
+    client: *mut AdeleClient,
+    conversation_id: *const c_char,
+    tail: i32,
+    after_count: i32,
+    include_roles_json: *const c_char,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let Some(conversation_id) = (unsafe { cstr(conversation_id) }) else {
+        return ptr::null_mut();
+    };
+    let include_roles: Vec<String> = unsafe { cstr(include_roles_json) }
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_command(api::Command::GetMessages {
+                conversation_id,
+                tail,
+                after_count,
+                include_roles,
+            })
+            .await
+        {
+            Ok(api::CommandResult::Messages(view)) => serde_json::to_string(&view)
+                .ok()
+                .map_or(ptr::null_mut(), string_to_cstr),
+            _ => ptr::null_mut(),
+        }
+    })
+}
+
+/// Create a conversation with `title`; returns the new conversation id as an
+/// owned C string (caller frees), or NULL on failure.
+///
+/// # Safety
+/// `client` must be live; `title` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_create_conversation(
+    client: *mut AdeleClient,
+    title: *const c_char,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let Some(title) = (unsafe { cstr(title) }) else {
+        return ptr::null_mut();
+    };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_command(api::Command::CreateConversation { title })
+            .await
+        {
+            Ok(api::CommandResult::ConversationId { id }) => string_to_cstr(id),
+            _ => ptr::null_mut(),
+        }
+    })
+}
+
+/// Delete a conversation. Returns `false` on a bad handle / failure.
+///
+/// # Safety
+/// `client` must be live; `conversation_id` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_delete_conversation(
+    client: *mut AdeleClient,
+    conversation_id: *const c_char,
+) -> bool {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return false;
+    };
+    let Some(conversation_id) = (unsafe { cstr(conversation_id) }) else {
+        return false;
+    };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        match connector.client().as_commands() {
+            Some(commands) => matches!(
+                commands
+                    .send_command(api::Command::DeleteConversation {
+                        id: conversation_id,
+                    })
+                    .await,
+                Ok(api::CommandResult::Ack)
+            ),
+            None => false,
+        }
+    })
+}
+
+/// Send a prompt with an optional per-message model override. `override_json`,
+/// when non-NULL, is `{"connection_id":"..","model_id":"..","effort":"low|medium|high"?}`
+/// (a malformed value is treated as no override). Returns the turn request-id as
+/// an owned C string (caller frees), or NULL on failure.
+///
+/// # Safety
+/// `client` must be live; `conversation_id` and `prompt` valid C strings;
+/// `override_json` NULL or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_send_prompt_with_override(
+    client: *mut AdeleClient,
+    conversation_id: *const c_char,
+    prompt: *const c_char,
+    override_json: *const c_char,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let (Some(conversation_id), Some(prompt)) =
+        (unsafe { cstr(conversation_id) }, unsafe { cstr(prompt) })
+    else {
+        return ptr::null_mut();
+    };
+    let override_selection = unsafe { cstr(override_json) }
+        .and_then(|s| serde_json::from_str::<api::SendPromptOverride>(&s).ok());
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_prompt_with_override(&conversation_id, &prompt, override_selection)
+            .await
+        {
+            Ok(request_id) => string_to_cstr(request_id),
+            Err(_) => ptr::null_mut(),
+        }
+    })
+}
+
+/// List available models as a JSON array of `ModelListing`. `connection_id`, when
+/// non-NULL, scopes to one connection; `refresh` forces a provider refetch.
+/// Returns NULL on failure; caller frees.
+///
+/// # Safety
+/// `client` must be live; `connection_id` NULL or a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_list_available_models(
+    client: *mut AdeleClient,
+    connection_id: *const c_char,
+    refresh: bool,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let connection_id = unsafe { cstr(connection_id) };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .list_available_models(connection_id.as_deref(), refresh)
+            .await
+        {
+            Ok(models) => serde_json::to_string(&models)
+                .ok()
+                .map_or(ptr::null_mut(), string_to_cstr),
+            Err(_) => ptr::null_mut(),
+        }
+    })
+}
+
+/// Subscribe this connection to background-task events (`task_started`,
+/// `task_progress`, `task_log_appended`, `task_completed`) and
+/// `scratchpad_changed`, which then arrive on the signal callback. Returns
+/// `false` on a bad handle / failure.
+///
+/// # Safety
+/// `client` must be a live handle from [`adele_client_connect`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_subscribe_background_tasks(client: *mut AdeleClient) -> bool {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return false;
+    };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        match connector.client().as_commands() {
+            Some(commands) => matches!(
+                commands
+                    .send_command(api::Command::SubscribeBackgroundTasks)
+                    .await,
+                Ok(api::CommandResult::Ack)
+            ),
+            None => false,
+        }
+    })
+}
+
+/// List background tasks as a JSON array of `TaskView`. `include_finished` adds
+/// terminal tasks; `limit` caps the count (`<= 0` = no limit). Returns NULL on
+/// failure; caller frees.
+///
+/// # Safety
+/// `client` must be a live handle from [`adele_client_connect`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_list_background_tasks(
+    client: *mut AdeleClient,
+    include_finished: bool,
+    limit: i32,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let limit = u32::try_from(limit).ok().filter(|&n| n > 0);
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_command(api::Command::ListBackgroundTasks {
+                include_finished,
+                limit,
+            })
+            .await
+        {
+            Ok(api::CommandResult::BackgroundTasks(tasks)) => serde_json::to_string(&tasks)
+                .ok()
+                .map_or(ptr::null_mut(), string_to_cstr),
+            _ => ptr::null_mut(),
+        }
+    })
+}
+
+/// Cancel a background task. Returns `false` on a bad handle / failure.
+///
+/// # Safety
+/// `client` must be live; `task_id` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_cancel_background_task(
+    client: *mut AdeleClient,
+    task_id: *const c_char,
+) -> bool {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return false;
+    };
+    let Some(task_id) = (unsafe { cstr(task_id) }) else {
+        return false;
+    };
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        match connector.client().as_commands() {
+            Some(commands) => matches!(
+                commands
+                    .send_command(api::Command::CancelBackgroundTask { id: task_id })
+                    .await,
+                Ok(api::CommandResult::Ack)
+            ),
+            None => false,
+        }
+    })
+}
+
+/// Fetch a page of a background task's logs as JSON
+/// (`{"entries":[TaskLogEntry...],"next_seq":N}`). `after_seq` skips already-seen
+/// entries (`< 0` = from oldest); `limit` caps the page (`<= 0` = server
+/// default). Returns NULL on failure; caller frees.
+///
+/// # Safety
+/// `client` must be live; `task_id` a valid C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn adele_client_get_background_task_logs(
+    client: *mut AdeleClient,
+    task_id: *const c_char,
+    after_seq: i64,
+    limit: i32,
+) -> *mut c_char {
+    let Some(client) = (unsafe { client.as_ref() }) else {
+        return ptr::null_mut();
+    };
+    let Some(task_id) = (unsafe { cstr(task_id) }) else {
+        return ptr::null_mut();
+    };
+    let after_seq = u64::try_from(after_seq).ok();
+    let limit = u32::try_from(limit).ok().filter(|&n| n > 0);
+    let connector = Arc::clone(&client.connector);
+    client.rt.block_on(async move {
+        let Some(commands) = connector.client().as_commands() else {
+            return ptr::null_mut();
+        };
+        match commands
+            .send_command(api::Command::GetBackgroundTaskLogs {
+                id: task_id,
+                after_seq,
+                limit,
+            })
+            .await
+        {
+            Ok(api::CommandResult::BackgroundTaskLogs { entries, next_seq }) => {
+                serde_json::to_string(&serde_json::json!({
+                    "entries": entries, "next_seq": next_seq,
+                }))
+                .ok()
+                .map_or(ptr::null_mut(), string_to_cstr)
+            }
+            _ => ptr::null_mut(),
+        }
+    })
+}
+
 /// Free a string returned by this library.
 ///
 /// # Safety
@@ -242,9 +606,12 @@ pub unsafe extern "C" fn adele_client_free(client: *mut AdeleClient) {
     }
 }
 
-/// Marshal a `SignalEvent` to a tagged JSON object for the C callback. Returns
-/// `None` for variants the chat surface does not consume (v1): `ContextUsage`,
-/// `ConversationWarning`, `ScratchpadChanged`, `Task*`.
+/// Marshal a `SignalEvent` to a tagged JSON object (`{"kind": ...}`) for the C
+/// callback. Exhaustive over `SignalEvent`: every variant is forwarded, so a new
+/// daemon event surfaces as a compile error here instead of being silently
+/// dropped. Returns `None` only if serialization fails. The background-task,
+/// context-usage, and scratchpad events arrive only after a connection subscribes
+/// via [`adele_client_subscribe_background_tasks`].
 fn signal_to_json(event: &SignalEvent) -> Option<String> {
     use SignalEvent as E;
     let value = match event {
@@ -311,7 +678,42 @@ fn signal_to_json(event: &SignalEvent) -> Option<String> {
         E::Disconnected { reason } => serde_json::json!({
             "kind": "disconnected", "reason": reason,
         }),
-        _ => return None,
+        // Meter + background-task events. Nested api types (warning, task, entry,
+        // status) ride through structurally — they derive Serialize.
+        E::ContextUsage {
+            conversation_id,
+            request_id,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        } => serde_json::json!({
+            "kind": "context_usage", "conversation_id": conversation_id,
+            "request_id": request_id, "used_tokens": used_tokens,
+            "budget_tokens": budget_tokens, "compaction_active": compaction_active,
+        }),
+        E::ConversationWarning {
+            conversation_id,
+            warning,
+        } => serde_json::json!({
+            "kind": "conversation_warning", "conversation_id": conversation_id, "warning": warning,
+        }),
+        E::TaskStarted { task } => serde_json::json!({ "kind": "task_started", "task": task }),
+        E::TaskProgress { id, progress_hint } => serde_json::json!({
+            "kind": "task_progress", "id": id, "progress_hint": progress_hint,
+        }),
+        E::TaskLogAppended { id, entry } => serde_json::json!({
+            "kind": "task_log_appended", "id": id, "entry": entry,
+        }),
+        E::TaskCompleted {
+            id,
+            status,
+            last_error,
+        } => serde_json::json!({
+            "kind": "task_completed", "id": id, "status": status, "last_error": last_error,
+        }),
+        E::ScratchpadChanged { conversation_id } => serde_json::json!({
+            "kind": "scratchpad_changed", "conversation_id": conversation_id,
+        }),
     };
     serde_json::to_string(&value).ok()
 }
@@ -352,12 +754,52 @@ mod tests {
     }
 
     #[test]
-    fn signal_to_json_drops_events_the_chat_surface_ignores() {
-        assert!(
-            signal_to_json(&SignalEvent::ScratchpadChanged {
-                conversation_id: "c".into(),
-            })
-            .is_none()
-        );
+    fn signal_to_json_forwards_scratchpad_changed() {
+        let json = signal_to_json(&SignalEvent::ScratchpadChanged {
+            conversation_id: "c".into(),
+        })
+        .expect("scratchpad_changed now drives the scratchpad pane");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["kind"], "scratchpad_changed");
+        assert_eq!(v["conversation_id"], "c");
+    }
+
+    #[test]
+    fn signal_to_json_forwards_context_usage_counts() {
+        let json = signal_to_json(&SignalEvent::ContextUsage {
+            conversation_id: "c".into(),
+            request_id: "r".into(),
+            used_tokens: 42,
+            budget_tokens: 100,
+            compaction_active: true,
+        })
+        .expect("context_usage drives the fill meter");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["kind"], "context_usage");
+        assert_eq!(v["used_tokens"], 42);
+        assert_eq!(v["budget_tokens"], 100);
+        assert_eq!(v["compaction_active"], true);
+    }
+
+    #[test]
+    fn signal_to_json_forwards_task_progress_with_optional_hint() {
+        let some = signal_to_json(&SignalEvent::TaskProgress {
+            id: "t".into(),
+            progress_hint: Some("step 2/3".into()),
+        })
+        .expect("task_progress updates the tasks panel");
+        let v: serde_json::Value = serde_json::from_str(&some).unwrap();
+        assert_eq!(v["kind"], "task_progress");
+        assert_eq!(v["id"], "t");
+        assert_eq!(v["progress_hint"], "step 2/3");
+
+        // A missing hint must serialize as JSON null, not be dropped.
+        let none = signal_to_json(&SignalEvent::TaskProgress {
+            id: "t".into(),
+            progress_hint: None,
+        })
+        .unwrap();
+        let vn: serde_json::Value = serde_json::from_str(&none).unwrap();
+        assert!(vn["progress_hint"].is_null());
     }
 }


### PR DESCRIPTION
## What & why

**PR 1 of 3 for the KDE native-client hard cutover** (#367 / #320). The plasmoids are losing their Python `dbus_client.py` helper for a native QML plugin; this expands the FFI's C ABI so the plugin can do **everything the QML wires today**, all over the existing UDS `Connector` (no D-Bus in the chat data path).

## New FFI functions (typed; cbindgen regenerates the header → 15 funcs)

- **Conversations:** `list_conversations` (± archived), `get_messages` (tail/after/roles window), `create_conversation`, `delete_conversation`.
- **Send:** `send_prompt_with_override` (per-message connection/model/effort pin — the QML's `--override-*`).
- `list_available_models` (the model picker).
- **Background tasks:** `subscribe_background_tasks`, `list_background_tasks`, `cancel_background_task`, `get_background_task_logs`.

Each routes through `as_commands().send_command(api::Command::…)` and matches the `api::CommandResult` — so the JSON returned is the **api-model** view types (which derive `Serialize`). The `client-common` return types (e.g. `types::ConversationSummary`) are *not* `Serialize`, so `send_command` is the one pattern that marshals cleanly.

## Signal-forwarding fixes

`signal_to_json` previously **dropped** `context_usage`, `conversation_warning`, and every `task_*` / `scratchpad_changed` event — needed by the tasks panel + context meter (they arrive once a connection calls `subscribe_background_tasks`). Now forwarded, and the match is **exhaustive over `SignalEvent`** — a new daemon event is a compile error here, not a silent drop.

## Why this shrinks the cutover

The Python helper's load-bearing blocking `await` poll (0.8 s server-side loop) + the 5 s late-response poll exist only because a one-shot subprocess can't hold a subscription. The plugin holds a **persistent Connector**, so these streamed events (`Chunk`/`Complete`/`Task*`) replace all of it — that's the #367 live-sync win.

## Testing

`clippy -D warnings` + `cargo fmt --check` + crate tests green; full-workspace `just check` green (pre-push hook, daemon up). New unit tests cover the newly-forwarded marshalling: `context_usage` counts, `scratchpad_changed`, `task_progress` with and without a hint. The request/response functions are thin wrappers over `Connector`/`send_command` (tested in client-common) and are exercised against a live daemon by the adele-kde C++ tests + QA in PR2/PR3.

Refs #367 / #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
