### PR TITLE
Dream cycle: extraction self-containment + proactive explicit writes

### DIFF
--- a/crates/core/src/prompts/runtime_system_instruction.txt
+++ b/crates/core/src/prompts/runtime_system_instruction.txt
@@ -16,7 +16,7 @@ Before responding, plan what you need, then gather it efficiently:
 - Current-turn instructions override stored data. If unclear after searching, ask one brief question rather than guess.
 
 == Knowledge base ==
-The KB (builtin_knowledge_base_write/search/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags.
+The KB (builtin_knowledge_base_write/search/list/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags. Use builtin_knowledge_base_list to page through entries when auditing or reviewing (it takes order, tags/exclude_tags, and source filters); write accepts a batch via `entries`, and you can re-tag an existing entry by passing its `id` with new `tags` and no `content`.
 
 SEARCH BEFORE ASKING (mandatory): Before you ask the user for any fact, preference, or project detail — and before you say you don't know or can't recall something — you MUST first call builtin_knowledge_base_search. Only ask the user if the search comes up empty. This applies every time: paths, names, defaults, where-credentials-live, "which X", "how do you usually", "what is your". Searching is cheap; asking for something you already stored is not. Do not skip this step.
 
@@ -27,6 +27,7 @@ Reading:
 - If a stored instruction or procedure applies, follow it.
 
 Writing:
+- Save proactively (no need to be asked): when the user states a durable fact in passing — a default location, a preference, a project path or convention, how they like something done — recognize it and store it in that same turn. First search for an existing entry and update it (pass its `id`) rather than creating a near-duplicate; create a new entry only if none exists.
 - Only durable, reusable, high-confidence information. Skip transient details unless asked.
 - Use a pointer-first 3-part shape: (1) context — what it is / what it's for; (2) gist — the high-signal summary; (3) pointer — where to find or update the full details next time.
 - Write self-contained prose, not key-value snippets. Good: "User's home address is 123 Main St, Springfield. Use as default for weather, directions, and local searches." Bad: "address: 123 Main St".

--- a/crates/core/src/prompts/sections/knowledge_base.txt
+++ b/crates/core/src/prompts/sections/knowledge_base.txt
@@ -1,5 +1,5 @@
 == Knowledge base ==
-The KB (builtin_knowledge_base_write/search/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags.
+The KB (builtin_knowledge_base_write/search/list/delete) is your unified store for preferences, memories, project context, and stored procedures. No separate memory or preferences store — everything lives here, organized by tags. Use builtin_knowledge_base_list to page through entries when auditing or reviewing (it takes order, tags/exclude_tags, and source filters); write accepts a batch via `entries`, and you can re-tag an existing entry by passing its `id` with new `tags` and no `content`.
 
 SEARCH BEFORE ASKING (mandatory): Before you ask the user for any fact, preference, or project detail — and before you say you don't know or can't recall something — you MUST first call builtin_knowledge_base_search. Only ask the user if the search comes up empty. This applies every time: paths, names, defaults, where-credentials-live, "which X", "how do you usually", "what is your". Searching is cheap; asking for something you already stored is not. Do not skip this step.
 
@@ -10,6 +10,7 @@ Reading:
 - If a stored instruction or procedure applies, follow it.
 
 Writing:
+- Save proactively (no need to be asked): when the user states a durable fact in passing — a default location, a preference, a project path or convention, how they like something done — recognize it and store it in that same turn. First search for an existing entry and update it (pass its `id`) rather than creating a near-duplicate; create a new entry only if none exists.
 - Only durable, reusable, high-confidence information. Skip transient details unless asked.
 - Use a pointer-first 3-part shape: (1) context — what it is / what it's for; (2) gist — the high-signal summary; (3) pointer — where to find or update the full details next time.
 - Write self-contained prose, not key-value snippets. Good: "User's home address is 123 Main St, Springfield. Use as default for weather, directions, and local searches." Bad: "address: 123 Main St".

--- a/crates/storage/src/dreaming/archival.rs
+++ b/crates/storage/src/dreaming/archival.rs
@@ -1,9 +1,16 @@
 //! Phase 3: archive old conversations.
 //!
 //! Marks conversations whose `updated_at` is older than `days` days ago
-//! as archived. Hard-deletion of the underlying messages is a separate
-//! concern. Consolidation tolerates the case where a fact's
-//! `source_conversation_id` no longer resolves.
+//! as archived. This is a non-destructive soft flag (`archived_at`); the
+//! messages and the conversation row remain, so a fact's
+//! `source_conversation_id` still resolves after archival. (The only hard
+//! deletion of a conversation is an explicit user-initiated delete.)
+//!
+//! Ordering is not a concern for the dream cycle: extraction processes a
+//! conversation's messages within the hour they arrive — long before the
+//! multi-day archival window — and holistic consolidation operates purely on
+//! the (self-contained) knowledge entries, never re-reading transcripts. So
+//! `source_conversation_id` is now informational provenance only.
 //!
 //! This phase iterates implicitly over all users — each row carries its
 //! own `user_id`, and the archival flag is set in place, so the

--- a/crates/storage/src/dreaming/extraction.rs
+++ b/crates/storage/src/dreaming/extraction.rs
@@ -374,10 +374,17 @@ fn build_extraction_system_prompt(registry: &[TagRecord]) -> String {
         ## Output format\n\
         \n\
         Return a JSON object with a `facts` array. Each fact has:\n\
-        - `content` (string): A self-contained prose sentence. If the fact only \
-        applies in a specific context (a project, tool, environment), include \
-        that context IN THE PROSE — never write a scope-naked fact like \
-        \"the project directory is /a\" without naming the project.\n\
+        - `content` (string): A fully SELF-CONTAINED prose sentence that will \
+        still make sense months from now with no access to this conversation. \
+        Resolve every referent inline: (a) name the subject — never \
+        \"he/she/they/it/this/that\"; write the actual person, project, tool, \
+        or file; (b) use absolute dates (\"2026-06-14\"), never relative ones \
+        (\"yesterday\", \"recently\"); (c) include the context that makes the \
+        fact useful — if it only applies to a specific project/tool/environment, \
+        say so IN THE PROSE, never a scope-naked fact like \"the project \
+        directory is /a\" without naming the project. A later cleanup pass sees \
+        ONLY this sentence (not the conversation), so anything it depends on \
+        must be written into it.\n\
         - `tags` (array of strings): Categorical tags from the registry below. \
         Pick only from registered tags. Tags describe WHAT KIND of fact this \
         is (e.g. `preference`, `architecture`), not the specific subject.\n\


### PR DESCRIPTION
Closes #395

Stacked on #394 (base = `feat/dream-holistic-consolidation`). Final piece of the overhaul.

- **Extraction self-containment** (`extraction.rs` prompt): facts must resolve referents inline — name the subject (no dangling pronouns), absolute dates, embed the context that makes the fact useful — because holistic consolidation sees only the stored sentence, never the transcript.
- **Proactive explicit writes** (system prompt): directive to recognize durable facts stated in passing and store/update them in that turn (search-then-update to avoid duplicates). Also documents the new `list` tool, batch `write`, and tags-only update. The monolithic-prompt regression snapshot is updated in lockstep.
- **Archival ordering** — no behavior change, by design. Investigation showed the risk the plan worried about doesn't exist: archival is a non-destructive soft flag (`archived_at`); the only hard delete is explicit user deletion; extraction processes a conversation's messages within the hour (well before the multi-day archival window); and holistic consolidation (#394) no longer reads transcripts. The stale module doc is corrected to note `source_conversation_id` is now informational provenance only.

`cargo check --workspace --all-targets` clean; core prompt tests (incl. the assembled-vs-monolith snapshot) and dreaming tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)