### PR TITLE
Add Consolidation purpose (KCM-configurable model)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -1157,6 +1157,8 @@ pub struct PurposesView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dreaming: Option<PurposeConfigView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consolidation: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<PurposeConfigView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub titling: Option<PurposeConfigView>,
@@ -1172,6 +1174,9 @@ impl PurposesView {
         }
         if let Some(v) = &self.dreaming {
             map.insert("dreaming".to_string(), v.clone());
+        }
+        if let Some(v) = &self.consolidation {
+            map.insert("consolidation".to_string(), v.clone());
         }
         if let Some(v) = &self.embedding {
             map.insert("embedding".to_string(), v.clone());

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -1729,6 +1729,7 @@ where
                 Ok(api::CommandResult::Purposes(api::PurposesView {
                     interactive: p.interactive.map(core_purpose_to_api),
                     dreaming: p.dreaming.map(core_purpose_to_api),
+                    consolidation: p.consolidation.map(core_purpose_to_api),
                     embedding: p.embedding.map(core_purpose_to_api),
                     titling: p.titling.map(core_purpose_to_api),
                 }))

--- a/crates/core/src/ports/inbound.rs
+++ b/crates/core/src/ports/inbound.rs
@@ -414,6 +414,7 @@ pub struct PurposeConfigPayload {
 pub struct PurposesView {
     pub interactive: Option<PurposeConfigPayload>,
     pub dreaming: Option<PurposeConfigPayload>,
+    pub consolidation: Option<PurposeConfigPayload>,
     pub embedding: Option<PurposeConfigPayload>,
     pub titling: Option<PurposeConfigPayload>,
 }

--- a/crates/core/src/service.rs
+++ b/crates/core/src/service.rs
@@ -3818,7 +3818,7 @@ mod tests {
         assert!(
             messages[0]
                 .content
-                .contains("builtin_knowledge_base_write/search/delete")
+                .contains("builtin_knowledge_base_write/search/list/delete")
         );
         assert!(messages[0].content.contains("builtin_sys_props"));
         assert!(messages[0].content.contains("builtin_tool_search"));

--- a/crates/daemon/src/api_surface.rs
+++ b/crates/daemon/src/api_surface.rs
@@ -533,6 +533,10 @@ impl ConnectionsService for DaemonConnectionsService {
                 .purposes
                 .get(PurposeKind::Dreaming)
                 .map(purpose_to_payload),
+            consolidation: config
+                .purposes
+                .get(PurposeKind::Consolidation)
+                .map(purpose_to_payload),
             embedding: config
                 .purposes
                 .get(PurposeKind::Embedding)

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -2581,6 +2581,10 @@ y = 2
             connection = "bedrock"
             model = "anthropic.claude-haiku-4-5"
 
+            [purposes.consolidation]
+            connection = "bedrock"
+            model = "us.anthropic.claude-sonnet-4-6"
+
             [purposes.embedding]
             connection = "local"
             model = "mxbai-embed-large:335m"

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -1388,11 +1388,26 @@ async fn main() -> Result<()> {
         tokio::sync::oneshot::channel::<()>();
     let consolidation_task = if dreaming_enabled && consolidation_interval_secs > 0 {
         if let Some(pool) = &pg_pool {
-            let resolved = config::resolve_consolidation_llm_config(daemon_config.as_ref());
+            // Prefer `[purposes.consolidation]` (settable from the KCM Purposes
+            // tab); fall back to `[backend_tasks.consolidation_llm]` →
+            // backend_tasks.llm → top-level `[llm]`.
+            let (resolved, consolidation_reasoning, source) =
+                match api_surface::resolve_purpose_dispatch(
+                    daemon_config.as_ref(),
+                    purposes::PurposeKind::Consolidation,
+                ) {
+                    Some((r, c)) => (r, c, "purposes.consolidation"),
+                    None => (
+                        config::resolve_consolidation_llm_config(daemon_config.as_ref()),
+                        Default::default(),
+                        "backend_tasks.consolidation_llm",
+                    ),
+                };
             tracing::info!(
-                "consolidation LLM connector={}, model={}, every {}s",
+                "consolidation LLM connector={}, model={}, source={}, every {}s",
                 resolved.connector,
                 resolved.model,
+                source,
                 consolidation_interval_secs
             );
             let consolidation_llm = build_llm_client(resolved);
@@ -1422,18 +1437,14 @@ async fn main() -> Result<()> {
                 let llm_fn: desktop_assistant_storage::dreaming::DreamingLlmFn =
                     Box::new(move |system_prompt, user_prompt| {
                         let llm = Arc::clone(&consolidation_llm);
+                        let reasoning = consolidation_reasoning;
                         Box::pin(async move {
                             let messages = vec![
                                 Message::new(Role::System, system_prompt),
                                 Message::new(Role::User, user_prompt),
                             ];
                             let response = llm
-                                .stream_completion(
-                                    messages,
-                                    &[],
-                                    Default::default(),
-                                    Box::new(|_| true),
-                                )
+                                .stream_completion(messages, &[], reasoning, Box::new(|_| true))
                                 .await
                                 .map_err(|e| e.to_string())?;
                             Ok(response.text)

--- a/crates/daemon/src/purposes.rs
+++ b/crates/daemon/src/purposes.rs
@@ -251,7 +251,8 @@ mod purposes_serde {
                         let Some(kind) = PurposeKind::from_key(&key) else {
                             return Err(M::Error::custom(format!(
                                 "unknown purpose `{key}`; expected one of \
-                                 `interactive`, `dreaming`, `embedding`, `titling`"
+                                 `interactive`, `dreaming`, `consolidation`, \
+                                 `embedding`, `titling`"
                             )));
                         };
                         if out.get(kind).is_some() {

--- a/crates/daemon/tests/fixtures/connections_migration/migrated_openai.toml
+++ b/crates/daemon/tests/fixtures/connections_migration/migrated_openai.toml
@@ -37,6 +37,8 @@ max_connections = 5
 dreaming_enabled = true
 dreaming_interval_secs = 3600
 archive_after_days = 7
+embedding_backfill_interval_secs = 300
+consolidation_interval_secs = 86400
 
 [purposes.interactive]
 connection = "default"

--- a/crates/daemon/tests/fixtures/purposes_migration/migrated_anthropic_backend.toml
+++ b/crates/daemon/tests/fixtures/purposes_migration/migrated_anthropic_backend.toml
@@ -27,6 +27,8 @@ max_connections = 5
 dreaming_enabled = true
 dreaming_interval_secs = 3600
 archive_after_days = 7
+embedding_backfill_interval_secs = 300
+consolidation_interval_secs = 86400
 
 [purposes.interactive]
 connection = "default"

--- a/crates/dbus-bridge/src/adapter/connections.rs
+++ b/crates/dbus-bridge/src/adapter/connections.rs
@@ -382,6 +382,7 @@ mod tests {
         let purposes = api::PurposesView {
             interactive: None,
             dreaming: None,
+            consolidation: None,
             embedding: None,
             titling: None,
         };

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -32,7 +32,7 @@ pub enum Effort {
 // PurposeKind
 // ---------------------------------------------------------------------------
 
-/// The four LLM purposes the daemon resolves independently. Used as a stable
+/// The LLM purposes the daemon resolves independently. Used as a stable
 /// keyed map via [`Self::as_key`] / [`Self::from_key`].
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -41,8 +41,11 @@ pub enum Effort {
 pub enum PurposeKind {
     /// The user-facing chat LLM. Cannot inherit (nothing to inherit from).
     Interactive,
-    /// Periodic fact extraction (the "dreaming" background task).
+    /// Periodic fact extraction (the frequent, cheap "dreaming" pass).
     Dreaming,
+    /// Holistic knowledge-base consolidation (the slower, heavier daily pass
+    /// that recomputes the whole KB — typically a stronger model).
+    Consolidation,
     /// Vector embeddings for memory and retrieval.
     Embedding,
     /// Short-title generation for conversations.
@@ -55,6 +58,7 @@ impl PurposeKind {
         match self {
             Self::Interactive => "interactive",
             Self::Dreaming => "dreaming",
+            Self::Consolidation => "consolidation",
             Self::Embedding => "embedding",
             Self::Titling => "titling",
         }
@@ -66,6 +70,7 @@ impl PurposeKind {
         match key {
             "interactive" => Some(Self::Interactive),
             "dreaming" => Some(Self::Dreaming),
+            "consolidation" => Some(Self::Consolidation),
             "embedding" => Some(Self::Embedding),
             "titling" => Some(Self::Titling),
             _ => None,
@@ -76,10 +81,11 @@ impl PurposeKind {
     /// tests and serialization round-trips. Order matches the schema
     /// migration order (interactive first because every other purpose
     /// can inherit from it).
-    pub fn all() -> [Self; 4] {
+    pub fn all() -> [Self; 5] {
         [
             Self::Interactive,
             Self::Dreaming,
+            Self::Consolidation,
             Self::Embedding,
             Self::Titling,
         ]


### PR DESCRIPTION
Closes #401

Makes the holistic-consolidation LLM a first-class **purpose**, so it's configurable on the KCM Purposes tab instead of only via the `[backend_tasks.consolidation_llm]` TOML block.

- `PurposeKind::Consolidation` in the protocol crate (`as_key`/`from_key`/`all`).
- `PurposesView` gains a `consolidation` field across the stack (core inbound, api-model + `to_map`, daemon `get_purposes`, application `GetPurposes` mapping, dbus-bridge test).
- The consolidation task resolves `[purposes.consolidation]` first (with its effort/reasoning), falling back to `[backend_tasks.consolidation_llm]` → `backend_tasks.llm` → `[llm]`. Nothing breaks if unset.

Also fixes **three unit tests the prior dream-cycle batch (#397/#399/#400) left red** — those PRs were validated with targeted test runs rather than full suites: two config-migration golden fixtures (missing `embedding_backfill_interval_secs` / `consolidation_interval_secs`) and the runtime-instruction substring assertion (`/list` was added to the KB tool list).

Full suites now green: daemon bin (299), core lib (391), application (72), dbus-bridge (113), api-model, protocol. `cargo check --workspace --all-targets` clean.

Pairs with adele-kde PR (Purposes-tab relabel + tooltips).