### PR TITLE
chore: fix fmt + clippy drift on main (Dream-cycle merges)

### DIFF
--- a/crates/core/src/ports/knowledge.rs
+++ b/crates/core/src/ports/knowledge.rs
@@ -99,7 +99,10 @@ pub type KnowledgeDeleteFn = Arc<
 /// Boxed async closure for fetching a single entry by id (used by the write
 /// tool to support partial updates that omit `content`).
 pub type KnowledgeGetFn = Arc<
-    dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<Option<KnowledgeEntry>, CoreError>> + Send>>
+    dyn Fn(
+            String,
+        )
+            -> Pin<Box<dyn Future<Output = Result<Option<KnowledgeEntry>, CoreError>> + Send>>
         + Send
         + Sync,
 >;
@@ -162,10 +165,7 @@ mod tests {
     struct MockKnowledgeStore;
 
     impl KnowledgeBaseStore for MockKnowledgeStore {
-        async fn write(
-            &self,
-            entry: KnowledgeEntry,
-        ) -> Result<KnowledgeEntry, CoreError> {
+        async fn write(&self, entry: KnowledgeEntry) -> Result<KnowledgeEntry, CoreError> {
             Ok(entry)
         }
 
@@ -218,7 +218,10 @@ mod tests {
     #[tokio::test]
     async fn mock_knowledge_store_search_returns_empty() {
         let store = MockKnowledgeStore;
-        let results = store.search("test", vec![0.0], None, None, 10).await.unwrap();
+        let results = store
+            .search("test", vec![0.0], None, None, 10)
+            .await
+            .unwrap();
         assert!(results.is_empty());
     }
 

--- a/crates/daemon/src/knowledge_service.rs
+++ b/crates/daemon/src/knowledge_service.rs
@@ -301,7 +301,7 @@ mod tests {
             _tag_filter: Option<Vec<String>>,
         ) -> Result<Vec<KnowledgeEntry>, CoreError> {
             let guard = self.entries.lock().unwrap();
-            Ok(guard.iter().cloned().skip(offset).take(limit).collect())
+            Ok(guard.iter().skip(offset).take(limit).cloned().collect())
         }
 
         async fn delete(&self, id: &str) -> Result<(), CoreError> {
@@ -319,8 +319,8 @@ mod tests {
     #[tokio::test]
     async fn create_assigns_id_and_persists() {
         let store = Arc::new(InMemoryStore::default());
-        let service = DaemonKnowledgeService::new(Arc::clone(&store))
-            .with_id_generator(|| "fixed-id".into());
+        let service =
+            DaemonKnowledgeService::new(Arc::clone(&store)).with_id_generator(|| "fixed-id".into());
 
         let entry = service
             .create_entry(
@@ -344,8 +344,8 @@ mod tests {
         // Embedding is decoupled from the write path: the service holds no
         // embedding closure and create must persist without one.
         let store = Arc::new(InMemoryStore::default());
-        let service = DaemonKnowledgeService::new(Arc::clone(&store))
-            .with_id_generator(|| "kb-c".into());
+        let service =
+            DaemonKnowledgeService::new(Arc::clone(&store)).with_id_generator(|| "kb-c".into());
 
         service
             .create_entry("payload".into(), vec![], serde_json::json!({}))
@@ -360,8 +360,8 @@ mod tests {
     #[tokio::test]
     async fn update_replaces_in_place() {
         let store = Arc::new(InMemoryStore::default());
-        let service = DaemonKnowledgeService::new(Arc::clone(&store))
-            .with_id_generator(|| "kb-x".into());
+        let service =
+            DaemonKnowledgeService::new(Arc::clone(&store)).with_id_generator(|| "kb-x".into());
 
         service
             .create_entry("orig".into(), vec![], serde_json::json!({}))

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -701,11 +701,16 @@ impl BuiltinToolService {
         let id = id_opt.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
         let content = content_opt
             .or_else(|| existing.as_ref().map(|e| e.content.clone()))
-            .ok_or_else(|| CoreError::ToolExecution("knowledge_base write requires content".into()))?;
+            .ok_or_else(|| {
+                CoreError::ToolExecution("knowledge_base write requires content".into())
+            })?;
         let tags = if tags_present {
             tags
         } else {
-            existing.as_ref().map(|e| e.tags.clone()).unwrap_or_default()
+            existing
+                .as_ref()
+                .map(|e| e.tags.clone())
+                .unwrap_or_default()
         };
         let mut metadata = existing
             .as_ref()
@@ -1289,7 +1294,6 @@ impl BuiltinToolService {
             }
         }
     }
-
 }
 
 fn required_string(args: &serde_json::Value, key: &str) -> Result<String, CoreError> {

--- a/crates/storage/src/dreaming/consolidation.rs
+++ b/crates/storage/src/dreaming/consolidation.rs
@@ -66,7 +66,9 @@ pub async fn run_consolidation_phase(
                 total.soft_deleted += stats.soft_deleted;
             }
             Err(e) => {
-                tracing::warn!("dreaming: holistic consolidation failed for user {user_id_str}: {e}")
+                tracing::warn!(
+                    "dreaming: holistic consolidation failed for user {user_id_str}: {e}"
+                )
             }
         }
     }
@@ -158,11 +160,7 @@ async fn consolidate_user(
                     }
                     merge_content.insert(canonical, (content, scope.filter(|s| !s.is_empty())));
                 }
-                RawOp::Edit {
-                    id,
-                    content,
-                    scope,
-                } => {
+                RawOp::Edit { id, content, scope } => {
                     if !valid.contains(id.as_str()) {
                         tracing::debug!("dreaming: ignoring edit of unknown id {id}");
                         continue;
@@ -358,8 +356,7 @@ fn build_user_prompt(entries: &[KbEntry]) -> String {
         prompt.push_str("scope: ");
         match e.metadata.effective_scope() {
             Some(scope) => {
-                let dims: Vec<String> =
-                    scope.0.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                let dims: Vec<String> = scope.0.iter().map(|(k, v)| format!("{k}={v}")).collect();
                 prompt.push_str(&dims.join(", "));
             }
             None => prompt.push_str("(universal)"),
@@ -467,9 +464,15 @@ mod tests {
     fn slice_entries_splits_over_budget() {
         // Each entry ~ MAX/3 chars, so 4 entries span 2 slices.
         let big = "x".repeat(MAX_HOLISTIC_PROMPT_CHARS / 3);
-        let entries: Vec<KbEntry> = (0..4).map(|i| entry(&format!("id{i}"), &big, &[])).collect();
+        let entries: Vec<KbEntry> = (0..4)
+            .map(|i| entry(&format!("id{i}"), &big, &[]))
+            .collect();
         let slices = slice_entries(entries);
-        assert!(slices.len() >= 2, "expected multiple slices, got {}", slices.len());
+        assert!(
+            slices.len() >= 2,
+            "expected multiple slices, got {}",
+            slices.len()
+        );
         // Every entry is preserved across slices.
         let total: usize = slices.iter().map(|s| s.len()).sum();
         assert_eq!(total, 4);
@@ -477,8 +480,9 @@ mod tests {
 
     #[test]
     fn slice_entries_keeps_small_kb_in_one_slice() {
-        let entries: Vec<KbEntry> =
-            (0..10).map(|i| entry(&format!("id{i}"), "short", &["t"])).collect();
+        let entries: Vec<KbEntry> = (0..10)
+            .map(|i| entry(&format!("id{i}"), "short", &["t"]))
+            .collect();
         let slices = slice_entries(entries);
         assert_eq!(slices.len(), 1);
         assert_eq!(slices[0].len(), 10);


### PR DESCRIPTION
`origin/main` is red on `just check` — rustfmt drift in 4 files + one clippy `iter_overeager_cloned` lint, landed by the recent Dream-cycle merges (#399/#400/#402) without the gate. This makes main green again (it's currently blocking everyone's pre-push).

- `cargo fmt --all` over the 4 drifted files (core/ports/knowledge.rs, daemon/knowledge_service.rs, mcp-client/builtin.rs, storage/dreaming/consolidation.rs).
- clippy: `knowledge_service.rs` `list()` cloned the whole vec before `skip`/`take` → reordered to `.skip().take().cloned()`.

No behavior change. `just check` green locally.