### PR TITLE
Add capability-gated builtin_notify desktop-notification tool

### DIFF
--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -31,6 +31,10 @@ pub mod tool_registry;
 /// Database query port — closure type for read-only SQL queries.
 pub mod database;
 
+/// Desktop-notification port — capability-gated closure for posting a desktop
+/// notification (freedesktop `org.freedesktop.Notifications`).
+pub mod notify;
+
 /// Conversation search port — outbound trait for full-text search over past messages.
 pub mod conversation_search;
 

--- a/crates/core/src/ports/notify.rs
+++ b/crates/core/src/ports/notify.rs
@@ -1,0 +1,60 @@
+//! Desktop-notification port.
+//!
+//! A capability-gated outbound closure for posting a desktop notification
+//! (freedesktop `org.freedesktop.Notifications` on Linux). The closure is only
+//! wired when a notification service is actually present on the session bus, so
+//! the `builtin_notify` tool simply isn't offered on a headless host — "is the
+//! capability present?" is decided at wiring time, distinct from "did a given
+//! call succeed?".
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::CoreError;
+
+/// Notification urgency, mapping to the freedesktop `urgency` hint
+/// (0 = low, 1 = normal, 2 = critical).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NotifyUrgency {
+    Low,
+    #[default]
+    Normal,
+    Critical,
+}
+
+impl NotifyUrgency {
+    /// Parse a tool-supplied urgency string; unknown/missing values map to
+    /// `Normal`.
+    pub fn parse(value: Option<&str>) -> Self {
+        match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+            Some("low") => Self::Low,
+            Some("critical") => Self::Critical,
+            _ => Self::Normal,
+        }
+    }
+
+    /// The freedesktop `urgency` hint byte.
+    pub fn hint(self) -> u8 {
+        match self {
+            Self::Low => 0,
+            Self::Normal => 1,
+            Self::Critical => 2,
+        }
+    }
+}
+
+/// Boxed async closure that posts a desktop notification: `(summary, body,
+/// urgency) → notification id`. Returns `Ok(None)` when the post was
+/// suppressed by rate-limiting (e.g. an identical notification fired moments
+/// ago), so callers can report "shown" vs "suppressed" without it being an
+/// error.
+pub type NotifyFn = Arc<
+    dyn Fn(
+            String,
+            String,
+            NotifyUrgency,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<u32>, CoreError>> + Send>>
+        + Send
+        + Sync,
+>;

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -18,6 +18,7 @@ mod config;
 mod connections;
 mod knowledge_service;
 mod model_defaults;
+mod notifications;
 mod purposes;
 mod registry;
 mod routing_llm;
@@ -905,6 +906,12 @@ async fn main() -> Result<()> {
                 Box::pin(async move { store.get(&id).await })
             }),
         );
+    }
+
+    // Desktop notifications (builtin_notify). Capability-gated: only wired when
+    // a freedesktop notification server answers on the session bus.
+    if let Some(notify_fn) = notifications::build_notify_fn().await {
+        builtin_tools = builtin_tools.with_notify(notify_fn);
     }
 
     // Background-task registry (#111/#115). Constructed BEFORE the scratchpad

--- a/crates/daemon/src/notifications.rs
+++ b/crates/daemon/src/notifications.rs
@@ -1,0 +1,130 @@
+//! Desktop-notification wiring for the `builtin_notify` tool.
+//!
+//! Capability-gated: [`build_notify_fn`] probes the session bus for a
+//! freedesktop notification server and returns a [`NotifyFn`] only when one is
+//! present. On a headless host (no session bus, or no notification daemon) it
+//! returns `None`, so the daemon never wires the tool and the model is simply
+//! not offered it — "is the capability present?" decided once, here, distinct
+//! from "did a given call succeed?".
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use desktop_assistant_core::CoreError;
+use desktop_assistant_core::ports::notify::{NotifyFn, NotifyUrgency};
+
+/// App name shown by the notification server.
+const APP_NAME: &str = "Adele";
+/// Identical (summary + body + urgency) notifications fired within this window
+/// are suppressed, so a misbehaving caller can't spam the user.
+const DEDUP_WINDOW: Duration = Duration::from_secs(10);
+
+#[zbus::proxy(
+    interface = "org.freedesktop.Notifications",
+    default_service = "org.freedesktop.Notifications",
+    default_path = "/org/freedesktop/Notifications"
+)]
+trait Notifications {
+    #[allow(clippy::too_many_arguments)]
+    async fn notify(
+        &self,
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: &[&str],
+        hints: HashMap<&str, zbus::zvariant::Value<'_>>,
+        expire_timeout: i32,
+    ) -> zbus::Result<u32>;
+
+    /// `(name, vendor, version, spec_version)` — used purely as a liveness
+    /// probe for the capability check.
+    async fn get_server_information(&self) -> zbus::Result<(String, String, String, String)>;
+}
+
+/// Build a [`NotifyFn`] when a notification server is reachable, else `None`.
+pub async fn build_notify_fn() -> Option<NotifyFn> {
+    let connection = match zbus::Connection::session().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            tracing::info!("builtin_notify disabled: no session D-Bus bus ({e})");
+            return None;
+        }
+    };
+
+    let proxy = match NotificationsProxy::new(&connection).await {
+        Ok(proxy) => proxy,
+        Err(e) => {
+            tracing::info!("builtin_notify disabled: notifications proxy unavailable ({e})");
+            return None;
+        }
+    };
+
+    // Capability probe: if no service owns the name this errors out, and we
+    // degrade by leaving the tool unwired.
+    match proxy.get_server_information().await {
+        Ok((name, vendor, version, _spec)) => tracing::info!(
+            "builtin_notify enabled: notification server {name} {version} ({vendor})"
+        ),
+        Err(e) => {
+            tracing::info!("builtin_notify disabled: no notification server ({e})");
+            return None;
+        }
+    }
+
+    let proxy = Arc::new(proxy);
+    // Last (content-hash, instant) for the dedup window.
+    let last: Arc<Mutex<Option<(u64, Instant)>>> = Arc::new(Mutex::new(None));
+
+    let notify_fn: NotifyFn = Arc::new(move |summary: String, body: String, urgency: NotifyUrgency| {
+        let proxy = Arc::clone(&proxy);
+        let last = Arc::clone(&last);
+        Box::pin(async move {
+            let key = {
+                let mut hasher = DefaultHasher::new();
+                summary.hash(&mut hasher);
+                body.hash(&mut hasher);
+                urgency.hint().hash(&mut hasher);
+                hasher.finish()
+            };
+
+            // Dedup. The guard is dropped before the await below — never held
+            // across a suspension point.
+            {
+                let mut guard = last.lock().unwrap();
+                if let Some((prev_key, when)) = *guard
+                    && prev_key == key
+                    && when.elapsed() < DEDUP_WINDOW
+                {
+                    return Ok(None);
+                }
+                *guard = Some((key, Instant::now()));
+            }
+
+            let mut hints: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
+            hints.insert("urgency", zbus::zvariant::Value::U8(urgency.hint()));
+
+            let id = proxy
+                .notify(
+                    APP_NAME,
+                    0,
+                    "dialog-information",
+                    &summary,
+                    &body,
+                    &[],
+                    hints,
+                    -1, // let the server choose the timeout
+                )
+                .await
+                .map_err(|e| CoreError::ToolExecution(format!("notification failed: {e}")))?;
+            Ok(Some(id))
+        })
+    });
+
+    Some(notify_fn)
+}

--- a/crates/mcp-client/src/builtin.rs
+++ b/crates/mcp-client/src/builtin.rs
@@ -13,6 +13,7 @@ use desktop_assistant_core::ports::knowledge::{
     KnowledgeDeleteFn, KnowledgeGetFn, KnowledgeListFn, KnowledgeListQuery, KnowledgeSearchFn,
     KnowledgeWriteFn, ListOrder, ListOrderOpt,
 };
+use desktop_assistant_core::ports::notify::{NotifyFn, NotifyUrgency};
 use desktop_assistant_core::ports::scratchpad::{
     MAX_KEYS_PER_CALL, MAX_NOTE_BYTES, MAX_NOTES_PER_WRITE, MAX_RESULTS_CEILING, NewScratchpadNote,
     RESPONSE_BYTE_BUDGET, ScratchpadClearFn, ScratchpadDeleteManyFn, ScratchpadGetManyFn,
@@ -27,6 +28,7 @@ const TOOL_KB_SEARCH: &str = "builtin_knowledge_base_search";
 const TOOL_KB_DELETE: &str = "builtin_knowledge_base_delete";
 const TOOL_KB_LIST: &str = "builtin_knowledge_base_list";
 const TOOL_SEARCH: &str = "builtin_tool_search";
+const TOOL_NOTIFY: &str = "builtin_notify";
 const TOOL_SYS_PROPS: &str = "builtin_sys_props";
 const TOOL_DB_QUERY: &str = "builtin_db_query";
 const TOOL_MCP_CONTROL: &str = "builtin_mcp_control";
@@ -68,6 +70,7 @@ pub struct BuiltinToolService {
     scratchpad_search_fn: Option<ScratchpadSearchFn>,
     scratchpad_delete_many_fn: Option<ScratchpadDeleteManyFn>,
     scratchpad_clear_fn: Option<ScratchpadClearFn>,
+    notify_fn: Option<NotifyFn>,
 }
 
 impl Default for BuiltinToolService {
@@ -98,12 +101,23 @@ impl BuiltinToolService {
             scratchpad_search_fn: None,
             scratchpad_delete_many_fn: None,
             scratchpad_clear_fn: None,
+            notify_fn: None,
         }
     }
 
     /// Configure the embedding function for generating query vectors.
     pub fn with_embedding(mut self, embed_fn: EmbedFn) -> Self {
         self.embed_fn = Some(embed_fn);
+        self
+    }
+
+    /// Configure the desktop-notification closure (#`builtin_notify`).
+    ///
+    /// Capability-gated: the daemon only calls this when a notification
+    /// service is present on the session bus, so the tool is simply absent on a
+    /// headless host rather than failing at call time.
+    pub fn with_notify(mut self, notify_fn: NotifyFn) -> Self {
+        self.notify_fn = Some(notify_fn);
         self
     }
 
@@ -211,7 +225,7 @@ impl BuiltinToolService {
     }
 
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
-        vec![
+        let mut defs = vec![
             ToolDefinition::new(
                 TOOL_KB_WRITE,
                 "Write or update knowledge base entries. Use for storing preferences, facts, \
@@ -556,7 +570,42 @@ impl BuiltinToolService {
                     }
                 }),
             ),
-        ]
+        ];
+
+        // Capability-gated: only advertise the notification tool when a
+        // notification service was wired (present on the session bus).
+        if self.notify_fn.is_some() {
+            defs.push(ToolDefinition::new(
+                TOOL_NOTIFY,
+                "Show a desktop notification to the user via the system notification service. \
+                 Use to surface something the user should see now — e.g. a long-running task \
+                 finished, or a time-sensitive finding worth interrupting for. Prefer the normal \
+                 reply for ordinary output; reserve notifications for things that warrant the \
+                 user's attention away from the chat. Only available when a desktop notification \
+                 service is present.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "summary": {
+                            "type": "string",
+                            "description": "Short title line (a few words)."
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Optional longer detail shown under the title."
+                        },
+                        "urgency": {
+                            "type": "string",
+                            "enum": ["low", "normal", "critical"],
+                            "description": "Urgency (default normal). 'critical' stays on screen until dismissed; use sparingly."
+                        }
+                    },
+                    "required": ["summary"]
+                }),
+            ));
+        }
+
+        defs
     }
 
     pub fn supports_tool(name: &str) -> bool {
@@ -587,6 +636,7 @@ impl BuiltinToolService {
             TOOL_KB_DELETE => self.kb_delete(arguments).await,
             TOOL_KB_LIST => self.kb_list(arguments).await,
             TOOL_SEARCH => self.tool_search(arguments).await,
+            TOOL_NOTIFY => self.notify(arguments).await,
             TOOL_SYS_PROPS => Ok(self.sys_props()),
             TOOL_DB_QUERY => self.db_query(arguments).await,
             TOOL_MCP_CONTROL => self.mcp_control(arguments).await,
@@ -914,6 +964,30 @@ impl BuiltinToolService {
             "next_cursor": page.next_cursor,
         })
         .to_string())
+    }
+
+    async fn notify(&self, arguments: serde_json::Value) -> Result<String, CoreError> {
+        let notify_fn = self.notify_fn.as_ref().ok_or_else(|| {
+            CoreError::ToolExecution("desktop notifications are not available".to_string())
+        })?;
+
+        let summary = required_string(&arguments, "summary")?;
+        let body = optional_string(&arguments, "body").unwrap_or_default();
+        let urgency = NotifyUrgency::parse(
+            arguments.get("urgency").and_then(serde_json::Value::as_str),
+        );
+
+        match notify_fn(summary, body, urgency).await? {
+            Some(id) => Ok(serde_json::json!({ "ok": true, "shown": true, "id": id }).to_string()),
+            // Suppressed by rate-limiting (e.g. an identical notification just
+            // fired) — report it without making it an error.
+            None => Ok(serde_json::json!({
+                "ok": true,
+                "shown": false,
+                "reason": "suppressed (duplicate of a recent notification)"
+            })
+            .to_string()),
+        }
     }
 
     async fn tool_search(&self, arguments: serde_json::Value) -> Result<String, CoreError> {
@@ -2441,6 +2515,76 @@ mod tests {
         let tools = json["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0]["name"], "jira__create_issue");
+    }
+
+    #[tokio::test]
+    async fn notify_absent_and_errors_without_capability() {
+        let service = BuiltinToolService::new();
+        // Not advertised when no notification capability is wired.
+        assert!(
+            !service
+                .tool_definitions()
+                .iter()
+                .any(|t| t.name == TOOL_NOTIFY)
+        );
+        // Calling it anyway is a clean error, not a panic.
+        let err = service
+            .execute_tool(TOOL_NOTIFY, serde_json::json!({"summary": "hi"}))
+            .await;
+        assert!(matches!(err, Err(CoreError::ToolExecution(_))));
+    }
+
+    #[tokio::test]
+    async fn notify_with_closure_reports_shown_and_suppressed() {
+        use std::sync::Arc;
+
+        // Returns an id for "show me", None for "duplicate" — keyed off summary.
+        let notify_fn: NotifyFn = Arc::new(|summary, _body, _urgency| {
+            Box::pin(async move {
+                if summary == "dup" {
+                    Ok(None)
+                } else {
+                    Ok(Some(42u32))
+                }
+            })
+        });
+        let service = BuiltinToolService::new().with_notify(notify_fn);
+
+        // Advertised once wired.
+        assert!(
+            service
+                .tool_definitions()
+                .iter()
+                .any(|t| t.name == TOOL_NOTIFY)
+        );
+
+        // summary is required.
+        assert!(
+            service
+                .execute_tool(TOOL_NOTIFY, serde_json::json!({"body": "no summary"}))
+                .await
+                .is_err()
+        );
+
+        let shown = service
+            .execute_tool(
+                TOOL_NOTIFY,
+                serde_json::json!({"summary": "Build done", "urgency": "low"}),
+            )
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&shown).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["shown"], true);
+        assert_eq!(json["id"], 42);
+
+        let suppressed = service
+            .execute_tool(TOOL_NOTIFY, serde_json::json!({"summary": "dup"}))
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&suppressed).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["shown"], false);
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Closes #408

Gives the agent a `builtin_notify` tool that posts a freedesktop desktop notification (`org.freedesktop.Notifications`, session D-Bus). Useful in the foreground ("ping me when the build's done") and the delivery primitive for the future scheduled-routines direction.

- **New `NotifyFn` port** + `NotifyUrgency` (`crates/core/src/ports/notify.rs`).
- **mcp-client:** `builtin_notify` (summary required, body/urgency optional). Only advertised in `tool_definitions()` when a notify closure is wired; handler reports `shown` vs `suppressed`.
- **daemon:** a `notifications` module with the zbus proxy + a capability probe (`GetServerInformation`); `main.rs` wires the tool only when a notification server answers on the session bus — otherwise it's simply absent (headless degrade), per the capability-detection principle.
- **Light dedup:** identical summary+body+urgency within 10s is suppressed so it can't spam.

Out of scope (future): unattended/scheduled use (prompt-injection hardening) and actionable notifications (action buttons → create task).

Tests: new builtin tests (absent+errors without capability; shown/suppressed/required-summary with a closure). Full suites green — core (391), daemon bin (299), mcp-client (76); `cargo check --workspace --all-targets` clean.