### PR TITLE
Step 1: authenticate local UDS connections by kernel peer-cred (#407)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "anyhow",
  "clap",
  "desktop-assistant-auth-jwt",
+ "desktop-assistant-peer-cred",
  "libc",
  "serde",
  "serde_json",
@@ -1494,6 +1495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-assistant-peer-cred"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "desktop-assistant-protocol"
 version = "0.1.0"
 dependencies = [
@@ -1547,6 +1557,7 @@ dependencies = [
  "desktop-assistant-auth-jwt",
  "desktop-assistant-core",
  "desktop-assistant-frame-codec",
+ "desktop-assistant-peer-cred",
  "desktop-assistant-transport-dispatch",
  "futures",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/api-model",
     "crates/application",
     "crates/frame-codec",
+    "crates/peer-cred",
     "crates/auth-jwt",
     "crates/ws-interface",
     "crates/core",
@@ -58,6 +59,7 @@ desktop-assistant-client-common = { path = "crates/client-common" }
 desktop-assistant-transport-dispatch = { path = "crates/transport-dispatch" }
 desktop-assistant-uds = { path = "crates/uds-interface" }
 desktop-assistant-frame-codec = { path = "crates/frame-codec" }
+desktop-assistant-peer-cred = { path = "crates/peer-cred" }
 serde_json = "1"
 toml = "1"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -37,8 +37,8 @@ use desktop_assistant_ws as ws;
 use settings_service::DaemonSettingsService;
 use store::PersistentConversationStore;
 use transports::{
-    OidcAwareAuth, WsAsUdsAuth, WsAuthDiscoveryProvider, WsBasicLogin, WsLoginMode, WsSettingsAuth,
-    daemon_host_label, env_bool, resolve_uds_socket_path, resolve_ws_login_mode,
+    OidcAwareAuth, PeerCredUdsAuth, WsAuthDiscoveryProvider, WsBasicLogin, WsLoginMode,
+    WsSettingsAuth, daemon_host_label, env_bool, resolve_uds_socket_path, resolve_ws_login_mode,
 };
 
 async fn shutdown_signal() {
@@ -2071,8 +2071,11 @@ async fn main() -> Result<()> {
             let uds_daemon_system_id = daemon_system_id.clone();
             tracing::info!("UDS listening on {}", path.display());
             Some(tokio::spawn(async move {
+                // Local transports authenticate by kernel peer-cred (#407);
+                // the WS validator is retained only as a migration-tolerant
+                // JWT fallback for the peer-cred-unavailable case.
                 let auth: Arc<dyn uds::UdsAuthValidator> =
-                    Arc::new(WsAsUdsAuth::new(ws_auth_for_uds));
+                    Arc::new(PeerCredUdsAuth::new(ws_auth_for_uds));
                 let config =
                     uds::UdsServerConfig::new(path).with_daemon_system_id(uds_daemon_system_id);
                 let server = uds::UdsServer::new(api_handler, auth, config);

--- a/crates/daemon/src/transports.rs
+++ b/crates/daemon/src/transports.rs
@@ -97,31 +97,66 @@ impl ws::WsAuthDiscovery for WsAuthDiscoveryProvider {
     }
 }
 
-/// Adapter: reuses the WS bearer-token validator for UDS connections so
-/// both transports honor the same JWT policy (local HS256 + OIDC RS256
-/// fallback) per `architecture-evolution.md` rule #2 (uniform JWT auth).
-pub(crate) struct WsAsUdsAuth {
-    validator: Arc<dyn ws::WsAuthValidator>,
+/// UDS auth for the **local trust model** (#407): authenticate by kernel
+/// peer-credentials, deriving the `UserId` from the connecting peer's username.
+/// No bearer token is required on a local Unix socket — the kernel-attested peer
+/// UID (`SO_PEERCRED`, unforgeable) *is* the authentication. This is the
+/// username the retired `adelie-mint` minter used to stamp as the JWT `sub`, so
+/// per-user identity is preserved.
+///
+/// This **reverses** `architecture-evolution.md` rule #2 (uniform JWT on every
+/// transport): JWT auth now belongs to the *remote* WS door only.
+///
+/// During the migration off the minter this stays **tolerant**: if the OS can't
+/// supply peer credentials but the client still presents a valid bearer token
+/// (the old uniform-JWT path), the token is accepted as a fallback. Once every
+/// local client has stopped minting tokens (#407 step 3) the fallback can go.
+pub(crate) struct PeerCredUdsAuth {
+    /// JWT fallback for the (rare) peer-cred-unavailable case during migration.
+    jwt_fallback: Arc<dyn ws::WsAuthValidator>,
 }
 
-impl WsAsUdsAuth {
-    pub(crate) fn new(validator: Arc<dyn ws::WsAuthValidator>) -> Self {
-        Self { validator }
+impl PeerCredUdsAuth {
+    pub(crate) fn new(jwt_fallback: Arc<dyn ws::WsAuthValidator>) -> Self {
+        Self { jwt_fallback }
     }
 }
 
 #[async_trait]
-impl uds::UdsAuthValidator for WsAsUdsAuth {
+impl uds::UdsAuthValidator for PeerCredUdsAuth {
     async fn validate_bearer_token(&self, token: &str) -> bool {
-        self.validator.validate_bearer_token(token).await
+        self.jwt_fallback.validate_bearer_token(token).await
     }
 
     async fn extract_user_id(&self, token: &str) -> Option<desktop_assistant_application::UserId> {
-        // Delegate to the same WS validator so UDS and WS share the
-        // JWT-to-user_id mapping. The bridge above already enforces
-        // uniform validation; #105's identity extraction follows the
-        // same path.
-        self.validator.extract_user_id(token).await
+        self.jwt_fallback.extract_user_id(token).await
+    }
+
+    async fn authenticate(
+        &self,
+        token: Option<&str>,
+        peer: Option<&uds::PeerIdentity>,
+    ) -> uds::UdsAuth {
+        // Local trust: the kernel-attested peer is the authentication. Derive
+        // the per-user identity from the peer username.
+        if let Some(peer) = peer {
+            return uds::UdsAuth::Allow(desktop_assistant_application::UserId::from(
+                peer.username.clone(),
+            ));
+        }
+        // Peer-cred unavailable — fall back to a valid bearer token (migration
+        // tolerance; see the struct docs).
+        match token {
+            Some(t) if self.jwt_fallback.validate_bearer_token(t).await => uds::UdsAuth::Allow(
+                self.jwt_fallback
+                    .extract_user_id(t)
+                    .await
+                    .unwrap_or_default(),
+            ),
+            _ => uds::UdsAuth::Reject(
+                "auth: no peer credentials and no valid bearer token".to_string(),
+            ),
+        }
     }
 }
 
@@ -407,5 +442,85 @@ mod tests {
         let result =
             resolve_ws_login_mode_decision("local-user".to_string(), None, None, false, false);
         assert!(result.is_none());
+    }
+
+    mod peer_cred_uds_auth {
+        use std::sync::Arc;
+
+        use async_trait::async_trait;
+        use desktop_assistant_application::UserId;
+        use desktop_assistant_uds::{PeerIdentity, UdsAuth, UdsAuthValidator};
+        use desktop_assistant_ws as ws;
+
+        use crate::transports::PeerCredUdsAuth;
+
+        /// JWT fallback stub: accepts only the literal token `"good"`, whose
+        /// `sub` is `"jwtuser"`.
+        struct StubJwt;
+
+        #[async_trait]
+        impl ws::WsAuthValidator for StubJwt {
+            async fn validate_bearer_token(&self, token: &str) -> bool {
+                token == "good"
+            }
+            async fn extract_user_id(&self, token: &str) -> Option<UserId> {
+                (token == "good").then(|| UserId::from("jwtuser"))
+            }
+        }
+
+        fn auth() -> PeerCredUdsAuth {
+            PeerCredUdsAuth::new(Arc::new(StubJwt))
+        }
+
+        fn peer(username: &str) -> PeerIdentity {
+            PeerIdentity {
+                uid: 1000,
+                username: username.to_string(),
+            }
+        }
+
+        fn allowed(outcome: UdsAuth) -> UserId {
+            match outcome {
+                UdsAuth::Allow(user) => user,
+                UdsAuth::Reject(reason) => panic!("expected Allow, got Reject({reason})"),
+            }
+        }
+
+        /// Peer-cred alone (no token) authenticates, and the `UserId` is the
+        /// peer's username — the local trust model (#407).
+        #[tokio::test]
+        async fn peer_cred_without_token_authenticates_as_peer_user() {
+            let outcome = auth().authenticate(None, Some(&peer("dave"))).await;
+            assert_eq!(allowed(outcome), UserId::from("dave"));
+        }
+
+        /// Peer-cred wins even when a (valid) token is also presented — the
+        /// kernel identity is ground truth on a local socket.
+        #[tokio::test]
+        async fn peer_cred_takes_precedence_over_a_token() {
+            let outcome = auth().authenticate(Some("good"), Some(&peer("dave"))).await;
+            assert_eq!(allowed(outcome), UserId::from("dave"));
+        }
+
+        /// Migration tolerance: with no peer-cred but a valid token, the token
+        /// is accepted and its `sub` is the identity.
+        #[tokio::test]
+        async fn valid_token_is_accepted_when_peer_cred_is_unavailable() {
+            let outcome = auth().authenticate(Some("good"), None).await;
+            assert_eq!(allowed(outcome), UserId::from("jwtuser"));
+        }
+
+        /// Neither peer-cred nor a valid token → rejected.
+        #[tokio::test]
+        async fn no_peer_cred_and_no_valid_token_is_rejected() {
+            assert!(matches!(
+                auth().authenticate(None, None).await,
+                UdsAuth::Reject(_)
+            ));
+            assert!(matches!(
+                auth().authenticate(Some("bogus"), None).await,
+                UdsAuth::Reject(_)
+            ));
+        }
     }
 }

--- a/crates/jwt-minter/Cargo.toml
+++ b/crates/jwt-minter/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow.workspace = true
 desktop-assistant-auth-jwt = { path = "../auth-jwt" }
+desktop-assistant-peer-cred.workspace = true
 libc = "0.2"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/jwt-minter/src/peer.rs
+++ b/crates/jwt-minter/src/peer.rs
@@ -1,96 +1,11 @@
-//! Peer-credential lookup over a connected `UnixStream`.
+//! Peer-credential lookup.
 //!
-//! `SO_PEERCRED` is the kernel-attested identity of whoever opened the
-//! other end of the socket. Tokio's `UnixStream::peer_cred` wraps the
-//! socket option directly; we only have to map the UID to a username via
-//! `getpwuid_r` for the `sub` claim.
+//! The implementation was relocated to the shared `desktop-assistant-peer-cred`
+//! crate (issue #407) so the UDS server can authenticate connections by
+//! peer-cred and this minter can be retired. This module re-exports it so the
+//! minter's existing `crate::peer::…` paths keep working unchanged until the
+//! crate is deleted.
 
-use std::ffi::CStr;
-
-use anyhow::{Context, anyhow};
-use tokio::net::UnixStream;
-
-/// The OS identity of a connected peer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PeerIdentity {
-    pub uid: u32,
-    pub username: String,
-}
-
-/// Read the kernel-attested peer credentials from `stream` and resolve
-/// the UID to a username via `getpwuid_r`.
-pub fn extract_peer_identity(stream: &UnixStream) -> anyhow::Result<PeerIdentity> {
-    let cred = stream
-        .peer_cred()
-        .context("failed to read SO_PEERCRED from peer socket")?;
-    let uid = cred.uid();
-    let username =
-        username_for_uid(uid)?.ok_or_else(|| anyhow!("no passwd entry for uid {uid}"))?;
-    Ok(PeerIdentity { uid, username })
-}
-
-/// Look up the username for `uid` via `getpwuid_r`.
-///
-/// Returns `Ok(None)` when the UID has no matching entry rather than an
-/// error so callers can distinguish "system call failed" from "no such user".
-pub fn username_for_uid(uid: u32) -> anyhow::Result<Option<String>> {
-    // Start with a comfortable buffer and grow on ERANGE.
-    let mut buf_size = sysconf_or(libc::_SC_GETPW_R_SIZE_MAX, 1024).max(1024);
-    let mut buf: Vec<libc::c_char> = vec![0; buf_size];
-    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
-    let mut result: *mut libc::passwd = std::ptr::null_mut();
-
-    loop {
-        // SAFETY: `&mut pwd` is a valid `passwd*` for the lifetime of the
-        // call; `buf` is a valid writable buffer of `buf_size` bytes; we
-        // pass a non-null `result` out-pointer per the getpwuid_r contract.
-        let rc = unsafe {
-            libc::getpwuid_r(
-                uid as libc::uid_t,
-                &mut pwd,
-                buf.as_mut_ptr(),
-                buf_size,
-                &mut result,
-            )
-        };
-        if rc == 0 {
-            if result.is_null() {
-                return Ok(None);
-            }
-            // SAFETY: `pwd.pw_name` is a NUL-terminated C string owned by
-            // `buf` (filled by `getpwuid_r`); we copy it into an owned
-            // `String` before `buf` is dropped.
-            let name = unsafe { CStr::from_ptr(pwd.pw_name) }
-                .to_str()
-                .context("passwd entry username is not valid UTF-8")?
-                .to_string();
-            return Ok(Some(name));
-        }
-        if rc == libc::ERANGE {
-            buf_size = buf_size.saturating_mul(2);
-            if buf_size > 1 << 20 {
-                return Err(anyhow!(
-                    "getpwuid_r requires implausibly large buffer (>1MiB)"
-                ));
-            }
-            buf.resize(buf_size, 0);
-            continue;
-        }
-        return Err(std::io::Error::from_raw_os_error(rc))
-            .with_context(|| format!("getpwuid_r({uid}) failed"));
-    }
-}
-
-/// The UID of the current process.
-pub fn current_uid() -> u32 {
-    // SAFETY: `getuid` is documented to always succeed and to have no
-    // thread-safety concerns; it takes no arguments.
-    unsafe { libc::getuid() as u32 }
-}
-
-fn sysconf_or(name: libc::c_int, fallback: usize) -> usize {
-    // SAFETY: `sysconf` is a libc query function with no thread-safety
-    // concerns; it accepts the integer constant `name`.
-    let value = unsafe { libc::sysconf(name) };
-    if value <= 0 { fallback } else { value as usize }
-}
+pub use desktop_assistant_peer_cred::{
+    PeerIdentity, current_uid, extract_peer_identity, username_for_uid,
+};

--- a/crates/peer-cred/Cargo.toml
+++ b/crates/peer-cred/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "desktop-assistant-peer-cred"
+version = "0.1.0"
+edition = "2024"
+license = "AGPL-3.0-or-later"
+
+[dependencies]
+anyhow.workspace = true
+libc = "0.2"
+tokio = { workspace = true, features = ["net"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "net"] }
+
+[lints]
+workspace = true

--- a/crates/peer-cred/src/lib.rs
+++ b/crates/peer-cred/src/lib.rs
@@ -1,0 +1,141 @@
+//! Kernel-attested peer-credential lookup over a connected `UnixStream`.
+//!
+//! `SO_PEERCRED` is the kernel's record of whoever opened the other end of a
+//! Unix-domain socket — an identity the peer cannot forge. Tokio's
+//! `UnixStream::peer_cred` wraps the socket option directly; we only have to map
+//! the UID to a username via `getpwuid_r`.
+//!
+//! This is the authentication primitive for *local* transports: on a UDS the
+//! peer UID is the auth, so no bearer token is required (see issue #407). The
+//! logic previously lived inside `jwt-minter`; it was relocated here so the
+//! UDS server can authenticate by peer-cred and the standalone minter can be
+//! retired.
+
+use std::ffi::CStr;
+
+use anyhow::{Context, anyhow};
+use tokio::net::UnixStream;
+
+/// The OS identity of a connected peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerIdentity {
+    pub uid: u32,
+    pub username: String,
+}
+
+/// Read the kernel-attested peer credentials from `stream` and resolve
+/// the UID to a username via `getpwuid_r`.
+pub fn extract_peer_identity(stream: &UnixStream) -> anyhow::Result<PeerIdentity> {
+    let cred = stream
+        .peer_cred()
+        .context("failed to read SO_PEERCRED from peer socket")?;
+    let uid = cred.uid();
+    let username =
+        username_for_uid(uid)?.ok_or_else(|| anyhow!("no passwd entry for uid {uid}"))?;
+    Ok(PeerIdentity { uid, username })
+}
+
+/// Look up the username for `uid` via `getpwuid_r`.
+///
+/// Returns `Ok(None)` when the UID has no matching entry rather than an
+/// error so callers can distinguish "system call failed" from "no such user".
+pub fn username_for_uid(uid: u32) -> anyhow::Result<Option<String>> {
+    // Start with a comfortable buffer and grow on ERANGE.
+    let mut buf_size = sysconf_or(libc::_SC_GETPW_R_SIZE_MAX, 1024).max(1024);
+    let mut buf: Vec<libc::c_char> = vec![0; buf_size];
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+
+    loop {
+        // SAFETY: `&mut pwd` is a valid `passwd*` for the lifetime of the
+        // call; `buf` is a valid writable buffer of `buf_size` bytes; we
+        // pass a non-null `result` out-pointer per the getpwuid_r contract.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid as libc::uid_t,
+                &mut pwd,
+                buf.as_mut_ptr(),
+                buf_size,
+                &mut result,
+            )
+        };
+        if rc == 0 {
+            if result.is_null() {
+                return Ok(None);
+            }
+            // SAFETY: `pwd.pw_name` is a NUL-terminated C string owned by
+            // `buf` (filled by `getpwuid_r`); we copy it into an owned
+            // `String` before `buf` is dropped.
+            let name = unsafe { CStr::from_ptr(pwd.pw_name) }
+                .to_str()
+                .context("passwd entry username is not valid UTF-8")?
+                .to_string();
+            return Ok(Some(name));
+        }
+        if rc == libc::ERANGE {
+            buf_size = buf_size.saturating_mul(2);
+            if buf_size > 1 << 20 {
+                return Err(anyhow!(
+                    "getpwuid_r requires implausibly large buffer (>1MiB)"
+                ));
+            }
+            buf.resize(buf_size, 0);
+            continue;
+        }
+        return Err(std::io::Error::from_raw_os_error(rc))
+            .with_context(|| format!("getpwuid_r({uid}) failed"));
+    }
+}
+
+/// The UID of the current process.
+pub fn current_uid() -> u32 {
+    // SAFETY: `getuid` is documented to always succeed and to have no
+    // thread-safety concerns; it takes no arguments.
+    unsafe { libc::getuid() as u32 }
+}
+
+fn sysconf_or(name: libc::c_int, fallback: usize) -> usize {
+    // SAFETY: `sysconf` is a libc query function with no thread-safety
+    // concerns; it accepts the integer constant `name`.
+    let value = unsafe { libc::sysconf(name) };
+    if value <= 0 { fallback } else { value as usize }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_uid_resolves_to_a_username() {
+        // The process's own UID must have a passwd entry with a non-empty name.
+        let name = username_for_uid(current_uid())
+            .expect("getpwuid_r should succeed for the current uid")
+            .expect("the current uid must have a passwd entry");
+        assert!(!name.is_empty(), "resolved username must be non-empty");
+    }
+
+    #[test]
+    fn implausible_uid_has_no_entry() {
+        // A UID near u32::MAX is reserved/unused on real systems, so the lookup
+        // must succeed at the syscall level but report "no such user" (None),
+        // not error.
+        let resolved = username_for_uid(u32::MAX - 1).expect("syscall should not fail");
+        assert!(
+            resolved.is_none(),
+            "an unused uid should resolve to None, got {resolved:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_identity_of_a_socketpair_is_the_current_user() {
+        // Both ends of a socketpair belong to this process, so the peer cred
+        // read off one end must be this process's own uid + username.
+        let (a, _b) = UnixStream::pair().expect("socketpair");
+        let id = extract_peer_identity(&a).expect("peer identity");
+        assert_eq!(id.uid, current_uid());
+        assert_eq!(
+            id.username,
+            username_for_uid(current_uid()).unwrap().unwrap()
+        );
+    }
+}

--- a/crates/uds-interface/Cargo.toml
+++ b/crates/uds-interface/Cargo.toml
@@ -18,6 +18,8 @@ desktop-assistant-api-model = { path = "../api-model" }
 desktop-assistant-application = { path = "../application" }
 desktop-assistant-transport-dispatch = { path = "../transport-dispatch" }
 desktop-assistant-frame-codec = { workspace = true }
+# Kernel peer-credential auth for local connections (#407).
+desktop-assistant-peer-cred = { workspace = true }
 # System-id co-location comparison (#248).
 desktop-assistant-core = { path = "../core" }
 

--- a/crates/uds-interface/src/lib.rs
+++ b/crates/uds-interface/src/lib.rs
@@ -37,7 +37,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use desktop_assistant_api_model as api;
-use desktop_assistant_application::AssistantApiHandler;
+use desktop_assistant_application::{AssistantApiHandler, UserId};
+use desktop_assistant_peer_cred::extract_peer_identity;
 use desktop_assistant_transport_dispatch::{AuthContext, TransportKind, dispatch_loop};
 use futures::stream;
 use tokio::io::AsyncWriteExt;
@@ -46,6 +47,7 @@ use tokio_util::sync::PollSender;
 use tracing::{debug, info, warn};
 
 pub use api::{WsFrame, WsRequest};
+pub use desktop_assistant_peer_cred::PeerIdentity;
 
 /// Default desktop path. The system-service flavor (`/run/adelie/sock`)
 /// is the daemon's responsibility — it picks the right default based
@@ -54,17 +56,32 @@ pub fn default_desktop_socket_path() -> Option<PathBuf> {
     std::env::var_os("XDG_RUNTIME_DIR").map(|p| PathBuf::from(p).join("adelie").join("sock"))
 }
 
-/// Result of the JWT handshake.
+/// Outcome of authenticating a UDS connection (#407).
 ///
-/// The validator only owns the bool/claims decision; the listener
-/// owns the wire framing. This means the validator can be implemented
-/// against any JWT library / claim shape without dragging
-/// `auth-jwt` into this crate's public API.
+/// The listener owns the wire framing; the validator only renders a verdict.
+pub enum UdsAuth {
+    /// Authenticated as this user — enter the dispatcher loop.
+    Allow(UserId),
+    /// Rejected — the listener writes `reason` as an error frame and closes.
+    Reject(String),
+}
+
+/// Result of the connection handshake.
+///
+/// The validator only owns the auth decision; the listener owns the wire
+/// framing. This means the validator can be implemented against any JWT
+/// library / claim shape without dragging `auth-jwt` into this crate's public
+/// API.
+///
+/// Authentication has two inputs: an optional handshake bearer token and the
+/// kernel-attested peer credentials of the connecting process. The default
+/// policy is **token-only** (back-compat with the uniform-JWT model): a valid
+/// token is required and peer-cred is ignored. A daemon that trusts local peers
+/// (issue #407) overrides [`Self::authenticate`] to accept the peer identity
+/// without a token.
 #[async_trait::async_trait]
 pub trait UdsAuthValidator: Send + Sync {
-    /// Validate a bearer token. Returning `true` enters the dispatcher
-    /// loop; returning `false` causes the listener to write an error
-    /// frame and close.
+    /// Validate a bearer token. Returning `true` accepts it; `false` rejects.
     async fn validate_bearer_token(&self, token: &str) -> bool;
 
     /// Extract the user id ([JWT `sub`]) from a bearer token that
@@ -75,9 +92,26 @@ pub trait UdsAuthValidator: Send + Sync {
     /// installs that don't care about identity can keep the default;
     /// multi-tenant or multi-user-host deploys override this method
     /// to return the JWT subject so storage queries scope per-user.
-    async fn extract_user_id(&self, token: &str) -> Option<desktop_assistant_application::UserId> {
+    async fn extract_user_id(&self, token: &str) -> Option<UserId> {
         let _ = token;
         None
+    }
+
+    /// Authenticate a connection from its handshake `token` (if any) and the
+    /// kernel-attested `peer` credentials (if the OS provided them).
+    ///
+    /// The default implementation is the historical token-only policy: require
+    /// a valid bearer token and ignore peer credentials. Local-trust daemons
+    /// override this to authenticate by `peer` instead (#407).
+    async fn authenticate(&self, token: Option<&str>, peer: Option<&PeerIdentity>) -> UdsAuth {
+        let _ = peer;
+        match token {
+            Some(t) if self.validate_bearer_token(t).await => {
+                UdsAuth::Allow(self.extract_user_id(t).await.unwrap_or_default())
+            }
+            Some(_) => UdsAuth::Reject("auth: invalid jwt".to_string()),
+            None => UdsAuth::Reject("auth: missing jwt in handshake".to_string()),
+        }
     }
 }
 
@@ -352,14 +386,20 @@ async fn handle_connection(
     daemon_system_id: Arc<Option<String>>,
     handshake_timeout: std::time::Duration,
 ) -> anyhow::Result<()> {
+    // Read the kernel-attested peer identity before splitting the stream
+    // (`peer_cred` is a `UnixStream` method). On local transports this is the
+    // authentication (#407); `None` if the OS couldn't supply it (the auth
+    // policy then falls back to the bearer token, if any).
+    let peer = extract_peer_identity(&stream).ok();
+
     let (mut read_half, mut write_half) = stream.into_split();
 
-    // Handshake: first frame is the JWT plus, optionally, the client's
+    // Handshake: first frame may carry a JWT plus, optionally, the client's
     // per-machine system id + host label for co-location (#248). Anything that
-    // isn't valid JSON, or has a missing/blank `jwt`, is rejected with an
-    // explicit error frame so clients can tell auth from framing problems. An
-    // older client sends the bare `{"jwt": "<token>"}`, which still parses (the
-    // id fields default to absent).
+    // isn't valid JSON is rejected with an explicit error frame so clients can
+    // tell auth from framing problems. The `jwt` field is optional — a
+    // local-trust daemon authenticates by peer-cred (above) and needs no token;
+    // an older client sends the bare `{"jwt": "<token>"}`, which still parses.
     //
     // The read is bounded by `handshake_timeout` (DT-7): a client that
     // connects and sends nothing must not pin a connection task forever.
@@ -386,34 +426,27 @@ async fn handle_connection(
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
 
-    let token = match token {
-        Some(t) => t,
-        None => {
-            write_error(&mut write_half, "", "auth: missing jwt in handshake").await?;
-            return Ok(());
-        }
-    };
-
     // System-id co-location (#248): compare the client's reported id to the
     // daemon's own. `None` (older client / unresolved daemon id) defers to the
     // transport heuristic. The id is a routing HINT, not a trust boundary — it
-    // is self-reported and no privilege is gated on it (auth is the JWT above).
+    // is self-reported and no privilege is gated on it (auth is below).
     let co_located = desktop_assistant_core::system_id::co_location_from_ids(
         daemon_system_id.as_deref(),
         handshake.system_id.as_deref(),
     );
     let client_label = handshake.host_label;
 
-    if !auth.validate_bearer_token(&token).await {
-        write_error(&mut write_half, "", "auth: invalid jwt").await?;
-        return Ok(());
-    }
-
-    // Identity (#105): the validator either returns the `sub` (multi-
-    // tenant deploys) or `None` (single-tenant fallback, mapped to
-    // the schema sentinel). The dispatcher installs this into the
-    // per-task task-local before each command runs.
-    let user_id = auth.extract_user_id(&token).await.unwrap_or_default();
+    // Authenticate from the (optional) token and the kernel peer-cred. The
+    // default validator requires a valid token; a local-trust daemon (#407)
+    // accepts the peer identity. Identity (#105): the resolved `UserId` is
+    // installed into the per-task task-local before each command runs.
+    let user_id = match auth.authenticate(token.as_deref(), peer.as_ref()).await {
+        UdsAuth::Allow(user_id) => user_id,
+        UdsAuth::Reject(reason) => {
+            write_error(&mut write_half, "", &reason).await?;
+            return Ok(());
+        }
+    };
 
     // Auth passed; enter the shared dispatcher.
     let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<anyhow::Result<WsRequest>>(16);

--- a/crates/uds-interface/tests/uds.rs
+++ b/crates/uds-interface/tests/uds.rs
@@ -681,3 +681,97 @@ async fn socket_file_and_parent_dir_permissions_are_tightened() {
 
     let _ = shutdown.send(());
 }
+
+// --- Peer-credential auth (#407) ---------------------------------------------
+
+/// A local-trust validator that mirrors the daemon's `PeerCredUdsAuth`:
+/// authenticate by the kernel peer identity, no bearer token required.
+struct PeerCredAuth;
+
+#[async_trait::async_trait]
+impl UdsAuthValidator for PeerCredAuth {
+    async fn validate_bearer_token(&self, _token: &str) -> bool {
+        // This validator never accepts tokens — peer-cred is the only path.
+        false
+    }
+
+    async fn authenticate(
+        &self,
+        _token: Option<&str>,
+        peer: Option<&desktop_assistant_uds::PeerIdentity>,
+    ) -> desktop_assistant_uds::UdsAuth {
+        match peer {
+            Some(p) => desktop_assistant_uds::UdsAuth::Allow(
+                desktop_assistant_application::UserId::from(p.username.clone()),
+            ),
+            None => desktop_assistant_uds::UdsAuth::Reject("auth: no peer credentials".to_string()),
+        }
+    }
+}
+
+fn start_server_with(
+    socket_path: PathBuf,
+    auth: Arc<dyn UdsAuthValidator>,
+) -> (
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+    tokio::sync::oneshot::Sender<()>,
+) {
+    let handler: Arc<dyn AssistantApiHandler> = Arc::new(PingHandler);
+    let config = UdsServerConfig::new(socket_path);
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let server = UdsServer::new(handler, auth, config);
+    let join = tokio::spawn(async move {
+        server
+            .serve_with_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await
+    });
+    (join, tx)
+}
+
+/// With a peer-cred validator, a handshake carrying **no** jwt is accepted —
+/// the kernel-attested peer identity is the authentication (#407). The
+/// connection then services commands normally.
+#[tokio::test]
+async fn uds_connection_without_jwt_proceeds_under_peer_cred() {
+    let dir = TempDir::new().unwrap();
+    let path = socket_path(&dir);
+    let (_join, shutdown) = start_server_with(path.clone(), Arc::new(PeerCredAuth));
+    wait_for_socket(&path).await;
+
+    let mut stream = UnixStream::connect(&path).await.unwrap();
+    // Tokenless handshake — not even a `jwt` field.
+    let handshake = serde_json::json!({});
+    write_frame(&mut stream, &serde_json::to_vec(&handshake).unwrap())
+        .await
+        .unwrap();
+
+    let req = api::WsRequest {
+        id: "1".into(),
+        command: api::Command::Ping,
+    };
+    write_frame(&mut stream, &serde_json::to_vec(&req).unwrap())
+        .await
+        .unwrap();
+
+    let raw = timeout(Duration::from_secs(2), read_frame(&mut stream))
+        .await
+        .expect("no response within 2s — tokenless peer-cred handshake should proceed")
+        .expect("io error on read_frame");
+    let frame: api::WsFrame = serde_json::from_slice(&raw).unwrap();
+    match frame {
+        api::WsFrame::Result { id, result } => {
+            assert_eq!(id, "1");
+            assert_eq!(
+                result,
+                api::CommandResult::Pong {
+                    value: "pong".into()
+                }
+            );
+        }
+        other => panic!("expected Pong, got {other:?}"),
+    }
+
+    let _ = shutdown.send(());
+}

--- a/docs/architecture-evolution.md
+++ b/docs/architecture-evolution.md
@@ -28,11 +28,18 @@ single-tenant deploy of the same server.
    load-bearing for correctness. Warm-process caches are valid as opportunistic
    optimization only. Forced by Lambda; healthy for k8s scaling.
 
-2. **JWT-only auth.** The daemon validates JWTs and extracts `sub` for
-   `user_id`. It trusts a configured set of issuers' JWKS. Production uses an
-   external IdP (Cognito, Authentik, Keycloak, etc.); desktop installs use a
-   local JWT minter that authenticates the OS user via `SO_PEERCRED`. No
-   peer-cred or session-based auth in the daemon's request path.
+2. **JWT on the remote door; peer-cred locally.** *(Revised 2026-06-14, issue
+   #407 — supersedes the original "JWT-only auth on every transport" rule.)* JWT
+   is a **remote-client** concern: the daemon validates JWTs and extracts `sub`
+   for `user_id` on the **WebSocket** door, trusting a configured set of issuers'
+   JWKS (external IdP — Cognito, Authentik, Keycloak — or the built-in HS256
+   issuer for the local single-user network door). **Local transports (UDS,
+   D-Bus) authenticate by kernel peer-credentials** (`SO_PEERCRED`): the
+   unforgeable peer UID *is* the auth, the `user_id` is the peer's username, and
+   **no bearer token is required**. The standalone `adelie-mint` JWT minter that
+   used to issue UDS tokens is therefore retired. (Rationale: peer-cred is
+   already the trust boundary on a per-user socket; requiring a JWT there forced
+   running a minter just to talk to your own daemon.)
 
 3. **Shared Postgres, user_id-scoped.** All personal-data tables carry
    `user_id`; queries are always scoped. Single-tenant desktop installs
@@ -136,8 +143,11 @@ single-tenant deploy of the same server.
   about; user_id scoping in code is the standard SaaS pattern and works at
   both desktop and multi-tenant scales.
 - **Custom OIDC IdP.** Too much engineering. Use Cognito / Authentik /
-  Keycloak in production. The local JWT minter is a desktop dev convenience,
-  not a real IdP.
-- **Peer-cred auth in the daemon's request path.** UDS endpoints stay
-  available for local clients but auth is still JWT (issued by the local
-  minter). Keeps the auth path uniform across deployments.
+  Keycloak in production. The built-in HS256 issuer is a desktop convenience
+  for the local single-user network door, not a real IdP.
+- ~~**Peer-cred auth in the daemon's request path.**~~ *(Reversed 2026-06-14,
+  issue #407.)* Local transports (UDS, D-Bus) now **do** authenticate by
+  `SO_PEERCRED` — see rule #2 above. The "keep auth uniform across deployments"
+  goal was outweighed by the cost of forcing a JWT minter onto every desktop
+  just to reach a per-user local socket; remote deployments still use JWT, so
+  the uniformity that matters (the network door) is preserved.


### PR DESCRIPTION
Part of #407 (local peer-cred auth + retire the minter), itself part of the OIDC-everywhere epic #378.

## What
Local transports stop requiring a JWT. The UDS server now authenticates by **kernel peer-credentials** (`SO_PEERCRED`): the unforgeable peer UID is the auth, and the `user_id` is the peer's username (exactly what the retired `adelie-mint` minter used to stamp as the JWT `sub`). The **WebSocket door is unchanged** — it still requires a Bearer JWT.

This **reverses** `architecture-evolution.md` rule #2 ("uniform JWT auth on every transport"); the doc is updated to record it. Rationale: peer-cred is already the trust boundary on a per-user socket, so requiring a JWT there just forced running a minter to talk to your own daemon.

## How
- **New `desktop-assistant-peer-cred` crate** — relocates the `SO_PEERCRED` + `getpwuid_r` lookup out of `jwt-minter` (which re-exports it until it's retired in a later step) so `uds-interface` can own peer-cred auth. No new third-party deps; unsafe FFI moved verbatim from the audited minter code.
- **`UdsAuthValidator::authenticate(token, peer) -> UdsAuth`** — new method; the handshake `jwt` is now optional. The **default impl is the historical token-only policy**, so existing implementors are unchanged and a tokenless connection is still rejected unless a validator opts into peer-cred.
- **`PeerCredUdsAuth`** (daemon) replaces `WsAsUdsAuth` on the UDS wiring: peer-cred wins; a valid JWT is still accepted when peer-cred is unavailable (**migration tolerance** — clients still minting keep working until #407 step 3 removes minting).

## Tests
- `peer-cred`: socketpair peer identity is the current user; uid→username; unused uid → `None` (not error).
- `uds-interface`: a **tokenless** handshake proceeds under a peer-cred validator (end-to-end Ping→Pong); existing token-required tests still pass.
- `daemon`: `PeerCredUdsAuth` verdicts — peer-cred-only allows as peer user; peer-cred beats a token; valid token accepted without peer-cred; neither → reject.
- `just`-equivalent gate: fmt clean, `clippy --workspace --all-targets` clean (`-D warnings`), affected-crate tests + 303 daemon unit tests green.

## Rollout (this is step 1 of #407)
Tolerant-first: the daemon accepts peer-cred **and** still honors a valid JWT on UDS, so nothing breaks mid-flight. Next: clients stop minting (step 3) → delete the minter (step 4) → configurable `iss`/`aud` (step 5).

## Not done here
Client-side minting removal, minter deletion, and configurable claims are follow-up steps under #407. Live round-trip against a running daemon (tui/gtk/voice/BFF tokenless) will be exercised once a client drops minting.

Closes nothing yet; refs #407.