### PR TITLE
Step 5: configurable HS256 issuer/audience per-host (#407)

### DIFF
--- a/crates/daemon/src/config/jwt.rs
+++ b/crates/daemon/src/config/jwt.rs
@@ -11,6 +11,7 @@
 //! changes.
 
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::anyhow;
@@ -27,22 +28,85 @@ fn ws_jwt_signing_key_account() -> &'static str {
     "ws_jwt_hs256_signing_key"
 }
 
-pub(super) fn default_ws_jwt_issuer() -> &'static str {
-    "org.desktopAssistant.local"
+/// The resolved built-in HS256 issuer identity (`iss`/`aud`), shared by the
+/// issue and validate paths so they can never drift. Seeded once at daemon
+/// startup from `[ws_auth.hs256]` via [`init_hs256_identity`]; any access before
+/// that (e.g. a unit test) lazily falls back to the per-host default.
+#[derive(Debug, Clone)]
+struct Hs256Identity {
+    issuer: String,
+    audience: String,
 }
 
-pub(super) fn default_ws_jwt_audience() -> &'static str {
-    "desktop-assistant-ws"
+static HS256_IDENTITY: OnceLock<Hs256Identity> = OnceLock::new();
+
+/// Best-effort local hostname for the default `iss`. Dependency-free, mirroring
+/// `client-common`'s resolver: kernel hostname, then `/etc/hostname`, then
+/// `$HOSTNAME`. Falls back to a fixed label so a token always has an issuer.
+fn local_hostname() -> String {
+    let from_file = |path: &str| {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+    from_file("/proc/sys/kernel/hostname")
+        .or_else(|| from_file("/etc/hostname"))
+        .or_else(|| {
+            std::env::var("HOSTNAME")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "desktop-assistant.local".to_string())
+}
+
+/// The per-host default identity used when config leaves a field unset:
+/// `iss` = local hostname, `aud` = `"<user>.adelie-ai"`.
+fn default_hs256_identity() -> Hs256Identity {
+    Hs256Identity {
+        issuer: local_hostname(),
+        audience: format!("{}.adelie-ai", current_username()),
+    }
+}
+
+/// Resolve the effective identity from config fields: a non-empty `issuer` /
+/// `audience` wins, otherwise the per-host default. Pure (no global state) so it
+/// can be unit-tested directly.
+fn resolve_hs256_identity(issuer: Option<String>, audience: Option<String>) -> Hs256Identity {
+    let non_empty = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+    let default = default_hs256_identity();
+    Hs256Identity {
+        issuer: non_empty(issuer).unwrap_or(default.issuer),
+        audience: non_empty(audience).unwrap_or(default.audience),
+    }
+}
+
+/// Seed the process-wide HS256 issuer identity from `[ws_auth.hs256]`. Call once
+/// at daemon startup, before serving. Empty/`None` fields fall back to the
+/// per-host default. First call wins; later calls are ignored (the identity is
+/// immutable for the process lifetime, which is what keeps issue == validate).
+pub(crate) fn init_hs256_identity(issuer: Option<String>, audience: Option<String>) {
+    let _ = HS256_IDENTITY.set(resolve_hs256_identity(issuer, audience));
+}
+
+fn hs256_identity() -> &'static Hs256Identity {
+    HS256_IDENTITY.get_or_init(default_hs256_identity)
+}
+
+pub(super) fn ws_jwt_issuer() -> &'static str {
+    &hs256_identity().issuer
+}
+
+pub(super) fn ws_jwt_audience() -> &'static str {
+    &hs256_identity().audience
 }
 
 /// Default lifetime of a daemon-minted WS JWT.
 ///
-/// DT-3 (#269): dropped from 30 days to 1 hour to match the jwt-minter's own
-/// default (`dbus-bridge`'s `token_ttl_seconds`). A leaked token is now a
-/// one-hour exposure, not a month, and clients re-mint transparently on
-/// expiry (the `Connector` already reconnects and replays). Existing configs
-/// that explicitly request a longer TTL via the minter keep working — this is
-/// only the default applied when no TTL is supplied.
+/// DT-3 (#269): dropped from 30 days to 1 hour. A leaked token is now a
+/// one-hour exposure, not a month, and clients re-issue transparently on expiry
+/// (the `Connector` already reconnects and replays).
 pub(super) fn default_ws_jwt_ttl_seconds() -> u64 {
     60 * 60
 }
@@ -98,20 +162,15 @@ pub(super) fn decode_ws_jwt_claims(token: &str) -> anyhow::Result<WsJwtClaims> {
 pub(super) fn decode_ws_jwt_claims_ignoring_revocation(token: &str) -> anyhow::Result<WsJwtClaims> {
     let signing_key = auth_jwt::read_signing_key_at(&signing_key_path())
         .ok_or_else(|| anyhow!("ws jwt signing key is not initialized"))?;
-    auth_jwt::decode(
-        token,
-        &signing_key,
-        default_ws_jwt_issuer(),
-        default_ws_jwt_audience(),
-    )
+    auth_jwt::decode(token, &signing_key, ws_jwt_issuer(), ws_jwt_audience())
 }
 
 pub fn generate_ws_jwt(subject: Option<String>) -> anyhow::Result<String> {
     let now = unix_timestamp_seconds()?;
     let claims = WsJwtClaims {
-        iss: default_ws_jwt_issuer().to_string(),
+        iss: ws_jwt_issuer().to_string(),
         sub: normalize_ws_jwt_subject(subject),
-        aud: default_ws_jwt_audience().to_string(),
+        aud: ws_jwt_audience().to_string(),
         exp: now.saturating_add(default_ws_jwt_ttl_seconds()),
         iat: now,
         nbf: now.saturating_sub(1),
@@ -259,4 +318,51 @@ pub(super) fn record_revocation_for_test(jti: &str, exp: u64) {
     let mut map = read_revocations();
     map.insert(jti.to_string(), exp);
     write_revocations(&map).expect("write test revocation");
+}
+
+#[cfg(test)]
+mod hs256_identity_tests {
+    //! Unit tests for the HS256 issuer-identity resolution (#407 step 5). These
+    //! exercise the pure `resolve_hs256_identity` so they don't touch the
+    //! process-global `OnceLock` (which would race other tests in this binary).
+
+    use super::{current_username, local_hostname, resolve_hs256_identity};
+
+    #[test]
+    fn config_values_win_when_present() {
+        let id = resolve_hs256_identity(
+            Some("issuer.example.com".to_string()),
+            Some("team.adelie-ai".to_string()),
+        );
+        assert_eq!(id.issuer, "issuer.example.com");
+        assert_eq!(id.audience, "team.adelie-ai");
+    }
+
+    #[test]
+    fn unset_fields_fall_back_to_per_host_defaults() {
+        let id = resolve_hs256_identity(None, None);
+        assert_eq!(id.issuer, local_hostname(), "default iss is the hostname");
+        assert_eq!(
+            id.audience,
+            format!("{}.adelie-ai", current_username()),
+            "default aud is <user>.adelie-ai"
+        );
+    }
+
+    #[test]
+    fn blank_fields_are_treated_as_unset() {
+        // Whitespace-only config values must not become the literal issuer/aud —
+        // they fall back to the defaults, so a stray empty string can't lock you
+        // out by minting tokens with an `aud` the validator won't expect.
+        let id = resolve_hs256_identity(Some("   ".to_string()), Some(String::new()));
+        assert_eq!(id.issuer, local_hostname());
+        assert_eq!(id.audience, format!("{}.adelie-ai", current_username()));
+    }
+
+    #[test]
+    fn one_field_overridden_other_defaulted() {
+        let id = resolve_hs256_identity(Some("pinned-issuer".to_string()), None);
+        assert_eq!(id.issuer, "pinned-issuer");
+        assert_eq!(id.audience, format!("{}.adelie-ai", current_username()));
+    }
 }

--- a/crates/daemon/src/config/mod.rs
+++ b/crates/daemon/src/config/mod.rs
@@ -38,6 +38,8 @@ pub use jwt::{
     current_username, generate_ws_jwt, prune_revocations, revoke_ws_jwt, validate_ws_jwt,
     ws_jwt_sub,
 };
+// Crate-internal: seeded once from main at startup (not part of the public API).
+pub(crate) use jwt::init_hs256_identity;
 pub use oidc::OidcValidator;
 
 // Resolution helpers — public API stays at `config::` for callers in
@@ -194,6 +196,12 @@ pub struct WsAuthConfig {
     pub methods: Vec<String>,
     #[serde(default)]
     pub oidc: Option<OidcConfig>,
+    /// Built-in HS256 issuer claims (`iss`/`aud`) for the daemon's own WS
+    /// `/login` tokens. Both fields default per-host (see [`Hs256Config`]); set
+    /// them to pin a stable identity (e.g. behind a load balancer). Omitted from
+    /// serialized config when left at its all-default (empty) form.
+    #[serde(default, skip_serializing_if = "Hs256Config::is_default")]
+    pub hs256: Hs256Config,
     /// Allowed browser origins for WebSocket and login requests.
     /// Empty (default) means no browser clients are permitted.
     /// Native clients (which do not send an Origin header) are always allowed.
@@ -206,8 +214,35 @@ impl Default for WsAuthConfig {
         Self {
             methods: default_ws_auth_methods(),
             oidc: None,
+            hs256: Hs256Config::default(),
             allowed_origins: vec![],
         }
+    }
+}
+
+/// Claims policy for the built-in HS256 issuer (the daemon's WS `/login`).
+///
+/// JWT is a network-door concern only — local transports authenticate by
+/// peer-cred (#407) — so this governs just the WebSocket door's own tokens. Both
+/// fields are issued **and** validated from this same config, so they can't
+/// drift. Unset (`None`) ⇒ a per-host default resolved at startup:
+/// `issuer` = the local hostname, `audience` = `"<user>.adelie-ai"` (a per-user
+/// daemon is a distinct service instance, so the user-scoped audience is honest).
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Hs256Config {
+    /// JWT `iss`. `None`/empty ⇒ the local hostname.
+    #[serde(default)]
+    pub issuer: Option<String>,
+    /// JWT `aud`. `None`/empty ⇒ `"<user>.adelie-ai"`.
+    #[serde(default)]
+    pub audience: Option<String>,
+}
+
+impl Hs256Config {
+    /// `true` when both fields are unset — the all-default form, omitted from
+    /// serialized config so an empty `[ws_auth.hs256]` table isn't emitted.
+    fn is_default(&self) -> bool {
+        self.issuer.is_none() && self.audience.is_none()
     }
 }
 
@@ -1361,8 +1396,8 @@ uds_socket = "/tmp/adelie.sock"
         let claims_2 = jwt::decode_ws_jwt_claims(&token_2).expect("decode second jwt");
         assert_eq!(claims_1.sub, "tui");
         assert_eq!(claims_2.sub, "plasmoid");
-        assert_eq!(claims_1.iss, jwt::default_ws_jwt_issuer());
-        assert_eq!(claims_1.aud, jwt::default_ws_jwt_audience());
+        assert_eq!(claims_1.iss, jwt::ws_jwt_issuer());
+        assert_eq!(claims_1.aud, jwt::ws_jwt_audience());
 
         // SAFETY: same scope as the matching `set_var` above; clean up
         // before exiting the test so we don't leak state between runs.

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -560,6 +560,20 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Seed the built-in HS256 issuer identity (iss/aud) once, before serving, so
+    // the issue and validate paths share a single immutable identity (#407 step
+    // 5). Unset `[ws_auth.hs256]` fields fall back to per-host defaults
+    // (hostname / "<user>.adelie-ai"). JWT is a network-door concern only —
+    // local transports authenticate by peer-cred — so this governs just the WS
+    // `/login` tokens.
+    {
+        let hs256 = daemon_config
+            .as_ref()
+            .map(|c| c.ws_auth.hs256.clone())
+            .unwrap_or_default();
+        config::init_hs256_identity(hs256.issuer, hs256.audience);
+    }
+
     // Transport enable/bind config (#279 item 3): the `[transports]` table is
     // the baseline; the matching `DESKTOP_ASSISTANT_*` env var overrides each
     // field when set. Absent table => historical defaults.


### PR DESCRIPTION
## What

The built-in HS256 issuer's `iss`/`aud` were hardcoded (`org.desktopAssistant.local` / `desktop-assistant-ws`). This makes them **config-driven and per-host**, shared between the issue and validate paths so they can never drift.

**Step 5** (final) of the [peer-cred / retire-minter plan](https://github.com/adelie-ai/desktop-assistant/issues/407) (epic #378).

- New **`[ws_auth.hs256]`** config (`Hs256Config { issuer, audience }`), both optional. Unset ⇒ per-host defaults: `iss` = local hostname, `aud` = `"<user>.adelie-ai"` (a per-user daemon is genuinely a distinct service instance, so the user-scoped audience is honest, not an overload). Omitted from serialized config when all-default — no empty table emitted.
- `config/jwt.rs`: replaced the `&'static str` issuer/audience with a process-global identity (`OnceLock<Hs256Identity>`) **seeded once at startup** via `init_hs256_identity` from `[ws_auth.hs256]`. Both `generate_ws_jwt` (issue) and `decode_ws_jwt_claims` (validate) read it → a custom `aud` is honored on both sides and a token with a different `aud`/`iss` is rejected. A pure `resolve_hs256_identity` keeps the resolution logic unit-testable without touching the global (no test races).
- Wired the seed in `main.rs` right after config load, before serving.

JWT is a **network-door concern only** — local transports authenticate by peer-cred (#407) — so this governs just the daemon's own WS `/login` tokens. The hostname-as-issuer is ephemeral in containers (= container id); since mint+validate happen in the same daemon it's self-consistent within a run, and tokens are short-TTL (acceptable; pin `[ws_auth.hs256]` for a stable identity behind a load balancer).

## Tests
- 4 resolver cases: config wins / per-host defaults / blank-treated-as-unset (a stray empty string can't lock you out) / mixed.
- Existing `ws_jwt_rejects_wrong_issuer` still passes (drift ⇒ reject).
- Gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` (`-D warnings`), 307 daemon tests.

## Follow-up (separate repo)
- The BFF (`adele-web-ui`) still hardcodes `ISSUER`/`AUDIENCE` consts; mirroring this `[ws_auth.hs256]` config there is a follow-up in that repo. The BFF validates its own tokens, so it's independent of this change — not a blocker.

Closes #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)